### PR TITLE
[front office] default template unescape title

### DIFF
--- a/templates/frontOffice/default/layout.tpl
+++ b/templates/frontOffice/default/layout.tpl
@@ -36,7 +36,7 @@ GNU General Public License : http://www.gnu.org/licenses/
     <meta charset="utf-8">
 
     {* Page Title *}
-    <title>{block name="page-title"}{strip}{if $page_title}{$page_title}{elseif $breadcrumbs}{foreach from=$breadcrumbs|array_reverse item=breadcrumb}{$breadcrumb.title} - {/foreach}{$store_name}{/if}{/strip}{/block}</title>
+    <title>{block name="page-title"}{strip}{if $page_title}{$page_title}{elseif $breadcrumbs}{foreach from=$breadcrumbs|array_reverse item=breadcrumb}{$breadcrumb.title|unescape} - {/foreach}{$store_name}{/if}{/strip}{/block}</title>
 
     {* Meta Tags *}
     <meta name="generator" content="{intl l='Thelia V2'}">


### PR DESCRIPTION
the Title wasn't unescape on default template
