### PR TITLE
Add ability to load assets from another template

### DIFF
--- a/core/lib/Thelia/Core/Template/Smarty/Assets/SmartyAssetsManager.php
+++ b/core/lib/Thelia/Core/Template/Smarty/Assets/SmartyAssetsManager.php
@@ -24,6 +24,7 @@
 namespace Thelia\Core\Template\Smarty\Assets;
 
 
+use Thelia\Core\Template\Smarty\SmartyParser;
 use Thelia\Log\Tlog;
 use Thelia\Tools\URL;
 use Thelia\Core\Template\Assets\AssetManagerInterface;
@@ -86,12 +87,28 @@ class SmartyAssetsManager
         }
     }
 
+    /**
+     * Retrieve asset URL
+     *
+     * @param string                    $assetType js|css|image
+     * @param array                     $params    Parameters
+     *                                             - file File path in the default template
+     *                                             - source module asset
+     *                                             - filters filter to apply
+     *                                             - debug
+     *                                             - template if you want to load asset from another template
+     * @param \Smarty_Internal_Template $template  Smarty Template
+     *
+     * @return string
+     * @throws \Exception
+     */
     public function computeAssetUrl($assetType, $params, \Smarty_Internal_Template $template)
     {
-        $file           = $params['file'];
-        $assetOrigin    = isset($params['source']) ? $params['source'] : "0";
-        $filters        = isset($params['filters']) ? $params['filters'] : '';
-        $debug          = isset($params['debug']) ? trim(strtolower($params['debug'])) == 'true' : false;
+        $file             = $params['file'];
+        $assetOrigin      = isset($params['source']) ? $params['source'] : "0";
+        $filters          = isset($params['filters']) ? $params['filters'] : '';
+        $debug            = isset($params['debug']) ? trim(strtolower($params['debug'])) == 'true' : false;
+        $webAssetTemplate = isset($params['template']) ? $params['template'] : false;
 
         /* we trick here relative thinking for file attribute */
         $file = ltrim($file, '/');
@@ -100,7 +117,8 @@ class SmartyAssetsManager
         }
 
         $smartyParser = $template->smarty;
-        $templateDefinition = $smartyParser->getTemplateDefinition();
+        /** @var SmartyParser $templateDefinition */
+        $templateDefinition = $smartyParser->getTemplateDefinition($webAssetTemplate);
 
         $templateDirectories = $smartyParser->getTemplateDirectories($templateDefinition->getType());
 

--- a/core/lib/Thelia/Core/Template/Smarty/SmartyParser.php
+++ b/core/lib/Thelia/Core/Template/Smarty/SmartyParser.php
@@ -178,9 +178,24 @@ class SmartyParser extends Smarty implements ParserInterface
         }
     }
 
-    public function getTemplateDefinition()
+    /**
+     * Get template definition
+     *
+     * @param bool $webAssetTemplate Allow to load asset from another template
+     *                               If the name of the template if provided
+     *
+     * @return TemplateDefinition
+     */
+    public function getTemplateDefinition($webAssetTemplate = false)
     {
-        return $this->templateDefinition;
+        $ret = $this->templateDefinition;
+        if ($webAssetTemplate) {
+            $customPath = str_replace($ret->getName(), $webAssetTemplate, $ret->getPath());
+            $ret->setName($webAssetTemplate);
+            $ret->setPath($customPath);
+        }
+
+        return $ret;
     }
 
     public function getTemplate()


### PR DESCRIPTION
- Use case : 
  If you want to easily manage several Thelia2 instances based on the same template 'baseTemplate' 
  And you just want to customize derived templates via smarty block extends
  While style being able to add a functionnality to all thelia2 instances easily by only modifiying 'baseTemplate'
- Arbo example:
  instanceThelia2_1/
  ----- templates/
  ---------- frontOffice/
  --------------- instance1/
  --------------- baseTemplate/

instanceThelia2_2/
----- templates/
---------- frontOffice/
--------------- instance2/
--------------- baseTemplate/
- Adding param 'template' to
  {javascripts file='assets/js/libs/jquery.js' template='baseTemplate'}
  {stylesheets file='assets/less/styles.less' filters='less'  template='baseTemplate' }
  {images file=assets/img/picture.png' template='baseTemplate'}

Keep up the good work
