### PR TITLE
Improve gitignore rules for modules and templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ phpunit.phar
 .DS_Store
 phpmyadmin
 composer.phar
-web/.
+web/.htaccess
 
 # Ignore everything in the "modules" directory, except the "default modules"
 local/modules/*


### PR DESCRIPTION
Generic rules used to ignore the modules or  the templates which are not by default.
