### PR TITLE
add route parameters to redirectToRoute method in BaseFrontController

### DIFF
--- a/core/lib/Thelia/Controller/Front/BaseFrontController.php
+++ b/core/lib/Thelia/Controller/Front/BaseFrontController.php
@@ -42,9 +42,9 @@ class BaseFrontController extends BaseController
      * @param array  $urlParameters the URL parametrs, as a var/value pair array
      * @param bool   $referenceType
      */
-    public function redirectToRoute($routeId, $urlParameters = array(), $referenceType = Router::ABSOLUTE_PATH)
+    public function redirectToRoute($routeId, array $urlParameters = [], array $routeParameters = [], $referenceType = Router::ABSOLUTE_PATH)
     {
-        $this->redirect(URL::getInstance()->absoluteUrl($this->getRoute($routeId, array(), $referenceType), $urlParameters));
+        $this->redirect(URL::getInstance()->absoluteUrl($this->getRoute($routeId, $routeParameters, $referenceType), $urlParameters));
     }
 
     public function checkAuth()

--- a/core/lib/Thelia/Module/BasePaymentModuleController.php
+++ b/core/lib/Thelia/Module/BasePaymentModuleController.php
@@ -156,9 +156,10 @@ abstract class BasePaymentModuleController extends BaseFrontController
 
         $this->redirectToRoute(
             'order.placed',
-            array(
+            [],
+            [
                 'order_id' => $order_id
-            ),
+            ],
             Router::ABSOLUTE_PATH
         );
     }
@@ -169,16 +170,17 @@ abstract class BasePaymentModuleController extends BaseFrontController
      * @param int         $order_id the order ID
      * @param string|null $message  an error message.
      */
-    public function redirectToFailurePage($order_id, $message = null)
+    public function redirectToFailurePage($order_id, $message)
     {
         $this->getLog()->addInfo("Redirecting customer to payment failure page");
 
         $this->redirectToRoute(
             'order.failed',
-            array(
+            [],
+            [
                 'order_id' => $order_id,
                 'message' => $message
-            ),
+            ],
             Router::ABSOLUTE_PATH
         );
     }


### PR DESCRIPTION
I had the route parameters to BaseFrontController::redirectToRoute, this method is useless without this parameter.

message is mandatory now for BasePaymentModuleController::redirectToFailurePage. If $message is null or empty, it's impossible to match the {message} parameter for `order.failed` route.
