### PR TITLE
put the module_include "customer_list_header" in the correct place

### DIFF
--- a/templates/backOffice/default/customers.html
+++ b/templates/backOffice/default/customers.html
@@ -54,8 +54,6 @@
                                             }
                                         </th>
 
-                                        {module_include location='customer_list_header'}
-
                                         <th class="object-title">
                                             {admin_sortable_header
                                                 current_order=$customer_order
@@ -77,6 +75,8 @@
                                                 label="{intl l='First name'}"
                                             }
                                         </th>
+
+                                        {module_include location='customer_list_header'}
 
                                         <th class="object-title">
                                             {admin_sortable_header

--- a/templates/backOffice/default/search.html
+++ b/templates/backOffice/default/search.html
@@ -43,6 +43,8 @@
                                     {intl l="firstname & lastname"}
                                 </th>
 
+                                {module_include location='customer_list_header'}
+
                                 <th>
                                     {intl l="last order"}
                                 </th>


### PR DESCRIPTION
In the templates customers, this module include was called before the firstname in the THEAD
whereas the module_include "customer_list_row" is called after the column Lastname
=> wrong order

Adding the module_include "customer_list_header" in the search.html template in the THEAD because there is the module_include "customer_list_row" in the TBODY
