### PR TITLE
Allow Content Loop to be ordered by created_at date

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -178,7 +178,6 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface
                     $search->clearOrderByColumns();
                     $search->addAscendingOrderByColumn('RAND()');
                     break(2);
-                    //OMNIMOD
                 case "created":
                     $search->addAscendingOrderByColumn('created_at');
                     break;


### PR DESCRIPTION
Needed for a project. This can be handy to build a blog like website.
