### PR TITLE
set the placedOrder in the createManual function

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -302,9 +302,6 @@ class Order extends BaseAction implements EventSubscriberInterface
      */
     public function createManual(OrderManualEvent $event)
     {
-        if(!$event->getOrder())
-            $event->setOrder(new \Thelia\Model\Order());
-
         $event->setPlacedOrder(
             $this->createOrder(
                 $event->getDispatcher(),
@@ -315,6 +312,8 @@ class Order extends BaseAction implements EventSubscriberInterface
                 $event->getCustomer()
             )
         );
+
+        $event->setOrder(new \Thelia\Model\Order());
     }
 
     /**


### PR DESCRIPTION
This update fill the placedOrder object during the createManual() function (in \Thelia\Action\Order.php).

This allow you to get the order informations after the call of the event :
TheliaEvents::ORDER_CREATE_MANUAL (by using the getter getPlacedOrder())
