### PR TITLE
Avoid JS console errors

### DIFF
--- a/templates/frontOffice/default/assets/js/script.js
+++ b/templates/frontOffice/default/assets/js/script.js
@@ -1,3 +1,26 @@
+// Avoid `console` errors in browsers that lack a console.
+(function() {
+    var method;
+    var noop = function () {};
+    var methods = [
+        'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
+        'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
+        'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
+        'timeStamp', 'trace', 'warn'
+    ];
+    var length = methods.length;
+    var console = (window.console = window.console || {});
+
+    while (length--) {
+        method = methods[length];
+
+        // Only stub undefined methods.
+        if (!console[method]) {
+            console[method] = noop;
+        }
+    }
+}());
+
 /* JQUERY PREVENT CONFLICT */
 (function ($) {
 


### PR DESCRIPTION
Use script from HTML5 Boilerplate to avoid console errors. 
https://github.com/h5bp/html5-boilerplate/blob/master/js/plugins.js
