### PR TITLE
Date formating should be able to cope with locale time format

### DIFF
--- a/core/lib/Thelia/Core/Template/Smarty/Plugins/Format.php
+++ b/core/lib/Thelia/Core/Template/Smarty/Plugins/Format.php
@@ -89,12 +89,10 @@ class Format extends AbstractSmartyPlugin
 
         $locale = $this->getParam($params,'locale', false);
 
-        if($locale === false)
-        {
+        if($locale === false) {
             return $date->format($format);
         } else {
-            if(function_exists('setlocale'))
-            {
+            if(function_exists('setlocale')) {
                 // Save the current locale
                 $system_locale = setlocale('LC_TIME', 0);
                 setlocale('LC_TIME', $locale);
@@ -104,7 +102,7 @@ class Format extends AbstractSmartyPlugin
 
                 return $localized_date;
             } else {
-                // No timestamp => error
+                // setlocale() function not available => error
                 throw new SmartyPluginException("The setlocale() function is not available on your system.");
             }
         }


### PR DESCRIPTION
Useful to display days and months name according to a given locale parameter (ex: fr_FR, de_DE,...)
