### PR TITLE
Automatic versionning of orders during the update 2.0.3

### DIFF
--- a/setup/update/2.0.3.sql
+++ b/setup/update/2.0.3.sql
@@ -97,6 +97,6 @@ SELECT
   `version`,
   `version_created_at`,
   `version_created_by`
-FROM `order`; 
+FROM `order`;
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Allow to initialize all orders in thelia by creating their first order_version
