### PR TITLE
correction of the filter visible in categoryTree.

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
@@ -61,7 +61,7 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
 
         $search->filterByParent($parent);
 
-        if ($visible != BooleanOrBothType::ANY) $search->filterByVisible($visible);
+        if ($visible !== BooleanOrBothType::ANY) $search->filterByVisible($visible);
 
         if ($exclude != null) $search->filterById($exclude, Criteria::NOT_IN);
 


### PR DESCRIPTION
If we use the parameter visible="1" in the loop category-tree, this test return always false : 
if ($visible != BooleanOrBothType::ANY) 

we need to compare the type as well with "!=="
