### PR TITLE
Add the reseller field in the customer form

### DIFF
--- a/core/lib/Thelia/Controller/Admin/CustomerController.php
+++ b/core/lib/Thelia/Controller/Admin/CustomerController.php
@@ -91,6 +91,7 @@ class CustomerController extends AbstractCrudController
                 'email'     => $object->getEmail(),
                 'title'     => $object->getTitleId(),
                 'discount'  => $object->getDiscount(),
+                'reseller'  => $object->getReseller(),
         );
 
         if ($address !== null) {

--- a/core/lib/Thelia/Form/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/CustomerUpdateForm.php
@@ -164,6 +164,12 @@ class CustomerUpdateForm extends BaseForm
                     'for' => 'discount'
                 )
             ))
+            ->add('reseller', 'integer', array(
+                'label' => Translator::getInstance()->trans('Reseller'),
+                'label_attr' => array(
+                    'for' => 'reseller'
+                )
+            ))                
         ;
     }
 

--- a/templates/backOffice/default/customer-edit.html
+++ b/templates/backOffice/default/customer-edit.html
@@ -95,6 +95,17 @@
                                                     </div>
                                                 {/form_field}
 
+                                                {form_field form=$form field='reseller'}
+                                                    <div class="form-group {if $error}has-error{/if}">
+                                                            <div class="checkbox">
+                                                                <label>
+                                                                    <input type="checkbox" id="{$label_attr.for}" name="{$name}" value="1" {if $value != 0}checked="checked"{/if}>
+                                                                    {$label}
+                                                                </label>
+                                                            </div>
+                                                    </div>
+                                                {/form_field}
+                                                
                                                 {form_field form=$form field='password'}
                                                     <div class="form-group {if $error}has-error{/if}">
                                                         <label for="{$label_attr.for}" class="control-label">{$label} (leave blank to keep current customer password) {if $required} <span class="required">*</span>{/if} : </label>


### PR DESCRIPTION
This patch add the 'Reseller' field in the customer form of the backend.

(This is my first pull request with GitHub ... Please tell me if something is wrong !)
