### PR TITLE
Fix hook registration and smarty modulecode argument

### DIFF
--- a/core/lib/Thelia/Core/Template/Smarty/Plugins/Hook.php
+++ b/core/lib/Thelia/Core/Template/Smarty/Plugins/Hook.php
@@ -83,7 +83,7 @@ class Hook extends AbstractSmartyPlugin
     {
         $hookName   = $this->getParam($params, 'name');
         $module     = intval($this->getParam($params, 'module', 0));
-        $moduleCode = intval($this->getParam($params, 'modulecode', 0));
+        $moduleCode = $this->getParam($params, 'modulecode', "");
 
         $type = $smarty->getTemplateDefinition()->getType();
 

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -615,11 +615,9 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
             ->setCode($hook["code"])
             ->setNative(false)
             ->setByModule(true)
+            ->setActive(isset($hook["active"]) && (bool) $hook["active"])
         ;
 
-        if ($hookModel === null) {
-            $event->setActive(isset($hook["active"]) && (bool) $hook["active"]);
-        }
         /**
          * Dispatch the event
          */


### PR DESCRIPTION
Module code argument was parsed as int, but this is generaly a string
        modifié:         core/lib/Thelia/Core/Template/Smarty/Plugins/Hook.php

Hook activate column was set as null on update ( 2nd, 3rd, ... activation of a module )
    modifié:         core/lib/Thelia/Module/BaseModule.php
