### PR TITLE
Allow format_date smarty function date parameter to be a well formatted datetime string

### DIFF
--- a/core/lib/Thelia/Core/Template/Smarty/Plugins/Format.php
+++ b/core/lib/Thelia/Core/Template/Smarty/Plugins/Format.php
@@ -78,7 +78,11 @@ class Format extends AbstractSmartyPlugin
         }
 
         if (!($date instanceof \DateTime)) {
-            return "";
+            try {
+                $date = new \DateTime($date);
+            } catch (\Exception $e) {
+                return "";
+            }
         }
 
         $format = $this->getParam($params, "format", false);


### PR DESCRIPTION
This PR allows the smarty function format_date to get a string as date parameter.
String formats can be found [here](http://php.net/manual/en/datetime.formats.compound.php)
example:

``` smarty
{format_date date="2014-08-25 08:12:34"}
```

```
modifié:         core/lib/Thelia/Core/Template/Smarty/Plugins/Format.php
```
