### PR TITLE
Variable with 'is' prefix  is not accessible with Smarty

### DIFF
--- a/core/lib/Thelia/Core/Template/Smarty/Plugins/DataAccessFunctions.php
+++ b/core/lib/Thelia/Core/Template/Smarty/Plugins/DataAccessFunctions.php
@@ -425,6 +425,9 @@ class DataAccessFunctions extends AbstractSmartyPlugin
                 }
 
                 $getter = sprintf("get%s", $this->underscoreToCamelcase($attribute));
+                if (!method_exists($data, $getter)) {
+                    $getter = sprintf("is%s", $this->underscoreToCamelcase($attribute));
+                }
                 if (method_exists($data, $getter)) {
                     $return =  $data->$getter();
 


### PR DESCRIPTION
(for example isNew)
