### PR TITLE
Correction of the count orders in backoofice home template

### DIFF
--- a/templates/backOffice/default/home.html
+++ b/templates/backOffice/default/home.html
@@ -91,7 +91,7 @@
                         <tr>
                             <th>{intl l="Orders"}</th>
                             <td>
-                                {count type="order" status="*" backend_context="1"}
+                                {count type="order" status="*" customer="*" backend_context="1"}
                             </td>
                         </tr>
                     {/loop}


### PR DESCRIPTION
The actual template was returning 0 in the total count orders of the website.
To correct this, we just need to add the param customer="*" :)
