### PR TITLE
Fix of fatal error if a module cannot be loaded

### DIFF
--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -239,13 +239,11 @@ class Thelia extends Kernel
                     }
 
                     $this->addStandardModuleTemplatesToParserEnvironment($parser, $module);
-                } catch (\InvalidArgumentException $e) {
+                } catch (\Exception $e) {
                     Tlog::getInstance()->addError(
                         sprintf("Failed to load module %s: %s", $module->getCode(), $e->getMessage()),
                         $e
                     );
-
-                    throw $e;
                 }
             }
 


### PR DESCRIPTION
When Thelia is trying to load an invalid or missing module, an exception is thrown. As only InvalidArgumentException was catched, this ends with a fatal error, preventing access to front and back office.  Even if the proper exception was thrown, it will be rethown, anyway.

The module has to be manually deleted from the database to fix the problem.

This PR changes this behavior, thus allowing to comfortably delete the faulty/missing module from the back-office.
