### PR TITLE
Fixed improper module argument assignment on hook registering

### DIFF
--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -682,7 +682,7 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
             ->setType($hook["type"])
             ->setCode($hook["code"])
             ->setNative(false)
-            ->setByModule(true)
+            ->setByModule(isset($hook["module"]) && (bool) $hook["module"])
             ->setActive(isset($hook["active"]) && (bool) $hook["active"])
         ;
 


### PR DESCRIPTION
New hook registered by module has the `module` argument automatically set to `true` but it is not the right behavior by default, and we should have the control on this argument. 
