### PR TITLE
allow to use the search_in search_term parameters in default orders template

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -82,6 +82,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
     {
         return array(
             'ref',
+            'invoice_ref',
             'customer_ref',
             'customer_firstname',
             'customer_lastname',
@@ -105,6 +106,9 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
             switch ($searchInElement) {
                 case 'ref':
                     $search->filterByRef($searchTerm, $searchCriteria);
+                    break;
+                case 'invoice_ref':
+                    $search->filterByInvoiceRef($searchTerm, $searchCriteria);
                     break;
                 case 'customer_ref':
                     $search->filterByCustomer(

--- a/templates/backOffice/default/orders.html
+++ b/templates/backOffice/default/orders.html
@@ -106,7 +106,7 @@
 
                             <tbody>
 
-                                {loop type="order" name="order-list" customer="*" order=$orders_order backend_context="1" page={$order_page} limit="{#max_displayed_orders#}" status=$status_filter|default:'*' }
+                                {loop type="order" name="order-list" customer="*" order=$orders_order backend_context="1" page={$order_page} limit="{#max_displayed_orders#}" status=$status_filter|default:'*' search_term=$search_term search_in="$search_in"}
 
                                     {loop type="currency" name="order-currency" id=$CURRENCY}
                                         {$orderCurrency=$SYMBOL}
@@ -159,7 +159,7 @@
 
                                             loop_ref       = "order-list"
                                             max_page_count = 10
-                                            page_url       = "{url path="/admin/orders" status=$status_filter orders_order=$orders_order}"
+                                            page_url       = "{url path="/admin/orders" status=$status_filter orders_order=$orders_order search_term=$search_term search_in="$search_in"}"
                                         }
 
                                     </td>


### PR DESCRIPTION
Allow the order-list loop to interpret this two parameters, to permit additional filters in the default backOffice template orders.html
