### PR TITLE
Fixed the request when exclude_template is set in Attribute and Feature loops

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Attribute.php
+++ b/core/lib/Thelia/Core/Template/Loop/Attribute.php
@@ -130,12 +130,8 @@ class Attribute extends BaseI18nLoop implements PropelSearchLoopInterface
             $exclude_attributes = AttributeTemplateQuery::create()->filterByTemplateId($exclude_template)->select('attribute_id')->find();
 
             $search
-                ->joinAttributeTemplate(null, Criteria::LEFT_JOIN)
-                ->withColumn(AttributeTemplateTableMap::POSITION, 'position')
                 ->filterById($exclude_attributes, Criteria::NOT_IN)
             ;
-
-            $this->useAttributePosistion = false;
         }
 
         $orders  = $this->getOrder();

--- a/core/lib/Thelia/Core/Template/Loop/Feature.php
+++ b/core/lib/Thelia/Core/Template/Loop/Feature.php
@@ -141,12 +141,8 @@ class Feature extends BaseI18nLoop implements PropelSearchLoopInterface
             $exclude_features = FeatureTemplateQuery::create()->filterByTemplateId($exclude_template)->select('feature_id')->find();
 
             $search
-                ->joinFeatureTemplate(null, Criteria::LEFT_JOIN)
-                ->withColumn(FeatureTemplateTableMap::POSITION, 'position')
                 ->filterById($exclude_features, Criteria::NOT_IN)
             ;
-
-            $this->useFeaturePosition = false;
         }
 
         $title = $this->getTitle();


### PR DESCRIPTION
If no specific template is set, we cannot use the position from the attribute_template (or feature_template), as the left join may return several attribute (or feature) occurences.
