### PR TITLE
Wrong cartItem returned in event if newness is true

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -63,9 +63,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
             if (null !== $productSaleElements) {
                 $productPrices = $productSaleElements->getPricesByCurrency($currency, $discount);
 
-                $cartItem = $this->doAddItem(
-                    $event->getDispatcher(),
-                    $cart, $productId, $productSaleElements, $quantity, $productPrices);
+                $cartItem = $this->doAddItem($event->getDispatcher(), $cart, $productId, $productSaleElements, $quantity, $productPrices);
             }
         } elseif ($append && $cartItem !== null) {
             $cartItem->addQuantity($quantity)->save();


### PR DESCRIPTION
If `newness` is true, the cartItem returned in the event is always the first matching cart item, and not the newest one.

Additionally, if `newness` _and_ `append` are true, the first matching cart item quantity is changed !

`newness` is not really an explicit term. Maybe `addAsNewCartItem` would be better ?
