### PR TITLE
Allow slash ended path info

### DIFF
--- a/core/lib/Thelia/Core/HttpFoundation/Request.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Request.php
@@ -13,6 +13,7 @@
 namespace Thelia\Core\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Request as BaseRequest;
+use Thelia\Model\ConfigQuery;
 
 /**
  * extends Symfony\Component\HttpFoundation\Request for adding some helpers
@@ -23,6 +24,24 @@ use Symfony\Component\HttpFoundation\Request as BaseRequest;
  */
 class Request extends BaseRequest
 {
+    /**
+     * Filter PathInfo to allow slash ending uri
+     *
+     * example:
+     * /admin will be the same as /admin/
+     */
+    public function getPathInfo()
+    {
+        $pathInfo = parent::getPathInfo();
+        $pathLength = strlen($pathInfo);
+
+        if ($pathInfo !== "/" && $pathInfo[$pathLength - 1] === "/" && (bool) ConfigQuery::read("allow_slash_ended_uri", false)) {
+            $this->pathInfo = $pathInfo = substr($pathInfo, 0, $pathLength - 1); // Remove the slash
+        }
+
+        return $pathInfo;
+    }
+
     public function getProductId()
     {
         return $this->get("product_id");

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -66,7 +66,9 @@ INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updat
 ('form_firewall_time_to_wait', '60', 0, 0, NOW(), NOW()),
 ('form_firewall_bruteforce_attempts', '10', 0, 0, NOW(), NOW()),
 ('form_firewall_attempts', '6', 0, 0, NOW(), NOW()),
-('form_firewall_active', '1', 0, 0, NOW(), NOW());
+('form_firewall_active', '1', 0, 0, NOW(), NOW()),
+
+('allow_slash_ended_uri', 1, 0, 0, NOW(), NOW());
 
 
 
@@ -3124,6 +3126,7 @@ SELECT @time := `id` FROM `config` WHERE `name` =  'form_firewall_time_to_wait';
 SELECT @bf_attempts := `id` FROM `config` WHERE `name` =  'form_firewall_bruteforce_attempts';
 SELECT @attempts := `id` FROM `config` WHERE `name` =  'form_firewall_attempts';
 SELECT @active := `id` FROM `config` WHERE `name` =  'form_firewall_active';
+SELECT @slash_ended_uri := `id` FROM `config` WHERE `name` =  'allow_slash_ended_uri';
 
 
 INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
@@ -3149,4 +3152,9 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
   (@active, 'en_US', '[Firewall] Activate the firewall', NULL, NULL, NULL),
   (@active, 'fr_FR', '[Pare-feu] Activer le pare-feu', NULL, NULL, NULL)
+;
+
+INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
+  (@slash_ended_uri, 'en_US', 'Allow slash ended uri', NULL, NULL, NULL),
+  (@slash_ended_uri, 'fr_FR', 'Autoriser les URI terminées par un slash', NULL, NULL, NULL)
 ;

--- a/setup/update/2.1.0-alpha2.sql
+++ b/setup/update/2.1.0-alpha2.sql
@@ -12,7 +12,8 @@ SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
 INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
 (@max_id + 1, 'cart.use_persistent_cookie', '0', 0, 0, NOW(), NOW()),
 (@max_id + 2, 'cart.cookie_name', 'thelia_cart', 0, 0, NOW(), NOW()),
-(@max_id + 3, 'cart.cookie_lifetime', '31536060', 0, 0, NOW(), NOW())
+(@max_id + 3, 'cart.cookie_lifetime', '31536060', 0, 0, NOW(), NOW()),
+(@max_id + 4, 'allow_slash_ended_uri', 1, 0, 0, NOW(), NOW())
 ;
 
 
@@ -23,6 +24,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (@max_id + 2, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (@max_id + 3, 'en_US', 'Life time of the cart cookie in the customer browser, in seconds', NULL, NULL, NULL),
 (@max_id + 3, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL)
+(@max_id + 4, 'en_US', 'Allow slash ended uri', NULL, NULL, NULL),
+(@max_id + 4, 'fr_FR', 'Autoriser les URI terminées par un slash', NULL, NULL, NULL)
 ;
 
 DELETE `config` WHERE `name`='currency_rate_update_url';


### PR DESCRIPTION
## Why this PR ?

Modern browser often auto-complete your URIs, and adds a slash at the end. ( Did you never go to `/admin/` because of Firefox ? )

Inspired by Github's way to "fix" it, here's a solution: ignore the last slash of the path info.
Here's an example:
Try to go to https://github.com/thelia/thelia and https://github.com/thelia/thelia/

The result is the same.

So why won't we allow to do that in thelia too ? :-)
