### PR TITLE
Add content type on all error message

### DIFF
--- a/core/lib/Thelia/Config/Resources/routing/api.xml
+++ b/core/lib/Thelia/Config/Resources/routing/api.xml
@@ -63,23 +63,23 @@
         <default key="_controller">Thelia:Api\Product:list</default>
     </route>
 
-    <route id="api.product.get" path="/api/products/{product_id}" methods="get">
+    <route id="api.product.get" path="/api/products/{productId}" methods="get">
         <default key="_controller">Thelia:Api\Product:getProduct</default>
-        <requirement key="product_id">\d+</requirement>
+        <requirement key="productId">\d+</requirement>
     </route>
 
-    <route id="api.product.update" path="/api/products/{product_id}" methods="put">
+    <route id="api.product.update" path="/api/products/{productId}" methods="put">
         <default key="_controller">Thelia:Api\Product:update</default>
-        <requirement key="product_id">\d+</requirement>
+        <requirement key="productId">\d+</requirement>
     </route>
 
     <route id="api.product.create" path="/api/products" methods="post">
         <default key="_controller">Thelia:Api\Product:create</default>
     </route>
 
-    <route id="api.product.delete" path="/api/products/{product_id}" methods="delete">
+    <route id="api.product.delete" path="/api/products/{productId}" methods="delete">
         <default key="_controller">Thelia:Api\Product:delete</default>
-        <requirement key="product_id">\d+</requirement>
+        <requirement key="productId">\d+</requirement>
     </route>
     <!-- end product route -->
 

--- a/core/lib/Thelia/Controller/Api/ImageController.php
+++ b/core/lib/Thelia/Controller/Api/ImageController.php
@@ -99,7 +99,12 @@ class ImageController extends BaseApiController
         $results = $imageLoop->exec($paginate);
 
         if ($results->isEmpty()) {
-            throw new HttpException(404, sprintf('{"error": "Image with id %d not found"}', $imageId));
+            return JsonResponse::create(
+                array(
+                    'error' => sprintf('image with id %d not found', $imageId)
+                ),
+                404
+            );
         }
 
         return JsonResponse::create($results);
@@ -252,7 +257,7 @@ class ImageController extends BaseApiController
         $errors = $this->processImage($fileController, $file, $entityId, $entity, $config);
 
         if (!empty($errors)) {
-            throw new HttpException(500, json_encode($errors));
+            throw new HttpException(500, json_encode($errors), null, ["Content-Type" => "application/json"]);
         }
     }
 
@@ -318,7 +323,12 @@ class ImageController extends BaseApiController
         $entityModel = $search->findPk($entityId);
 
         if (null === $entityModel) {
-            throw new HttpException(404, sprintf('{"error": "%s with id %d not found"}', $entity, $entityId));
+            throw new HttpException(
+                404,
+                sprintf('{"error": "%s with id %d not found"}', $entity, $entityId),
+                null,
+                ["Content-Type" => "application/json"]
+            );
         }
 
         return $entityModel;
@@ -339,7 +349,12 @@ class ImageController extends BaseApiController
         $imageModel = $search->findPk($imageId);
 
         if (null === $imageModel) {
-            throw new HttpException(404, sprintf('{"error": "image with id %d not found"}', $imageId));
+            throw new HttpException(
+                404,
+                sprintf('{"error": "image with id %d not found"}', $imageId),
+                null,
+                ["Content-Type" => "application/json"]
+            );
         }
 
         return $imageModel;


### PR DESCRIPTION
An API client can't guess effectively which kind of data we send to him if he doesn't have the content type
