### PR TITLE
Add filter table name on database backup

### DIFF
--- a/core/lib/Thelia/Install/Database.php
+++ b/core/lib/Thelia/Install/Database.php
@@ -100,6 +100,7 @@ class Database
      * @param  string                          $sql  SQL query
      * @param  array                           $args SQL request parameters (PDO style)
      * @throws \RuntimeException|\PDOException if something goes wrong.
+     * @return \PDOStatement
      */
     public function execute($sql, $args = array())
     {
@@ -114,6 +115,8 @@ class Database
         if ($success === false || $stmt->errorCode() != 0) {
             throw new \RuntimeException("Failed to execute SQL '$sql', arguments:" . print_r($args, 1).", error:".print_r($stmt->errorInfo(), 1));
         }
+
+        return $stmt;
     }
 
     /**
@@ -177,15 +180,13 @@ class Database
                 continue;
             }
 
-            $result = $this->connection->prepare('SELECT * FROM `' . $table . '`');
-            $result->execute();
+            $result = $this->execute('SELECT * FROM `' . $table . '`');
 
             $fieldCount = $result->columnCount();
 
             $data[] = 'DROP TABLE `' . $table . '`;';
 
-            $resultStruct = $this->connection->prepare('SHOW CREATE TABLE `' . $table . '`');
-            $resultStruct->execute();
+            $resultStruct = $this->execute('SHOW CREATE TABLE `' . $table . '`');
 
             $rowStruct = $resultStruct->fetch(PDO::FETCH_NUM);
 


### PR DESCRIPTION
This is an answer to #910, you can't bind a table name with PDO as it will quote the string.
For instance, if you do:

``` php
<?php
$stmt = $connection->prepare('SELECT * FROM ?');
$stmt->bindValue(1, $table);
$stmt->execute();
```

You'll get the SQL Error:

```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''accessory'' at line 1
```

As it will try to execute:

``` sql
SELECT * FROM 'accessory';
```

A solution would be to filter the tablename ourself in the loop.
Here, the allowed characters are `a-zA-Z0-9_-`
