### PR TITLE
Force the product to have pses on free product test

### DIFF
--- a/tests/phpunit/Thelia/Tests/Coupon/Type/FreeProductTest.php
+++ b/tests/phpunit/Thelia/Tests/Coupon/Type/FreeProductTest.php
@@ -43,7 +43,15 @@ class FreeProductTest extends \PHPUnit_Framework_TestCase
         $currency = CurrencyQuery::create()->filterByCode('EUR')->findOne();
 
         // Find a product
-        $this->freeProduct = ProductQuery::create()->findOne();
+        $this->freeProduct = ProductQuery::create()
+            ->joinProductSaleElements("pse_join")
+            ->addJoinCondition("pse_join", "is_default = ?", 1, null, \PDO::PARAM_INT)
+            ->findOne()
+        ;
+
+        if (null === $this->freeProduct) {
+            $this->markTestSkipped("You can't run this test as there's no product with associated product_sale_elements");
+        }
 
         $this->originalPrice = $this->freeProduct->getDefaultSaleElements()->getPricesByCurrency($currency)->getPrice();
         $this->originalPromo = $this->freeProduct->getDefaultSaleElements()->getPromo();
@@ -432,6 +440,8 @@ class FreeProductTest extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
-        $this->freeProduct->getDefaultSaleElements()->setPromo($this->originalPromo)->save();
+        if (null !== $this->freeProduct) {
+            $this->freeProduct->getDefaultSaleElements()->setPromo($this->originalPromo)->save();
+        }
     }
 }


### PR DESCRIPTION
Sometimes on the tests, we have the error

```
............................................................... 63 / 783 ( 8%)
............................................................... 126 / 783 ( 16%)
............................................................... 189 / 783 ( 24%)
..........................FSS.................................. 252 / 783 ( 32%)
............................................................... 315 / 783 ( 40%)
............................................................... 378 / 783 ( 48%)
............................................................... 441 / 783 ( 56%)
...................................F..........................PHP Fatal error: Call to a member function getPricesByCurrency() on a non-object in /home/travis/build/thelia/thelia/tests/phpunit/Thelia/Tests/Coupon/Type/FreeProductTest.php on line 48
```

The problem may come from the DB. The chosen product may not have any default pse. So the `getDefaultSaleElements()` method returns null.
