### PR TITLE
Fix error when error on passing virtual order to 'Paid' status

### DIFF
--- a/core/lib/Thelia/Controller/Admin/ProductController.php
+++ b/core/lib/Thelia/Controller/Admin/ProductController.php
@@ -85,6 +85,7 @@ use Thelia\Form\ProductCombinationGenerationForm;
 use Thelia\Model\TaxRuleQuery;
 use Thelia\TaxEngine\Calculator;
 use Thelia\Tools\NumberFormat;
+use Thelia\Type\BooleanOrBothType;
 
 /**
  * Manages products
@@ -1693,10 +1694,10 @@ class ProductController extends AbstractSeoCrudController
          * Compute documents with the associated loop
          */
         $documentLoop = new Document($this->container);
-        // select only not visible documents
+
         $documentLoop->initializeArgs([
             "product" => $pse->getProductId(),
-            "visible" => 0
+            "visible" => BooleanOrBothType::ANY, // Do not restrict on visibility for single association
         ]);
 
         $documents = $documentLoop
@@ -1740,8 +1741,10 @@ class ProductController extends AbstractSeoCrudController
          * Compute documents with the associated loop
          */
         $documentLoop = new Document($this->container);
+        // select only not visible documents
         $documentLoop->initializeArgs([
             "product" => $pse->getProductId(),
+            "visible" => 0,
         ]);
 
         $documents = $documentLoop

--- a/local/modules/VirtualProductDelivery/EventListeners/SendMail.php
+++ b/local/modules/VirtualProductDelivery/EventListeners/SendMail.php
@@ -90,10 +90,15 @@ class SendMail implements EventSubscriberInterface
                 $this->mailer->send($instance);
 
                 Tlog::getInstance()->debug("Virtual product download message sent to customer ".$customer->getEmail());
-            }
-            else {
+            } else {
                 $customer = $order->getCustomer();
-                Tlog::getInstance()->debug("Virtual product download message no contact email customer_id", $customer->getId());
+
+                Tlog::getInstance()->debug(
+                    "Virtual product download message no contact email for customer id '{customer_id}'",
+                    [
+                        "customer_id" => $customer->getId()
+                    ]
+                );
             }
         }
     }


### PR DESCRIPTION
If you create an order with a virtual product and pass it to 'Paid', if you didn't configure the store email, there was a blank page as the Tlog::debug method wasn't used correctly ( the second argument must be an array )

Moreover, you should be able to associate an online document to a product sale element, as it doesn't have anything to do with virtual products.
