### PR TITLE
Ignore FK constraint on cart for 2.0

### DIFF
--- a/setup/update/2.0.5.sql
+++ b/setup/update/2.0.5.sql
@@ -1,7 +1,9 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
-UPDATE `config` SET `value`='2.0.4' WHERE `name`='thelia_version';
-UPDATE `config` SET `value`='4' WHERE `name`='thelia_release_version';
+ALTER TABLE `order` DROP FOREIGN KEY `fk_order_cart_id`;
+
+UPDATE `config` SET `value`='2.0.5' WHERE `name`='thelia_version';
+UPDATE `config` SET `value`='5' WHERE `name`='thelia_release_version';
 UPDATE `config` SET `value`='0' WHERE `name`='thelia_minus_version';
 UPDATE `config` SET `value`='' WHERE `name`='thelia_extra_version';
 


### PR DESCRIPTION
This fixes a bug when creating an order and then going back before finishing it.
Fix only for 2.0
