### PR TITLE
Fix non-existent link into pagination

### DIFF
--- a/templates/frontOffice/default/brand.html
+++ b/templates/frontOffice/default/brand.html
@@ -157,7 +157,7 @@
                                         </li>
                                         {if $PAGE eq $LAST}
                                             {if $CURRENT eq $LAST}
-                                                <li>
+                                                <li class="disabled">
                                                     <span class="next"><i class="icon-next"></i></span>
                                                 </li>
                                             {else}

--- a/templates/frontOffice/default/category.html
+++ b/templates/frontOffice/default/category.html
@@ -167,7 +167,7 @@
                                 </li>
                                 {if $PAGE eq $LAST}
                                     {if $CURRENT eq $LAST}
-                                        <li>
+                                        <li class="disabled">
                                             <span class="next"><i class="icon-next"></i></span>
                                         </li>
                                     {else}

--- a/templates/frontOffice/default/includes/toolbar.html
+++ b/templates/frontOffice/default/includes/toolbar.html
@@ -57,7 +57,7 @@
                     </li>
                     {if $PAGE eq $LAST}
                         {if $CURRENT eq $LAST}
-                            <li>
+                            <li class="disabled">
                                 <span class="next"><i class="icon-next"></i></span>
                             </li>
                         {else}


### PR DESCRIPTION
Non-existent page links are available (like ?page=0 or ?page=-1) because we can click on the "prev" and "next" link even if they have the disabled class.
