### PR TITLE
TinyMCE imported CSS could now be used in the editor

### DIFF
--- a/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
+++ b/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
@@ -19,7 +19,7 @@
             "advlist autolink link image lists charmap print preview hr anchor pagebreak",
             "searchreplace wordcount visualblocks visualchars insertdatetime media nonbreaking",
             "table contextmenu directionality emoticons paste textcolor responsivefilemanager",
-            "fullscreen code youtube"
+            "fullscreen code youtube importcss"
         ],
 
         // See available controls at http://www.tinymce.com/wiki.php/Controls
@@ -44,7 +44,8 @@
 
         // Styles (CSS or LESS) available in the editor could be defined in assets/css/editor.less file.
         {stylesheets file='assets/css/editor.less' filters='less' source='Tinymce'}
-        content_css: "{$asset_url}"
+        content_css: "{$asset_url}",
+        importcss_append: true
         {/stylesheets}
     });
 </script>


### PR DESCRIPTION
Imported CSS is now displayed in the "format" menu, the 'importcss' plugin was missing.
