### PR TITLE
allow fallback on local variable if the order status label doesn't exist

### DIFF
--- a/templates/backOffice/default/admin-layout.tpl
+++ b/templates/backOffice/default/admin-layout.tpl
@@ -205,7 +205,7 @@
                                             <li role="menuitem">
                                                 <a class="clearfix" data-target="{url path="admin/orders/$LABEL"}" href="{url path="admin/orders" status={$ID}}">
                                                     <span class="pull-left">{$TITLE}</span>
-                                                    <span class="label label-{#$orderStatusLabel#} pull-right">{count type="order" customer="*" backend_context="1" status={$ID}}</span>
+                                                    <span class="label label-{#$orderStatusLabel#|default:${"order_$CODE"}} pull-right">{count type="order" customer="*" backend_context="1" status={$ID}}</span>
                                                 </a>
                                             </li>
                                         {/loop}


### PR DESCRIPTION
This can be used by modules that adds order status. They don't have to edit the config file for that (:
