### PR TITLE
Add the possibility to get current url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - config : 
     - environment variable can be used in the database.yml file. See [https://github.com/thelia/thelia/pull/968](https://github.com/thelia/thelia/pull/968)
     - Allow other projects to override thelia directories constants by using composer "autoload"["file"] entries
+- smarty:
+    - Add the "current" argument on smarty "url" function that allows you to get the same page but with differant url parameters
 
 # 2.1.0-beta1
 

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -41,9 +41,21 @@ class UrlGenerator extends AbstractSmartyPlugin
     public function generateUrlFunction($params, &$smarty)
     {
         // the path to process
+        $current = $this->getParam($params, 'current', false);
         $path  = $this->getParam($params, 'path', null);
         $file  = $this->getParam($params, 'file', null); // Do not invoke index.php in URL (get a static file in web space
         $noamp = $this->getParam($params, 'noamp', null); // Do not change & in &amp;
+
+        if ($current) {
+            $path = $this->request->getPathInfo();
+            unset($params["current"]); // Delete the current param, so it isn't included in the url
+
+            // Then build the query variables
+            $params = array_merge(
+                $this->request->query->all(),
+                $params
+            );
+        }
 
         if ($file !== null) {
             $path = $file;


### PR DESCRIPTION
This PR allows you to get the current url with our smarty plugin.

Just use the syntax

``` smarty
{url current="1" anotherArg=$value}
```

If you define an argument in the function that already exist in the url, it will override the current one.
Example:

My url is: http://example.com/?foo=1&bar=2

the result of:

``` smarty
{url current="1" bar=3}
```

will be http://example.com/?foo=1&bar=3
