### PR TITLE
Fix for deprecated constructor parameters

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Feed.php
+++ b/core/lib/Thelia/Core/Template/Loop/Feed.php
@@ -63,6 +63,7 @@ class Feed extends BaseLoop implements ArraySearchLoopInterface
 
     public function parseResults(LoopResult $loopResult)
     {
+        /** @var \SimplePie_Item $item */
         foreach ($loopResult->getResultDataCollection() as $item) {
             $loopResultRow = new LoopResultRow();
 


### PR DESCRIPTION
This is a fix for the following warning: 

Deprecated: Passing parameters to the constructor is no longer supported. Please use set_feed_url(), set_cache_location(), and set_cache_location() directly. in /home/poupoupidou/thelia/core/vendor/simplepie/simplepie/library/SimplePie.php on line 640
