### PR TITLE
Set visibilty of BaseController getErrorMessage method to "protected"

### DIFF
--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -181,7 +181,7 @@ abstract class BaseController extends ContainerAware
      * @param  \Symfony\Component\Form\Form $form
      * @return string                       the error string
      */
-    private function getErrorMessages(\Symfony\Component\Form\Form $form)
+    protected function getErrorMessages(\Symfony\Component\Form\Form $form)
     {
         $errors = '';
 


### PR DESCRIPTION
To allow a custom controller (child class of `BaseController`) to override this method