### PR TITLE
Fix the module skeleton location when creating module

### DIFF
--- a/core/lib/Thelia/Command/ModuleGenerateCommand.php
+++ b/core/lib/Thelia/Command/ModuleGenerateCommand.php
@@ -92,7 +92,7 @@ class ModuleGenerateCommand extends BaseModuleGenerate
         $fs = new Filesystem();
 
         try {
-            $skeletonDir = str_replace("/", DIRECTORY_SEPARATOR, THELIA_ROOT . "/core/lib/Thelia/Command/Skeleton/Module/");
+            $skeletonDir = str_replace("/", DIRECTORY_SEPARATOR, __DIR__ . "/Skeleton/Module/");
 
             // config.xml file
             $filename = $this->moduleDirectory . DIRECTORY_SEPARATOR . "Config" . DIRECTORY_SEPARATOR . "config.xml";


### PR DESCRIPTION
When using the fancy new way of installing Thelia with componants managed by Composer, the module:create command breaks.
This is because the command assume that the Thelia core will always be in THELIA_ROOT, which is not always true anymore.

This change instead builds the skeleton directory path from the command file directory.