### PR TITLE
valeur de caractéristique (feature_values)

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -394,7 +394,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     $search->joinFeatureProduct($featureAlias, Criteria::LEFT_JOIN)
                         ->addJoinCondition($featureAlias, "`$featureAlias`.FEATURE_ID = ?", $feature, null, \PDO::PARAM_INT);
                     if ($feature_value != '*') {
-                        $search->addJoinCondition($featureAlias, "`$featureAlias`.BY_DEFAULT = ?", $feature_value, null, \PDO::PARAM_STR);
+                        $search->addJoinCondition($featureAlias, "`$featureAlias`.FREE_TEXT_VALUE = ?", $feature_value, null, \PDO::PARAM_STR);
                     }
                 }
 


### PR DESCRIPTION
j'ai remplacé BY_DEFAULT par FREE_TEXT_VALUE.
puisque dans la table feature_product BY_DEFAULT n'éxiste pas et je supose que $feature_value doit être associé à FREE_TEXT_VALUE.

Bonne année :)