### PR TITLE
set all new PSE as non default if one already exist. Fix #1025

### DIFF
--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -56,7 +56,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             if ($salesElement == null) {
                 // Create a new default product sale element
-                $salesElement = $event->getProduct()->createProductSaleElement($con, 0, 0, 0, $event->getCurrencyId(), true);
+                $salesElement = $event->getProduct()->createProductSaleElement($con, 0, 0, 0, $event->getCurrencyId(), false);
             } else {
                 // This (new) one is the default
                 $salesElement->setIsDefault(true)->save($con);

--- a/templates/frontOffice/default/product.html
+++ b/templates/frontOffice/default/product.html
@@ -44,6 +44,8 @@
 
             {$pse_count=$PSE_COUNT}
 
+            {$pse_count}
+
             {* Use the meta tag to specify content that is not visible on the page in any way *}
             {loop name="brand.feature" type="brand" product="{$ID}"}
                 <meta itemprop="brand" content="{$TITLE}">

--- a/tests/phpunit/Thelia/Tests/bootstrap.php
+++ b/tests/phpunit/Thelia/Tests/bootstrap.php
@@ -7,7 +7,7 @@
  */
 ini_set('session.use_cookies', 0);
 $env = "test";
-require_once __DIR__ . '/../../../../core/bootstrap.php';
+require_once __DIR__ . '/../../../../core/vendor/autoload.php';
 
 use Thelia\Core\Thelia;
 


### PR DESCRIPTION
When a new combination is added, this new one is flag as default so it is possible to have many PSE as default for a single product.