### PR TITLE
Translations in pdf and email (module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.0-beta3
+
+- abilities to translate email and pdf templates in modules
+-  support of taxes for postage amount
+
+
 # 2.1.0-beta2
 
 - config : 

--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -19,11 +19,14 @@ use Thelia\Core\Event\Message\MessageDeleteEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\Message\MessageUpdateEvent;
 use Thelia\Core\Event\Message\MessageCreateEvent;
+use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Model\MessageQuery;
 use Thelia\Form\MessageModificationForm;
 use Thelia\Form\MessageCreationForm;
 use Symfony\Component\Finder\Finder;
 use Thelia\Core\Template\TemplateHelper;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
 
 /**
  * Manages messages sent by mail
@@ -168,6 +171,30 @@ class MessageController extends AbstractCrudController
 
         foreach ($finder as $file) {
             $list[] = $file->getBasename();
+        }
+
+        // Add modules templates
+        $modules = ModuleQuery::getActivated();
+        /** @var Module $module */
+        foreach ($modules as $module) {
+
+            $dir = $module->getAbsoluteTemplateBasePath() . DS . TemplateDefinition::EMAIL_SUBDIR . DS . 'default';
+
+            if (file_exists($dir)) {
+                $finder = Finder::create()
+                    ->files()
+                    ->in($dir)
+                    ->ignoreDotFiles(true)
+                    ->sortByName()
+                    ->name("*.$requiredExtension");
+
+                foreach ($finder as $file) {
+                    $fileName = $file->getBasename();
+                    if (!in_array($fileName, $list)) {
+                        $list[] = $fileName;
+                    }
+                }
+            }
         }
 
         return $list;

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -109,27 +109,33 @@ class TranslationsController extends BaseAdminController
                         $i18n_directory = $module->getAbsoluteAdminIncludesI18nPath();
                         $walkMode = TemplateHelper::WALK_MODE_TEMPLATE;
                     } elseif (! empty($module_part)) {
-                        // Front or back office template, form of $module_part is [bo|fo].subdir-name
+                        // Front, back, pdf or email office template,
+                        // form of $module_part is [bo|fo|pdf|email].subdir-name
                         list($type, $subdir) = explode('.', $module_part);
 
-                        if ($type == 'bo') {
-                            $directory = $module->getAbsoluteBackOfficeTemplatePath($subdir);
-                            $domain = $module->getBackOfficeTemplateTranslationDomain($subdir);
-                            $i18n_directory = $module->getAbsoluteBackOfficeI18nTemplatePath($subdir);
-                        } elseif ($type == 'fo') {
-                            $directory = $module->getAbsoluteFrontOfficeTemplatePath($subdir);
-                            $domain = $module->getFrontOfficeTemplateTranslationDomain($subdir);
-                            $i18n_directory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
-                        } elseif ($type == 'email') {
-                            $directory = $module->getAbsoluteEmailTemplatePath($subdir);
-                            $domain = $module->getEmailTemplateTranslationDomain($subdir);
-                            $i18n_directory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
-                        } elseif ($type == 'pdf') {
-                            $directory = $module->getAbsolutePdfTemplatePath($subdir);
-                            $domain = $module->getPdfTemplateTranslationDomain($subdir);
-                            $i18n_directory = $module->getAbsolutePdfI18nTemplatePath($subdir);
-                        } else {
-                            throw new \InvalidArgumentException("Undefined module template type: '$type'.");
+                        switch ($type) {
+                            case 'bo':
+                                $directory = $module->getAbsoluteBackOfficeTemplatePath($subdir);
+                                $domain = $module->getBackOfficeTemplateTranslationDomain($subdir);
+                                $i18n_directory = $module->getAbsoluteBackOfficeI18nTemplatePath($subdir);
+                                break;
+                            case 'fo':
+                                $directory = $module->getAbsoluteFrontOfficeTemplatePath($subdir);
+                                $domain = $module->getFrontOfficeTemplateTranslationDomain($subdir);
+                                $i18n_directory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
+                                break;
+                            case 'email':
+                                $directory = $module->getAbsoluteEmailTemplatePath($subdir);
+                                $domain = $module->getEmailTemplateTranslationDomain($subdir);
+                                $i18n_directory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
+                                break;
+                            case 'pdf':
+                                $directory = $module->getAbsolutePdfTemplatePath($subdir);
+                                $domain = $module->getPdfTemplateTranslationDomain($subdir);
+                                $i18n_directory = $module->getAbsolutePdfI18nTemplatePath($subdir);
+                                break;
+                            default:
+                                throw new \InvalidArgumentException("Undefined module template type: '$type'.");
                         }
 
                         $walkMode = TemplateHelper::WALK_MODE_TEMPLATE;

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -120,6 +120,14 @@ class TranslationsController extends BaseAdminController
                             $directory = $module->getAbsoluteFrontOfficeTemplatePath($subdir);
                             $domain = $module->getFrontOfficeTemplateTranslationDomain($subdir);
                             $i18n_directory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
+                        } elseif ($type == 'email') {
+                            $directory = $module->getAbsoluteEmailTemplatePath($subdir);
+                            $domain = $module->getEmailTemplateTranslationDomain($subdir);
+                            $i18n_directory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
+                        } elseif ($type == 'pdf') {
+                            $directory = $module->getAbsolutePdfTemplatePath($subdir);
+                            $domain = $module->getPdfTemplateTranslationDomain($subdir);
+                            $i18n_directory = $module->getAbsolutePdfI18nTemplatePath($subdir);
                         } else {
                             throw new \InvalidArgumentException("Undefined module template type: '$type'.");
                         }
@@ -139,6 +147,12 @@ class TranslationsController extends BaseAdminController
 
                     $templateArguments['front_office_templates'] =
                         implode(',', $this->getModuleTemplateNames($module, TemplateDefinition::FRONT_OFFICE));
+
+                    $templateArguments['email_templates'] =
+                        implode(',', $this->getModuleTemplateNames($module, TemplateDefinition::EMAIL));
+
+                    $templateArguments['pdf_templates'] =
+                        implode(',', $this->getModuleTemplateNames($module, TemplateDefinition::PDF));
 
                     // Check if we have admin-include files
                     try {

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -263,39 +263,7 @@ class Thelia extends Kernel
             /** @var Module $module */
             foreach ($modules as $module) {
                 try {
-                    // Core module translation
-                    if (is_dir($dir = $module->getAbsoluteI18nPath())) {
-                        $translationDirs[$module->getTranslationDomain()] = $dir;
-                    }
-
-                    // Admin includes translation
-                    if (is_dir($dir = $module->getAbsoluteAdminIncludesI18nPath())) {
-                        $translationDirs[$module->getAdminIncludesTranslationDomain()] = $dir;
-                    }
-
-                    // Module back-office template, if any
-                    $templates =
-                        TemplateHelper::getInstance()->getList(
-                            TemplateDefinition::BACK_OFFICE,
-                            $module->getAbsoluteTemplateBasePath()
-                        );
-
-                    foreach ($templates as $template) {
-                        $translationDirs[$module->getBackOfficeTemplateTranslationDomain($template->getName())] =
-                            $module->getAbsoluteBackOfficeI18nTemplatePath($template->getName());
-                    }
-
-                    // Module front-office template, if any
-                    $templates =
-                        TemplateHelper::getInstance()->getList(
-                            TemplateDefinition::FRONT_OFFICE,
-                            $module->getAbsoluteTemplateBasePath()
-                        );
-
-                    foreach ($templates as $template) {
-                        $translationDirs[$module->getFrontOfficeTemplateTranslationDomain($template->getName())] =
-                            $module->getAbsoluteFrontOfficeI18nTemplatePath($template->getName());
-                    }
+                    $this->getModuleTranslationDirectories($module, $translationDirs);
 
                     $this->addStandardModuleTemplatesToParserEnvironment($parser, $module);
                 } catch (\Exception $e) {
@@ -322,6 +290,67 @@ class Thelia extends Kernel
             if ($translationDirs) {
                 $this->loadTranslation($container, $translationDirs);
             }
+        }
+    }
+
+    private function getModuleTranslationDirectories(Module $module, array &$translationDirs)
+    {
+        // Core module translation
+        if (is_dir($dir = $module->getAbsoluteI18nPath())) {
+            $translationDirs[$module->getTranslationDomain()] = $dir;
+        }
+
+        // Admin includes translation
+        if (is_dir($dir = $module->getAbsoluteAdminIncludesI18nPath())) {
+            $translationDirs[$module->getAdminIncludesTranslationDomain()] = $dir;
+        }
+
+        // Module back-office template, if any
+        $templates =
+            TemplateHelper::getInstance()->getList(
+                TemplateDefinition::BACK_OFFICE,
+                $module->getAbsoluteTemplateBasePath()
+            );
+
+        foreach ($templates as $template) {
+            $translationDirs[$module->getBackOfficeTemplateTranslationDomain($template->getName())] =
+                $module->getAbsoluteBackOfficeI18nTemplatePath($template->getName());
+        }
+
+        // Module front-office template, if any
+        $templates =
+            TemplateHelper::getInstance()->getList(
+                TemplateDefinition::FRONT_OFFICE,
+                $module->getAbsoluteTemplateBasePath()
+            );
+
+        foreach ($templates as $template) {
+            $translationDirs[$module->getFrontOfficeTemplateTranslationDomain($template->getName())] =
+                $module->getAbsoluteFrontOfficeI18nTemplatePath($template->getName());
+        }
+
+        // Module pdf template, if any
+        $templates =
+            TemplateHelper::getInstance()->getList(
+                TemplateDefinition::PDF,
+                $module->getAbsoluteTemplateBasePath()
+            );
+
+        foreach ($templates as $template) {
+            $translationDirs[$module->getPdfTemplateTranslationDomain($template->getName())] =
+                $module->getAbsolutePdfI18nTemplatePath($template->getName());
+        }
+
+        // Module email template, if any
+        $templates =
+            TemplateHelper::getInstance()->getList(
+                TemplateDefinition::EMAIL,
+                $module->getAbsoluteTemplateBasePath()
+            );
+
+        foreach ($templates as $template) {
+            $translationDirs[$module->getEmailTemplateTranslationDomain($template->getName())] =
+                $module->getAbsoluteEmailI18nTemplatePath($template->getName());
         }
     }
 

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -263,7 +263,7 @@ class Thelia extends Kernel
             /** @var Module $module */
             foreach ($modules as $module) {
                 try {
-                    $this->getModuleTranslationDirectories($module, $translationDirs);
+                    $this->loadModuleTranslationDirectories($module, $translationDirs);
 
                     $this->addStandardModuleTemplatesToParserEnvironment($parser, $module);
                 } catch (\Exception $e) {
@@ -293,7 +293,7 @@ class Thelia extends Kernel
         }
     }
 
-    private function getModuleTranslationDirectories(Module $module, array &$translationDirs)
+    private function loadModuleTranslationDirectories(Module $module, array &$translationDirs)
     {
         // Core module translation
         if (is_dir($dir = $module->getAbsoluteI18nPath())) {

--- a/core/lib/Thelia/Model/Module.php
+++ b/core/lib/Thelia/Model/Module.php
@@ -85,6 +85,57 @@ class Module extends BaseModule
         return $this->getTranslationDomain(). '.fo.' . $templateName;
     }
 
+    public function getAbsolutePdfTemplatePath($subdir)
+    {
+        return sprintf(
+            "%s".DS."%s".DS."%s",
+            $this->getAbsoluteTemplateBasePath(),
+            TemplateDefinition::PDF_SUBDIR,
+            $subdir
+        );
+    }
+
+    public function getAbsolutePdfI18nTemplatePath($subdir)
+    {
+        return sprintf(
+            "%s".DS."%s".DS."%s",
+            $this->getAbsoluteI18nPath(),
+            TemplateDefinition::PDF_SUBDIR,
+            $subdir
+        );
+    }
+
+    public function getPdfTemplateTranslationDomain($templateName)
+    {
+        return $this->getTranslationDomain(). '.pdf.' . $templateName;
+    }
+
+
+    public function getAbsoluteEmailTemplatePath($subdir)
+    {
+        return sprintf(
+            "%s".DS."%s".DS."%s",
+            $this->getAbsoluteTemplateBasePath(),
+            TemplateDefinition::EMAIL_SUBDIR,
+            $subdir
+        );
+    }
+
+    public function getAbsoluteEmailI18nTemplatePath($subdir)
+    {
+        return sprintf(
+            "%s".DS."%s".DS."%s",
+            $this->getAbsoluteI18nPath(),
+            TemplateDefinition::EMAIL_SUBDIR,
+            $subdir
+        );
+    }
+
+    public function getEmailTemplateTranslationDomain($templateName)
+    {
+        return $this->getTranslationDomain(). '.email.' . $templateName;
+    }
+
     /**
      * @return string the module's base directory path, relative to THELIA_MODULE_DIR
      */

--- a/templates/backOffice/default/translations.html
+++ b/templates/backOffice/default/translations.html
@@ -151,6 +151,20 @@
                                                         {/foreach}
                                                     {/if}
 
+                                                    {if $email_templates != ''}
+                                                        {foreach explode(',', $email_templates) as $template}
+                                                            {$option_value = "email.{$template}"}
+                                                            <option value="{$option_value}" {if $module_part == $option_value}selected="selected"{/if}>Email template "{$template}"</option>
+                                                        {/foreach}
+                                                    {/if}
+
+                                                    {if $pdf_templates != ''}
+                                                        {foreach explode(',', $pdf_templates) as $template}
+                                                            {$option_value = "pdf.{$template}"}
+                                                            <option value="{$option_value}" {if $module_part == $option_value}selected="selected"{/if}>Pdf template "{$template}"</option>
+                                                        {/foreach}
+                                                    {/if}
+
                                                 </select>
                                             </div>
                                         </div>


### PR DESCRIPTION
You can now translate email and pdf templates located in modules.

2 domains have been added : `module_code.pdf.template_name` and `module_code.email.template_name` 
