### PR TITLE
implement cart management without persistent cookie

### DIFF
--- a/core/lib/Thelia/Command/Skeleton/Module/schema.xml
+++ b/core/lib/Thelia/Command/Skeleton/Module/schema.xml
@@ -28,5 +28,3 @@
     -->
     <external-schema filename="local/config/schema.xml" referenceOnly="true" />
 </database>
-
-

--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -177,7 +177,6 @@ class MessageController extends AbstractCrudController
         $modules = ModuleQuery::getActivated();
         /** @var Module $module */
         foreach ($modules as $module) {
-
             $dir = $module->getAbsoluteTemplateBasePath() . DS . TemplateDefinition::EMAIL_SUBDIR . DS . 'default';
 
             if (file_exists($dir)) {

--- a/core/lib/Thelia/Core/Event/ActionEvent.php
+++ b/core/lib/Thelia/Core/Event/ActionEvent.php
@@ -57,8 +57,6 @@ abstract class ActionEvent extends Event
                 } else {
                     $this->{$functionName}($field->getData());
                 }
-
-
             } else {
                 $this->{$field->getName()} = $field->getData();
             }

--- a/core/lib/Thelia/Core/Form/Type/Field/AreaIdType.php
+++ b/core/lib/Thelia/Core/Form/Type/Field/AreaIdType.php
@@ -22,7 +22,6 @@ use Thelia\Model\AreaQuery;
  */
 class AreaIdType extends AbstractIdType
 {
-
     /**
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      *

--- a/core/lib/Thelia/Core/Form/Type/Field/CategoryIdType.php
+++ b/core/lib/Thelia/Core/Form/Type/Field/CategoryIdType.php
@@ -22,7 +22,6 @@ use Thelia\Model\CategoryQuery;
  */
 class CategoryIdType extends AbstractIdType
 {
-
     /**
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      *

--- a/core/lib/Thelia/Core/Form/Type/Field/ContentIdType.php
+++ b/core/lib/Thelia/Core/Form/Type/Field/ContentIdType.php
@@ -22,7 +22,6 @@ use Thelia\Model\ContentQuery;
  */
 class ContentIdType extends AbstractIdType
 {
-
     /**
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      *

--- a/core/lib/Thelia/Core/Form/Type/Field/FolderIdType.php
+++ b/core/lib/Thelia/Core/Form/Type/Field/FolderIdType.php
@@ -22,7 +22,6 @@ use Thelia\Model\FolderQuery;
  */
 class FolderIdType extends AbstractIdType
 {
-
     /**
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      *

--- a/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
@@ -213,6 +213,10 @@ class Session extends BaseSession
 
             $cartEvent = new CartRestoreEvent();
 
+            if (null !== $cart) {
+                $cartEvent->setCart($cart);
+            }
+
             $dispatcher->dispatch(TheliaEvents::CART_RESTORE_CURRENT, $cartEvent);
 
             if (null === $cart = $cartEvent->getCart()) {
@@ -276,10 +280,9 @@ class Session extends BaseSession
     {
         $customer = $this->getCustomerUser();
 
-        return (null === $customer && $cart->getCustomerId() !== null)
-               ||
-               (null !== $customer && $cart->getCustomerId() == $customer->getId())
-        ;
+        return (null !== $customer && $cart->getCustomerId() == $customer->getId())
+            ||
+        (null === $customer && $cart->getCustomerId() === null);
     }
 
     // -- Order ------------------------------------------------------------------

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -14,7 +14,7 @@ echo -e "\n\033[01;34m[INFO] Activating Hook Test Module\033[00m\n"
 php Thelia module:activate HookTest
 
 echo -e "\n\033[01;34m[INFO] Running unit tests\033[00m\n"
-phpunit $*
+./bin/phpunit
 
 echo -e "\n\033[01;34m[INFO] Desactivating Hook Test Module\033[00m\n"
 php Thelia module:deactivate HookTest


### PR DESCRIPTION
If the cart cookie is not used, it is impossible to use Thelia.

This PR fix this problem.