### PR TITLE
Set visibility of BaseController::getErrorMessage method to protected

### DIFF
--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -202,7 +202,7 @@ abstract class BaseController extends ContainerAware
      * @param  \Symfony\Component\Form\Form $form
      * @return string                       the error string
      */
-    private function getErrorMessages(Form $form)
+    protected function getErrorMessages(Form $form)
     {
         $errors = '';
 


### PR DESCRIPTION
I'm sorry @gmichard, but as you don't rebase your PR, I've done the work for you (: