### PR TITLE
Implementation of calls to modules install() or update() methods.

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -286,7 +286,7 @@ class Module extends BaseAction implements EventSubscriberInterface
         $moduleDescriptorFile = sprintf('%s%s%s%s%s', $modulePath, DS, 'Config', DS, 'module.xml');
         $moduleManagement = new ModuleManagement();
         $file = new SplFileInfo($moduleDescriptorFile);
-        $module = $moduleManagement->updateModule($file);
+        $module = $moduleManagement->updateModule($file, $this->container);
 
         // activate if old was activated
         if ($activated) {

--- a/core/lib/Thelia/Command/ModuleRefreshCommand.php
+++ b/core/lib/Thelia/Command/ModuleRefreshCommand.php
@@ -14,6 +14,7 @@ namespace Thelia\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Thelia\Exception\InvalidModuleException;
 use Thelia\Module\ModuleManagement;
 
 /**
@@ -37,8 +38,14 @@ class ModuleRefreshCommand extends ContainerAwareCommand
         try {
             $moduleManagement = new ModuleManagement;
             $moduleManagement->updateModules($this->getContainer());
+        } catch (InvalidModuleException $ime) {
+            throw new \RuntimeException(
+                sprintf('One or more modules could not be refreshed : %s', $ime->getErrorsAsString("\n"))
+            );
         } catch (\Exception $e) {
-            throw new \RuntimeException(sprintf('Refresh modules list fail with Exception : [%d] %s', $e->getCode(), $e->getMessage()));
+            throw new \RuntimeException(
+                sprintf('Refresh modules list fail with Exception : [%d] %s', $e->getCode(), $e->getMessage())
+            );
         }
 
         if (method_exists($output, 'renderBlock')) {

--- a/core/lib/Thelia/Command/ModuleRefreshCommand.php
+++ b/core/lib/Thelia/Command/ModuleRefreshCommand.php
@@ -36,7 +36,7 @@ class ModuleRefreshCommand extends ContainerAwareCommand
     {
         try {
             $moduleManagement = new ModuleManagement;
-            $moduleManagement->updateModules();
+            $moduleManagement->updateModules($this->getContainer());
         } catch (\Exception $e) {
             throw new \RuntimeException(sprintf('Refresh modules list fail with Exception : [%d] %s', $e->getCode(), $e->getMessage()));
         }

--- a/core/lib/Thelia/Controller/Admin/ModuleController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleController.php
@@ -196,7 +196,7 @@ class ModuleController extends AbstractCrudController
 
         try {
             $moduleManagement = new ModuleManagement();
-            $moduleManagement->updateModules();
+            $moduleManagement->updateModules($this->getContainer());
         } catch (InvalidModuleException $ex) {
             $this->moduleErrors = $ex->getErrors();
         } catch (Exception $ex) {

--- a/core/lib/Thelia/Exception/InvalidModuleException.php
+++ b/core/lib/Thelia/Exception/InvalidModuleException.php
@@ -35,4 +35,16 @@ class InvalidModuleException extends \RuntimeException
     {
         return $this->errors;
     }
+
+    public function getErrorsAsString($separator = "\n")
+    {
+        $message = '';
+
+        /** @var \Exception $error */
+        foreach ($this->errors as $error) {
+            $message .= $error->getMessage() . $separator;
+        }
+
+        return rtrim($message, $separator);
+    }
 }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -188,7 +188,10 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
     {
         if (is_array($titles)) {
             foreach ($titles as $locale => $title) {
-                $moduleI18n = ModuleI18nQuery::create()->filterById($module->getId())->filterByLocale($locale)->findOne();
+                $moduleI18n = ModuleI18nQuery::create()
+                    ->filterById($module->getId())->filterByLocale($locale)
+                    ->findOne();
+
                 if (null === $moduleI18n) {
                     $moduleI18n = new ModuleI18n();
                     $moduleI18n
@@ -279,12 +282,18 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
                     $image->setPosition($imagePosition);
                     $image->save($con);
 
-                    $imageDirectory = sprintf("%s/../../../../local/media/images/module", __DIR__);
+                    $imageDirectory = THELIA_LOCAL_DIR . "media/images/module";
                     $imageFileName = sprintf("%s-%d-%s", $module->getCode(), $image->getId(), $fileName);
 
                     $increment = 0;
                     while (file_exists($imageDirectory . '/' . $imageFileName)) {
-                        $imageFileName = sprintf("%s-%d-%d-%s", $module->getCode(), $image->getId(), $increment, $fileName);
+                        $imageFileName = sprintf(
+                            "%s-%d-%d-%s",
+                            $module->getCode(),
+                            $image->getId(),
+                            $increment,
+                            $fileName
+                        );
                         $increment++;
                     }
 
@@ -293,13 +302,19 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
                     if (! is_dir($imageDirectory)) {
                         if (! @mkdir($imageDirectory, 0777, true)) {
                             $con->rollBack();
-                            throw new ModuleException(sprintf("Cannot create directory : %s", $imageDirectory), ModuleException::CODE_NOT_FOUND);
+                            throw new ModuleException(
+                                sprintf("Cannot create directory : %s", $imageDirectory),
+                                ModuleException::CODE_NOT_FOUND
+                            );
                         }
                     }
 
                     if (! @copy($filePath, $imagePath)) {
                         $con->rollBack();
-                        throw new ModuleException(sprintf("Cannot copy file : %s to : %s", $filePath, $imagePath), ModuleException::CODE_NOT_FOUND);
+                        throw new ModuleException(
+                            sprintf("Cannot copy file : %s to : %s", $filePath, $imagePath),
+                            ModuleException::CODE_NOT_FOUND
+                        );
                     }
 
                     $image->setFile($imageFileName);
@@ -322,7 +337,10 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
             $this->moduleModel = ModuleQuery::create()->findOneByCode($this->getCode());
 
             if (null === $this->moduleModel) {
-                throw new ModuleException(sprintf("Module Code `%s` not found", $this->getCode()), ModuleException::CODE_NOT_FOUND);
+                throw new ModuleException(
+                    sprintf("Module Code `%s` not found", $this->getCode()),
+                    ModuleException::CODE_NOT_FOUND
+                );
             }
         }
 
@@ -344,7 +362,10 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
 
         if (! isset(self::$moduleIds[$code])) {
             if (null === $module = ModuleQuery::create()->findOneByCode($code)) {
-                throw new ModuleException(sprintf("Module Code `%s` not found", $code), ModuleException::CODE_NOT_FOUND);
+                throw new ModuleException(
+                    sprintf("Module Code `%s` not found", $code),
+                    ModuleException::CODE_NOT_FOUND
+                );
             }
 
             self::$moduleIds[$code] = $module->getId();
@@ -447,7 +468,8 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
      *  - arrays
      *  - one or many instance(s) of \Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface
      *
-     * in the first case, your array must contains 2 indexes. The first is the compiler instance and the second the compilerPass type.
+     * in the first case, your array must contains 2 indexes.
+     * The first is the compiler instance and the second the compilerPass type.
      * Example :
      * return array(
      *  array(
@@ -480,12 +502,23 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
     }
 
     /**
-     * This method is called when the plugin is installed for the first time, using
-     * zip upload method.
+     * This method is called when the plugin is installed for the first time
      *
      * @param ConnectionInterface $con
      */
-    public function install(ConnectionInterface $con = null)
+    public function install(ConnectionInterface $con)
+    {
+        // Override this method to do something useful.
+    }
+
+    /**
+     * This method is called when a newer version of the plugin is installed
+     *
+     * @param string $currentVersion the current (installed) module version, as defined in the module.xml file
+     * @param string $newVersion the new module version, as defined in the module.xml file
+     * @param ConnectionInterface $con
+     */
+    public function update($currentVersion, $newVersion, ConnectionInterface $con)
     {
         // Override this method to do something useful.
     }
@@ -497,7 +530,7 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
      *
      * @return bool true to continue module activation, false to prevent it.
      */
-    public function preActivation(ConnectionInterface $con = null)
+    public function preActivation(ConnectionInterface $con)
     {
         // Override this method to do something useful.
         return true;
@@ -508,7 +541,7 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
      *
      * @param ConnectionInterface $con
      */
-    public function postActivation(ConnectionInterface $con = null)
+    public function postActivation(ConnectionInterface $con)
     {
         // Override this method to do something useful.
     }
@@ -519,13 +552,13 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
      * @param  ConnectionInterface $con
      * @return bool                true to continue module de-activation, false to prevent it.
      */
-    public function preDeactivation(ConnectionInterface $con = null)
+    public function preDeactivation(ConnectionInterface $con)
     {
         // Override this method to do something useful.
         return true;
     }
 
-    public function postDeactivation(ConnectionInterface $con = null)
+    public function postDeactivation(ConnectionInterface $con)
     {
         // Override this method to do something useful.
     }
@@ -537,7 +570,7 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
      * @param ConnectionInterface $con
      * @param bool                $deleteModuleData if true, the module should remove all its data from the system.
      */
-    public function destroy(ConnectionInterface $con = null, $deleteModuleData = false)
+    public function destroy(ConnectionInterface $con, $deleteModuleData = false)
     {
         // Override this method to do something useful.
     }
@@ -804,10 +837,5 @@ class BaseModule extends ContainerAware implements BaseModuleInterface
         }
 
         return $value;
-    }
-
-    public static function getModuleCategories()
-    {
-        return self::$moduleCategories;
     }
 }

--- a/core/lib/Thelia/Module/BaseModuleInterface.php
+++ b/core/lib/Thelia/Module/BaseModuleInterface.php
@@ -16,15 +16,15 @@ use Propel\Runtime\Connection\ConnectionInterface;
 
 interface BaseModuleInterface
 {
-    public function install(ConnectionInterface $con = null);
+    public function install(ConnectionInterface $con);
 
-    public function preActivation(ConnectionInterface $con = null);
+    public function preActivation(ConnectionInterface $con);
 
-    public function postActivation(ConnectionInterface $con = null);
+    public function postActivation(ConnectionInterface $con);
 
-    public function preDeactivation(ConnectionInterface $con = null);
+    public function preDeactivation(ConnectionInterface $con);
 
-    public function postDeactivation(ConnectionInterface $con = null);
+    public function postDeactivation(ConnectionInterface $con);
 
-    public function destroy(ConnectionInterface $con = null, $deleteModuleData = false);
+    public function destroy(ConnectionInterface $con, $deleteModuleData = false);
 }

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -96,7 +96,8 @@ class ModuleManagement
 
             $action = 'install';
         } elseif ($version !== $module->getVersion()) {
-            $previousVersion = $module->getVersion();
+            $currentVersion = $module->getVersion();
+            $newVersion = $module->getVersion();
             $action = 'update';
         } else {
             $action = 'none';
@@ -124,7 +125,7 @@ class ModuleManagement
             if ($action == 'install') {
                 $instance->install($con);
             } elseif ($action == 'update') {
-                $instance->update($previousVersion, $con);
+                $instance->update($currentVersion, $version, $con);
             }
 
             $con->commit();

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -16,6 +16,7 @@ use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use SplFileInfo;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Thelia\Exception\InvalidModuleException;
 use Thelia\Model\Map\ModuleTableMap;
@@ -40,7 +41,7 @@ class ModuleManagement
         $this->baseModuleDir = THELIA_MODULE_DIR;
     }
 
-    public function updateModules()
+    public function updateModules(ContainerInterface $container)
     {
         $finder = new Finder();
 
@@ -52,7 +53,7 @@ class ModuleManagement
 
         foreach ($finder as $file) {
             try {
-                $this->updateModule($file);
+                $this->updateModule($file, $container);
             } catch (\Exception $ex) {
                 // Guess module code
                 $moduleCode = basename(dirname(dirname($file)));
@@ -67,35 +68,47 @@ class ModuleManagement
     }
 
     /**
+     * Update module information, and invoke install() for new modules (e.g. modules
+     * just discovered), or update() modules for which version number ha changed.
      *
-     *
-     * @param SplFileInfo $file
+     * @param SplFileInfo $file the module.xml file descriptor
+     * @param ContainerInterface $container the container
      *
      * @return Module
      *
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function updateModule($file)
+    public function updateModule($file, ContainerInterface $container)
     {
         $descriptorValidator = $this->getDescriptorValidator();
 
         $content   = $descriptorValidator->getDescriptor($file->getRealPath());
         $reflected = new \ReflectionClass((string)$content->fullnamespace);
         $code      = basename(dirname($reflected->getFileName()));
+        $version   = (string)$content->version;
 
         $module = ModuleQuery::create()->filterByCode($code)->findOne();
+
         if (null === $module) {
             $module = new Module();
             $module->setActivate(0);
+
+            $action = 'install';
+        } elseif ($version !== $module->getVersion()) {
+            $previousVersion = $module->getVersion();
+            $action = 'update';
+        } else {
+            $action = 'none';
         }
 
         $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
         $con->beginTransaction();
+
         try {
             $module
                 ->setCode($code)
-                ->setVersion((string)$content->version)
+                ->setVersion($version)
                 ->setFullNamespace((string)$content->fullnamespace)
                 ->setType($this->getModuleType($reflected))
                 ->setCategory((string)$content->type)
@@ -103,10 +116,21 @@ class ModuleManagement
 
             $this->saveDescription($module, $content, $con);
 
+            // Tell the module to install() or update()
+            $instance = $module->createInstance();
+
+            $instance->setContainer($container);
+
+            if ($action == 'install') {
+                $instance->install($con);
+            } elseif ($action == 'update') {
+                $instance->update($previousVersion, $con);
+            }
+
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (PropelException $ex) {
             $con->rollBack();
-            throw $e;
+            throw $ex;
         }
 
         return $module;

--- a/tests/phpunit/Thelia/Tests/Command/ModuleRefreshCommandTest.php
+++ b/tests/phpunit/Thelia/Tests/Command/ModuleRefreshCommandTest.php
@@ -40,7 +40,7 @@ class ModuleRefreshCommandTest extends PHPUnit_Framework_TestCase
     public function testModuleRefreshCommand()
     {
         $moduleManagement = new ModuleManagement;
-        $moduleManagement->updateModules();
+        $moduleManagement->updateModules($this->getContainer());
 
         $module = ModuleQuery::create()->filterByType(1)->orderByPosition(Criteria::DESC)->findOne();
 


### PR DESCRIPTION
This PR implements calls to BaseModule::install() and BaseModule::update() methods when the module list
 is refreshed, or when a new module is uploaded.

ModuleInterface has been modified, to make the $con connection parameter mandatory, as leaving it as optional will (theorically) force each module to test if $con is null before using it. Practically, it is never checked, and always passed by the callers. So let's make it mandatory, il will not eat some bread.