### PR TITLE
Add the customers/checkLogin API endpoint

### DIFF
--- a/core/lib/Thelia/Config/Resources/form-api.xml
+++ b/core/lib/Thelia/Config/Resources/form-api.xml
@@ -10,6 +10,7 @@
         <!-- Forms for Customer -->
         <form name="thelia.api.customer.create" class="Thelia\Form\Api\Customer\CustomerCreateForm"/>
         <form name="thelia.api.customer.update" class="Thelia\Form\Api\Customer\CustomerUpdateForm"/>
+        <form name="thelia.api.customer.login" class="Thelia\Form\Api\Customer\CustomerLogin"/>
 
         <!-- Forms for Category -->
         <form name="thelia.api.category.create" class="Thelia\Form\Api\Category\CategoryCreationForm"/>

--- a/core/lib/Thelia/Config/Resources/routing/api.xml
+++ b/core/lib/Thelia/Config/Resources/routing/api.xml
@@ -32,6 +32,9 @@
         <requirement key="customer_id">\d+</requirement>
     </route>
 
+    <route id="api.customer.checkLogin" path="/api/customers/checkLogin" methods="post">
+        <default key="_controller">Thelia:Api\Customer:checkLogin</default>
+    </route>
     <!-- end customer route -->
 
     <!-- title route -->

--- a/core/lib/Thelia/Form/Api/Customer/CustomerLogin.php
+++ b/core/lib/Thelia/Form/Api/Customer/CustomerLogin.php
@@ -1,0 +1,39 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Form\Api\Customer;
+
+use Thelia\Form\CustomerLogin as BaseCustomerLogin;
+
+/**
+ * Customer login form for the API.
+ *
+ * Class CustomerLogin
+ * @package Thelia\Form\Api\Customer
+ * @author Baptiste Cabarrou <bcabarrou@openstudio.fr>
+ */
+class CustomerLogin extends BaseCustomerLogin
+{
+    public function buildForm()
+    {
+        parent::buildForm();
+
+        $this->formBuilder->remove('remember_me');
+        // "I am an existing customer"
+        $this->formBuilder->get('account')->setEmptyData(1)->setDataLocked(true);
+    }
+
+    public function getName()
+    {
+        return '';
+    }
+}

--- a/tests/phpunit/Thelia/Tests/Api/CustomerControllerTest.php
+++ b/tests/phpunit/Thelia/Tests/Api/CustomerControllerTest.php
@@ -19,6 +19,7 @@ use Thelia\Tests\ApiTestCase;
  * Class CustomerControllerTest
  * @package Thelia\Tests\Api
  * @author Manuel Raynaud <manu@thelia.net>
+ * @author Baptiste Cabarrou <bcabarrou@openstudio.fr>
  */
 class CustomerControllerTest extends ApiTestCase
 {
@@ -304,5 +305,86 @@ class CustomerControllerTest extends ApiTestCase
         );
 
         $this->assertEquals(500, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @covers \Thelia\Controller\Api\CustomerController::checkLoginAction
+     */
+    public function testCheckLogin()
+    {
+        $logins = [
+            'email'    => CustomerQuery::create()->findPk(1)->getEmail(),
+            'password' => 'azerty'
+        ];
+
+        $requestContent = json_encode($logins);
+
+        $client = static::createClient();
+        $servers = $this->getServerParameters();
+        $servers['CONTENT_TYPE'] = 'application/json';
+        $client->request(
+            'POST',
+            '/api/customers/checkLogin?&sign='.$this->getSignParameter($requestContent),
+            [],
+            [],
+            $servers,
+            $requestContent
+        );
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @covers \Thelia\Controller\Api\CustomerController::checkLoginAction
+     */
+    public function testCheckLoginWithUnexistingEmail()
+    {
+        $logins = [
+            'email'    => 'test@exemple.com',
+            'password' => 'azerty'
+        ];
+
+        $requestContent = json_encode($logins);
+
+        $client = static::createClient();
+        $servers = $this->getServerParameters();
+        $servers['CONTENT_TYPE'] = 'application/json';
+        $client->request(
+            'POST',
+            '/api/customers/checkLogin?&sign='.$this->getSignParameter($requestContent),
+            [],
+            [],
+            $servers,
+            $requestContent
+        );
+
+        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @covers \Thelia\Controller\Api\CustomerController::checkLoginAction
+     */
+    public function testCheckLoginWithWrongPassword()
+    {
+        $logins = [
+            'email'    => CustomerQuery::create()->findPk(1)->getEmail(),
+            'password' => 'notthis'
+        ];
+
+        $requestContent = json_encode($logins);
+
+        $client = static::createClient();
+        $servers = $this->getServerParameters();
+        $servers['CONTENT_TYPE'] = 'application/json';
+        $client->request(
+            'POST',
+            '/api/customers/checkLogin?&sign='.$this->getSignParameter($requestContent),
+            [],
+            [],
+            $servers,
+            $requestContent
+        );
+
+        $this->assertEquals(404, $client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
This endpoint allows to check if an email and password are valid login credentials for a customer, and retrieve this customer if they are.

Some thoughs and questions on HTTP return codes:
- a success (customer exists) is a 200
- a malformed query will be a 500 for consistancy with the other API methods, but maybe it should be a 400 (Bad Request)
- an email not in use will be a 404
- an incorrect password will also be a 404 since we check if (email, password) map to a customer. Or should it be 403 ?

The method also call the getAction method to get the customer if it exists, is it OK ?

A PR to update documentation will follow.