### PR TITLE
Add render function for smarty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add the 'images-folder' tag into module.xml file to deploy the modules images
 - Add the 'module:list' command, that shows the modules state 
 - Update Admin Logs to add the resource ID when available.
+- Add render smarty function, that executes the controller given in the action parameter.
 
 # 2.1.2
 

--- a/local/modules/TheliaSmarty/Config/config.xml
+++ b/local/modules/TheliaSmarty/Config/config.xml
@@ -66,6 +66,13 @@
             <tag name="thelia.parser.register_plugin"/>
         </service>
 
+        <service id="smarty.plugin.render" class="TheliaSmarty\Template\Plugins\Render" scope="request">
+            <argument type="service" id="controller_resolver" />
+            <argument type="service" id="request" />
+            <argument type="service" id="service_container" />
+            <tag name="thelia.parser.register_plugin"/>
+        </service>
+
         <service id="smart.plugin.form" class="TheliaSmarty\Template\Plugins\Form" scope="request">
             <tag name="thelia.parser.register_plugin"/>
 

--- a/local/modules/TheliaSmarty/Template/AbstractSmartyPlugin.php
+++ b/local/modules/TheliaSmarty/Template/AbstractSmartyPlugin.php
@@ -91,7 +91,7 @@ abstract class AbstractSmartyPlugin
     }
 
     /**
-     * @return an array of SmartyPluginDescriptor
+     * @return SmartyPluginDescriptor[] an array of SmartyPluginDescriptor
      */
     abstract public function getPluginDescriptors();
 }

--- a/local/modules/TheliaSmarty/Template/Plugins/Render.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Render.php
@@ -1,0 +1,171 @@
+<?php
+/*************************************************************************************/
+/* This file is part of the Thelia package.                                          */
+/*                                                                                   */
+/* Copyright (c) OpenStudio                                                          */
+/* email : dev@thelia.net                                                            */
+/* web : http://www.thelia.net                                                       */
+/*                                                                                   */
+/* For the full copyright and license information, please view the LICENSE.txt       */
+/* file that was distributed with this source code.                                  */
+/*************************************************************************************/
+
+namespace TheliaSmarty\Template\Plugins;
+
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\Controller\ControllerResolver;
+use Thelia\Core\HttpFoundation\Request;
+use TheliaSmarty\Template\AbstractSmartyPlugin;
+use TheliaSmarty\Template\Exception\SmartyPluginException;
+use TheliaSmarty\Template\SmartyPluginDescriptor;
+
+/**
+ * Class Render
+ * @package TheliaSmarty\Template\Plugins
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+class Render extends AbstractSmartyPlugin
+{
+    /**
+     * @var ControllerResolver
+     */
+    protected $controllerResolver;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    /**
+     * @param ControllerResolver $controllerResolver
+     * @param Request            $request
+     * @param Container          $container
+     */
+    public function __construct(ControllerResolver $controllerResolver, Request $request, Container $container)
+    {
+        $this->controllerResolver = $controllerResolver;
+        $this->request = $request;
+        $this->container = $container;
+    }
+
+    /**
+     * @param $params
+     * @return mixed|string
+     * @throws SmartyPluginException
+     */
+    public function processRender($params)
+    {
+        if (null === $params["action"]) {
+            throw new SmartyPluginException(
+                "You must declare the 'action' parameter in the 'render' smarty function"
+            );
+        }
+
+        $request = $this->prepareRequest($params);
+
+        $controller = $this->controllerResolver->getController($request);
+        $controllerParameters = $this->controllerResolver->getArguments($request, $controller);
+
+        $response = call_user_func_array($controller, $controllerParameters);
+
+        if ($response instanceof Response) {
+            return $response->getContent();
+        }
+
+        return $response;
+    }
+
+    protected function prepareRequest(array $params)
+    {
+        // Get action
+        $action = $this->popParameter($params, "action");
+
+        // Then get and filter query, request and method
+        $query = $this->popParameter($params, "query");
+        $query = $this->filterArrayStrParam($query);
+        $request = $this->popParameter($params, "request");
+        $request = $this->filterArrayStrParam($request);
+        $method = strtoupper($this->popParameter($params, "method", "GET"));
+
+        // Then build the request
+        $requestObject = clone $this->request;
+        $requestObject->query = new ParameterBag($query);
+        $requestObject->request = new ParameterBag($request);
+        $requestObject->attributes = new ParameterBag(["_controller" => $action]);
+
+        // Apply the method
+        if (!empty($request) && "GET" === $method) {
+            $requestObject->setMethod("POST");
+        } else {
+            $requestObject->setMethod($method);
+        }
+
+        // Then all the attribute parameters
+        foreach ($params as $key => $attribute) {
+            $requestObject->attributes->set($key, $attribute);
+        }
+
+        $this->container->set("request", $requestObject);
+
+        return $requestObject;
+    }
+
+    /**
+     * @param $param
+     * @return array
+     *
+     * If $param is an array, return it.
+     * Else parser it to translate a=b&c=d&e[]=f&g[h]=i to
+     * ["a"=>"b","c"=>"d","e"=>["f"],"g"=>["h"=>"i"]
+     */
+    protected function filterArrayStrParam($param)
+    {
+        if (is_array($param)) {
+            return $param;
+        }
+
+        parse_str($param, $param);
+
+        if (false === $param) {
+            return [];
+        }
+
+        return $param;
+    }
+
+    /**
+     * @param  array $params
+     * @param $name
+     * @param  null  $default
+     * @return mixed
+     *
+     * Get a parameter then unset it
+     */
+    protected function popParameter(array $params, $name, $default = null)
+    {
+        $param = $this->getParam($params, $name, $default);
+
+        if (array_key_exists($name, $params)) {
+            unset($params[$name]);
+        }
+
+        return $param;
+    }
+
+    /**
+     * @return SmartyPluginDescriptor[] an array of SmartyPluginDescriptor
+     */
+    public function getPluginDescriptors()
+    {
+        return array(
+            new SmartyPluginDescriptor('function', 'render', $this, 'processRender'),
+        );
+    }
+}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/Controller/TestController.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/Controller/TestController.php
@@ -1,0 +1,49 @@
+<?php
+/*************************************************************************************/
+/* This file is part of the Thelia package.                                          */
+/*                                                                                   */
+/* Copyright (c) OpenStudio                                                          */
+/* email : dev@thelia.net                                                            */
+/* web : http://www.thelia.net                                                       */
+/*                                                                                   */
+/* For the full copyright and license information, please view the LICENSE.txt       */
+/* file that was distributed with this source code.                                  */
+/*************************************************************************************/
+
+namespace TheliaSmarty\Tests\Template\Plugin\Controller;
+
+use Thelia\Controller\Front\BaseFrontController;
+use Thelia\Core\HttpFoundation\Response;
+
+/**
+ * Class TestController
+ * @package TheliaSmarty\Tests\Template\Plugin\Controller
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+class TestController extends BaseFrontController
+{
+    public function testAction()
+    {
+        return new Response("world");
+    }
+
+    public function testParamsAction($paramA, $paramB)
+    {
+        return new Response($paramA.$paramB);
+    }
+
+    public function testMethodAction()
+    {
+        return $this->getRequest()->getMethod();
+    }
+
+    public function testQueryAction()
+    {
+        return $this->getRequest()->query->get("foo");
+    }
+
+    public function testRequestAction()
+    {
+        return $this->getRequest()->request->get("foo").$this->getRequest()->getMethod();
+    }
+}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/RenderTest.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/RenderTest.php
@@ -1,0 +1,80 @@
+<?php
+/*************************************************************************************/
+/* This file is part of the Thelia package.                                          */
+/*                                                                                   */
+/* Copyright (c) OpenStudio                                                          */
+/* email : dev@thelia.net                                                            */
+/* web : http://www.thelia.net                                                       */
+/*                                                                                   */
+/* For the full copyright and license information, please view the LICENSE.txt       */
+/* file that was distributed with this source code.                                  */
+/*************************************************************************************/
+
+namespace TheliaSmarty\Tests\Template\Plugin;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use TheliaSmarty\Template\Plugins\Render;
+use Thelia\Core\Controller\ControllerResolver;
+
+/**
+ * Class RenderTest
+ * @package TheliaSmarty\Tests\Template\Plugin
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+class RenderTest extends SmartyPluginTestCase
+{
+    public function testRenderWithoutParams()
+    {
+        $data = $this->render("test.html");
+
+        $this->assertEquals("Hello, world!", $data);
+    }
+
+    public function testRenderWithParams()
+    {
+        $data = $this->render("testParams.html");
+
+        $this->assertEquals("Hello, world!", $data);
+    }
+
+    public function testMethodParameter()
+    {
+        $data = $this->render("testMethod.html");
+
+        $this->assertEquals("PUT", $data);
+    }
+
+    public function testQueryArrayParamater()
+    {
+        $this->smarty->assign("query", ["foo" => "bar"]);
+        $data = $this->render("testQueryArray.html");
+
+        $this->assertEquals("bar", $data);
+    }
+
+    public function testQueryStringParamater()
+    {
+        $data = $this->render("testQueryString.html");
+
+        $this->assertEquals("bar", $data);
+    }
+
+    public function testRequestParamater()
+    {
+        $data = $this->render("testRequest.html");
+
+        $this->assertEquals("barPOSTbazPUT", $data);
+    }
+
+    /**
+     * @return \TheliaSmarty\Template\AbstractSmartyPlugin
+     */
+    protected function getPlugin(ContainerBuilder $container)
+    {
+        return new Render(
+            new ControllerResolver($container),
+            $container->get("request"),
+            $container
+        );
+    }
+}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
@@ -1,0 +1,54 @@
+<?php
+/*************************************************************************************/
+/* This file is part of the Thelia package.                                          */
+/*                                                                                   */
+/* Copyright (c) OpenStudio                                                          */
+/* email : dev@thelia.net                                                            */
+/* web : http://www.thelia.net                                                       */
+/*                                                                                   */
+/* For the full copyright and license information, please view the LICENSE.txt       */
+/* file that was distributed with this source code.                                  */
+/*************************************************************************************/
+
+namespace TheliaSmarty\Tests\Template\Plugin;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Tests\ContainerAwareTestCase;
+use TheliaSmarty\Template\SmartyParser;
+
+/**
+ * Class SmartyPluginTestCase
+ * @package TheliaSmarty\Tests\Template\Plugin
+ * @author Benjamin Perche <bperche@openstudio.fr>
+ */
+abstract class SmartyPluginTestCase extends ContainerAwareTestCase
+{
+    /** @var SmartyParser */
+    protected $smarty;
+
+    /**
+     * Use this method to build the container with the services that you need.
+     */
+    protected function buildContainer(ContainerBuilder $container)
+    {
+        $this->smarty = new SmartyParser(
+            $container->get("request"),
+            $container->get("event_dispatcher"),
+            new ParserContext($container->get("request"))
+        );
+
+        $this->smarty->addPlugins($this->getPlugin($container));
+        $this->smarty->registerPlugins();
+    }
+
+    protected function render($template)
+    {
+        return $this->smarty->fetch(__DIR__.DS."fixture".DS.$template);
+    }
+
+    /**
+     * @return \TheliaSmarty\Template\AbstractSmartyPlugin
+     */
+    abstract protected function getPlugin(ContainerBuilder $container);
+}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/test.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/test.html
@@ -1,0 +1,1 @@
+Hello, {render action="TheliaSmarty\Tests\Template\Plugin:Test:test"}!

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testMethod.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testMethod.html
@@ -1,0 +1,1 @@
+{render action="TheliaSmarty\Tests\Template\Plugin:Test:testMethod" method="PUT"}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testParams.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testParams.html
@@ -1,0 +1,1 @@
+{render action="TheliaSmarty\Tests\Template\Plugin:Test:testParams" paramA="Hello, " paramB="world!"}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testQueryArray.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testQueryArray.html
@@ -1,0 +1,1 @@
+{render action="TheliaSmarty\Tests\Template\Plugin:Test:testQuery" query=$query}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testQueryString.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testQueryString.html
@@ -1,0 +1,1 @@
+{render action="TheliaSmarty\Tests\Template\Plugin:Test:testQuery" query="foo=bar"}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testRequest.html
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/fixture/testRequest.html
@@ -1,0 +1,1 @@
+{render action="TheliaSmarty\Tests\Template\Plugin:Test:testRequest" request="foo=bar"}{render action="TheliaSmarty\Tests\Template\Plugin:Test:testRequest" request="foo=baz" method="put"}


### PR DESCRIPTION
This implements a ```render``` function for Smarty.
It works like symfony twig extension.

How to use it ?
---

the render function takes a mandatory argument ```action```, that is the method of the action. It supports ```a:b:c``` notation. 
Example:
```smarty
{render action="Module:Foo:bar"}
```
Will executes ```Module\Controller\FooController::barAction``` and print the result.

__You can specify the request method__:
```smarty
{render action="Module:Foo:bar" method="PUT"}
```

__You can specify the query parameters__:
```smarty
{render action="Module:Foo:bar" query="foo=bar&baz=thelia"}
{render action="Module:Foo:bar" query=$anArray}
```

__Same for request__ _(if the method isn't specified, it will automaticly set it to POST)_:
```smarty
{render action="Module:Foo:bar" request="foo=bar&baz=thelia"}
{render action="Module:Foo:bar" request=$anArray}
```

All the other parameters will be used as the method parameters.
You can execute the following controller:
```php
<?php

namespace Module\Controller\FooController;

use Thelia\Controller\Front\BaseFrontController;
use Thelia\Core\HttpFoundation\Response;

class TestController extends BaseFrontController
{
    public function barAction($paramA, $paramB)
    {
        return new Response($paramA . $paramB);
    }
}
```

with then method:
```smarty
{render action="Module:Foo:bar" paramA="foo" paramB="bar"}
```