### PR TITLE
The default less compiler is now oyejorge/less.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "thelia/currency-converter": "~1.0",
         "smarty/smarty": "v3.1.19",
         "symfony/class-loader": "2.3.*",
-        "maximebf/debugbar": "dev-master"
+        "maximebf/debugbar": "dev-master",
+        "oyejorge/less.php": "~1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b36442ed7b32394594d3bdce64d3d079",
+    "hash": "4963bc607a10371ba87cc5a21832e2de",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -444,6 +444,65 @@
                 "debug"
             ],
             "time": "2014-11-02 19:44:24"
+        },
+        {
+            "name": "oyejorge/less.php",
+            "version": "v1.7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oyejorge/less.php.git",
+                "reference": "82372b389386ae1edab55495eae4b400cca3c86c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/oyejorge/less.php/zipball/82372b389386ae1edab55495eae4b400cca3c86c",
+                "reference": "82372b389386ae1edab55495eae4b400cca3c86c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "bin": [
+                "bin/lessc"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Less": "lib/"
+                },
+                "classmap": [
+                    "lessc.inc.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Agar",
+                    "homepage": "https://github.com/agar"
+                },
+                {
+                    "name": "Martin Jantošovič",
+                    "homepage": "https://github.com/Mordred"
+                },
+                {
+                    "name": "Josh Schmidt",
+                    "homepage": "https://github.com/oyejorge"
+                }
+            ],
+            "description": "PHP port of the Javascript version of LESS http://lesscss.org",
+            "homepage": "http://lessphp.gpeasy.com",
+            "keywords": [
+                "css",
+                "less",
+                "less.js",
+                "lesscss",
+                "php",
+                "stylesheet"
+            ],
+            "time": "2014-06-05 16:09:50"
         },
         {
             "name": "propel/propel",

--- a/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
+++ b/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
@@ -17,6 +17,7 @@ use Assetic\FilterManager;
 use Assetic\Filter;
 use Assetic\Factory\AssetFactory;
 use Assetic\AssetWriter;
+use Thelia\Core\Template\Assets\Filter\LessDotPhpFilter;
 use Thelia\Model\ConfigQuery;
 use Thelia\Log\Tlog;
 use Symfony\Component\Filesystem\Filesystem;
@@ -213,7 +214,11 @@ class AsseticAssetManager implements AssetManagerInterface
 
                 switch ($filter_name) {
                     case 'less':
-                        $filterManager->set('less', new Filter\LessphpFilter());
+                        $filterManager->set('less', new LessDotPhpFilter());
+                        break;
+
+                    case 'less_legacy':
+                        $filterManager->set('less_legacy', new Filter\LessphpFilter());
                         break;
 
                     case 'sass':

--- a/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
+++ b/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
@@ -1,0 +1,75 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Assets\Filter;
+
+use Assetic\Asset\AssetInterface;
+use Assetic\Filter\LessphpFilter;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Log\Tlog;
+
+/**
+ * Loads LESS files using the oyejorge/less.php PHP implementation of less.
+ *
+ * @link http://lessphp.gpeasy.com
+ *
+ * @author David Buchmann <david@liip.ch>
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ * @author Franck Allimant <franck@cqfdev.fr>
+ */
+class LessDotPhpFilter extends LessphpFilter
+{
+    /** @var string the compiler cache directory */
+    private $cacheDir;
+
+    public function __construct()
+    {
+        // Assign and create the cache directory, if required.
+        $this->cacheDir = THELIA_CACHE_DIR . DS . 'less.php';
+
+        if (! is_dir($this->cacheDir)) {
+            $fs = new Filesystem();
+
+            $fs->mkdir($this->cacheDir);
+        }
+    }
+
+    public function filterLoad(AssetInterface $asset)
+    {
+        $filePath = $asset->getSourceRoot() . DS . $asset->getSourcePath();
+
+        Tlog::getInstance()->addDebug("Starting CSS processing: $filePath...");
+
+        $importDirs = [];
+
+        if ($dir = $asset->getSourceDirectory()) {
+            $importDirs[$dir] = '';
+        }
+
+        foreach ($this->loadPaths as $loadPath) {
+            $importDirs[$loadPath] = '';
+        }
+
+        $options = [
+            'cache_dir'     => $this->cacheDir,
+            'relativeUrls'  => false, // Relative paths in less files will be left unchanged.
+            'compress'      => true,
+            'import_dirs'   => $importDirs
+        ];
+
+        $css_file_name = \Less_Cache::Get([$filePath => ''], $options);
+
+        $asset->setContent(file_get_contents($this->cacheDir . DS . $css_file_name));
+
+        Tlog::getInstance()->addDebug("CSS processing done.");
+    }
+}

--- a/templates/frontOffice/default/layout.tpl
+++ b/templates/frontOffice/default/layout.tpl
@@ -28,14 +28,15 @@ GNU General Public License : http://www.gnu.org/licenses/
 {block name="no-return-functions"}{/block}
 {assign var="store_name" value="{config key="store_name"}"}
 {assign var="store_description" value="{config key="store_description"}"}
+{assign var="lang_code" value={lang attr="code"}}
 {if not $store_name}{assign var="store_name" value="{intl l='Thelia V2'}"}{/if}
 {if not $store_description}{assign var="store_description" value="$store_name"}{/if}
 
 {* paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither *}
-<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang="{lang attr="code"}"> <![endif]-->
-<!--[if IE 7 ]><html class="no-js oldie ie7" lang="{lang attr="code"}"> <![endif]-->
-<!--[if IE 8 ]><html class="no-js oldie ie8" lang="{lang attr="code"}"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--><html lang="{lang attr="code"}" class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang="{$lang_code}"> <![endif]-->
+<!--[if IE 7 ]><html class="no-js oldie ie7" lang="{$lang_code}"> <![endif]-->
+<!--[if IE 8 ]><html class="no-js oldie ie8" lang="{$lang_code}"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--><html lang="{$v}" class="no-js"> <!--<![endif]-->
 <head>
     {hook name="main.head-top"}
     {* Test if javascript is enabled *}
@@ -237,7 +238,10 @@ GNU General Public License : http://www.gnu.org/licenses/
 </script>
 
 <script src="//ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/jquery.validate.min.js"></script>
-<script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/localization/messages_{lang attr="code"}.js"></script>
+{* do no try to load messages_en, as this file does not exists *}
+{if $lang_code != 'en'}
+    <script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.13.1/localization/messages_{$lang_code}.js"></script>
+{/if}
 
 
 {javascripts file='assets/js/bootstrap/bootstrap.js'}


### PR DESCRIPTION
This PR add a new LESS PHP compiler, oyejorge/less.php, which compiles successfully bootstrap 3.x LESS files. The previous one, leafo/lessphp, is an assetic dependecy and is not removed.

The default compiler is now oyejorge/less.php, but leafo/lessphp remains available, using `filters="less_legacy"` ìn the `stylesheets` smarty function. :gift:

This PR also contains a minor fix in the default front template layout.
