### PR TITLE
Adding/updating a module hook is now working

### DIFF
--- a/core/lib/Thelia/Action/ModuleHook.php
+++ b/core/lib/Thelia/Action/ModuleHook.php
@@ -106,10 +106,13 @@ class ModuleHook extends BaseAction implements EventSubscriberInterface
     {
         $moduleHook = new ModuleHookModel();
 
+        // todo: test if classname and method exists
         $moduleHook
             ->setModuleId($event->getModuleId())
             ->setHookId($event->getHookId())
             ->setActive(false)
+            ->setClassname($event->getClassname())
+            ->setMethod($event->getMethod())
             ->setModuleActive($this->isModuleActive($event->getModuleId()))
             ->setHookActive($this->isHookActive($event->getHookId()))
             ->setPosition($this->getLastPositionInHook($event->getHookId()))
@@ -124,7 +127,7 @@ class ModuleHook extends BaseAction implements EventSubscriberInterface
             // todo: test if classname and method exists
             $moduleHook
                 ->setHookId($event->getHookId())
-                ->setModuleId($event->getModuleHookId())
+                ->setModuleId($event->getModuleId())
                 ->setClassname($event->getClassname())
                 ->setMethod($event->getMethod())
                 ->setActive($event->getActive())

--- a/core/lib/Thelia/Controller/Admin/ModuleHookController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleHookController.php
@@ -19,6 +19,7 @@ use Thelia\Core\Event\Hook\ModuleHookToggleActivationEvent;
 use Thelia\Core\Event\Hook\ModuleHookUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Form\ModuleHookCreationForm;
@@ -115,6 +116,7 @@ class ModuleHookController extends AbstractCrudController
      * Hydrate the update form for this object, before passing it to the update template
      *
      * @param ModuleHook $object
+     * @return ModuleHookModificationForm
      */
     protected function hydrateObjectForm($object)
     {
@@ -133,7 +135,8 @@ class ModuleHookController extends AbstractCrudController
     /**
      * Creates the creation event with the provided form data
      *
-     * @param unknown $formData
+     * @param array $formData
+     * @return ModuleHookCreateEvent
      */
     protected function getCreationEvent($formData)
     {
@@ -145,7 +148,8 @@ class ModuleHookController extends AbstractCrudController
     /**
      * Creates the update event with the provided form data
      *
-     * @param unknown $formData
+     * @param array $formData
+     * @return ModuleHookUpdateEvent
      */
     protected function getUpdateEvent($formData)
     {
@@ -185,6 +189,7 @@ class ModuleHookController extends AbstractCrudController
      * Return true if the event contains the object, e.g. the action has updated the object in the event.
      *
      * @param ModuleHookEvent $event
+     * @return bool
      */
     protected function eventContainsObject($event)
     {
@@ -195,6 +200,7 @@ class ModuleHookController extends AbstractCrudController
      * Get the created object from an event.
      *
      * @param ModuleHookEvent $event
+     * @return null|ModuleHook
      */
     protected function getObjectFromEvent($event)
     {
@@ -203,6 +209,7 @@ class ModuleHookController extends AbstractCrudController
 
     /**
      * Load an existing object from the database
+     * @return null|ModuleHook
      */
     protected function getExistingObject()
     {
@@ -215,17 +222,27 @@ class ModuleHookController extends AbstractCrudController
     /**
      * Returns the object label form the object event (name, title, etc.)
      *
-     * @param unknown $object
+     * @param ModuleHook $object
+     * @return string
      */
     protected function getObjectLabel($object)
     {
-        // TODO: Implement getObjectLabel() method.
+        try {
+            return sprintf(
+                "%s on %s",
+                $object->getModule()->getTitle(),
+                $object->getHook()->getTitle()
+            );
+        } catch (\Exception $ex) {
+            return "Undefined module hook";
+        }
     }
 
     /**
      * Returns the object ID from the object
      *
      * @param ModuleHook $object
+     * @return int
      */
     protected function getObjectId($object)
     {
@@ -235,7 +252,8 @@ class ModuleHookController extends AbstractCrudController
     /**
      * Render the main list template
      *
-     * @param unknown $currentOrder , if any, null otherwise.
+     * @param string $currentOrder , if any, null otherwise.
+     * @return Response
      */
     protected function renderListTemplate($currentOrder)
     {
@@ -247,12 +265,16 @@ class ModuleHookController extends AbstractCrudController
 
     /**
      * Render the edition template
+     * @return Response
      */
     protected function renderEditionTemplate()
     {
         return $this->render('module-hook-edit', $this->getEditionArgument());
     }
 
+    /**
+     * @return array
+     */
     protected function getEditionArgument()
     {
         return [
@@ -262,6 +284,7 @@ class ModuleHookController extends AbstractCrudController
 
     /**
      * Redirect to the edition template
+     * @return Response
      */
     protected function redirectToEditionTemplate($request = null, $country = null)
     {

--- a/core/lib/Thelia/Core/Event/Hook/ModuleHookCreateEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/ModuleHookCreateEvent.php
@@ -21,9 +21,12 @@ class ModuleHookCreateEvent extends ModuleHookEvent
 {
     protected $module_id;
     protected $hook_id;
+    protected $classname;
+    protected $method;
 
     /**
-     * @param mixed $hook_id
+     * @param int $hook_id
+     * @return $this
      */
     public function setHookId($hook_id)
     {
@@ -33,7 +36,7 @@ class ModuleHookCreateEvent extends ModuleHookEvent
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getHookId()
     {
@@ -41,7 +44,8 @@ class ModuleHookCreateEvent extends ModuleHookEvent
     }
 
     /**
-     * @param mixed $module_id
+     * @param int $module_id
+     * @return $this
      */
     public function setModuleId($module_id)
     {
@@ -51,10 +55,48 @@ class ModuleHookCreateEvent extends ModuleHookEvent
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getModuleId()
     {
         return $this->module_id;
+    }
+
+    /**
+     * @param string $classname
+     * @return $this
+     */
+    public function setClassname($classname)
+    {
+        $this->classname = $classname;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassname()
+    {
+        return $this->classname;
+    }
+
+    /**
+     * @param string $method
+     * @return $this
+     */
+    public function setMethod($method)
+    {
+        $this->method = $method;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
     }
 }

--- a/core/lib/Thelia/Core/Event/Hook/ModuleHookUpdateEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/ModuleHookUpdateEvent.php
@@ -20,12 +20,11 @@ namespace Thelia\Core\Event\Hook;
 class ModuleHookUpdateEvent extends ModuleHookCreateEvent
 {
     protected $module_hook_id;
-    protected $classname;
-    protected $method;
     protected $active;
 
     /**
-     * @param mixed $module_hook_id
+     * @param int $module_hook_id
+     * @return $this
      */
     public function setModuleHookId($module_hook_id)
     {
@@ -35,7 +34,7 @@ class ModuleHookUpdateEvent extends ModuleHookCreateEvent
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getModuleHookId()
     {
@@ -43,7 +42,8 @@ class ModuleHookUpdateEvent extends ModuleHookCreateEvent
     }
 
     /**
-     * @param mixed $active
+     * @param bool $active
+     * @return $this
      */
     public function setActive($active)
     {
@@ -53,46 +53,10 @@ class ModuleHookUpdateEvent extends ModuleHookCreateEvent
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getActive()
     {
         return $this->active;
-    }
-
-    /**
-     * @param mixed $classname
-     */
-    public function setClassname($classname)
-    {
-        $this->classname = $classname;
-
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getClassname()
-    {
-        return $this->classname;
-    }
-
-    /**
-     * @param mixed $method
-     */
-    public function setMethod($method)
-    {
-        $this->method = $method;
-
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getMethod()
-    {
-        return $this->method;
     }
 }

--- a/core/lib/Thelia/Form/ModuleHookCreationForm.php
+++ b/core/lib/Thelia/Form/ModuleHookCreationForm.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\Hook;
 use Thelia\Model\HookQuery;
+use Thelia\Model\Map\HookI18nTableMap;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
@@ -128,10 +129,13 @@ class ModuleHookCreationForm extends BaseForm
         $choices = array();
         $hooks = HookQuery::create()
             ->filterByActivate(true, Criteria::EQUAL)
+            ->joinWithI18n($this->translator->getLocale())
+            ->orderBy('HookI18n.title', Criteria::ASC)
             ->find();
+
         /** @var Hook $hook */
         foreach ($hooks as $hook) {
-            $choices[$hook->getId()] = $hook->getTitle();
+            $choices[$hook->getId()] = $hook->getTitle() . ' (code ' . $hook->getCode() . ')';
         }
 
         return $choices;

--- a/core/lib/Thelia/Form/ModuleHookCreationForm.php
+++ b/core/lib/Thelia/Form/ModuleHookCreationForm.php
@@ -19,7 +19,6 @@ use Symfony\Component\Validator\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\Hook;
 use Thelia\Model\HookQuery;
-use Thelia\Model\Map\HookI18nTableMap;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
@@ -59,7 +58,7 @@ class ModuleHookCreationForm extends BaseForm
                         new NotBlank()
                     ),
                     "label" => Translator::getInstance()->trans("Hook"),
-                    "label_attr" => array("for" => "locale_create")
+                    "label_attr" => array("for" => "hook_id")
                 )
             )
             ->add(

--- a/core/lib/Thelia/Form/ModuleHookModificationForm.php
+++ b/core/lib/Thelia/Form/ModuleHookModificationForm.php
@@ -32,14 +32,6 @@ class ModuleHookModificationForm extends ModuleHookCreationForm
 
         $this->formBuilder
             ->add("id", "hidden", array("constraints" => array(new GreaterThan(array('value' => 0)))))
-            ->add("hook_id", "choice", array(
-                "choices" => $this->getHookChoices(),
-                "constraints" => array(
-                    new NotBlank()
-                ),
-                "label" => Translator::getInstance()->trans("Hook"),
-                "label_attr" => array("for" => "locale_create")
-            ))
             ->add("active", "checkbox", array(
                 "label" => Translator::getInstance()->trans("Active"),
                 "required" => false,
@@ -48,20 +40,6 @@ class ModuleHookModificationForm extends ModuleHookCreationForm
                 )
             ))
         ;
-    }
-
-    protected function getHookChoices()
-    {
-        $choices = array();
-        $hooks = HookQuery::create()
-            ->filterByActivate(true, Criteria::EQUAL)
-            ->find();
-        /** @var Hook $hook */
-        foreach ($hooks as $hook) {
-            $choices[$hook->getId()] = $hook->getTitle();
-        }
-
-        return $choices;
     }
 
     public function getName()

--- a/templates/backOffice/default/hooks.html
+++ b/templates/backOffice/default/hooks.html
@@ -220,8 +220,6 @@
             {/loop}
         {/custom_render_form_field}
 
-        {if $form_error}<div class="alert alert-danger">{$form_error_message}</div>{/if}
-
         {render_form_field form=$form field='code'}
         {render_form_field form=$form field='type'}
         {render_form_field form=$form field='native' value="0"}

--- a/templates/backOffice/default/module-hooks.html
+++ b/templates/backOffice/default/module-hooks.html
@@ -209,7 +209,7 @@ form_error_message = $form_error_message
 
     dialog_id       = "delete_module_dialog"
     dialog_title    = {intl l="Remove a module from a hook"}
-    dialog_message  = {intl l="Do you really want to remove this module ?"}
+    dialog_message  = {intl l="Do you really want to remove this module from this hook ?"}
 
     form_action         = {token_url path='/admin/module-hooks/delete'}
     form_content        = {$smarty.capture.delete_module_dialog nofilter}

--- a/templates/backOffice/default/module-hooks.html
+++ b/templates/backOffice/default/module-hooks.html
@@ -99,7 +99,7 @@
                     data-code="{$CODE}"
                     >
                     <div class="title title-without-tabs">
-                        {$ID}. {$TITLE}
+                        {$ID}. {$TITLE} (<span class="text-lowercase">{$CODE}</span>)
                         <div class="text-right pull-right">
                             <a class="btn btn-primary action-edit-hook-btn" href="{url path="/admin/hook/update/{$ID}" }" title="{intl l='Change this hook'}">
                                 <span class="glyphicon glyphicon-edit"></span>
@@ -168,8 +168,6 @@
     {* on success, redirect to the edition page, _ID_ is replaced with the created object ID, see controller  *}
     <input type="hidden" name="{$name}" value="{url path='/admin/module-hook/update/_ID_'}" />
     {/form_field}
-
-    {if $form_error}<div class="alert alert-danger">{$form_error_message}</div>{/if}
 
     {render_form_field form=$form field="module_id"}
     {render_form_field form=$form field="hook_id"}


### PR DESCRIPTION
This PR fixes creation and update of a module hook, and offers a better hook select menu in create and update Module Hook (#1087)