### PR TITLE
Images may be zoomed before crop, to match required image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update Admin Logs to add the resource ID when available.
 - Add render smarty function, that executes the controller given in the action parameter.
 - Allow modules to use document and image loop with the ```query_namespace``` argument
+- Enable image zoom in image loop before cropping to guarantee that the resulting image will match the required size, even if the original image is smaller. This feature is active only if the ```allow_zoom``` parameter is true.
 
 # 2.1.2
 

--- a/core/lib/Thelia/Core/Event/Image/ImageEvent.php
+++ b/core/lib/Thelia/Core/Event/Image/ImageEvent.php
@@ -77,13 +77,16 @@ class ImageEvent extends CachedFileEvent
      */
     protected $imageObject;
 
+    /** @var  bool */
+    protected $allowZoom;
+
     /**
      * @return boolean true if the required image is the original image (resize_mode and background_color are not significant)
      */
     public function isOriginalImage()
     {
         return empty($this->width) && empty($this->height) /* && empty($this->resize_mode) && empty($this->background_color) not significant */
-                && empty($this->effects) && empty($this->rotation) && empty($this->quality);
+        && empty($this->effects) && empty($this->rotation) && empty($this->quality);
     }
 
     /**
@@ -234,5 +237,24 @@ class ImageEvent extends CachedFileEvent
     public function getImageObject()
     {
         return $this->imageObject;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowZoom()
+    {
+        return $this->allowZoom;
+    }
+
+    /**
+     * @param bool $allowZoom
+     * @return $this
+     */
+    public function setAllowZoom($allowZoom)
+    {
+        $this->allowZoom = $allowZoom;
+
+        return $this;
     }
 }

--- a/core/lib/Thelia/Core/Template/Loop/Image.php
+++ b/core/lib/Thelia/Core/Template/Loop/Image.php
@@ -12,6 +12,7 @@
 
 namespace Thelia\Core\Template\Loop;
 
+use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Thelia\Core\Template\Element\BaseI18nLoop;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Loop\Argument\Argument;
@@ -82,7 +83,8 @@ class Image extends BaseI18nLoop implements PropelSearchLoopInterface
             Argument::createIntTypeArgument('source_id'),
             Argument::createBooleanTypeArgument('force_return', true),
             Argument::createBooleanTypeArgument('ignore_processing_errors', true),
-            Argument::createAnyTypeArgument('query_namespace', 'Thelia\\Model')
+            Argument::createAnyTypeArgument('query_namespace', 'Thelia\\Model'),
+            Argument::createBooleanTypeArgument('allow_zoom', false)
         );
 
         // Add possible image sources
@@ -170,7 +172,9 @@ class Image extends BaseI18nLoop implements PropelSearchLoopInterface
             $id = $this->getId();
 
             if (is_null($source_id) && is_null($id)) {
-                throw new \InvalidArgumentException("If 'source' argument is specified, 'id' or 'source_id' argument should be specified");
+                throw new \InvalidArgumentException(
+                    "If 'source' argument is specified, 'id' or 'source_id' argument should be specified"
+                );
             }
 
             $search = $this->createSearchQuery($source, $source_id);
@@ -196,7 +200,9 @@ class Image extends BaseI18nLoop implements PropelSearchLoopInterface
         }
 
         if ($search == null) {
-            throw new \InvalidArgumentException(sprintf("Unable to find image source. Valid sources are %s", implode(',', $this->possible_sources)));
+            throw new \InvalidArgumentException(
+                sprintf("Unable to find image source. Valid sources are %s", implode(',', $this->possible_sources))
+            );
         }
 
         return $search;
@@ -243,6 +249,8 @@ class Image extends BaseI18nLoop implements PropelSearchLoopInterface
         $background_color = $this->getBackgroundColor();
         $quality = $this->getQuality();
         $effects = $this->getEffects();
+
+        $event->setAllowZoom($this->getAllowZoom());
 
         if (! is_null($effects)) {
             $effects = explode(',', $effects);


### PR DESCRIPTION
This feature is enabled by setting the new Image loop `allow_zoom` parameter to 1. This parameter is off by default.