### PR TITLE
Throw assets errors when in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add render smarty function, that executes the controller given in the action parameter.
 - Allow modules to use document and image loop with the ```query_namespace``` argument
 - Enable image zoom in image loop before cropping to guarantee that the resulting image will match the required size, even if the original image is smaller. This feature is active only if the ```allow_zoom``` parameter is true.
+- When in development mode, an exception is thrown when an error occurs when processing assets, thus helping to diagnose missing files, LESS syntax errors, and the like.
 
 # 2.1.2
 

--- a/core/lib/Thelia/Core/Template/Assets/AssetManagerInterface.php
+++ b/core/lib/Thelia/Core/Template/Assets/AssetManagerInterface.php
@@ -54,4 +54,9 @@ interface AssetManagerInterface
      * @return string The URL to the generated asset file.
      */
     public function processAsset($assetSource, $assetDirectoryBase, $webAssetsDirectoryBase, $webAssetsTemplate, $webAssetsKey, $outputUrl, $assetType, $filters, $debug);
+
+    /**
+     * @return bool true if the AssetManager was started in debug mode
+     */
+    public function isDebugMode();
 }

--- a/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
+++ b/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
@@ -333,4 +333,12 @@ class AsseticAssetManager implements AssetManagerInterface
 
         return rtrim($outputUrl, '/') . '/' . trim($outputRelativeWebPath, '/') . '/' . trim($assetFileDirectoryInAssetDirectory, '/') . '/' . ltrim($assetTargetFilename, '/');
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isDebugMode()
+    {
+        return $this->debugMode;
+    }
 }


### PR DESCRIPTION
When in development mode, an exception is thrown when an error occurs when processing assets, thus helping to diagnose missing files, LESS syntax errors, and the like.

In production mode, nothing changes.

A LESS syntax error

![image 685](https://cloud.githubusercontent.com/assets/2197734/5955821/4e5b7768-a7a7-11e4-83ad-314d81ca5cee.png)

Missing asset : 

![image 686](https://cloud.githubusercontent.com/assets/2197734/5955838/72663620-a7a7-11e4-86ff-f6496c03bf0c.png)
