### PR TITLE
Properly catch AuthenticationException and redirect the response on the good route. Fix #1108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add missing static keyword for ```Thelia\Core\HttpFoundation\JsonResponse::createError```
 - Do not register previous url on XmlHttpRequest
 - Fix deploy image directory destination
+- Fix redirect response if a AuthenticationException is catched
 
 # 2.1.1
 

--- a/core/lib/Thelia/Action/HttpException.php
+++ b/core/lib/Thelia/Action/HttpException.php
@@ -118,7 +118,7 @@ class HttpException extends BaseAction implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            KernelEvents::EXCEPTION => array("checkHttpException", 128),
+            KernelEvents::EXCEPTION => ["checkHttpException", 128],
         );
     }
 }

--- a/core/lib/Thelia/Core/EventListener/ViewListener.php
+++ b/core/lib/Thelia/Core/EventListener/ViewListener.php
@@ -78,9 +78,6 @@ class ViewListener implements EventSubscriberInterface
             }
         } catch (ResourceNotFoundException $e) {
             throw new NotFoundHttpException();
-        } catch (AuthenticationException $ex) {
-            // Redirect to the login template
-            $response = RedirectResponse::create($this->container->get('thelia.url.manager')->viewUrl($ex->getLoginTemplate()));
         } catch (OrderException $e) {
             switch ($e->getCode()) {
                 case OrderException::CART_EMPTY:


### PR DESCRIPTION
When a AuthenticationException is thrown, the ErrorListener will catch it and generate the good RedirectResponse.