### PR TITLE
Fix domain translation in hook modules

### DIFF
--- a/local/modules/HookContact/Hook/FrontHook.php
+++ b/local/modules/HookContact/Hook/FrontHook.php
@@ -30,7 +30,7 @@ class FrontHook extends BaseHook {
             $event->add(array(
                 "id" => "contact-footer-body",
                 "class" => "contact",
-                "title" => $this->trans("Contact", array(), "hookcontact.fo.default"),
+                "title" => $this->trans("Contact", array(), "hookcontact"),
                 "content" => $content
             ));
         }

--- a/local/modules/HookLinks/Hook/FrontHook.php
+++ b/local/modules/HookLinks/Hook/FrontHook.php
@@ -30,7 +30,7 @@ class FrontHook extends BaseHook {
             $event->add(array(
                 "id" => "links-footer-body",
                 "class" => "default",
-                "title" => $this->trans("Useful links", array(), "hooklinks.fo.default"),
+                "title" => $this->trans("Useful links", array(), "hooklinks"),
                 "content" => $content
             ));
         }

--- a/local/modules/HookNavigation/Hook/FrontHook.php
+++ b/local/modules/HookNavigation/Hook/FrontHook.php
@@ -36,7 +36,7 @@ class FrontHook extends BaseHook {
             $event->add(array(
                 "id" => "navigation-footer-body",
                 "class" => "links",
-                "title" => $this->trans("Latest articles", array(), "hooknavigation.fo.default"),
+                "title" => $this->trans("Latest articles", array(), "hooknavigation"),
                 "content" => $content
             ));
         }

--- a/local/modules/HookNewsletter/Hook/FrontHook.php
+++ b/local/modules/HookNewsletter/Hook/FrontHook.php
@@ -30,7 +30,7 @@ class FrontHook extends BaseHook {
             $event->add(array(
                 "id" => "newsletter-footer-body",
                 "class" => "newsletter",
-                "title" => $this->trans("Newsletter", array(), "hooknewsletter.fo.default"),
+                "title" => $this->trans("Newsletter", array(), "hooknewsletter"),
                 "content" => $content
             ));
         }

--- a/local/modules/HookNewsletter/templates/frontOffice/default/main-footer-body.html
+++ b/local/modules/HookNewsletter/templates/frontOffice/default/main-footer-body.html
@@ -1,13 +1,13 @@
-<p id="newsletter-describe">{intl l="Sign up to receive our latest news." d="newsletter.fo.default"}</p>
+<p id="newsletter-describe">{intl l="Sign up to receive our latest news." d="hooknewsletter.fo.default"}</p>
 {form name="thelia.front.newsletter"}
 <form id="form-newsletter-mini" action="{url path="/newsletter"}" method="post">
 {form_hidden_fields form=$form}
 {form_field form=$form field="email"}
 <div class="form-group">
-    <label for="{$label_attr.for}-mini">{intl l="Email address" d="newsletter.fo.default"}</label>
-    <input type="email" name="{$name}" id="{$label_attr.for}-mini" class="form-control" maxlength="255" placeholder="{intl l="Your email address" d="newsletter.fo.default"}" aria-describedby="newsletter-describe" {if $required} aria-required="true" required{/if} autocomplete="off">
+    <label for="{$label_attr.for}-mini">{intl l="Email address" d="hooknewsletter.fo.default"}</label>
+    <input type="email" name="{$name}" id="{$label_attr.for}-mini" class="form-control" maxlength="255" placeholder="{intl l="Your email address" d="hooknewsletter.fo.default"}" aria-describedby="newsletter-describe" {if $required} aria-required="true" required{/if} autocomplete="off">
 </div>
 {/form_field}
-<button type="submit" class="btn btn-subscribe">{intl l="Subscribe" d="newsletter.fo.default"}</button>
+<button type="submit" class="btn btn-subscribe">{intl l="Subscribe" d="hooknewsletter.fo.default"}</button>
 </form>
 {/form}

--- a/local/modules/HookSocial/Hook/FrontHook.php
+++ b/local/modules/HookSocial/Hook/FrontHook.php
@@ -30,7 +30,7 @@ class FrontHook extends BaseHook {
             $event->add(array(
                 "id" => "social-footer-body",
                 "class" => "social",
-                "title" => $this->trans("Follow us", array(), "hooksocial.fo.default"),
+                "title" => $this->trans("Follow us", array(), "hooksocial"),
                 "content" => $content
             ));
         }


### PR DESCRIPTION
Remove ".fo.default" in FrontHook.php in 
- HookContact
- HookLinks
- HookNavigation
- HookNewsletter
- HookSocial

Replace "newsletter" by "hooknewsletter" in newsletter hook domains.