### PR TITLE
verify backup directory permission before trying to make a backup. Fix #1123

### DIFF
--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -178,6 +178,7 @@ class Update
         $database = new Database($this->connection);
 
         $this->backupFile = THELIA_ROOT . $this->backupDir . 'update.sql';
+        $backupDir = THELIA_ROOT . $this->backupDir;
 
         $fs = new Filesystem();
 
@@ -185,8 +186,12 @@ class Update
             $this->log('debug', sprintf('Backup database to file : %s', $this->backupFile));
 
             // test if backup dir exists
-            if (!$fs->exists(THELIA_ROOT . $this->backupDir)) {
-                $fs->mkdir(THELIA_ROOT . $this->backupDir);
+            if (!$fs->exists($backupDir)) {
+                $fs->mkdir($backupDir);
+            }
+
+            if (!is_writable($backupDir)) {
+                throw new \RuntimeException(sprintf('impossible to write in directory : %s', $backupDir));
             }
 
             // test if backup file already exists
@@ -198,10 +203,8 @@ class Update
             $database->backupDb($this->backupFile);
         } catch (\Exception $ex) {
             $this->log('error', sprintf('error during backup process with message : %s', $ex->getMessage()));
-            return false;
+            throw $ex;
         }
-
-        return true;
     }
 
     /**

--- a/setup/update.php
+++ b/setup/update.php
@@ -124,8 +124,11 @@ $updateError = null;
 try {
     // backup db
     if (true === $backup) {
-        if (false === $update->backupDb()) {
-            echo PHP_EOL . 'Sorry, your database can\'t be backed up. Try to do it manually.' . PHP_EOL;
+        try {
+            $update->backupDb();
+            echo sprintf(PHP_EOL . 'Your database has been backed up. The sql file : %s'. PHP_EOL, $update->getBackupFile());
+        } catch (\Exception $e) {
+            echo PHP_EOL . 'Sorry, your database can\'t be backed up. Reason : ' . $e->getMessage() . PHP_EOL;
             exit(4);
         }
     }

--- a/web/install/updater.php
+++ b/web/install/updater.php
@@ -51,17 +51,8 @@ $backup = (isset($_GET['backup']) && $_GET['backup'] == 1);
 
             // Backup
             if ($backup) {
-                if (false === $update->backupDb()) {
-                    $continue = false ;
-                    ?>
-                    <div class="alert alert-danger">
-                        <p><?php
-                            echo $trans->trans(
-                                'Sorry, your database can\'t be backed up. Try to do it manually'
-                            );
-                            ?></p>
-                    </div><?php
-                } else {
+                try {
+                    $update->backupDb();
                     ?>
                     <div class="alert alert-success">
                     <p><?php
@@ -70,6 +61,16 @@ $backup = (isset($_GET['backup']) && $_GET['backup'] == 1);
                             [
                                 '%file' => $update->getBackupFile()
                             ]
+                        );
+                        ?></p>
+                    </div><?php
+                } catch (\Exception $e) {
+                    $continue = false ;
+                    ?>
+                    <div class="alert alert-danger">
+                    <p><?php
+                        echo $trans->trans(
+                            'Sorry, your database can\'t be backed up. Reason : ' . $e->getMessage()
                         );
                         ?></p>
                     </div><?php


### PR DESCRIPTION
the permission on the backup directory was not made before launching it.

Now if it's impossible to write in this directory, an error message is displayed.