### PR TITLE
Fixed option hash generation

### DIFF
--- a/core/lib/Thelia/Core/Event/Image/ImageEvent.php
+++ b/core/lib/Thelia/Core/Event/Image/ImageEvent.php
@@ -96,7 +96,7 @@ class ImageEvent extends CachedFileEvent
     {
         return md5(
             $this->width . $this->height . $this->resize_mode . $this->background_color . implode(',', $this->effects)
-            . $this->rotation
+            . $this->rotation . $this->allowZoom
         );
     }
 


### PR DESCRIPTION
The allow_zoom parameter was missing from the image hash options generation.