### PR TITLE
Customer confirm email and customer change email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Add parameter "page_param_name" for template admin pagination.html. if "page_param_name" is empty, then the name of the parameter is "page"
 - Add "Refunded" order status
 - Add environment specific config file loading in modules
+- Add the possibility for customers to change their email, backoffice configuration variables customer_change_email
+- Add confirmation email for customers, backoffice configuration variables customer_confirm_email
 
 # 2.1.2
 

--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -94,7 +94,7 @@ class Customer extends BaseAction implements EventSubscriberInterface
         }
 
         if ($event->getEmail() !== null) {
-            $customer->setEmail($event->getEmail());
+            $customer->setEmail($event->getEmail(), $event->getEmailUpdateAllowed());
         }
 
         if ($event->getPassword() !== null) {

--- a/core/lib/Thelia/Form/Api/Customer/CustomerCreateForm.php
+++ b/core/lib/Thelia/Form/Api/Customer/CustomerCreateForm.php
@@ -27,6 +27,7 @@ class CustomerCreateForm extends BaseCustomerCreateForm
         parent::buildForm();
 
         $this->formBuilder
+            ->remove('email_confirm')
             ->remove('password_confirm')
             ->remove('agreed')
             ->add('lang', 'integer', [

--- a/core/lib/Thelia/Form/CustomerCreateForm.php
+++ b/core/lib/Thelia/Form/CustomerCreateForm.php
@@ -86,6 +86,23 @@ class CustomerCreateForm extends AddressCreateForm
                 ),
                 "required" => false
             ));
+
+        //confirm email
+        if (intval(ConfigQuery::read("customer_confirm_email", 0))) {
+            $this->formBuilder->add("email_confirm", "email", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Email(),
+                    new Constraints\Callback(array("methods" => array(
+                        array($this, "verifyEmailField")
+                    )))
+                ),
+                "label" => Translator::getInstance()->trans("Confirm Email Address"),
+                "label_attr" => array(
+                    "for" => "email_confirm"
+                )
+            ));
+        }
     }
 
     public function verifyPasswordField($value, ExecutionContextInterface $context)
@@ -94,6 +111,15 @@ class CustomerCreateForm extends AddressCreateForm
 
         if ($data["password"] != $data["password_confirm"]) {
             $context->addViolation(Translator::getInstance()->trans("password confirmation is not the same as password field"));
+        }
+    }
+
+    public function verifyEmailField($value, ExecutionContextInterface $context)
+    {
+        $data = $context->getRoot()->getData();
+
+        if ($data["email"] != $data["email_confirm"]) {
+            $context->addViolation(Translator::getInstance()->trans("email confirmation is not the same as email field"));
         }
     }
 

--- a/core/lib/Thelia/Form/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/CustomerUpdateForm.php
@@ -13,6 +13,7 @@
 namespace Thelia\Form;
 
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
 
 /**
@@ -73,11 +74,24 @@ class CustomerUpdateForm extends BaseForm
             ))
             ->add("email", "email", array(
                 "constraints" => array(
-                    new Constraints\NotBlank()
+                    new Constraints\NotBlank(),
+                    new Constraints\Email()
                 ),
                 "label" => Translator::getInstance()->trans("Email address"),
                 "label_attr" => array(
                     "for" => "email"
+                )
+            ))
+            ->add("email_confirm", "email", array(
+                "constraints" => array(
+                    new Constraints\Email(),
+                    new Constraints\Callback(array("methods" => array(
+                        array($this, "verifyEmailField")
+                    )))
+                ),
+                "label" => Translator::getInstance()->trans("Confirm Email address"),
+                "label_attr" => array(
+                    "for" => "email_confirm"
                 )
             ))
             ->add("password", "text", array(
@@ -178,5 +192,14 @@ class CustomerUpdateForm extends BaseForm
     public function getName()
     {
         return "thelia_customer_update";
+    }
+
+    public function verifyEmailField($value, ExecutionContextInterface $context)
+    {
+        $data = $context->getRoot()->getData();
+
+        if (isset($data["email_confirm"]) && $data["email"] != $data["email_confirm"]) {
+            $context->addViolation(Translator::getInstance()->trans("email confirmation is not the same as email field"));
+        }
     }
 }

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -335,7 +335,9 @@ class CustomerController extends BaseFrontController
 
                 $configCustomerChangeEmail = intval(ConfigQuery::read('customer_change_email', 0));
 
-                if (!$configCustomerChangeEmail) {
+                if ($configCustomerChangeEmail) {
+                    $customerChangeEvent->setEmailUpdateAllowed(true);
+                } else {
                     $customerChangeEvent->setEmailUpdateAllowed(false);
                 }
 

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -252,6 +252,7 @@ class CustomerController extends BaseFrontController
             'firstname'    => $customer->getFirstName(),
             'lastname'     => $customer->getLastName(),
             'email'        => $customer->getEmail(),
+            'email_confirm'        => $customer->getEmail(),
             'newsletter'   => null !== NewsletterQuery::create()->findOneByEmail($customer->getEmail()),
         );
 

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -333,13 +333,7 @@ class CustomerController extends BaseFrontController
                 $customerChangeEvent = $this->createEventInstance($form->getData());
                 $customerChangeEvent->setCustomer($customer);
 
-                $configCustomerChangeEmail = intval(ConfigQuery::read('customer_change_email', 0));
-
-                if ($configCustomerChangeEmail) {
-                    $customerChangeEvent->setEmailUpdateAllowed(true);
-                } else {
-                    $customerChangeEvent->setEmailUpdateAllowed(false);
-                }
+                $customerChangeEvent->setEmailUpdateAllowed((intval(ConfigQuery::read('customer_change_email', 0))) ? true : false);
 
                 $this->dispatch(TheliaEvents::CUSTOMER_UPDATEPROFILE, $customerChangeEvent);
 

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -324,6 +324,7 @@ class CustomerController extends BaseFrontController
             $customerProfileUpdateForm = new CustomerProfileUpdateForm($this->getRequest());
 
             try {
+                /** @var Customer $customer */
                 $customer = $this->getSecurityContext()->getCustomerUser();
                 $newsletterOldEmail = $customer->getEmail();
 
@@ -331,8 +332,13 @@ class CustomerController extends BaseFrontController
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
                 $customerChangeEvent->setCustomer($customer);
-                // We do not allow customer email modification
-                $customerChangeEvent->setEmailUpdateAllowed(false);
+
+                $configCustomerChangeEmail = intval(ConfigQuery::read('customer_change_email', 0));
+
+                if (!$configCustomerChangeEmail) {
+                    $customerChangeEvent->setEmailUpdateAllowed(false);
+                }
+
                 $this->dispatch(TheliaEvents::CUSTOMER_UPDATEPROFILE, $customerChangeEvent);
 
                 $updatedCustomer = $customerChangeEvent->getCustomer();

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -151,7 +151,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
 (36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
-(36, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
+(37, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -71,7 +71,8 @@ INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updat
 ('error_message.show', '1', 0, 0, NOW(), NOW()),
 ('error_message.page_name', 'error.html', 0, 0, NOW(), NOW()),
 
-('customer_change_email', '0', 0, 0, NOW(), NOW())
+('customer_change_email', '0', 0, 0, NOW(), NOW()),
+('customer_confirm_email', '1', 0, 0, NOW(), NOW())
 ;
 
 
@@ -113,7 +114,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'en_US', 'Name of the cart cookie', NULL, NULL, NULL),
 (35, 'en_US', 'Life time of the cart cookie in the customer browser, in seconds', NULL, NULL, NULL),
 (36, 'en_US', 'Life time of the session cookie in the customer browser, in seconds', NULL, NULL, NULL),
-(37, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(37, 'en_US', 'Allow customers to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(38, 'en_US', 'Ask the customers to confirm their email, 1 for yes, 0 for no', NULL, NULL, NULL),
 
 (1, 'fr_FR', 'Vérifier la présence de produits en stock (1) ou l''ignorer (0) lors de l''affichage et la modification des quantités commandées', NULL, NULL, NULL),
 (2, 'fr_FR', 'Nom du modèle de front-office actif', NULL, NULL, NULL),
@@ -151,7 +153,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
 (36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
-(37, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
+(37, 'fr_FR', 'Permettre aux utilisateurs de changer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
+(38, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -69,7 +69,9 @@ INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updat
 
 ('allow_slash_ended_uri', '1', 0, 0, NOW(), NOW()),
 ('error_message.show', '1', 0, 0, NOW(), NOW()),
-('error_message.page_name', 'error.html', 0, 0, NOW(), NOW())
+('error_message.page_name', 'error.html', 0, 0, NOW(), NOW()),
+
+('customer_change_email', '0', 0, 0, NOW(), NOW())
 ;
 
 
@@ -111,6 +113,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'en_US', 'Name of the cart cookie', NULL, NULL, NULL),
 (35, 'en_US', 'Life time of the cart cookie in the customer browser, in seconds', NULL, NULL, NULL),
 (36, 'en_US', 'Life time of the session cookie in the customer browser, in seconds', NULL, NULL, NULL),
+(37, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
 
 (1, 'fr_FR', 'Vérifier la présence de produits en stock (1) ou l''ignorer (0) lors de l''affichage et la modification des quantités commandées', NULL, NULL, NULL),
 (2, 'fr_FR', 'Nom du modèle de front-office actif', NULL, NULL, NULL),
@@ -147,7 +150,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (33, 'fr_FR', 'Utiliser un cookie persistant pour memoriser le panier du client', NULL, NULL, NULL),
 (34, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
-(36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL)
+(36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
+(36, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -154,7 +154,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
 (36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
 (37, 'fr_FR', 'Permettre aux utilisateurs de changer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
-(38, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
+(38, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/update/sql/2.2.0-alpha1.sql
+++ b/setup/update/sql/2.2.0-alpha1.sql
@@ -34,14 +34,17 @@ INSERT INTO  `order_status_i18n` VALUES
 
 ALTER TABLE `admin_log` ADD `resource_id` INTEGER AFTER `resource` ;
 
-INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
-('customer_change_email', '0', 0, 0, NOW(), NOW())
+-- new config
+
+SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
+
+INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
+(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW())
 ;
 
-SELECT @max := MAX(`id`) FROM `config`;
-
 INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
-(@max, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
-(@max, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+(@max_id + 1, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 1, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/sql/2.2.0-alpha1.sql
+++ b/setup/update/sql/2.2.0-alpha1.sql
@@ -34,4 +34,14 @@ INSERT INTO  `order_status_i18n` VALUES
 
 ALTER TABLE `admin_log` ADD `resource_id` INTEGER AFTER `resource` ;
 
+INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
+('customer_change_email', '0', 0, 0, NOW(), NOW())
+;
+
+SELECT @max := MAX(`id`) FROM `config`;
+
+INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
+(@max, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/sql/2.2.0-alpha1.sql
+++ b/setup/update/sql/2.2.0-alpha1.sql
@@ -39,12 +39,16 @@ ALTER TABLE `admin_log` ADD `resource_id` INTEGER AFTER `resource` ;
 SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
 
 INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
-(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW())
+(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW()),
+(@max_id + 2, 'customer_confirm_email', '0', 0, 0, NOW(), NOW())
 ;
 
 INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
-(@max_id + 1, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
-(@max_id + 1, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+(@max_id + 1, 'en_US', 'Allow customers to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 1, 'fr_FR', 'Permettre aux clients de changer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
+(@max_id + 2, 'en_US', 'Ask the customers to confirm their email, 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 2, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
+;
 
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -86,10 +86,10 @@
                                 </div>
                             </div><!--/.form-group-->
                         {/form_field}
-                        {form_field form=$form field="email"}
 
                         {assign var="customer_change_email" value={config key="customer_change_email"}}
 
+                        {form_field form=$form field="email"}
                         <div class="form-group group-email {if $error}has-error{/if}">
                             <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
 
@@ -105,6 +105,22 @@
                             </div>
                         </div><!--/.form-group-->
                         {/form_field}
+
+                        {if {config key="customer_confirm_email"} && $customer_change_email}
+                        {form_field form=$form field="email_confirm"}
+                            <div class="form-group group-email {if $error}has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
+
+                                <div class="control-input">
+                                    <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email confirm"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
+                                    {if $error }
+                                        <span class="help-block">{$message}</span>
+                                        {assign var="error_focus" value="true"}
+                                    {/if}
+                                </div>
+                            </div><!--/.form-group-->
+                        {/form_field}
+                        {/if}
                     </div>
                 </fieldset>
 

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -95,6 +95,9 @@
 
                             <div class="control-input">
                                 <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if} {if !$customer_change_email}disabled{/if}>
+                                {if !$customer_change_email}
+                                    <div class="alert alert-info" role="alert">{intl l="If you want to change your email, please contact us."} <strong><a href="{url path="/contact"}" title="{intl l="Contact page"}">{intl l="Contact page"}</a></strong></div>
+                                {/if}
                                 {if $error }
                                     <span class="help-block">{$message}</span>
                                     {assign var="error_focus" value="true"}

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -87,11 +87,14 @@
                             </div><!--/.form-group-->
                         {/form_field}
                         {form_field form=$form field="email"}
+
+                        {assign var="customer_change_email" value={config key="customer_change_email"}}
+
                         <div class="form-group group-email {if $error}has-error{/if}">
                             <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
 
                             <div class="control-input">
-                                <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if} disabled>
+                                <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if} {if !$customer_change_email}disabled{/if}>
                                 {if $error }
                                     <span class="help-block">{$message}</span>
                                     {assign var="error_focus" value="true"}

--- a/templates/frontOffice/default/register.html
+++ b/templates/frontOffice/default/register.html
@@ -93,6 +93,21 @@
                             </div>
                         </div><!--/.form-group-->
                         {/form_field}
+                        {if {config key="customer_confirm_email"}}
+                        {form_field form=$form field="email_confirm"}
+                            <div class="form-group group-email{if $error} has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
+
+                                <div class="control-input">
+                                    <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email confirm"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
+                                    {if $error }
+                                        <span class="help-block">{$message}</span>
+                                        {assign var="error_focus" value="true"}
+                                    {/if}
+                                </div>
+                            </div><!--/.form-group-->
+                        {/form_field}
+                        {/if}
                         {form_field form=$form field="phone"}
                             <div class="form-group group-phone{if $error} has-error{/if}">
                                 <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>

--- a/tests/functionnal/casperjs/exe/front/20_register.js
+++ b/tests/functionnal/casperjs/exe/front/20_register.js
@@ -53,6 +53,7 @@ casper.test.begin('Register', 15, function suite(test) {
             'thelia_customer_create[firstname]': 'thelia',
             'thelia_customer_create[lastname]': 'thelia',
             'thelia_customer_create[email]': 'test@thelia.net',
+            'thelia_customer_create[email_confirm]': 'test@thelia.net',
             'thelia_customer_create[phone]': '',
             'thelia_customer_create[cellphone]': '',
             'thelia_customer_create[company]': 'OpenStudio',
@@ -82,6 +83,7 @@ casper.test.begin('Register', 15, function suite(test) {
 
             this.fill('form#form-register', {
                 'thelia_customer_create[email]': newEmail,
+                'thelia_customer_create[email_confirm]': newEmail,
                 'thelia_customer_create[password]': 'thelia',
                 'thelia_customer_create[password_confirm]': 'thelia'
             }, false);


### PR DESCRIPTION
Hello,

Add the ability to ask customers to change and confirm their email.

configuration variable customer_confirm_email.
0 ==> no confirm
1 ==> confirm

configuration variable customer_change_email.
0 ==> no confirm
1 ==> confirm

For customer_confirm_email :
- Default config value 1 for new thelia install.
- Default config value 0 for thelia update, to keep compatibility with older templates.

For customer_change_email :
- Default config value 0

Cheers,

