### PR TITLE
Admin pagination, add param "page_param_name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add shop language choice on install wizard
 - Remove redundant * on product-edit
 - Add the possibility for customers to change their email, backoffice configuration variables customer_change_email
+- Add confirmation email for customers, backoffice configuration variables customer_confirm_email
 
 # 2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add confirmation modal on documents deletion
 - Add shop language choice on install wizard
 - Remove redundant * on product-edit
+- Add the possibility for customers to change their email, backoffice configuration variables customer_change_email
 
 # 2.1.2
 

--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -94,7 +94,7 @@ class Customer extends BaseAction implements EventSubscriberInterface
         }
 
         if ($event->getEmail() !== null) {
-            $customer->setEmail($event->getEmail());
+            $customer->setEmail($event->getEmail(), $event->getEmailUpdateAllowed());
         }
 
         if ($event->getPassword() !== null) {

--- a/core/lib/Thelia/Form/CustomerCreateForm.php
+++ b/core/lib/Thelia/Form/CustomerCreateForm.php
@@ -86,6 +86,23 @@ class CustomerCreateForm extends AddressCreateForm
                 ),
                 "required" => false
             ));
+
+        //confirm email
+        if (intval(ConfigQuery::read("customer_confirm_email", 0))) {
+            $this->formBuilder->add("email_confirm", "email", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Email(),
+                    new Constraints\Callback(array("methods" => array(
+                        array($this, "verifyEmailField")
+                    )))
+                ),
+                "label" => Translator::getInstance()->trans("Confirm Email Address"),
+                "label_attr" => array(
+                    "for" => "email_confirm"
+                )
+            ));
+        }
     }
 
     public function verifyPasswordField($value, ExecutionContextInterface $context)
@@ -94,6 +111,15 @@ class CustomerCreateForm extends AddressCreateForm
 
         if ($data["password"] != $data["password_confirm"]) {
             $context->addViolation(Translator::getInstance()->trans("password confirmation is not the same as password field"));
+        }
+    }
+
+    public function verifyEmailField($value, ExecutionContextInterface $context)
+    {
+        $data = $context->getRoot()->getData();
+
+        if ($data["email"] != $data["email_confirm"]) {
+            $context->addViolation(Translator::getInstance()->trans("email confirmation is not the same as email field"));
         }
     }
 

--- a/core/lib/Thelia/Form/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/CustomerUpdateForm.php
@@ -13,6 +13,7 @@
 namespace Thelia\Form;
 
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
 
 /**
@@ -73,11 +74,24 @@ class CustomerUpdateForm extends BaseForm
             ))
             ->add("email", "email", array(
                 "constraints" => array(
-                    new Constraints\NotBlank()
+                    new Constraints\NotBlank(),
+                    new Constraints\Email()
                 ),
                 "label" => Translator::getInstance()->trans("Email address"),
                 "label_attr" => array(
                     "for" => "email"
+                )
+            ))
+            ->add("email_confirm", "email", array(
+                "constraints" => array(
+                    new Constraints\Email(),
+                    new Constraints\Callback(array("methods" => array(
+                        array($this, "verifyEmailField")
+                    )))
+                ),
+                "label" => Translator::getInstance()->trans("Confirm Email address"),
+                "label_attr" => array(
+                    "for" => "email_confirm"
                 )
             ))
             ->add("password", "text", array(
@@ -178,5 +192,14 @@ class CustomerUpdateForm extends BaseForm
     public function getName()
     {
         return "thelia_customer_update";
+    }
+
+    public function verifyEmailField($value, ExecutionContextInterface $context)
+    {
+        $data = $context->getRoot()->getData();
+
+        if (isset($data["email_confirm"]) && $data["email"] != $data["email_confirm"]) {
+            $context->addViolation(Translator::getInstance()->trans("email confirmation is not the same as email field"));
+        }
     }
 }

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -324,6 +324,7 @@ class CustomerController extends BaseFrontController
             $customerProfileUpdateForm = new CustomerProfileUpdateForm($this->getRequest());
 
             try {
+                /** @var Customer $customer */
                 $customer = $this->getSecurityContext()->getCustomerUser();
                 $newsletterOldEmail = $customer->getEmail();
 
@@ -331,8 +332,9 @@ class CustomerController extends BaseFrontController
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
                 $customerChangeEvent->setCustomer($customer);
-                // We do not allow customer email modification
-                $customerChangeEvent->setEmailUpdateAllowed(false);
+
+                $customerChangeEvent->setEmailUpdateAllowed((intval(ConfigQuery::read('customer_change_email', 0))) ? true : false);
+
                 $this->dispatch(TheliaEvents::CUSTOMER_UPDATEPROFILE, $customerChangeEvent);
 
                 $updatedCustomer = $customerChangeEvent->getCustomer();

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -252,6 +252,7 @@ class CustomerController extends BaseFrontController
             'firstname'    => $customer->getFirstName(),
             'lastname'     => $customer->getLastName(),
             'email'        => $customer->getEmail(),
+            'email_confirm'        => $customer->getEmail(),
             'newsletter'   => null !== NewsletterQuery::create()->findOneByEmail($customer->getEmail()),
         );
 

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -71,7 +71,8 @@ INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updat
 ('error_message.show', '1', 0, 0, NOW(), NOW()),
 ('error_message.page_name', 'error.html', 0, 0, NOW(), NOW()),
 
-('customer_change_email', '0', 0, 0, NOW(), NOW())
+('customer_change_email', '0', 0, 0, NOW(), NOW()),
+('customer_confirm_email', '1', 0, 0, NOW(), NOW())
 ;
 
 
@@ -113,7 +114,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'en_US', 'Name of the cart cookie', NULL, NULL, NULL),
 (35, 'en_US', 'Life time of the cart cookie in the customer browser, in seconds', NULL, NULL, NULL),
 (36, 'en_US', 'Life time of the session cookie in the customer browser, in seconds', NULL, NULL, NULL),
-(37, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(37, 'en_US', 'Allow customers to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(38, 'en_US', 'Ask the customers to confirm their email, 1 for yes, 0 for no', NULL, NULL, NULL),
 
 (1, 'fr_FR', 'Vérifier la présence de produits en stock (1) ou l''ignorer (0) lors de l''affichage et la modification des quantités commandées', NULL, NULL, NULL),
 (2, 'fr_FR', 'Nom du modèle de front-office actif', NULL, NULL, NULL),
@@ -151,7 +153,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
 (36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
-(37, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
+(37, 'fr_FR', 'Permettre aux utilisateurs de changer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
+(38, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -69,7 +69,9 @@ INSERT INTO `config` (`name`, `value`, `secured`, `hidden`, `created_at`, `updat
 
 ('allow_slash_ended_uri', '1', 0, 0, NOW(), NOW()),
 ('error_message.show', '1', 0, 0, NOW(), NOW()),
-('error_message.page_name', 'error.html', 0, 0, NOW(), NOW())
+('error_message.page_name', 'error.html', 0, 0, NOW(), NOW()),
+
+('customer_change_email', '0', 0, 0, NOW(), NOW())
 ;
 
 
@@ -111,6 +113,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (34, 'en_US', 'Name of the cart cookie', NULL, NULL, NULL),
 (35, 'en_US', 'Life time of the cart cookie in the customer browser, in seconds', NULL, NULL, NULL),
 (36, 'en_US', 'Life time of the session cookie in the customer browser, in seconds', NULL, NULL, NULL),
+(37, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
 
 (1, 'fr_FR', 'Vérifier la présence de produits en stock (1) ou l''ignorer (0) lors de l''affichage et la modification des quantités commandées', NULL, NULL, NULL),
 (2, 'fr_FR', 'Nom du modèle de front-office actif', NULL, NULL, NULL),
@@ -147,7 +150,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 (33, 'fr_FR', 'Utiliser un cookie persistant pour memoriser le panier du client', NULL, NULL, NULL),
 (34, 'fr_FR', 'Nom du cookie de stockage du panier', NULL, NULL, NULL),
 (35, 'fr_FR', 'Durée de vie du cookie du panier dans le navigateur du client, en secondes', NULL, NULL, NULL),
-(36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL)
+(36, 'fr_FR', 'Durée de vie du cookie de la session dans le navigateur du client, en secondes', NULL, NULL, NULL),
+(37, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `created_at`, `updated_at`) VALUES

--- a/setup/update/sql/2.2.0-alpha1.sql
+++ b/setup/update/sql/2.2.0-alpha1.sql
@@ -29,12 +29,16 @@ ALTER TABLE `admin_log` ADD `resource_id` INTEGER AFTER `resource` ;
 SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
 
 INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
-(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW())
+(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW()),
+(@max_id + 2, 'customer_confirm_email', '0', 0, 0, NOW(), NOW())
 ;
 
 INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
-(@max_id + 1, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
-(@max_id + 1, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+(@max_id + 1, 'en_US', 'Allow customers to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 1, 'fr_FR', 'Permettre aux clients de changer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL),
+(@max_id + 2, 'en_US', 'Ask the customers to confirm their email, 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 2, 'fr_FR', 'Demander aux clients de confirmer leur email. 1 pour oui, 0 pour non', NULL, NULL, NULL)
+;
 
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/sql/2.2.0-alpha1.sql
+++ b/setup/update/sql/2.2.0-alpha1.sql
@@ -24,4 +24,17 @@ INSERT INTO  `hook_i18n` (`id`, `locale`, `title`, `description`, `chapo`) VALUE
 
 ALTER TABLE `admin_log` ADD `resource_id` INTEGER AFTER `resource` ;
 
+-- new config
+
+SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
+
+INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
+(@max_id + 1, 'customer_change_email', '0', 0, 0, NOW(), NOW())
+;
+
+INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `postscriptum`) VALUES
+(@max_id + 1, 'en_US', 'Allow users to change their email. 1 for yes, 0 for no', NULL, NULL, NULL),
+(@max_id + 1, 'fr_FR', 'Permettre aux utilisateurs de changer leurs email. 1 pour oui, 0 pour non', NULL, NULL, NULL);
+
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/templates/backOffice/default/includes/pagination.html
+++ b/templates/backOffice/default/includes/pagination.html
@@ -17,6 +17,10 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
     {$page_url="$page_url?"}
 {/if}
 
+{if !$page_param_name}
+    {assign var="page_param_name" value="page"}
+{/if}
+
 <div class="text-center">
     <ul class="pagination pagination-centered">
         {pageloop rel=$loop_ref limit=$max_page_count}
@@ -31,8 +35,8 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
 
             {if $PAGE == $START}
                 {if $has_prev}
-                    <li><a title="{intl l="Go to first page"}" href="{$page_url nofilter}page=1">&laquo;</a></li>
-                    <li><a title="{intl l="Go to previous page"}" href="{$page_url nofilter}page={$prev_page}">&lsaquo;</a></li>
+                    <li><a title="{intl l="Go to first page"}" href="{$page_url nofilter}{$page_param_name}=1">&laquo;</a></li>
+                    <li><a title="{intl l="Go to previous page"}" href="{$page_url nofilter}{$page_param_name}={$prev_page}">&lsaquo;</a></li>
 
                     {if $has_pages_before}
                         <li title="{intl l="More pages before"}" class="disabled"><a href="#">&hellip;</a></li>
@@ -45,7 +49,7 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
             {/if}
 
             {if $PAGE != $CURRENT}
-                <li><a href="{$page_url nofilter}page={$PAGE}">{$PAGE}</a></li>
+                <li><a href="{$page_url nofilter}{$page_param_name}={$PAGE}">{$PAGE}</a></li>
             {else}
                 <li class="active"><a href="#">{$PAGE}</a></li>
             {/if}
@@ -56,8 +60,8 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
                         <li title="{intl l="More pages after"}" class="disabled"><a href="#">&hellip;</a></li>
                     {/if}
 
-                    <li><a title="{intl l="Go to next page"}" href="{$page_url nofilter}page={$next_page}">&rsaquo;</a></li>
-                    <li><a title="{intl l="Go to last page"}" href="{$page_url nofilter}page={$last_page}">&raquo;</a></li>
+                    <li><a title="{intl l="Go to next page"}" href="{$page_url nofilter}{$page_param_name}={$next_page}">&rsaquo;</a></li>
+                    <li><a title="{intl l="Go to last page"}" href="{$page_url nofilter}{$page_param_name}={$last_page}">&raquo;</a></li>
 
                 {else}
                     <li class="disabled"><a href="#">&rsaquo;</a></li>

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -87,11 +87,17 @@
                             </div><!--/.form-group-->
                         {/form_field}
                         {form_field form=$form field="email"}
+
+                        {assign var="customer_change_email" value={config key="customer_change_email"}}
+
                         <div class="form-group group-email {if $error}has-error{/if}">
                             <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
 
                             <div class="control-input">
-                                <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if} disabled>
+                                <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if} {if !$customer_change_email}disabled{/if}>
+                                {if !$customer_change_email}
+                                    <div class="alert alert-info" role="alert">{intl l="If you want to change your email, please contact us."} <strong><a href="{url path="/contact"}" title="{intl l="Contact page"}">{intl l="Contact page"}</a></strong></div>
+                                {/if}
                                 {if $error }
                                     <span class="help-block">{$message}</span>
                                     {assign var="error_focus" value="true"}

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -86,10 +86,10 @@
                                 </div>
                             </div><!--/.form-group-->
                         {/form_field}
-                        {form_field form=$form field="email"}
 
                         {assign var="customer_change_email" value={config key="customer_change_email"}}
 
+                        {form_field form=$form field="email"}
                         <div class="form-group group-email {if $error}has-error{/if}">
                             <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
 
@@ -105,6 +105,22 @@
                             </div>
                         </div><!--/.form-group-->
                         {/form_field}
+
+                        {if {config key="customer_confirm_email"} && $customer_change_email}
+                        {form_field form=$form field="email_confirm"}
+                            <div class="form-group group-email {if $error}has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
+
+                                <div class="control-input">
+                                    <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email confirm"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
+                                    {if $error }
+                                        <span class="help-block">{$message}</span>
+                                        {assign var="error_focus" value="true"}
+                                    {/if}
+                                </div>
+                            </div><!--/.form-group-->
+                        {/form_field}
+                        {/if}
                     </div>
                 </fieldset>
 

--- a/templates/frontOffice/default/register.html
+++ b/templates/frontOffice/default/register.html
@@ -93,6 +93,21 @@
                             </div>
                         </div><!--/.form-group-->
                         {/form_field}
+                        {if {config key="customer_confirm_email"}}
+                        {form_field form=$form field="email_confirm"}
+                            <div class="form-group group-email{if $error} has-error{/if}">
+                                <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
+
+                                <div class="control-input">
+                                    <input type="email" name="{$name}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder email confirm"}" value="{$smarty.get.email|default:$value}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
+                                    {if $error }
+                                        <span class="help-block">{$message}</span>
+                                        {assign var="error_focus" value="true"}
+                                    {/if}
+                                </div>
+                            </div><!--/.form-group-->
+                        {/form_field}
+                        {/if}
                         {form_field form=$form field="phone"}
                             <div class="form-group group-phone{if $error} has-error{/if}">
                                 <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>


### PR DESCRIPTION
Hello,
Add param "page_param_name" in pagination.html for several pagination in the same page.
The param "page_param_name" change the name get variable. 
Default name "page".

Exemple : 
```smarty
{include
file = "includes/pagination.html"
loop_ref       = "order-list"
max_page_count = 10
page_param_anme = "order_page"
page_url  = "{url path="/admin/customer/update" customer_id=$customer_id}"
}
```
Cheers, 