### PR TITLE
Add param "page_param_name" for pagination.html and update customer-edit tpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add confirmation modal on documents deletion
 - Add shop language choice on install wizard
 - Remove redundant * on product-edit
+- Add parameter "page_param_name" for template admin pagination.html. if "page_param_name" is empty, then the name of the parameter is "page"
 
 # 2.1.2
 

--- a/templates/backOffice/default/customer-edit.html
+++ b/templates/backOffice/default/customer-edit.html
@@ -319,12 +319,11 @@
                                             <td colspan="7">
                                                 {include
                                                 file = "includes/pagination.html"
-
+                                                page_param_name = "order_page"
                                                 loop_ref       = "order-list"
                                                 max_page_count = 10
-                                                page_url       = "{url path="/admin/customer/update" customer_id=$customer_id}"
+                                                page_url       = "{url path="/admin/customer/update" customer_id=$customer_id page=$page}"
                                                 }
-
                                             </td>
                                         </tr>
                                         </tfoot>

--- a/templates/backOffice/default/includes/pagination.html
+++ b/templates/backOffice/default/includes/pagination.html
@@ -17,6 +17,10 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
     {$page_url="$page_url?"}
 {/if}
 
+{if !$page_param_name}
+    {assign var="page_param_name" value="page"}
+{/if}
+
 <div class="text-center">
     <ul class="pagination pagination-centered">
         {pageloop rel=$loop_ref limit=$max_page_count}
@@ -31,8 +35,8 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
 
             {if $PAGE == $START}
                 {if $has_prev}
-                    <li><a title="{intl l="Go to first page"}" href="{$page_url nofilter}page=1">&laquo;</a></li>
-                    <li><a title="{intl l="Go to previous page"}" href="{$page_url nofilter}page={$prev_page}">&lsaquo;</a></li>
+                    <li><a title="{intl l="Go to first page"}" href="{$page_url nofilter}{$page_param_name}=1">&laquo;</a></li>
+                    <li><a title="{intl l="Go to previous page"}" href="{$page_url nofilter}{$page_param_name}={$prev_page}">&lsaquo;</a></li>
 
                     {if $has_pages_before}
                         <li title="{intl l="More pages before"}" class="disabled"><a href="#">&hellip;</a></li>
@@ -45,7 +49,7 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
             {/if}
 
             {if $PAGE != $CURRENT}
-                <li><a href="{$page_url nofilter}page={$PAGE}">{$PAGE}</a></li>
+                <li><a href="{$page_url nofilter}{$page_param_name}={$PAGE}">{$PAGE}</a></li>
             {else}
                 <li class="active"><a href="#">{$PAGE}</a></li>
             {/if}
@@ -56,8 +60,8 @@ $page_url : the URL of the page. The parameter page=x is appended to this URL.
                         <li title="{intl l="More pages after"}" class="disabled"><a href="#">&hellip;</a></li>
                     {/if}
 
-                    <li><a title="{intl l="Go to next page"}" href="{$page_url nofilter}page={$next_page}">&rsaquo;</a></li>
-                    <li><a title="{intl l="Go to last page"}" href="{$page_url nofilter}page={$last_page}">&raquo;</a></li>
+                    <li><a title="{intl l="Go to next page"}" href="{$page_url nofilter}{$page_param_name}={$next_page}">&rsaquo;</a></li>
+                    <li><a title="{intl l="Go to last page"}" href="{$page_url nofilter}{$page_param_name}={$last_page}">&raquo;</a></li>
 
                 {else}
                     <li class="disabled"><a href="#">&rsaquo;</a></li>


### PR DESCRIPTION
Hello,
Add param "page_param_name" in pagination.html for several pagination in the same page.
The param "page_param_name" change the name get variable. 
Default name "page".

Exemple : 
```smarty
{include
file = "includes/pagination.html"
loop_ref       = "order-list"
max_page_count = 10
page_param_name = "order_page"
page_url  = "{url path="/admin/customer/update" customer_id=$customer_id}"
}
```
Cheers, 