### PR TITLE
Display a meaningful message when deleting a module referenced by an order.

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -153,7 +153,6 @@ class Module extends BaseAction implements EventSubscriberInterface
         $con->beginTransaction();
 
         if (null !== $module = ModuleQuery::create()->findPk($event->getModuleId(), $con)) {
-
             try {
                 if (null === $module->getFullNamespace()) {
                     throw new \LogicException(

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -29,8 +29,10 @@ use Thelia\Core\Event\Order\OrderPaymentEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Translation\Translator;
+use Thelia\Exception\FileNotFoundException;
 use Thelia\Exception\ModuleException;
 use Thelia\Log\Tlog;
+use Thelia\Model\Base\OrderQuery;
 use Thelia\Model\Map\ModuleTableMap;
 use Thelia\Model\ModuleQuery;
 use Thelia\Module\BaseModule;
@@ -147,10 +149,10 @@ class Module extends BaseAction implements EventSubscriberInterface
 
     public function delete(ModuleDeleteEvent $event)
     {
-        if (null !== $module = ModuleQuery::create()->findPk($event->getModuleId())) {
-            $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
-            $con->beginTransaction();
+        $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
+        $con->beginTransaction();
 
+        if (null !== $module = ModuleQuery::create()->findPk($event->getModuleId(), $con)) {
             try {
                 if (null === $module->getFullNamespace()) {
                     throw new \LogicException(
@@ -161,14 +163,15 @@ class Module extends BaseAction implements EventSubscriberInterface
                     );
                 }
 
-                // If module is activated, check if we can deactivate it
-                if ($module->getActivate()) {
-                    // check for modules that depend of this one
-                    $this->checkDeactivation($module);
-                }
-
                 try {
+                    // First, try to create an instance
                     $instance = $module->createInstance();
+
+                    // Then, if module is activated, check if we can deactivate it
+                    if ($module->getActivate()) {
+                        // check for modules that depend of this one
+                        $this->checkDeactivation($module);
+                    }
 
                     $instance->setContainer($this->container);
 
@@ -184,6 +187,31 @@ class Module extends BaseAction implements EventSubscriberInterface
                     Tlog::getInstance()->addWarning(
                         Translator::getInstance()->trans(
                             'Failed to create instance of module "%name%" when trying to delete module. Module directory has probably been deleted',
+                            ['%name%' => $module->getCode()]
+                        )
+                    );
+                } catch (FileNotFoundException $fnfe) {
+                    // The module directory has been deleted.
+                    // Log a warning, and delete the database entry.
+                    Tlog::getInstance()->addWarning(
+                        Translator::getInstance()->trans(
+                            'Module "%name%" directory was not found',
+                            ['%name%' => $module->getCode()]
+                        )
+                    );
+                }
+
+                // If the module is referenced by an order, display a meaningful error
+                // instead of 'delete cannot delete' caused by a constraint violation.
+                // FIXME: we hav to find a way to delete modules used by order.
+                if (
+                    null !== OrderQuery::create()->findByDeliveryModuleId($module->getId())
+                    ||
+                    null !== OrderQuery::create()->findByDeliveryModuleId($module->getId())
+                ) {
+                    throw new \LogicException(
+                        Translator::getInstance()->trans(
+                            'The module "%name%" is currently in use by at least one order, and can\'t be deleted.',
                             ['%name%' => $module->getCode()]
                         )
                     );

--- a/core/lib/Thelia/Model/ModuleQuery.php
+++ b/core/lib/Thelia/Model/ModuleQuery.php
@@ -3,6 +3,7 @@
 namespace Thelia\Model;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Thelia\Log\Tlog;
 use Thelia\Model\Base\ModuleQuery as BaseModuleQuery;
 use Thelia\Module\BaseModule;
 
@@ -75,14 +76,18 @@ class ModuleQuery extends BaseModuleQuery
 
         /** @var \Thelia\Model\Module $module */
         foreach ($modules as $module) {
-            if (null !== $container) {
-                $instance = $module->getDeliveryModuleInstance($container);
-            } else {
-                $instance = $module->createInstance();
-            }
+            try {
+                if (null !== $container) {
+                    $instance = $module->getDeliveryModuleInstance($container);
+                } else {
+                    $instance = $module->createInstance();
+                }
 
-            if (true === $instance->handleVirtualProductDelivery()) {
-                $result[] = $instance;
+                if (true === $instance->handleVirtualProductDelivery()) {
+                    $result[] = $instance;
+                }
+            } catch (\Exception $ex) {
+                Tlog::getInstance()->addError("Failed to instantiate module ".$module->getCode(), $ex);
             }
         }
 

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -19,6 +19,7 @@ use SplFileInfo;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Thelia\Exception\InvalidModuleException;
+use Thelia\Log\Tlog;
 use Thelia\Model\Map\ModuleTableMap;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
@@ -136,7 +137,9 @@ class ModuleManagement
             }
 
             $con->commit();
-        } catch (PropelException $ex) {
+        } catch (\Exception $ex) {
+            Tlog::getInstance()->addError("Failed to update module ".$module->getCode(), $ex);
+
             $con->rollBack();
             throw $ex;
         }


### PR DESCRIPTION
This is a TEMPORARY fix for #1145. This issue should not be closed, as we have to find a way to delete modules even if they're referenced by existing orders.