### PR TITLE
Allow to hardlink TinyMCE rather than symlink

### DIFF
--- a/core/lib/Thelia/Action/Document.php
+++ b/core/lib/Thelia/Action/Document.php
@@ -41,6 +41,12 @@ use Thelia\Tools\URL;
  */
 class Document extends BaseCachedFile implements EventSubscriberInterface
 {
+
+    /**
+     * @var string Config key for document delivery mode
+     */
+    const CONFIG_DELIVERY_MODE = 'original_document_delivery_mode';
+
     /**
      * @return string root of the document cache directory in web space
      */
@@ -78,7 +84,7 @@ class Document extends BaseCachedFile implements EventSubscriberInterface
                 throw new DocumentException(sprintf("Source document file %s does not exists.", $sourceFile));
             }
 
-            $mode = ConfigQuery::read('original_document_delivery_mode', 'symlink');
+            $mode = ConfigQuery::read(self::CONFIG_DELIVERY_MODE, 'symlink');
 
             if ($mode == 'symlink') {
                 if (false == symlink($sourceFile, $originalDocumentPathInCache)) {

--- a/local/modules/Tinymce/Resources/js/tinymce/filemanager/config/config.php
+++ b/local/modules/Tinymce/Resources/js/tinymce/filemanager/config/config.php
@@ -5,7 +5,19 @@ use Thelia\Model\ConfigQuery;
 
 $env = 'prod';
 
-require __DIR__ . '/../../../../../../../../core/vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../../../../../../core/vendor/autoload.php')) {
+    // Symlinked with std install
+    require_once __DIR__ . '/../../../../../../../../core/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../core/vendor/autoload.php')) {
+    // Hard copy with std install
+    require_once __DIR__ . '/../../../../core/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../../../../../bootstrap.php')) {
+    // Symlinked with thelia-project
+    require_once __DIR__ . '/../../../../../../../../bootstrap.php';
+} elseif (file_exists(__DIR__ . '/../../../../bootstrap.php')) {
+    // Hard copy with thelia-project
+    require_once __DIR__ . '/../../../../bootstrap.php';
+}
 
 /** @var Request $request */
 $request = Request::createFromGlobals();

--- a/tests/phpunit/Thelia/Tests/Action/DocumentTest.php
+++ b/tests/phpunit/Thelia/Tests/Action/DocumentTest.php
@@ -190,7 +190,7 @@ class DocumentTest extends \Thelia\Tests\TestCaseWithURLToolSetup
         $document = new Document($this->getFileManager());
 
         // mock cache configuration.
-        $config = ConfigQuery::create()->filterByName('original_document_delivery_mode')->findOne();
+        $config = ConfigQuery::create()->filterByName(Document::CONFIG_DELIVERY_MODE)->findOne();
 
         if ($config != null) {
             $oldval = $config->getValue();
@@ -221,7 +221,7 @@ class DocumentTest extends \Thelia\Tests\TestCaseWithURLToolSetup
         $document = new Document($this->getFileManager());
 
         // mock cache configuration.
-        $config = ConfigQuery::create()->filterByName('original_document_delivery_mode')->findOne();
+        $config = ConfigQuery::create()->filterByName(Document::CONFIG_DELIVERY_MODE)->findOne();
 
         if ($config != null) {
             $oldval = $config->getValue();


### PR DESCRIPTION
Some shared hosting don't handle symlink in the right way. So, this PR allow TinyMCE to hardlink in webroot rather than symlink according to `original_document_delivery_mode` configuration variable.