### PR TITLE
Order drop-down width fix

### DIFF
--- a/templates/backOffice/default/assets/css/styles.css
+++ b/templates/backOffice/default/assets/css/styles.css
@@ -1287,3 +1287,4 @@ ul.document-list>li{padding:5px;line-height:1.428571429;border-top:1px solid #dd
 .product-pse-image-container{position:relative;width:100px;height:75px}.product-pse-image-container>.is-associated{box-shadow:0 0 5px 0 #f39922}
 .product-pse-image-container>img{cursor:pointer}
 .product-pse-image-join-glyphicon{position:absolute;right:0;color:#f39922}
+#orders_menu .dropdown-menu{min-width: 230px;}

--- a/templates/backOffice/default/assets/less/bootstrap/dropdowns.less
+++ b/templates/backOffice/default/assets/less/bootstrap/dropdowns.less
@@ -213,3 +213,9 @@
   }
 }
 
+// Enlarge order dropdown menu to prevent wrapping in some languages
+#orders_menu {
+    .dropdown-menu {
+        min-width: 230px;
+    }
+}


### PR DESCRIPTION
The order drop-down menu is enlarged to 230px, thus preventing line wrap in some languages :

Before:
![image 008](https://cloud.githubusercontent.com/assets/2197734/6200298/b6f3a6c0-b471-11e4-90b3-353282625d8b.png)

After:
![image 007](https://cloud.githubusercontent.com/assets/2197734/6200297/af1713e2-b471-11e4-864b-b5f2965bf195.png)
