### PR TITLE
Fixed language when previewing e-mails

### DIFF
--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -241,9 +241,9 @@ class MessageController extends AbstractCrudController
         }
 
         if ($html) {
-            $content = $message->getHtmlMessageBody($parser);
+            $content = $message->setLocale($this->getCurrentEditionLocale())->getHtmlMessageBody($parser);
         } else {
-            $content = $message->getTextMessageBody($parser);
+            $content = $message->setLocale($this->getCurrentEditionLocale())->getTextMessageBody($parser);
         }
 
         return new Response($content);

--- a/templates/email/default/account_changed_by_admin.txt
+++ b/templates/email/default/account_changed_by_admin.txt
@@ -1,3 +1,4 @@
+{default_translation_domain domain='email.default'}
 {intl l="Hello,"}
 
 {intl l="Your account at %store_name has been changed by one of our managers." store_name={config key="store_name"}}.

--- a/templates/email/default/account_created_by_admin.txt
+++ b/templates/email/default/account_created_by_admin.txt
@@ -1,3 +1,4 @@
+{default_translation_domain domain='email.default'}
 {intl l="Hello,"}
 
 {intl l="An account at %store_name has been created by one of our managers." store_name={config key="store_name"}}.

--- a/templates/email/default/order_confirmation.txt
+++ b/templates/email/default/order_confirmation.txt
@@ -1,3 +1,4 @@
+{default_translation_domain domain='email.default'}
 {loop name="order.invoice" type="order" id=$order_id customer="*"}
 {loop name="currency.order" type="currency" id=$CURRENCY}
     {assign "orderCurrencySymbol" $SYMBOL}

--- a/templates/email/default/order_notification.txt
+++ b/templates/email/default/order_notification.txt
@@ -1,3 +1,4 @@
+{default_translation_domain domain='email.default'}
 {loop name="order.invoice" type="order" id=$order_id customer="*"}
 {loop name="currency.order" type="currency" id=$CURRENCY}
     {assign "orderCurrencySymbol" $SYMBOL}

--- a/templates/email/default/password.txt
+++ b/templates/email/default/password.txt
@@ -1,3 +1,4 @@
+{default_translation_domain domain='email.default'}
 {intl l="Hello,"}
 
 {intl l="You have requested a new password for your account at %store_name" store_name={config key="store_name"}}.


### PR DESCRIPTION
When previewing email, the current edition language was ignored, and the en_US version was always displayed.

This PR fixes the problem.