### PR TITLE
Fix for "Cart invalid token" message when updating cart

### DIFF
--- a/local/modules/Cheque/templates/frontOffice/default/order-placed.additional-payment-info.html
+++ b/local/modules/Cheque/templates/frontOffice/default/order-placed.additional-payment-info.html
@@ -16,6 +16,6 @@
 </blockquote>
 <p><span class="glyphicon glyphicon-warning-sign"></span> {intl d='cheque.fo.default' l="Be sure to sign your cheque !"}</p>
 
-{loop type="module-config" name="cheque-instructions" module="cheque" variable="instructions"}
+{loop type="module-config" name="cheque-instructions" module="cheque" variable="instructions" locale={lang attr='locale'}}
 <p>{$VALUE nofilter}</p>
 {/loop}

--- a/templates/frontOffice/default/cart.html
+++ b/templates/frontOffice/default/cart.html
@@ -88,7 +88,7 @@
                                         {/loop}
                                     </dl>
                                 </div>
-                                <a href="{token_url path="/cart/delete/$ITEM_ID"}" class="btn btn-remove"><i class="icon-trash"></i> {intl l="Remove"}</a>
+                                <a href="{token_url path="/cart/delete/$ITEM_ID" success_url={url path='/cart'}}" class="btn btn-remove"><i class="icon-trash"></i> {intl l="Remove"}</a>
                             </td>
                             <td class="unitprice">
                                 {if $IS_PROMO == 1}
@@ -103,6 +103,7 @@
                             <td class="qty">
                                 <div class="form-group group-qty">
                                     <form action="{token_url path="/cart/update"}" class="form-inline" method="post">
+                                        <input type="hidden" name="success_url" value="{url path='/cart'}">
                                         <input type="hidden" name="cart_item" value="{$ITEM_ID}">
                                         <div class="form-group">
                                             {if $STOCK <= 500}

--- a/templates/frontOffice/default/order-invoice.html
+++ b/templates/frontOffice/default/order-invoice.html
@@ -132,7 +132,7 @@
                         <td class="subprice">
                             <span class="price">{format_money number={$real_price * $QUANTITY} symbol={currency attr="symbol"}}</span>
                         </td>
-                    </tr>invoice-address
+                    </tr>
 
                     {/loop}
 


### PR DESCRIPTION
This PR fixes the 'invalid token' message when reloading the cart page after deleting an item, by forcing a redirection to the cart page after a delete of a quantity change action.