### PR TITLE
Use of BaseController::createForm() instead of explicit form instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix deploy image directory destination
 - Fix redirect response if a AuthenticationException is catched
 - The PaymentModule log default level is now INFO instead of ERROR
+- Direct instantiations of Thelia forms is deprecated. BaseController::createForm() should be used instead.
 
 # 2.1.1
 

--- a/core/lib/Thelia/Config/Resources/form-api.xml
+++ b/core/lib/Thelia/Config/Resources/form-api.xml
@@ -16,9 +16,13 @@
         <form name="thelia.api.category.create" class="Thelia\Form\Api\Category\CategoryCreationForm"/>
         <form name="thelia.api.category.update" class="Thelia\Form\Api\Category\CategoryModificationForm"/>
 
-
         <!-- Product sale elements form -->
         <form name="thelia.api.product_sale_elements" class="Thelia\Form\Api\ProductSaleElements\ProductSaleElementsForm" />
+
+        <!-- Product sale elements form -->
+        <form name="thelia.api.product.creation" class="Thelia\Form\Api\Product\ProductCreationForm" />
+        <form name="thelia.api.product.modification" class="Thelia\Form\Api\Product\ProductModificationForm" />
+
 
     </forms>
 </config>

--- a/core/lib/Thelia/Config/Resources/form.xml
+++ b/core/lib/Thelia/Config/Resources/form.xml
@@ -83,6 +83,7 @@
         <form name="thelia.admin.feature.modification" class="Thelia\Form\FeatureModificationForm"/>
 
         <form name="thelia.admin.attributeav.creation" class="Thelia\Form\AttributeAvCreationForm"/>
+        <form name="thelia.admin.attributeav.modification" class="Thelia\Form\AttributeAvCreationForm"/>
 
         <form name="thelia.admin.featureav.creation" class="Thelia\Form\FeatureAvCreationForm"/>
 

--- a/core/lib/Thelia/Controller/Admin/AbstractCrudController.php
+++ b/core/lib/Thelia/Controller/Admin/AbstractCrudController.php
@@ -12,9 +12,9 @@
 
 namespace Thelia\Controller\Admin;
 
+use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Core\Event\UpdatePositionEvent;
 
 /**
  * An abstract CRUD controller for Thelia ADMIN, to manage basic CRUD operations on a givent object.

--- a/core/lib/Thelia/Controller/Admin/AbstractSeoCrudController.php
+++ b/core/lib/Thelia/Controller/Admin/AbstractSeoCrudController.php
@@ -14,7 +14,7 @@ namespace Thelia\Controller\Admin;
 
 use Thelia\Core\Event\UpdateSeoEvent;
 use Thelia\Core\Security\AccessManager;
-
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Form\SeoForm;
 
@@ -90,7 +90,7 @@ abstract class AbstractSeoCrudController extends AbstractCrudController
      */
     protected function getUpdateSeoForm()
     {
-        return new SeoForm($this->getRequest());
+        return $this->createForm(AdminForm::SEO);
     }
 
     /**
@@ -133,7 +133,7 @@ abstract class AbstractSeoCrudController extends AbstractCrudController
             'meta_keywords'     => $object->getMetaKeywords()
         );
 
-        $seoForm = new SeoForm($this->getRequest(), "form", $data);
+        $seoForm = $this->createForm(AdminForm::SEO, "form", $data);
         $this->getParserContext()->addForm($seoForm);
 
         // URL based on the language

--- a/core/lib/Thelia/Controller/Admin/AddressController.php
+++ b/core/lib/Thelia/Controller/Admin/AddressController.php
@@ -14,11 +14,10 @@ namespace Thelia\Controller\Admin;
 
 use Thelia\Core\Event\Address\AddressCreateOrUpdateEvent;
 use Thelia\Core\Event\Address\AddressEvent;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\AddressCreateForm;
-use Thelia\Form\AddressUpdateForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\CustomerQuery;
 
@@ -83,7 +82,7 @@ class AddressController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new AddressCreateForm($this->getRequest());
+        return $this->createForm(AdminForm::ADDRESS_CREATE);
     }
 
     /**
@@ -91,14 +90,14 @@ class AddressController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new AddressUpdateForm($this->getRequest());
+        return $this->createForm(AdminForm::ADDRESS_UPDATE);
     }
 
     /**
      * Fills in the form data array
      *
      * @param  unknown        $object
-     * @return multitype:NULL
+     * @return array
      */
     protected function createFormDataArray($object)
     {
@@ -126,7 +125,7 @@ class AddressController extends AbstractCrudController
      */
     protected function hydrateObjectForm($object)
     {
-        return new AddressUpdateForm($this->getRequest(), "form", $this->createFormDataArray($object));
+        return $this->createForm(AdminForm::ADDRESS_UPDATE, "form", $this->createFormDataArray($object));
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/AdministratorController.php
+++ b/core/lib/Thelia/Controller/Admin/AdministratorController.php
@@ -12,11 +12,10 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Administrator\AdministratorEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Form\AdministratorCreationForm;
-use Thelia\Form\AdministratorModificationForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\AdminQuery;
 
 class AdministratorController extends AbstractCrudController
@@ -36,12 +35,12 @@ class AdministratorController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new AdministratorCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::ADMINISTRATOR_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new AdministratorModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::ADMINISTRATOR_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -101,7 +100,7 @@ class AdministratorController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new AdministratorModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::ADMINISTRATOR_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/AdvancedConfigurationController.php
+++ b/core/lib/Thelia/Controller/Admin/AdvancedConfigurationController.php
@@ -16,9 +16,7 @@ use Thelia\Core\Event\Cache\CacheEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Form\Cache\AssetsFlushForm;
-use Thelia\Form\Cache\CacheFlushForm;
-use Thelia\Form\Cache\ImagesAndDocumentsCacheFlushForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 
@@ -44,7 +42,7 @@ class AdvancedConfigurationController extends BaseAdminController
             return $result;
         }
 
-        $form = new CacheFlushForm($this->getRequest());
+        $form = $this->createForm(AdminForm::CACHE_FLUSH);
         try {
             $this->validateForm($form);
 
@@ -63,7 +61,7 @@ class AdvancedConfigurationController extends BaseAdminController
             return $result;
         }
 
-        $form = new AssetsFlushForm($this->getRequest());
+        $form = $this->createForm(AdminForm::ASSETS_FLUSH);
         try {
             $this->validateForm($form);
 
@@ -82,7 +80,7 @@ class AdvancedConfigurationController extends BaseAdminController
             return $result;
         }
 
-        $form = new ImagesAndDocumentsCacheFlushForm($this->getRequest());
+        $form = $this->createForm(AdminForm::IMAGES_AND_DOCUMENTS_CACHE_FLUSH);
         try {
             $this->validateForm($form);
 

--- a/core/lib/Thelia/Controller/Admin/ApiController.php
+++ b/core/lib/Thelia/Controller/Admin/ApiController.php
@@ -21,8 +21,7 @@ use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Translation\Translator;
-use Thelia\Form\Api\ApiCreateForm;
-use Thelia\Form\Api\ApiUpdateForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\Api;
 use Thelia\Model\ApiQuery;
@@ -96,7 +95,7 @@ class ApiController extends BaseAdminController
             return $response;
         }
 
-        $form = new ApiCreateForm($this->getRequest());
+        $form = $this->createForm(AdminForm::API_CREATE);
         $error_msg = null;
         try {
             $createForm = $this->validateForm($form);
@@ -131,7 +130,7 @@ class ApiController extends BaseAdminController
     public function updateAction($api_id)
     {
         if (null === $response = $this->checkApiAccess($api_id, AccessManager::UPDATE)) {
-            $form = new ApiUpdateForm($this->getRequest(), 'form', ['profile' => $this->api->getProfileId()]);
+            $form = $this->createForm(AdminForm::API_UPDATE, 'form', ['profile' => $this->api->getProfileId()]);
 
             $this->getParserContext()->addForm($form);
 
@@ -153,7 +152,7 @@ class ApiController extends BaseAdminController
     private function doUpdate(Api $api)
     {
         $error_msg = null;
-        $form = new ApiUpdateForm($this->getRequest());
+        $form = $this->createForm(AdminForm::API_UPDATE);
         try {
             $updateForm = $this->validateForm($form);
 

--- a/core/lib/Thelia/Controller/Admin/AreaController.php
+++ b/core/lib/Thelia/Controller/Admin/AreaController.php
@@ -12,7 +12,6 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Area\AreaAddCountryEvent;
 use Thelia\Core\Event\Area\AreaCreateEvent;
 use Thelia\Core\Event\Area\AreaDeleteEvent;
@@ -21,10 +20,8 @@ use Thelia\Core\Event\Area\AreaUpdateEvent;
 use Thelia\Core\Event\Area\AreaUpdatePostageEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\Area\AreaCountryForm;
-use Thelia\Form\Area\AreaCreateForm;
-use Thelia\Form\Area\AreaModificationForm;
-use Thelia\Form\Area\AreaPostageForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\AreaQuery;
 
@@ -58,7 +55,7 @@ class AreaController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new AreaCreateForm($this->getRequest());
+        return $this->createForm(AdminForm::AREA_CREATE);
     }
 
     /**
@@ -66,7 +63,7 @@ class AreaController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new AreaModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::AREA_MODIFICATION);
     }
 
     /**
@@ -80,7 +77,7 @@ class AreaController extends AbstractCrudController
             'name' => $object->getName()
         );
 
-        return new AreaModificationForm($this->getRequest(), 'form', $data);
+        return $this->createForm(AdminForm::AREA_MODIFICATION, 'form', $data);
     }
 
     /**
@@ -227,7 +224,7 @@ class AreaController extends AbstractCrudController
             return $response;
         }
 
-        $areaCountryForm = new AreaCountryForm($this->getRequest());
+        $areaCountryForm = $this->createForm(AdminForm::AREA_COUNTRY);
         $error_msg = null;
         try {
             $form = $this->validateForm($areaCountryForm);
@@ -297,7 +294,7 @@ class AreaController extends AbstractCrudController
             return $response;
         }
 
-        $areaUpdateForm = new AreaPostageForm($this->getRequest());
+        $areaUpdateForm = $this->createForm(AdminForm::AREA_POSTAGE);
         $error_msg = null;
 
         try {

--- a/core/lib/Thelia/Controller/Admin/AttributeAvController.php
+++ b/core/lib/Thelia/Controller/Admin/AttributeAvController.php
@@ -12,15 +12,15 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Attribute\AttributeAvDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Attribute\AttributeAvUpdateEvent;
 use Thelia\Core\Event\Attribute\AttributeAvCreateEvent;
-use Thelia\Model\AttributeAvQuery;
-use Thelia\Form\AttributeAvModificationForm;
-use Thelia\Form\AttributeAvCreationForm;
+use Thelia\Core\Event\Attribute\AttributeAvDeleteEvent;
+use Thelia\Core\Event\Attribute\AttributeAvUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\AttributeAvModificationForm;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\AttributeAvQuery;
 
 /**
  * Manages attributes-av
@@ -46,12 +46,12 @@ class AttributeAvController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new AttributeAvCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::ATTRIBUTE_AV_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new AttributeAvModificationForm($this->getRequest());
+        throw new \LogicException("Attribute Av. modification is not yet implemented");
     }
 
     protected function getCreationEvent($formData)
@@ -104,17 +104,7 @@ class AttributeAvController extends AbstractCrudController
 
     protected function hydrateObjectForm($object)
     {
-        $data = array(
-            'id'           => $object->getId(),
-            'locale'       => $object->getLocale(),
-            'title'        => $object->getTitle(),
-            'chapo'        => $object->getChapo(),
-            'description'  => $object->getDescription(),
-            'postscriptum' => $object->getPostscriptum()
-        );
-
-        // Setup the object form
-        return new AttributeAvModificationForm($this->getRequest(), "form", $data);
+        throw new \LogicException("Attribute Av. modification is not yet implemented");
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/AttributeController.php
+++ b/core/lib/Thelia/Controller/Admin/AttributeController.php
@@ -12,19 +12,17 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Attribute\AttributeDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Attribute\AttributeUpdateEvent;
-use Thelia\Core\Event\Attribute\AttributeCreateEvent;
-use Thelia\Core\Security\AccessManager;
-use Thelia\Model\AttributeQuery;
-use Thelia\Form\AttributeModificationForm;
-use Thelia\Form\AttributeCreationForm;
-use Thelia\Core\Event\UpdatePositionEvent;
-
 use Thelia\Core\Event\Attribute\AttributeAvUpdateEvent;
+use Thelia\Core\Event\Attribute\AttributeCreateEvent;
+use Thelia\Core\Event\Attribute\AttributeDeleteEvent;
 use Thelia\Core\Event\Attribute\AttributeEvent;
+use Thelia\Core\Event\Attribute\AttributeUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\AttributeQuery;
 
 /**
  * Manages attributes
@@ -50,12 +48,12 @@ class AttributeController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new AttributeCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::ATTRIBUTE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new AttributeModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::ATTRIBUTE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -141,7 +139,7 @@ class AttributeController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new AttributeModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::ATTRIBUTE_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/BrandController.php
+++ b/core/lib/Thelia/Controller/Admin/BrandController.php
@@ -21,8 +21,8 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Form\Brand\BrandCreationForm;
 use Thelia\Form\Brand\BrandModificationForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Brand;
 use Thelia\Model\BrandQuery;
 
@@ -54,7 +54,7 @@ class BrandController extends AbstractSeoCrudController
      */
     protected function getCreationForm()
     {
-        return new BrandCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::BRAND_CREATION);
     }
 
     /**
@@ -62,7 +62,7 @@ class BrandController extends AbstractSeoCrudController
      */
     protected function getUpdateForm()
     {
-        return new BrandModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::BRAND_MODIFICATION);
     }
 
     /**
@@ -89,7 +89,7 @@ class BrandController extends AbstractSeoCrudController
         ];
 
         // Setup the object form
-        return new BrandModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::BRAND_MODIFICATION, "form", $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/CategoryController.php
+++ b/core/lib/Thelia/Controller/Admin/CategoryController.php
@@ -12,23 +12,22 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Category\CategoryDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Category\CategoryUpdateEvent;
-use Thelia\Core\Event\Category\CategoryCreateEvent;
-use Thelia\Core\Security\AccessManager;
-use Thelia\Model\CategoryQuery;
-use Thelia\Form\CategoryModificationForm;
-use Thelia\Form\CategoryCreationForm;
-use Thelia\Core\Event\UpdatePositionEvent;
-use Thelia\Core\Event\Category\CategoryToggleVisibilityEvent;
-use Thelia\Core\Event\Category\CategoryDeleteContentEvent;
-use Thelia\Core\Event\Category\CategoryAddContentEvent;
-use Thelia\Model\FolderQuery;
-use Thelia\Model\ContentQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Core\Event\Category\CategoryAddContentEvent;
+use Thelia\Core\Event\Category\CategoryCreateEvent;
+use Thelia\Core\Event\Category\CategoryDeleteContentEvent;
+use Thelia\Core\Event\Category\CategoryDeleteEvent;
+use Thelia\Core\Event\Category\CategoryToggleVisibilityEvent;
+use Thelia\Core\Event\Category\CategoryUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\CategoryAssociatedContentQuery;
+use Thelia\Model\CategoryQuery;
+use Thelia\Model\ContentQuery;
+use Thelia\Model\FolderQuery;
 
 /**
  * Manages categories
@@ -55,12 +54,12 @@ class CategoryController extends AbstractSeoCrudController
 
     protected function getCreationForm()
     {
-        return new CategoryCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::CATEGORY_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new CategoryModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::CATEGORY_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -132,7 +131,7 @@ class CategoryController extends AbstractSeoCrudController
         );
 
         // Setup the object form
-        return new CategoryModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::CATEGORY_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/ConfigController.php
+++ b/core/lib/Thelia/Controller/Admin/ConfigController.php
@@ -12,15 +12,14 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Config\ConfigDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Config\ConfigUpdateEvent;
 use Thelia\Core\Event\Config\ConfigCreateEvent;
+use Thelia\Core\Event\Config\ConfigDeleteEvent;
+use Thelia\Core\Event\Config\ConfigUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\ConfigQuery;
-use Thelia\Form\ConfigModificationForm;
-use Thelia\Form\ConfigCreationForm;
 
 /**
  * Manages variables
@@ -46,12 +45,12 @@ class ConfigController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new ConfigCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::CONFIG_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new ConfigModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::CONFIG_MODIFICATION);
     }
 
     protected function getCreationEvent($data)
@@ -117,7 +116,7 @@ class ConfigController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new ConfigModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::CONFIG_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/ConfigStoreController.php
+++ b/core/lib/Thelia/Controller/Admin/ConfigStoreController.php
@@ -12,9 +12,9 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\ConfigStoreForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\ConfigQuery;
 
 /**
@@ -36,7 +36,7 @@ class ConfigStoreController extends BaseAdminController
         }
 
         // The form is self-hydrated
-        $configStoreForm = new ConfigStoreForm($this->getRequest(), 'form');
+        $configStoreForm = $this->createForm(AdminForm::CONFIG_STORE);
 
         $this->getParserContext()->addForm($configStoreForm);
 
@@ -51,7 +51,7 @@ class ConfigStoreController extends BaseAdminController
 
         $error_msg = false;
         $response = null;
-        $configStoreForm = new ConfigStoreForm($this->getRequest());
+        $configStoreForm = $this->createForm(AdminForm::CONFIG_STORE);
 
         try {
             $form = $this->validateForm($configStoreForm);

--- a/core/lib/Thelia/Controller/Admin/ContentController.php
+++ b/core/lib/Thelia/Controller/Admin/ContentController.php
@@ -12,8 +12,6 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\HttpFoundation\Response;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Content\ContentAddFolderEvent;
 use Thelia\Core\Event\Content\ContentCreateEvent;
 use Thelia\Core\Event\Content\ContentDeleteEvent;
@@ -22,9 +20,10 @@ use Thelia\Core\Event\Content\ContentToggleVisibilityEvent;
 use Thelia\Core\Event\Content\ContentUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\ContentCreationForm;
-use Thelia\Form\ContentModificationForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Content;
 use Thelia\Model\ContentQuery;
 
@@ -116,7 +115,7 @@ class ContentController extends AbstractSeoCrudController
      */
     protected function getCreationForm()
     {
-        return new ContentCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::CONTENT_CREATION);
     }
 
     /**
@@ -124,7 +123,7 @@ class ContentController extends AbstractSeoCrudController
      */
     protected function getUpdateForm()
     {
-        return new ContentModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::CONTENT_MODIFICATION);
     }
 
     /**
@@ -150,7 +149,7 @@ class ContentController extends AbstractSeoCrudController
         );
 
         // Setup the object form
-        return new ContentModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::CONTENT_MODIFICATION, "form", $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/CountryController.php
+++ b/core/lib/Thelia/Controller/Admin/CountryController.php
@@ -12,15 +12,14 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Country\CountryCreateEvent;
 use Thelia\Core\Event\Country\CountryDeleteEvent;
 use Thelia\Core\Event\Country\CountryToggleDefaultEvent;
 use Thelia\Core\Event\Country\CountryUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\CountryCreationForm;
-use Thelia\Form\CountryModificationForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Log\Tlog;
 use Thelia\Model\CountryQuery;
 
@@ -49,7 +48,7 @@ class CountryController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new CountryCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::COUNTRY_CREATION);
     }
 
     /**
@@ -57,7 +56,7 @@ class CountryController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new CountryModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::COUNTRY_MODIFICATION);
     }
 
     /**
@@ -76,7 +75,7 @@ class CountryController extends AbstractCrudController
             'isoalpha3' => $object->getIsoalpha3(),
         );
 
-        return new CountryModificationForm($this->getRequest(), 'form', $data);
+        return $this->createForm(AdminForm::COUNTRY_MODIFICATION, 'form', $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/CouponController.php
+++ b/core/lib/Thelia/Controller/Admin/CouponController.php
@@ -16,18 +16,18 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Router;
+use Thelia\Condition\ConditionCollection;
 use Thelia\Condition\ConditionFactory;
 use Thelia\Condition\Implementation\ConditionInterface;
-use Thelia\Core\Event\Coupon\CouponDeleteEvent;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Coupon\CouponCreateOrUpdateEvent;
+use Thelia\Core\Event\Coupon\CouponDeleteEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Coupon\CouponFactory;
 use Thelia\Coupon\CouponManager;
-use Thelia\Condition\ConditionCollection;
 use Thelia\Coupon\Type\CouponInterface;
-use Thelia\Form\CouponCreationForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
 use Thelia\Model\Coupon;
@@ -199,7 +199,7 @@ class CouponController extends BaseAdminController
             $args['conditions'] = $this->cleanConditionForTemplate($conditions);
 
             // Setup the object form
-            $changeForm = new CouponCreationForm($this->getRequest(), 'form', $data);
+            $changeForm = $this->createForm(AdminForm::COUPON_CREATION, 'form', $data);
 
             // Pass it to the parser
             $this->getParserContext()->addForm($changeForm);
@@ -821,7 +821,7 @@ class CouponController extends BaseAdminController
             $data["code"] = $coupon->getCode();
         }
 
-        return new CouponCreationForm($this->getRequest(), "form", $data, $options);
+        return $this->createForm(AdminForm::COUPON_CREATION, "form", $data, $options);
     }
 
     public function deleteAction()

--- a/core/lib/Thelia/Controller/Admin/CurrencyController.php
+++ b/core/lib/Thelia/Controller/Admin/CurrencyController.php
@@ -12,16 +12,15 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Currency\CurrencyDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Currency\CurrencyUpdateEvent;
 use Thelia\Core\Event\Currency\CurrencyCreateEvent;
-use Thelia\Model\CurrencyQuery;
-use Thelia\Form\CurrencyModificationForm;
-use Thelia\Form\CurrencyCreationForm;
+use Thelia\Core\Event\Currency\CurrencyDeleteEvent;
+use Thelia\Core\Event\Currency\CurrencyUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\CurrencyQuery;
 
 /**
  * Manages currencies
@@ -47,12 +46,12 @@ class CurrencyController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new CurrencyCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::CURRENCY_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new CurrencyModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::CURRENCY_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -118,7 +117,7 @@ class CurrencyController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new CurrencyModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::CURRENCY_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/CustomerController.php
+++ b/core/lib/Thelia/Controller/Admin/CustomerController.php
@@ -12,13 +12,12 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Customer\CustomerCreateOrUpdateEvent;
 use Thelia\Core\Event\Customer\CustomerEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Exception\CustomerException;
-use Thelia\Form\CustomerCreateForm;
-use Thelia\Form\CustomerUpdateForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\CustomerQuery;
 use Thelia\Tools\Password;
 
@@ -44,12 +43,12 @@ class CustomerController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new CustomerCreateForm($this->getRequest());
+        return $this->createForm(AdminForm::CUSTOMER_CREATE);
     }
 
     protected function getUpdateForm()
     {
-        return new CustomerUpdateForm($this->getRequest());
+        return $this->createForm(AdminForm::CUSTOMER_UPDATE);
     }
 
     protected function getCreationEvent($formData)
@@ -116,7 +115,7 @@ class CustomerController extends AbstractCrudController
         }
 
         // A loop is used in the template
-        return new CustomerUpdateForm($this->getRequest(), 'form', $data);
+        return $this->createForm(AdminForm::CUSTOMER_UPDATE, 'form', $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/ExportController.php
+++ b/core/lib/Thelia/Controller/Admin/ExportController.php
@@ -12,20 +12,20 @@
 
 namespace Thelia\Controller\Admin;
 
+use Thelia\Core\Event\ImportExport as ImportExportEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\FileFormat\Archive\AbstractArchiveBuilder;
 use Thelia\Core\FileFormat\Archive\ArchiveBuilderManagerTrait;
+use Thelia\Core\FileFormat\Formatting\AbstractFormatter;
 use Thelia\Core\FileFormat\Formatting\FormatterManagerTrait;
+use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Loop\Export as ExportLoop;
-use Thelia\Core\Event\ImportExport as ImportExportEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\FileFormat\Archive\AbstractArchiveBuilder;
-use Thelia\Core\FileFormat\Formatting\AbstractFormatter;
-use Thelia\Core\HttpFoundation\Response;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\ExportForm;
 use Thelia\ImportExport\Export\DocumentsExportInterface;
 use Thelia\ImportExport\Export\ExportHandler;
 use Thelia\ImportExport\Export\ImagesExportInterface;
@@ -77,7 +77,7 @@ class ExportController extends BaseAdminController
         /**
          * Define and validate the form
          */
-        $form = new ExportForm($this->getRequest());
+        $form = $this->createForm(AdminForm::EXPORT);
         $errorMessage = null;
 
         try {

--- a/core/lib/Thelia/Controller/Admin/FeatureAvController.php
+++ b/core/lib/Thelia/Controller/Admin/FeatureAvController.php
@@ -12,15 +12,15 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Feature\FeatureAvDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Feature\FeatureAvUpdateEvent;
 use Thelia\Core\Event\Feature\FeatureAvCreateEvent;
-use Thelia\Model\FeatureAvQuery;
-use Thelia\Form\FeatureAvModificationForm;
-use Thelia\Form\FeatureAvCreationForm;
+use Thelia\Core\Event\Feature\FeatureAvDeleteEvent;
+use Thelia\Core\Event\Feature\FeatureAvUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Form\FeatureAvModificationForm;
+use Thelia\Model\FeatureAvQuery;
 
 /**
  * Manages features-av
@@ -46,12 +46,12 @@ class FeatureAvController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new FeatureAvCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::FEATURE_AV_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new FeatureAvModificationForm($this->getRequest());
+        throw new \LogicException("Featiure Av. modification is not yet implemented");
     }
 
     protected function getCreationEvent($formData)
@@ -104,17 +104,7 @@ class FeatureAvController extends AbstractCrudController
 
     protected function hydrateObjectForm($object)
     {
-        $data = array(
-            'id'           => $object->getId(),
-            'locale'       => $object->getLocale(),
-            'title'        => $object->getTitle(),
-            'chapo'        => $object->getChapo(),
-            'description'  => $object->getDescription(),
-            'postscriptum' => $object->getPostscriptum()
-        );
-
-        // Setup the object form
-        return new FeatureAvModificationForm($this->getRequest(), "form", $data);
+        throw new \LogicException("Feature Av. modification is not yet implemented");
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/FeatureController.php
+++ b/core/lib/Thelia/Controller/Admin/FeatureController.php
@@ -12,19 +12,17 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Feature\FeatureDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Feature\FeatureUpdateEvent;
-use Thelia\Core\Event\Feature\FeatureCreateEvent;
-use Thelia\Core\Security\AccessManager;
-use Thelia\Model\FeatureQuery;
-use Thelia\Form\FeatureModificationForm;
-use Thelia\Form\FeatureCreationForm;
-use Thelia\Core\Event\UpdatePositionEvent;
-
 use Thelia\Core\Event\Feature\FeatureAvUpdateEvent;
+use Thelia\Core\Event\Feature\FeatureCreateEvent;
+use Thelia\Core\Event\Feature\FeatureDeleteEvent;
 use Thelia\Core\Event\Feature\FeatureEvent;
+use Thelia\Core\Event\Feature\FeatureUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\FeatureQuery;
 
 /**
  * Manages features
@@ -50,12 +48,12 @@ class FeatureController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new FeatureCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::FEATURE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new FeatureModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::FEATURE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -141,7 +139,7 @@ class FeatureController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new FeatureModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::FEATURE_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/FileController.php
+++ b/core/lib/Thelia/Controller/Admin/FileController.php
@@ -425,7 +425,7 @@ class FileController extends BaseAdminController
 
         $fileModelInstance = $fileManager->getModelInstance($objectType, $parentType);
 
-        $fileUpdateForm = $fileModelInstance->getUpdateFormInstance($this->getRequest());
+        $fileUpdateForm = $this->createForm($fileModelInstance->getUpdateFormId());
 
         /** @var FileModelInterface $file */
         $file = $fileModelInstance->getQueryInstance()->findPk($fileId);

--- a/core/lib/Thelia/Controller/Admin/FolderController.php
+++ b/core/lib/Thelia/Controller/Admin/FolderController.php
@@ -12,16 +12,15 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\HttpFoundation\Request;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Folder\FolderCreateEvent;
 use Thelia\Core\Event\Folder\FolderDeleteEvent;
 use Thelia\Core\Event\Folder\FolderToggleVisibilityEvent;
 use Thelia\Core\Event\Folder\FolderUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
-use Thelia\Form\FolderCreationForm;
-use Thelia\Form\FolderModificationForm;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\FolderQuery;
 
 /**
@@ -52,7 +51,7 @@ class FolderController extends AbstractSeoCrudController
      */
     protected function getCreationForm()
     {
-        return new FolderCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::FOLDER_CREATION);
     }
 
     /**
@@ -60,7 +59,7 @@ class FolderController extends AbstractSeoCrudController
      */
     protected function getUpdateForm()
     {
-        return new FolderModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::FOLDER_MODIFICATION);
     }
 
     /**
@@ -86,7 +85,7 @@ class FolderController extends AbstractSeoCrudController
         );
 
         // Setup the object form
-        return new FolderModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::FOLDER_MODIFICATION, "form", $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/HookController.php
+++ b/core/lib/Thelia/Controller/Admin/HookController.php
@@ -26,8 +26,7 @@ use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Translation\Translator;
-use Thelia\Form\HookCreationForm;
-use Thelia\Form\HookModificationForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Log\Tlog;
 use Thelia\Model\Hook;
 use Thelia\Model\HookQuery;
@@ -227,7 +226,7 @@ class HookController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new HookCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::HOOK_CREATION);
     }
 
     /**
@@ -235,7 +234,7 @@ class HookController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new HookModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::HOOK_MODIFICATION);
     }
 
     /**
@@ -261,7 +260,7 @@ class HookController extends AbstractCrudController
             'description' => $object->getDescription(),
         ];
 
-        return new HookModificationForm($this->getRequest(), 'form', $data);
+        return $this->createForm(AdminForm::HOOK_MODIFICATION, 'form', $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/ImportController.php
+++ b/core/lib/Thelia/Controller/Admin/ImportController.php
@@ -27,8 +27,8 @@ use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Loop\Import as ImportLoop;
 use Thelia\Exception\FileNotFoundException;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\ImportForm;
 use Thelia\ImportExport\Import\ImportHandler;
 use Thelia\Model\ImportCategoryQuery;
 use Thelia\Model\ImportQuery;
@@ -76,7 +76,7 @@ class ImportController extends BaseAdminController
         /**
          * Get needed services
          */
-        $form = new ImportForm($this->getRequest());
+        $form = $this->createForm(AdminForm::IMPORT);
         $errorMessage = null;
         $successMessage = null;
 

--- a/core/lib/Thelia/Controller/Admin/LangController.php
+++ b/core/lib/Thelia/Controller/Admin/LangController.php
@@ -21,10 +21,8 @@ use Thelia\Core\Event\Lang\LangUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\Lang\LangCreateForm;
-use Thelia\Form\Lang\LangDefaultBehaviorForm;
-use Thelia\Form\Lang\LangUpdateForm;
 use Thelia\Form\Lang\LangUrlEvent;
 use Thelia\Form\Lang\LangUrlForm;
 use Thelia\Log\Tlog;
@@ -52,7 +50,7 @@ class LangController extends BaseAdminController
         foreach (LangQuery::create()->find() as $lang) {
             $data[LangUrlForm::LANG_PREFIX.$lang->getId()] = $lang->getUrl();
         }
-        $langUrlForm = new LangUrlForm($this->getRequest(), 'form', $data);
+        $langUrlForm = $this->createForm(AdminForm::LANG_URL, 'form', $data);
         $this->getParserContext()->addForm($langUrlForm);
 
         return $this->render('languages', array_merge($param, array(
@@ -71,7 +69,7 @@ class LangController extends BaseAdminController
 
         $lang = LangQuery::create()->findPk($lang_id);
 
-        $langForm = new LangUpdateForm($this->getRequest(), 'form', array(
+        $langForm = $this->createForm(AdminForm::LANG_UPDATE, 'form', array(
             'id' => $lang->getId(),
             'title' => $lang->getTitle(),
             'code' => $lang->getCode(),
@@ -98,7 +96,7 @@ class LangController extends BaseAdminController
 
         $error_msg = false;
 
-        $langForm = new LangUpdateForm($this->getRequest());
+        $langForm = $this->createForm(AdminForm::LANG_UPDATE);
 
         try {
             $form = $this->validateForm($langForm);
@@ -203,7 +201,7 @@ class LangController extends BaseAdminController
             return $response;
         }
 
-        $createForm = new LangCreateForm($this->getRequest());
+        $createForm = $this->createForm(AdminForm::LANG_CREATE);
 
         $error_msg = false;
 
@@ -298,7 +296,7 @@ class LangController extends BaseAdminController
 
         $error_msg = false;
 
-        $behaviorForm = new LangDefaultBehaviorForm($this->getRequest());
+        $behaviorForm = $this->createForm(AdminForm::LANG_DEFAULT_BEHAVIOR);
 
         try {
             $form = $this->validateForm($behaviorForm);
@@ -338,7 +336,7 @@ class LangController extends BaseAdminController
         }
 
         $error_msg = false;
-        $langUrlForm = new LangUrlForm($this->getRequest());
+        $langUrlForm = $this->createForm(AdminForm::LANG_URL);
 
         try {
             $form = $this->validateForm($langUrlForm);

--- a/core/lib/Thelia/Controller/Admin/MailingSystemController.php
+++ b/core/lib/Thelia/Controller/Admin/MailingSystemController.php
@@ -16,8 +16,8 @@ use Thelia\Core\Event\MailingSystem\MailingSystemEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\JsonResponse;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\MailingSystemModificationForm;
 use Thelia\Model\ConfigQuery;
 
 class MailingSystemController extends BaseAdminController
@@ -44,7 +44,7 @@ class MailingSystemController extends BaseAdminController
         );
 
         // Setup the object form
-        $form = new MailingSystemModificationForm($this->getRequest(), "form", $data);
+        $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION, "form", $data);
 
         // Pass it to the parser
         $this->getParserContext()->addForm($form);
@@ -63,7 +63,7 @@ class MailingSystemController extends BaseAdminController
         $error_msg = false;
 
         // Create the form from the request
-        $form = new MailingSystemModificationForm($this->getRequest());
+        $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION);
 
         try {
             // Check the form against constraints violations

--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -12,19 +12,18 @@
 
 namespace Thelia\Controller\Admin;
 
+use Symfony\Component\Finder\Finder;
+use Thelia\Core\Event\Message\MessageCreateEvent;
+use Thelia\Core\Event\Message\MessageDeleteEvent;
+use Thelia\Core\Event\Message\MessageUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Message\MessageDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Message\MessageUpdateEvent;
-use Thelia\Core\Event\Message\MessageCreateEvent;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Model\MessageQuery;
-use Thelia\Form\MessageModificationForm;
-use Thelia\Form\MessageCreationForm;
-use Symfony\Component\Finder\Finder;
 use Thelia\Core\Template\TemplateHelper;
+use Thelia\Form\Definition\AdminForm;
+use Thelia\Model\MessageQuery;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
@@ -52,12 +51,12 @@ class MessageController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new MessageCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::MESSAGE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new MessageModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::MESSAGE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -126,7 +125,7 @@ class MessageController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new MessageModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::MESSAGE_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/ModuleHookController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleHookController.php
@@ -23,7 +23,7 @@ use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Form\ModuleHookCreationForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\ModuleHookModificationForm;
 use Thelia\Model\IgnoredModuleHook;
 use Thelia\Model\IgnoredModuleHookQuery;
@@ -104,7 +104,7 @@ class ModuleHookController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new ModuleHookCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::MODULE_HOOK_CREATION);
     }
 
     /**
@@ -112,7 +112,7 @@ class ModuleHookController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new ModuleHookModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::MODULE_HOOK_MODIFICATION);
     }
 
     /**
@@ -132,7 +132,7 @@ class ModuleHookController extends AbstractCrudController
             'active'    => $object->getActive(),
         ];
 
-        return new ModuleHookModificationForm($this->getRequest(), 'form', $data);
+        return $this->createForm(AdminForm::MODULE_HOOK_MODIFICATION, 'form', $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/OrderController.php
+++ b/core/lib/Thelia/Controller/Admin/OrderController.php
@@ -12,11 +12,11 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Order\OrderAddressEvent;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Form\OrderUpdateAddress;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\OrderAddressQuery;

--- a/core/lib/Thelia/Controller/Admin/ProductController.php
+++ b/core/lib/Thelia/Controller/Admin/ProductController.php
@@ -15,73 +15,66 @@ namespace Thelia\Controller\Admin;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Thelia\Core\Event\FeatureProduct\FeatureProductDeleteEvent;
 use Thelia\Core\Event\FeatureProduct\FeatureProductUpdateEvent;
-use Thelia\Core\Event\Product\ProductEvent;
 use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
 use Thelia\Core\Event\MetaData\MetaDataDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Product\ProductUpdateEvent;
-use Thelia\Core\Event\Product\ProductCreateEvent;
-use Thelia\Core\Event\Product\ProductAddCategoryEvent;
-use Thelia\Core\Event\Product\ProductDeleteCategoryEvent;
-use Thelia\Core\Event\Product\ProductDeleteEvent;
-use Thelia\Core\Event\Product\ProductToggleVisibilityEvent;
-use Thelia\Core\Event\Product\ProductDeleteContentEvent;
-use Thelia\Core\Event\Product\ProductAddContentEvent;
 use Thelia\Core\Event\Product\ProductAddAccessoryEvent;
-use Thelia\Core\Event\Product\ProductDeleteAccessoryEvent;
+use Thelia\Core\Event\Product\ProductAddCategoryEvent;
+use Thelia\Core\Event\Product\ProductAddContentEvent;
 use Thelia\Core\Event\Product\ProductCombinationGenerationEvent;
+use Thelia\Core\Event\Product\ProductCreateEvent;
+use Thelia\Core\Event\Product\ProductDeleteAccessoryEvent;
+use Thelia\Core\Event\Product\ProductDeleteCategoryEvent;
+use Thelia\Core\Event\Product\ProductDeleteContentEvent;
+use Thelia\Core\Event\Product\ProductDeleteEvent;
+use Thelia\Core\Event\Product\ProductEvent;
 use Thelia\Core\Event\Product\ProductSetTemplateEvent;
-use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Event\Product\ProductToggleVisibilityEvent;
+use Thelia\Core\Event\Product\ProductUpdateEvent;
+use Thelia\Core\Event\ProductSaleElement\ProductSaleElementCreateEvent;
 use Thelia\Core\Event\ProductSaleElement\ProductSaleElementDeleteEvent;
 use Thelia\Core\Event\ProductSaleElement\ProductSaleElementUpdateEvent;
-use Thelia\Core\Event\ProductSaleElement\ProductSaleElementCreateEvent;
-
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\HttpFoundation\JsonResponse;
 use Thelia\Core\HttpFoundation\Response;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\AccessManager;
-
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\Loop\Document;
 use Thelia\Core\Template\Loop\Image;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
+use Thelia\Form\ProductModificationForm;
 use Thelia\Model\AccessoryQuery;
 use Thelia\Model\AttributeAv;
+use Thelia\Model\AttributeAvQuery;
+use Thelia\Model\AttributeQuery;
 use Thelia\Model\CategoryQuery;
 use Thelia\Model\Content;
+use Thelia\Model\ContentQuery;
+use Thelia\Model\Country;
+use Thelia\Model\Currency;
+use Thelia\Model\CurrencyQuery;
 use Thelia\Model\Feature;
 use Thelia\Model\FeatureQuery;
 use Thelia\Model\FeatureTemplateQuery;
 use Thelia\Model\FolderQuery;
-use Thelia\Model\ContentQuery;
-use Thelia\Model\AttributeQuery;
-use Thelia\Model\AttributeAvQuery;
-use Thelia\Model\MetaDataQuery;
 use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductAssociatedContentQuery;
 use Thelia\Model\ProductDocument;
 use Thelia\Model\ProductDocumentQuery;
 use Thelia\Model\ProductImageQuery;
+use Thelia\Model\ProductPrice;
+use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductQuery;
-use Thelia\Model\ProductAssociatedContentQuery;
-use Thelia\Model\ProductSaleElements as ProductSaleElementsModel;
 use Thelia\Model\ProductSaleElements;
-use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\ProductSaleElements as ProductSaleElementsModel;
 use Thelia\Model\ProductSaleElementsProductDocument;
 use Thelia\Model\ProductSaleElementsProductDocumentQuery;
 use Thelia\Model\ProductSaleElementsProductImage;
 use Thelia\Model\ProductSaleElementsProductImageQuery;
-use Thelia\Model\ProductPriceQuery;
-use Thelia\Model\ProductPrice;
-use Thelia\Model\Currency;
-use Thelia\Model\CurrencyQuery;
-use Thelia\Model\Country;
-use Thelia\Model\Product;
-
-use Thelia\Form\ProductCreationForm;
-use Thelia\Form\ProductModificationForm;
-use Thelia\Form\ProductSaleElementUpdateForm;
-use Thelia\Form\ProductDefaultSaleElementUpdateForm;
-use Thelia\Form\ProductCombinationGenerationForm;
-
+use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Model\TaxRuleQuery;
 use Thelia\TaxEngine\Calculator;
 use Thelia\Tools\NumberFormat;
@@ -140,12 +133,12 @@ class ProductController extends AbstractSeoCrudController
 
     protected function getCreationForm()
     {
-        return new ProductCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::PRODUCT_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new ProductModificationForm($this->getRequest(), "form", [], [], $this->container);
+        return $this->createForm(AdminForm::PRODUCT_MODIFICATION, "form", [], [], $this->container);
     }
 
     protected function getCreationEvent($formData)
@@ -332,10 +325,10 @@ class ProductController extends AbstractSeoCrudController
                 $this->appendValue($combinationPseData, "ean_code", $saleElement->getEanCode());
             }
 
-            $defaultPseForm = new ProductDefaultSaleElementUpdateForm($this->getRequest(), "form", $defaultPseData);
+            $defaultPseForm = $this->createForm(AdminForm::PRODUCT_DEFAULT_SALE_ELEMENT_UPDATE, "form", $defaultPseData);
             $this->getParserContext()->addForm($defaultPseForm);
 
-            $combinationPseForm = new ProductSaleElementUpdateForm($this->getRequest(), "form", $combinationPseData);
+            $combinationPseForm = $this->createForm(AdminForm::PRODUCT_SALE_ELEMENT_UPDATE, "form", $combinationPseData);
             $this->getParserContext()->addForm($combinationPseForm);
         }
 
@@ -366,7 +359,7 @@ class ProductController extends AbstractSeoCrudController
         }
 
         // Setup the object form
-        return new ProductModificationForm($this->getRequest(), "form", $data, [], $this->container);
+        return $this->createForm(AdminForm::PRODUCT_MODIFICATION, "form", $data, [], $this->container);
     }
 
     /**
@@ -1152,7 +1145,7 @@ class ProductController extends AbstractSeoCrudController
     public function updateProductSaleElementsAction()
     {
         return $this->processProductSaleElementUpdate(
-            new ProductSaleElementUpdateForm($this->getRequest())
+            $this->createForm(AdminForm::PRODUCT_SALE_ELEMENT_UPDATE)
         );
     }
 
@@ -1162,7 +1155,7 @@ class ProductController extends AbstractSeoCrudController
     public function updateProductDefaultSaleElementAction()
     {
         return $this->processProductSaleElementUpdate(
-            new ProductDefaultSaleElementUpdateForm($this->getRequest())
+            $this->createForm(AdminForm::PRODUCT_DEFAULT_SALE_ELEMENT_UPDATE)
         );
     }
 
@@ -1196,7 +1189,7 @@ class ProductController extends AbstractSeoCrudController
             return $response;
         }
 
-        $changeForm = new ProductCombinationGenerationForm($this->getRequest());
+        $changeForm = $this->createForm(AdminForm::PRODUCT_COMBINATION_GENERATION);
 
         try {
             // Check the form against constraints violations

--- a/core/lib/Thelia/Controller/Admin/ProfileController.php
+++ b/core/lib/Thelia/Controller/Admin/ProfileController.php
@@ -12,13 +12,12 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\AccessManager;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Profile\ProfileEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\ProfileCreationForm;
-use Thelia\Form\ProfileModificationForm;
 use Thelia\Form\ProfileUpdateModuleAccessForm;
 use Thelia\Form\ProfileUpdateResourceAccessForm;
 use Thelia\Model\ProfileQuery;
@@ -40,12 +39,12 @@ class ProfileController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new ProfileCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::PROFILE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new ProfileModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::PROFILE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -103,7 +102,7 @@ class ProfileController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new ProfileModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::PROFILE_MODIFICATION, "form", $data);
     }
 
     protected function hydrateResourceUpdateForm($object)
@@ -113,7 +112,7 @@ class ProfileController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new ProfileUpdateResourceAccessForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::PROFILE_UPDATE_RESOURCE_ACCESS, "form", $data);
     }
 
     protected function hydrateModuleUpdateForm($object)
@@ -123,7 +122,7 @@ class ProfileController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new ProfileUpdateModuleAccessForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::PROFILE_UPDATE_MODULE_ACCESS, "form", $data);
     }
 
     protected function getObjectFromEvent($event)
@@ -305,7 +304,7 @@ class ProfileController extends AbstractCrudController
         $error_msg = false;
 
         // Create the form from the request
-        $changeForm = new ProfileUpdateResourceAccessForm($this->getRequest());
+        $changeForm = $this->createForm(AdminForm::PROFILE_UPDATE_RESOURCE_ACCESS);
 
         try {
             // Check the form against constraints violations
@@ -368,7 +367,7 @@ class ProfileController extends AbstractCrudController
         $error_msg = false;
 
         // Create the form from the request
-        $changeForm = new ProfileUpdateModuleAccessForm($this->getRequest());
+        $changeForm = $this->createForm(AdminForm::PROFILE_UPDATE_MODULE_ACCESS);
 
         try {
             // Check the form against constraints violations

--- a/core/lib/Thelia/Controller/Admin/SaleController.php
+++ b/core/lib/Thelia/Controller/Admin/SaleController.php
@@ -23,7 +23,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Form\Sale\SaleCreationForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Sale\SaleModificationForm;
 use Thelia\Model\Sale;
 use Thelia\Model\SaleProduct;
@@ -54,7 +54,7 @@ class SaleController extends AbstractCrudController
      */
     protected function getCreationForm()
     {
-        return new SaleCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::SALE_CREATION);
     }
 
     /**
@@ -62,7 +62,7 @@ class SaleController extends AbstractCrudController
      */
     protected function getUpdateForm()
     {
-        return new SaleModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::SALE_MODIFICATION);
     }
 
     /**
@@ -117,7 +117,7 @@ class SaleController extends AbstractCrudController
         ];
 
         // Setup the object form
-        return new SaleModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::SALE_MODIFICATION, "form", $data);
     }
 
     /**

--- a/core/lib/Thelia/Controller/Admin/SessionController.php
+++ b/core/lib/Thelia/Controller/Admin/SessionController.php
@@ -12,14 +12,13 @@
 
 namespace Thelia\Controller\Admin;
 
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Authentication\AdminUsernamePasswordFormAuthenticator;
+use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\User\UserInterface;
 use Thelia\Form\AdminLogin;
-use Thelia\Core\Security\Authentication\AdminUsernamePasswordFormAuthenticator;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\AdminLog;
-use Thelia\Core\Security\Exception\AuthenticationException;
-
-use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\LangQuery;

--- a/core/lib/Thelia/Controller/Admin/ShippingZoneController.php
+++ b/core/lib/Thelia/Controller/Admin/ShippingZoneController.php
@@ -12,11 +12,11 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\ShippingZone\ShippingZoneAddAreaEvent;
 use Thelia\Core\Event\ShippingZone\ShippingZoneRemoveAreaEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Form\ShippingZone\ShippingZoneAddArea;
 use Thelia\Form\ShippingZone\ShippingZoneRemoveArea;

--- a/core/lib/Thelia/Controller/Admin/SystemLogController.php
+++ b/core/lib/Thelia/Controller/Admin/SystemLogController.php
@@ -12,9 +12,9 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Form\SystemLogConfigurationForm;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 
@@ -82,7 +82,7 @@ class SystemLogController extends BaseAdminController
         }
 
         // Hydrate the general configuration form
-        $systemLogForm = new SystemLogConfigurationForm($this->getRequest(), 'form', array(
+        $systemLogForm = $this->createForm(AdminForm::SYSTEM_LOG_CONFIGURATION, 'form', array(
             'level'             => ConfigQuery::read(Tlog::VAR_LEVEL, Tlog::DEFAULT_LEVEL),
             'format'            => ConfigQuery::read(Tlog::VAR_PREFIXE, Tlog::DEFAUT_PREFIXE),
             'show_redirections' => ConfigQuery::read(Tlog::VAR_SHOW_REDIRECT, Tlog::DEFAUT_SHOW_REDIRECT),
@@ -103,7 +103,7 @@ class SystemLogController extends BaseAdminController
 
         $error_msg = false;
 
-        $systemLogForm = new SystemLogConfigurationForm($this->getRequest());
+        $systemLogForm = $this->createForm(AdminForm::SYSTEM_LOG_CONFIGURATION);
 
         try {
             $form = $this->validateForm($systemLogForm);

--- a/core/lib/Thelia/Controller/Admin/TaxController.php
+++ b/core/lib/Thelia/Controller/Admin/TaxController.php
@@ -12,13 +12,12 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Tax\TaxEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Form\TaxCreationForm;
-use Thelia\Form\TaxModificationForm;
-use Thelia\Model\TaxQuery;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Tax;
+use Thelia\Model\TaxQuery;
 
 class TaxController extends AbstractCrudController
 {
@@ -37,14 +36,14 @@ class TaxController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        $form = new TaxCreationForm($this->getRequest(), 'form', [], ["tax_engine" => $this->container->get('thelia.taxEngine')]);
+        $form = $this->createForm(AdminForm::TAX_CREATION, 'form', [], ["tax_engine" => $this->container->get('thelia.taxEngine')]);
 
         return $form;
     }
 
     protected function getUpdateForm()
     {
-        return new TaxModificationForm($this->getRequest(), 'form', [], ["tax_engine" => $this->container->get('thelia.taxEngine')]);
+        return $this->createForm(AdminForm::TAX_MODIFICATION, 'form', [], ["tax_engine" => $this->container->get('thelia.taxEngine')]);
     }
 
     protected function getCreationEvent($formData)
@@ -101,7 +100,12 @@ class TaxController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new TaxModificationForm($this->getRequest(), "form", $data, ["tax_engine" => $this->container->get('thelia.taxEngine')]);
+        return $this->createForm(
+            AdminForm::TAX_MODIFICATION,
+            "form",
+            $data,
+            ["tax_engine" => $this->container->get('thelia.taxEngine')]
+        );
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/TaxRuleController.php
+++ b/core/lib/Thelia/Controller/Admin/TaxRuleController.php
@@ -12,17 +12,14 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Event\Tax\TaxRuleEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
-use Thelia\Form\TaxRuleCreationForm;
-use Thelia\Form\TaxRuleModificationForm;
-use Thelia\Form\TaxRuleTaxListUpdateForm;
 use Thelia\Model\CountryQuery;
 use Thelia\Model\TaxRuleQuery;
-use Thelia\Form\TaxCreationForm;
 
 class TaxRuleController extends AbstractCrudController
 {
@@ -48,7 +45,12 @@ class TaxRuleController extends AbstractCrudController
         //
         // So we create an instance of TaxCreationForm here (we have the container), and put it in the ParserContext.
         // This way, the Form plugin will use this instance, instead on creating it.
-        $taxCreationForm = new TaxCreationForm($this->getRequest(), 'form', array(), array("tax_engine" => $this->container->get('thelia.taxEngine')));
+        $taxCreationForm = $this->createForm(
+            AdminForm::TAX_CREATION,
+            'form',
+            array(),
+            array("tax_engine" => $this->container->get('thelia.taxEngine'))
+        );
 
         $this->getParserContext()->addForm($taxCreationForm);
 
@@ -57,12 +59,12 @@ class TaxRuleController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new TaxRuleCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::TAX_RULE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new TaxRuleModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::TAX_RULE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -125,7 +127,7 @@ class TaxRuleController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new TaxRuleModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::TAX_RULE_MODIFICATION, "form", $data);
     }
 
     protected function hydrateTaxUpdateForm($object)
@@ -135,7 +137,7 @@ class TaxRuleController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new TaxRuleTaxListUpdateForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::TAX_RULE_TAX_LIST_UPDATE, "form", $data);
     }
 
     protected function getObjectFromEvent($event)
@@ -272,7 +274,7 @@ class TaxRuleController extends AbstractCrudController
         $error_msg = false;
 
         // Create the form from the request
-        $changeForm = new TaxRuleTaxListUpdateForm($this->getRequest());
+        $changeForm = $this->createForm(AdminForm::TAX_RULE_TAX_LIST_UPDATE);
 
         try {
             // Check the form against constraints violations

--- a/core/lib/Thelia/Controller/Admin/TemplateController.php
+++ b/core/lib/Thelia/Controller/Admin/TemplateController.php
@@ -12,21 +12,20 @@
 
 namespace Thelia\Controller\Admin;
 
-use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Core\Event\Template\TemplateDeleteEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Event\Template\TemplateUpdateEvent;
-use Thelia\Core\Event\Template\TemplateCreateEvent;
-use Thelia\Core\Security\AccessManager;
-use Thelia\Model\TemplateQuery;
-use Thelia\Form\TemplateModificationForm;
-use Thelia\Form\TemplateCreationForm;
-use Thelia\Core\Event\Template\TemplateDeleteAttributeEvent;
 use Thelia\Core\Event\Template\TemplateAddAttributeEvent;
 use Thelia\Core\Event\Template\TemplateAddFeatureEvent;
+use Thelia\Core\Event\Template\TemplateCreateEvent;
+use Thelia\Core\Event\Template\TemplateDeleteAttributeEvent;
+use Thelia\Core\Event\Template\TemplateDeleteEvent;
 use Thelia\Core\Event\Template\TemplateDeleteFeatureEvent;
-use Thelia\Model\FeatureTemplateQuery;
+use Thelia\Core\Event\Template\TemplateUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\AttributeTemplateQuery;
+use Thelia\Model\FeatureTemplateQuery;
+use Thelia\Model\TemplateQuery;
 
 /**
  * Manages product templates
@@ -52,12 +51,12 @@ class TemplateController extends AbstractCrudController
 
     protected function getCreationForm()
     {
-        return new TemplateCreationForm($this->getRequest());
+        return $this->createForm(AdminForm::TEMPLATE_CREATION);
     }
 
     protected function getUpdateForm()
     {
-        return new TemplateModificationForm($this->getRequest());
+        return $this->createForm(AdminForm::TEMPLATE_MODIFICATION);
     }
 
     protected function getCreationEvent($formData)
@@ -105,7 +104,7 @@ class TemplateController extends AbstractCrudController
         );
 
         // Setup the object form
-        return new TemplateModificationForm($this->getRequest(), "form", $data);
+        return $this->createForm(AdminForm::TEMPLATE_MODIFICATION, "form", $data);
     }
 
     protected function getObjectFromEvent($event)

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -13,13 +13,13 @@
 namespace Thelia\Controller\Admin;
 
 use Symfony\Component\Finder\Finder;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\AccessManager;
+use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Template\TemplateHelper;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
-use Thelia\Core\Template\TemplateHelper;
-use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Tools\URL;
 
 /**

--- a/core/lib/Thelia/Controller/Api/CategoryController.php
+++ b/core/lib/Thelia/Controller/Api/CategoryController.php
@@ -21,6 +21,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\Loop\Category;
 use Thelia\Model\CategoryQuery;
+use Thelia\Form\Definition\ApiForm;
 
 /**
  * Class CategoryController
@@ -56,7 +57,7 @@ class CategoryController extends AbstractCrudApiController
      */
     protected function getCreationForm(array $data = array())
     {
-        return $this->createForm("thelia.api.category.create", "form", $data);
+        return $this->createForm(ApiForm::CATEGORY_CREATION, "form", $data);
     }
 
     /**
@@ -65,7 +66,7 @@ class CategoryController extends AbstractCrudApiController
      */
     protected function getUpdateForm(array $data = array())
     {
-        return $this->createForm("thelia.api.category.update", "form", $data, [
+        return $this->createForm(ApiForm::CATEGORY_MODIFICATION, "form", $data, [
             'method' => 'PUT',
         ]);
     }

--- a/core/lib/Thelia/Controller/Api/CustomerController.php
+++ b/core/lib/Thelia/Controller/Api/CustomerController.php
@@ -27,6 +27,7 @@ use Thelia\Core\Security\User\UserInterface;
 use Thelia\Core\Template\Loop\Customer;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\CustomerQuery;
+use Thelia\Form\Definition\ApiForm;
 
 /**
  * Class CustomerController
@@ -70,7 +71,7 @@ class CustomerController extends AbstractCrudApiController
      */
     protected function getCreationForm(array $data = array())
     {
-        return $this->createForm("thelia.api.customer.create");
+        return $this->createForm(ApiForm::CUSTOMER_CREATE);
     }
 
     /**
@@ -80,7 +81,7 @@ class CustomerController extends AbstractCrudApiController
     protected function getUpdateForm(array $data = array())
     {
         return $this->createForm(
-            "thelia.api.customer.update",
+            ApiForm::CUSTOMER_UPDATE,
             "form",
             [],
             ['method' => 'PUT']
@@ -192,7 +193,7 @@ class CustomerController extends AbstractCrudApiController
         $this->checkAuth($this->resources, $this->modules, AccessManager::VIEW);
 
         $request = $this->getRequest();
-        $customerLoginForm = $this->createForm("thelia.api.customer.login");
+        $customerLoginForm = $this->createForm(ApiForm::CUSTOMER_LOGIN);
 
         try {
             $this->validateForm($customerLoginForm, "post");

--- a/core/lib/Thelia/Controller/Api/ProductController.php
+++ b/core/lib/Thelia/Controller/Api/ProductController.php
@@ -26,6 +26,7 @@ use Thelia\Core\Template\Loop\Product;
 use Thelia\Form\Api\Product\ProductCreationForm;
 use Thelia\Form\Api\Product\ProductModificationForm;
 use Thelia\Model\ProductQuery;
+use Thelia\Form\Definition\ApiForm;
 
 /**
  * Class ProductController
@@ -90,8 +91,7 @@ class ProductController extends BaseApiController
     {
         $this->checkAuth(AdminResources::PRODUCT, [], AccessManager::CREATE);
 
-        $request = $this->getRequest();
-        $form = new ProductCreationForm($request, 'form', [], ['csrf_protection' => false]);
+        $form = $this->createForm(ApiForm::PRODUCT_CREATION, 'form', [], ['csrf_protection' => false]);
 
         try {
             $creationForm = $this->validateForm($form);
@@ -109,7 +109,7 @@ class ProductController extends BaseApiController
 
             $this->dispatch(TheliaEvents::PRODUCT_UPDATE, $updateEvent);
 
-            $request->query->set('lang', $creationForm->get('locale')->getData());
+            $this->getRequest()->query->set('lang', $creationForm->get('locale')->getData());
             $response = $this->getProductAction($product->getId());
             $response->setStatusCode(201);
 
@@ -125,10 +125,8 @@ class ProductController extends BaseApiController
 
         $this->checkProductExists($productId);
 
-        $request = $this->getRequest();
-
-        $form = new ProductModificationForm(
-            $request,
+        $form = $this->createForm(
+            ApiForm::PRODUCT_MODIFICATION,
             'form',
             ['id' => $productId],
             [
@@ -136,6 +134,8 @@ class ProductController extends BaseApiController
                 'method' => 'PUT'
             ]
         );
+
+        $request = $this->getRequest();
 
         $data = $request->request->all();
         $data['id'] = $productId;

--- a/core/lib/Thelia/Controller/Api/ProductSaleElementsController.php
+++ b/core/lib/Thelia/Controller/Api/ProductSaleElementsController.php
@@ -23,6 +23,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\JsonResponse;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Country;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
 use Thelia\Model\Product;
@@ -33,6 +34,7 @@ use Thelia\Core\Template\Loop\ProductSaleElements as ProductSaleElementsLoop;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Model\TaxRuleQuery;
 use Thelia\TaxEngine\Calculator;
+use Thelia\Form\Definition\ApiForm;
 
 /**
  * Class ProductSaleElementsController
@@ -130,7 +132,7 @@ class ProductSaleElementsController extends BaseApiController
     {
         $this->checkAuth(AdminResources::PRODUCT, [], AccessManager::CREATE);
 
-        $baseForm = $this->createForm("thelia.api.product_sale_elements", "form", [], [
+        $baseForm = $this->createForm(ApiForm::PRODUCT_SALE_ELEMENTS, "form", [], [
             "validation_groups" => ["create", "Default"],
             'csrf_protection' => false,
             "cascade_validation" => true,
@@ -193,7 +195,7 @@ class ProductSaleElementsController extends BaseApiController
     {
         $this->checkAuth(AdminResources::PRODUCT, [], AccessManager::UPDATE);
 
-        $baseForm = $this->createForm("thelia.api.product_sale_elements", "form", [], [
+        $baseForm = $this->createForm(ApiForm::PRODUCT_SALE_ELEMENTS, "form", [], [
             "validation_groups" => ["update", "Default"],
             'csrf_protection' => false,
             "cascade_validation" => true,

--- a/core/lib/Thelia/Controller/Api/TitleController.php
+++ b/core/lib/Thelia/Controller/Api/TitleController.php
@@ -12,20 +12,14 @@
 
 namespace Thelia\Controller\Api;
 
-use Propel\Runtime\Propel;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Thelia\Core\Event\CustomerTitle\CustomerTitleEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\Loop\Title;
 use Thelia\Model\CustomerTitleI18nQuery;
 use Thelia\Model\CustomerTitleQuery;
-use Thelia\Model\Map\CustomerTitleTableMap;
 
 /**
  * Class TitleController

--- a/core/lib/Thelia/Files/FileModelInterface.php
+++ b/core/lib/Thelia/Files/FileModelInterface.php
@@ -57,14 +57,6 @@ interface FileModelInterface
     public function getUpdateFormId();
 
     /**
-     * Get the form instance used to change this object information
-     *
-     * @param Request $request the current request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request);
-    /**
      * @return string the path to the upload directory where files are stored, without final slash
      */
     public function getUploadDir();
@@ -150,4 +142,12 @@ interface FileModelInterface
      * @return FileModelInterface
      */
     public function setLocale($locale);
+
+    /**
+     * Set the current locale
+     *
+     * @param  bool            $visible true if the file is visible, false otherwise
+     * @return FileModelInterface
+     */
+    public function setVisible($visible);
 }

--- a/core/lib/Thelia/Form/BaseForm.php
+++ b/core/lib/Thelia/Form/BaseForm.php
@@ -95,6 +95,15 @@ abstract class BaseForm
      */
     private $type;
 
+    /**
+     * @param Request $request
+     * @param string $type
+     * @param array $data
+     * @param array $options
+     * @param ContainerInterface $container
+     * @deprecated Thelia forms should not be instantiated directly. Please use BaseController::createForm() instead
+     * @see BaseController::createForm()
+     */
     public function __construct(
         Request $request,
         $type = "form",

--- a/core/lib/Thelia/Form/Definition/AdminForm.php
+++ b/core/lib/Thelia/Form/Definition/AdminForm.php
@@ -1,0 +1,156 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Form\Definition;
+
+/**
+ * Class AdminForm
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * @package Thelia\Form\Definition
+ */
+final class AdminForm
+{
+    const ADMIN_LOGIN = 'thelia.admin.login';
+    const SEO = 'thelia.admin.seo';
+
+    const CUSTOMER_CREATE = 'thelia.admin.customer.create';
+    const CUSTOMER_UPDATE = 'thelia.admin.customer.update';
+
+    const ADDRESS_CREATE = 'thelia.admin.address.create';
+    const ADDRESS_UPDATE = 'thelia.admin.address.update';
+
+    const CATEGORY_CREATION = 'thelia.admin.category.creation';
+    const CATEGORY_MODIFICATION = 'thelia.admin.category.modification';
+    const CATEGORY_IMAGE_MODIFICATION = 'thelia.admin.category.image.modification';
+    const CATEGORY_DOCUMENT_MODIFICATION = 'thelia.admin.category.document.modification';
+
+    const PRODUCT_CREATION = 'thelia.admin.product.creation';
+    const PRODUCT_MODIFICATION = 'thelia.admin.product.modification';
+    const PRODUCT_DETAILS_MODIFICATION = 'thelia.admin.product.details.modification';
+    const PRODUCT_IMAGE_MODIFICATION = 'thelia.admin.product.image.modification';
+    const PRODUCT_DOCUMENT_MODIFICATION = 'thelia.admin.product.document.modification';
+
+    const PRODUCT_SALE_ELEMENT_UPDATE = 'thelia.admin.product_sale_element.update';
+    const PRODUCT_DEFAULT_SALE_ELEMENT_UPDATE = 'thelia.admin.product_default_sale_element.update';
+    const PRODUCT_COMBINATION_GENERATION = 'thelia.admin.product_combination.build';
+
+    const PRODUCT_DELETE = 'thelia.admin.product.deletion';
+
+    const FOLDER_CREATION = 'thelia.admin.folder.creation';
+    const FOLDER_MODIFICATION = 'thelia.admin.folder.modification';
+    const FOLDER_IMAGE_MODIFICATION = 'thelia.admin.folder.image.modification';
+    const FOLDER_DOCUMENT_MODIFICATION = 'thelia.admin.folder.document.modification';
+
+    const CONTENT_CREATION = 'thelia.admin.content.creation';
+    const CONTENT_MODIFICATION = 'thelia.admin.content.modification';
+    const CONTENT_IMAGE_MODIFICATION = 'thelia.admin.content.image.modification';
+    const CONTENT_DOCUMENT_MODIFICATION = 'thelia.admin.content.document.modification';
+
+    const BRAND_CREATION = 'thelia.admin.brand.creation';
+    const BRAND_MODIFICATION = 'thelia.admin.brand.modification';
+    const BRAND_IMAGE_MODIFICATION = 'thelia.admin.brand.image.modification';
+    const BRAND_DOCUMENT_MODIFICATION = 'thelia.admin.brand.document.modification';
+
+    const CART_ADD = 'thelia.cart.add';
+
+    const ORDER_DELIVERY = 'thelia.order.delivery';
+    const ORDER_PAYMENT = 'thelia.order.payment';
+    const ORDER_UPDATE_ADDRESS = 'thelia.order.update.address';
+
+    const COUPON_CODE = 'thelia.order.coupon';
+
+    const CONFIG_CREATION = 'thelia.admin.config.creation';
+    const CONFIG_MODIFICATION = 'thelia.admin.config.modification';
+
+    const MESSAGE_CREATION = 'thelia.admin.message.creation';
+    const MESSAGE_MODIFICATION = 'thelia.admin.message.modification';
+
+    const CURRENCY_CREATION = 'thelia.admin.currency.creation';
+    const CURRENCY_MODIFICATION = 'thelia.admin.currency.modification';
+
+    const COUPON_CREATION = 'thelia.admin.coupon.creation';
+
+    const ATTRIBUTE_CREATION = 'thelia.admin.attribute.creation';
+    const ATTRIBUTE_MODIFICATION = 'thelia.admin.attribute.modification';
+
+    const FEATURE_CREATION = 'thelia.admin.feature.creation';
+    const FEATURE_MODIFICATION = 'thelia.admin.feature.modification';
+
+    const ATTRIBUTE_AV_CREATION = 'thelia.admin.attributeav.creation';
+
+    const FEATURE_AV_CREATION = 'thelia.admin.featureav.creation';
+
+    const TAX_RULE_MODIFICATION = 'thelia.admin.taxrule.modification';
+    const TAX_RULE_TAX_LIST_UPDATE = 'thelia.admin.taxrule.taxlistupdate';
+    const TAX_RULE_CREATION = 'thelia.admin.taxrule.add';
+
+    const TAX_MODIFICATION = 'thelia.admin.tax.modification';
+    const TAX_TAX_LIST_UPDATE = 'thelia.admin.tax.taxlistupdate';
+    const TAX_CREATION = 'thelia.admin.tax.add';
+
+    const PROFILE_CREATION = 'thelia.admin.profile.add';
+    const PROFILE_MODIFICATION = 'thelia.admin.profile.modification';
+    const PROFILE_UPDATE_RESOURCE_ACCESS = 'thelia.admin.profile.resource-access.modification';
+    const PROFILE_UPDATE_MODULE_ACCESS = 'thelia.admin.profile.module-access.modification';
+
+    const ADMINISTRATOR_CREATION = 'thelia.admin.administrator.add';
+    const ADMINISTRATOR_MODIFICATION = 'thelia.admin.administrator.update';
+
+    const MAILING_SYSTEM_MODIFICATION = 'thelia.admin.mailing-system.update';
+
+    const TEMPLATE_CREATION = 'thelia.admin.template.creation';
+    const TEMPLATE_MODIFICATION = 'thelia.admin.template.modification';
+
+    const COUNTRY_CREATION = 'thelia.admin.country.creation';
+    const COUNTRY_MODIFICATION = 'thelia.admin.country.modification';
+
+    const AREA_CREATE = 'thelia.admin.area.create';
+    const AREA_MODIFICATION = 'thelia.admin.area.modification';
+    const AREA_COUNTRY = 'thelia.admin.area.country';
+    const AREA_POSTAGE = 'thelia.admin.area.postage';
+
+    const SHIPPING_ZONE_ADD_AREA = 'thelia.shopping_zone_area';
+    const SHIPPING_ZONE_REMOVE_AREA = 'thelia.shopping_zone_remove_area';
+
+    const LANG_UPDATE = 'thelia.lang.update';
+    const LANG_CREATE = 'thelia.lang.create';
+    const LANG_DEFAULT_BEHAVIOR = 'thelia.lang.default_BEHAVIOR';
+    const LANG_URL = 'thelia.lang.url';
+
+    const CONFIG_STORE = 'thelia.configuration.store';
+    const SYSTEM_LOG_CONFIGURATION = 'thelia.system-logs.configuration';
+
+    const MODULE_MODIFICATION = 'thelia.admin.module.modification';
+    const MODULE_INSTALL = 'thelia.admin.module.install';
+
+    const HOOK_CREATION = 'thelia.admin.hook.creation';
+    const HOOK_MODIFICATION = 'thelia.admin.hook.modification';
+
+    const MODULE_HOOK_CREATION = 'thelia.admin.module-hook.creation';
+    const MODULE_HOOK_MODIFICATION = 'thelia.admin.module-hook.modification';
+
+    const CACHE_FLUSH = 'thelia.cache.flush';
+    const ASSETS_FLUSH = 'thelia.assets.flush';
+    const IMAGES_AND_DOCUMENTS_CACHE_FLUSH = 'thelia.images-and-documents-cache.flush';
+
+    const EXPORT = 'thelia.export';
+    const IMPORT = 'thelia.import';
+
+    const SALE_CREATION = 'thelia.admin.sale.creation';
+    const SALE_MODIFICATION = 'thelia.admin.sale.modification';
+
+    const EMPTY_FORM = 'thelia.empty';
+
+    const API_CREATE = 'thelia_api_create';
+    const API_UPDATE = 'thelia_api_update';
+}

--- a/core/lib/Thelia/Form/Definition/ApiForm.php
+++ b/core/lib/Thelia/Form/Definition/ApiForm.php
@@ -10,23 +10,27 @@
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
 
-namespace Thelia\Controller\Admin;
-
-use Thelia\Core\Security\AccessManager;
-use Thelia\Core\Security\Resource\AdminResources;
+namespace Thelia\Form\Definition;
 
 /**
- * Class LanguageController
- * @package Thelia\Controller\Admin
- * @author Manuel Raynaud <manu@thelia.net>
+ * Class ApiForm
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * @package TheliaFormDefinition
  */
-class LanguageController extends BaseAdminController
+final class ApiForm
 {
-    public function defaultAction()
-    {
-        if (null !== $response = $this->checkAuth(AdminResources::LANGUAGE, array(), AccessManager::VIEW)) {
-            return $response;
-        }
-        return $this->render("languages");
-    }
+    const EMPTY_FORM = 'thelia.api.empty';
+
+    const CUSTOMER_CREATE = 'thelia.api.customer.create';
+    const CUSTOMER_UPDATE = 'thelia.api.customer.update';
+    const CUSTOMER_LOGIN = 'thelia.api.customer.login';
+
+    const CATEGORY_CREATION = 'thelia.api.category.create';
+    const CATEGORY_MODIFICATION = 'thelia.api.category.update';
+
+    const PRODUCT_SALE_ELEMENTS = 'thelia.api.product_sale_elements';
+
+    const PRODUCT_CREATION = 'thelia.api.product.creation';
+    const PRODUCT_MODIFICATION = 'thelia.api.product.modification';
 }

--- a/core/lib/Thelia/Form/Definition/FrontForm.php
+++ b/core/lib/Thelia/Form/Definition/FrontForm.php
@@ -10,23 +10,23 @@
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
 
-namespace Thelia\Controller\Admin;
-
-use Thelia\Core\Security\AccessManager;
-use Thelia\Core\Security\Resource\AdminResources;
+namespace Thelia\Form\Definition;
 
 /**
- * Class LanguageController
- * @package Thelia\Controller\Admin
- * @author Manuel Raynaud <manu@thelia.net>
+ * Class FrontForm
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * @package Thelia\Form\Definition
  */
-class LanguageController extends BaseAdminController
+final class FrontForm
 {
-    public function defaultAction()
-    {
-        if (null !== $response = $this->checkAuth(AdminResources::LANGUAGE, array(), AccessManager::VIEW)) {
-            return $response;
-        }
-        return $this->render("languages");
-    }
+    const CUSTOMER_LOGIN = 'thelia.front.customer.login';
+    const CUSTOMER_LOST_PASSWORD = 'thelia.front.customer.lostpassword';
+    const CUSTOMER_CREATE = 'thelia.front.customer.create';
+    const CUSTOMER_PROFILE_UPDATE = 'thelia.front.customer.profile.update';
+    const CUSTOMER_PASSWORD_UPDATE = 'thelia.front.customer.password.update';
+    const ADDRESS_CREATE = 'thelia.front.address.create';
+    const ADDRESS_UPDATE = 'thelia.front.address.update';
+    const CONTACT = 'thelia.front.contact';
+    const NEWSLETTER = 'thelia.front.newsletter';
 }

--- a/core/lib/Thelia/Model/BrandDocument.php
+++ b/core/lib/Thelia/Model/BrandDocument.php
@@ -9,6 +9,7 @@ use Thelia\Files\FileModelInterface;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\Brand\BrandDocumentModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\BrandDocument as BaseBrandDocument;
 use Thelia\Model\Breadcrumb\BrandBreadcrumbTrait;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
@@ -85,19 +86,7 @@ class BrandDocument extends BaseBrandDocument implements BreadcrumbInterface, Fi
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.brand.document.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new BrandDocumentModification($request);
+        return AdminForm::BRAND_DOCUMENT_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/BrandImage.php
+++ b/core/lib/Thelia/Model/BrandImage.php
@@ -8,6 +8,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\Brand\BrandImageModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\BrandImage as BaseBrandImage;
 use Thelia\Model\Breadcrumb\BrandBreadcrumbTrait;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
@@ -85,19 +86,7 @@ class BrandImage extends BaseBrandImage implements FileModelInterface, Breadcrum
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.brand.image.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new BrandImageModification($request);
+        return AdminForm::BRAND_IMAGE_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/CategoryDocument.php
+++ b/core/lib/Thelia/Model/CategoryDocument.php
@@ -9,6 +9,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\CategoryDocumentModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\CategoryDocument as BaseCategoryDocument;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
@@ -95,19 +96,7 @@ class CategoryDocument extends BaseCategoryDocument implements BreadcrumbInterfa
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.category.document.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new CategoryDocumentModification($request);
+        return AdminForm::CATEGORY_DOCUMENT_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/CategoryImage.php
+++ b/core/lib/Thelia/Model/CategoryImage.php
@@ -9,6 +9,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\CategoryImageModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\CategoryImage as BaseCategoryImage;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
@@ -95,19 +96,7 @@ class CategoryImage extends BaseCategoryImage implements BreadcrumbInterface, Fi
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.category.image.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new CategoryImageModification($request);
+        return AdminForm::CATEGORY_IMAGE_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/ContentDocument.php
+++ b/core/lib/Thelia/Model/ContentDocument.php
@@ -11,6 +11,7 @@ use Thelia\Files\FileModelInterface;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\ContentDocumentModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\ContentDocument as BaseContentDocument;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
 use Thelia\Model\Breadcrumb\FolderBreadcrumbTrait;
@@ -95,19 +96,7 @@ class ContentDocument extends BaseContentDocument implements BreadcrumbInterface
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.content.document.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new ContentDocumentModification($request);
+        return AdminForm::CONTENT_DOCUMENT_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/ContentImage.php
+++ b/core/lib/Thelia/Model/ContentImage.php
@@ -9,6 +9,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
 use Thelia\Form\ContentImageModification;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\Base\ContentImage as BaseContentImage;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Model\Breadcrumb\BreadcrumbInterface;
@@ -93,19 +94,7 @@ class ContentImage extends BaseContentImage implements BreadcrumbInterface, File
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.content.image.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new ContentImageModification($request);
+        return AdminForm::CONTENT_IMAGE_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/FolderDocument.php
+++ b/core/lib/Thelia/Model/FolderDocument.php
@@ -8,6 +8,7 @@ use Symfony\Component\Routing\Router;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\FolderDocumentModification;
 use Thelia\Model\Base\FolderDocument as BaseFolderDocument;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -93,19 +94,7 @@ class FolderDocument extends BaseFolderDocument implements BreadcrumbInterface, 
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.folder.document.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new FolderDocumentModification($request);
+        return AdminForm::FOLDER_DOCUMENT_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/FolderImage.php
+++ b/core/lib/Thelia/Model/FolderImage.php
@@ -8,6 +8,7 @@ use Symfony\Component\Routing\Router;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\FolderImageModification;
 use Thelia\Model\Base\FolderImage as BaseFolderImage;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -93,19 +94,7 @@ class FolderImage extends BaseFolderImage implements BreadcrumbInterface, FileMo
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.folder.image.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new FolderImageModification($request);
+        return AdminForm::FOLDER_IMAGE_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/ProductDocument.php
+++ b/core/lib/Thelia/Model/ProductDocument.php
@@ -8,6 +8,7 @@ use Symfony\Component\Routing\Router;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Files\FileModelParentInterface;
 use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\ProductDocumentModification;
 use Thelia\Model\Base\ProductDocument as BaseProductDocument;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -95,19 +96,7 @@ class ProductDocument extends BaseProductDocument implements BreadcrumbInterface
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.product.document.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new ProductDocumentModification($request);
+        return AdminForm::PRODUCT_DOCUMENT_MODIFICATION;
     }
 
     /**

--- a/core/lib/Thelia/Model/ProductImage.php
+++ b/core/lib/Thelia/Model/ProductImage.php
@@ -7,6 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Router;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Form\BaseForm;
+use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\ProductImageModification;
 use Thelia\Model\Base\ProductImage as BaseProductImage;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -94,19 +95,7 @@ class ProductImage extends BaseProductImage implements BreadcrumbInterface, File
      */
     public function getUpdateFormId()
     {
-        return 'thelia.admin.product.image.modification';
-    }
-
-    /**
-     * Get the form instance used to change this object information
-     *
-     * @param \Thelia\Core\HttpFoundation\Request $request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new ProductImageModification($request);
+        return AdminForm::PRODUCT_IMAGE_MODIFICATION;
     }
 
     /**

--- a/local/modules/Carousel/Controller/ConfigurationController.php
+++ b/local/modules/Carousel/Controller/ConfigurationController.php
@@ -43,7 +43,7 @@ class ConfigurationController extends BaseAdminController
         }
 
         $request = $this->getRequest();
-        $form = new CarouselImageForm($request);
+        $form = $this->createForm('carousel.image');
         $error_message = null;
         try {
             $this->validateForm($form);
@@ -115,7 +115,8 @@ class ConfigurationController extends BaseAdminController
 
         $request = $this->getRequest();
 
-        $form = new CarouselUpdateForm($request);
+        $form = $this->createForm('carousel.update');
+
         $error_message = null;
 
         try {

--- a/local/modules/Carousel/Model/Carousel.php
+++ b/local/modules/Carousel/Model/Carousel.php
@@ -72,18 +72,6 @@ class Carousel extends BaseCarousel implements FileModelInterface
     }
 
     /**
-     * Get the form instance used to change this object information
-     *
-     * @param Request $request the current request
-     *
-     * @return BaseForm the form
-     */
-    public function getUpdateFormInstance(Request $request)
-    {
-        return new CarouselImageForm($request);
-    }
-
-    /**
      * @return string the path to the upload directory where files are stored, without final slash
      */
     public function getUploadDir()

--- a/local/modules/Cheque/Controller/ConfigureController.php
+++ b/local/modules/Cheque/Controller/ConfigureController.php
@@ -49,7 +49,7 @@ class ConfigureController extends BaseAdminController
         $ex = null;
 
         // Create the Form from the request
-        $configurationForm = new ConfigurationForm($this->getRequest());
+        $configurationForm = $this->createForm('cheque.instructions.configure');
 
         try {
             // Check the form against constraints violations

--- a/local/modules/Front/Controller/AddressController.php
+++ b/local/modules/Front/Controller/AddressController.php
@@ -30,6 +30,7 @@ use Thelia\Core\Event\Address\AddressEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Form\AddressCreateForm;
 use Thelia\Form\AddressUpdateForm;
+use Thelia\Form\Definition\FrontForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\AddressQuery;
 
@@ -65,7 +66,7 @@ class AddressController extends BaseFrontController
 
         $this->checkAuth();
 
-        $addressCreate = new AddressCreateForm($this->getRequest());
+        $addressCreate = $this->createForm(FrontForm::ADDRESS_CREATE);
         $message = false;
         try {
             $customer = $this->getSecurityContext()->getCustomerUser();
@@ -134,7 +135,7 @@ class AddressController extends BaseFrontController
         $this->checkAuth();
         $request = $this->getRequest();
 
-        $addressUpdate = new AddressUpdateForm($request);
+        $addressUpdate = $this->createForm(FrontForm::ADDRESS_UPDATE);
         $message = false;
         try {
             $customer = $this->getSecurityContext()->getCustomerUser();

--- a/local/modules/Front/Controller/ContactController.php
+++ b/local/modules/Front/Controller/ContactController.php
@@ -25,6 +25,7 @@ namespace Front\Controller;
 
 use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Form\ContactForm;
+use Thelia\Form\Definition\FrontForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Model\ConfigQuery;
 
@@ -41,7 +42,7 @@ class ContactController extends BaseFrontController
     public function sendAction()
     {
         $error_message = false;
-        $contactForm = new ContactForm($this->getRequest());
+        $contactForm = $this->createForm(FrontForm::CONTACT);
 
         try {
             $form = $this->validateForm($contactForm);

--- a/local/modules/Front/Controller/NewsletterController.php
+++ b/local/modules/Front/Controller/NewsletterController.php
@@ -27,8 +27,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\Event\Newsletter\NewsletterEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Form\NewsletterForm;
+use Thelia\Form\Definition\FrontForm;
 use Thelia\Log\Tlog;
+use Thelia\Model\Customer;
 
 /**
  * Class NewsletterController
@@ -41,10 +42,9 @@ class NewsletterController extends BaseFrontController
     public function subscribeAction()
     {
         $errorMessage = false;
-        $newsletterForm = new NewsletterForm($this->getRequest());
+        $newsletterForm = $this->createForm(FrontForm::NEWSLETTER);
 
         try {
-
             $form = $this->validateForm($newsletterForm);
 
             $event = new NewsletterEvent(
@@ -52,6 +52,7 @@ class NewsletterController extends BaseFrontController
                 $this->getRequest()->getSession()->getLang()->getLocale()
             );
 
+            /** @var Customer $customer */
             if (null !== $customer = $this->getSecurityContext()->getCustomerUser()) {
                 $event->setFirstname($customer->getFirstname());
                 $event->setLastname($customer->getLastname());
@@ -97,6 +98,5 @@ class NewsletterController extends BaseFrontController
                 ->setGeneralError($errorMessage)
             ;
         }
-
     }
 }


### PR DESCRIPTION
All core form explicit instantiations (`$form = new SomeForm();`) are replaced by calls to `BaseController::createForm()`, (`$form = $this->createForm('some.form');`)

Three sets of constants are created (AdminForm, FrontForm and ApiForm), to define a constant for each of the core forms.

Minor CS fixes in some places.