### PR TITLE
Add cache on the graph of the home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add the `country` and `order` parameters to Area loop
 - Add the `area` parameter to Module loop
 - Improved Shipping zones management
-
+- Add cache on the graph of the home page, possibility to disable cache or change ttl cache, with the configuration variables admin_cache_home_stats_enable admin_cache_home_stats_ttl
 
 # 2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Add the `country` and `order` parameters to Area loop
 - Add the `area` parameter to Module loop
 - Improved Shipping zones management
-- Add cache on the graph of the home page, possibility to disable cache or change ttl cache, with the configuration variables admin_cache_home_stats_enable admin_cache_home_stats_ttl
+- Add cache on the graph of the home page, possibility to disable cache or change ttl cache, with the configuration variable admin_cache_home_stats_ttl
 
 # 2.1.2
 

--- a/core/lib/Thelia/Controller/Admin/HomeController.php
+++ b/core/lib/Thelia/Controller/Admin/HomeController.php
@@ -57,11 +57,10 @@ class HomeController extends BaseAdminController
         if ($cacheEnable) {
             $context = "_" . $this->getRequest()->query->get('month', date('m')) . "_" . $this->getRequest()->query->get('year', date('Y'));
 
-            $cacheDir = $this->getCacheDir();
             $cacheKey = self::STATS_CACHE_KEY . $context;
             $cacheExpire = intval(ConfigQuery::read("admin_cache_home_stats_ttl", '600'));
 
-            $cacheDriver = new FilesystemCache($cacheDir);
+            $cacheDriver = new FilesystemCache($this->getCacheDir());
 
             if (!$this->getRequest()->query->get('flush', "0")) {
                 $cacheContent = $cacheDriver->fetch($cacheKey);
@@ -143,7 +142,7 @@ class HomeController extends BaseAdminController
     {
         $cacheDir = $this->container->getParameter("kernel.cache_dir");
         $cacheDir = rtrim($cacheDir, '/');
-        $cacheDir .= '/' . self::STATS_CACHE_DIR . '/';
+        $cacheDir .= DIRECTORY_SEPARATOR . self::STATS_CACHE_DIR . DIRECTORY_SEPARATOR;
 
         return $cacheDir;
     }

--- a/core/lib/Thelia/Controller/Admin/HomeController.php
+++ b/core/lib/Thelia/Controller/Admin/HomeController.php
@@ -50,15 +50,14 @@ class HomeController extends BaseAdminController
             return $response;
         }
 
-        $cacheEnable = intval(ConfigQuery::read("admin_cache_home_stats_enable", '1'));
+        $cacheExpire = ConfigQuery::getAdminCacheHomeStatsTTL();
 
         $cacheContent = false;
 
-        if ($cacheEnable) {
+        if ($cacheExpire) {
             $context = "_" . $this->getRequest()->query->get('month', date('m')) . "_" . $this->getRequest()->query->get('year', date('Y'));
 
             $cacheKey = self::STATS_CACHE_KEY . $context;
-            $cacheExpire = intval(ConfigQuery::read("admin_cache_home_stats_ttl", '600'));
 
             $cacheDriver = new FilesystemCache($this->getCacheDir());
 
@@ -125,7 +124,7 @@ class HomeController extends BaseAdminController
 
             $cacheContent = json_encode($data);
 
-            if ($cacheEnable) {
+            if ($cacheExpire) {
                 $cacheDriver->save($cacheKey, $cacheContent, $cacheExpire);
             }
         }

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -279,5 +279,10 @@ class ConfigQuery extends BaseConfigQuery
     {
         static::write("error_message.page_name", $v);
     }
+
+    public static function getAdminCacheHomeStatsTTL()
+    {
+        return intval(static::read("admin_cache_home_stats_ttl", 600));
+    }
 }
 // ConfigQuery

--- a/templates/backOffice/default/home.html
+++ b/templates/backOffice/default/home.html
@@ -18,10 +18,13 @@
 				<div class="title title-without-tabs clearfix">
 					{intl l='Dashboard'}
                     <div class="btn-group pull-right">
-						<button type="button" class="btn btn-default js-stats-change-month" data-month-offset="-1"><span class="glyphicon glyphicon-chevron-left"></span></button>
-						<button type="button" class="btn btn-default" disabled><span class="glyphicon glyphicon-calendar"></span></button>
-						<button type="button" class="btn btn-default js-stats-change-month" data-month-offset="+1"><span class="glyphicon glyphicon-chevron-right"></span></button>
-					</div>
+                        <button type="button" class="btn btn-default js-stats-change-month" data-month-offset="-1"><span class="glyphicon glyphicon-chevron-left"></span></button>
+                        <button type="button" class="btn btn-default" disabled><span class="glyphicon glyphicon-calendar"></span></button>
+                        <button type="button" class="btn btn-default js-stats-change-month" data-month-offset="+1"><span class="glyphicon glyphicon-chevron-right"></span></button>
+                    </div>
+                    <div class="btn-group pull-right">
+                        <button type="button" class="btn btn-default js-stats-change-month" data-month-offset="0"><span class="glyphicon glyphicon-refresh"></span></button>
+                    </div>
 				</div>
 
 				<div class="text-center clearfix">
@@ -378,14 +381,30 @@ jQuery(function($){
 
     $('.js-stats-change-month').click(function(e){
         $('.js-stats-change-month').attr('disabled', true);
-        jQplotDate.setMonth(parseInt(jQplotDate.getMonth()) + parseInt($(this).data('month-offset')));
-        retrieveJQPlotJson(jQplotDate.getMonth()+1, jQplotDate.getFullYear(), function(){$('.js-stats-change-month').attr('disabled', false);});
 
+        var flush = 0, move = parseInt($(this).data('month-offset'));
+
+        if (move !== 0) {
+            jQplotDate.setMonth(parseInt(jQplotDate.getMonth()) + move);
+        } else {
+            flush = 1;
+        }
+
+        retrieveJQPlotJson(
+            jQplotDate.getMonth()+1,
+            jQplotDate.getFullYear(),
+            function(){$('.js-stats-change-month').attr('disabled', false);},
+            flush
+        );
     });
 
-    function retrieveJQPlotJson(month, year, callback) {
+    function retrieveJQPlotJson(month, year, callback, flush) {
 
-        $.getJSON(url, {month: month, year: year})
+        if (typeof flush === "undefined") {
+            flush = 0;
+        }
+
+        $.getJSON(url, {month: month, year: year, flush: flush})
             .done(function(data) {
                 jQplotData = data;
                 jsonSuccessLoad();


### PR DESCRIPTION
Add cache on the graph of the home page.
Possibility to disable cache or change ttl cache, with the configuration variable admin_cache_home_stats_ttl

Default value for admin_cache_home_stats_ttl = 600

If admin_cache_home_stats_ttl == 0, then the cache is disabled.

Add btn for clear cache in graph toolbar.

Cheers,