### PR TITLE
Added the failsafe parameter to assets processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add confirmation email for customers, backoffice configuration variables customer_confirm_email
 - Refactor ```Thelia\Controller\BaseController::createForm``` into a factory service ```Thelia\Core\Form\TheliaFormFactory```
 - Refactor ```Thelia\Controller\BaseController::validateForm``` and ```Thelia\Controller\BaseController::getErrorMessages``` into a service ```Thelia\Core\Form\TheliaFormValidator```
+- Add the "failsafe=[true|false]" parameter to the assets smarty functions (stylesheets, images, javascripts).
 
 # 2.1.2
 

--- a/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsManager.php
+++ b/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsManager.php
@@ -219,6 +219,9 @@ class SmartyAssetsManager
         if ($repeat) {
             $url = '';
             try {
+                // Check if we're in failsafe mode
+                $isfailsafe = isset($params['failsafe']) ? $params['failsafe'] : false;
+
                 $url = $this->computeAssetUrl($assetType, $params, $template);
 
                 if (empty($url)) {
@@ -227,7 +230,7 @@ class SmartyAssetsManager
                     Tlog::getInstance()->addWarning($message);
 
                     // In debug mode, throw exception
-                    if ($this->assetsManager->isDebugMode()) {
+                    if ($this->assetsManager->isDebugMode() && ! $isfailsafe) {
                         throw new TheliaProcessException($message);
                     }
                 }
@@ -241,7 +244,7 @@ class SmartyAssetsManager
                 );
 
                 // If we're in development mode, just retrow the exception, so that it will be displayed
-                if ($this->assetsManager->isDebugMode()) {
+                if ($this->assetsManager->isDebugMode() && ! $isfailsafe) {
                     throw $ex;
                 }
             }


### PR DESCRIPTION
When true, the `failsafe` parameter prevent the re-throw of exceptions when an asset is not found, even in development mode.

Example usage of this parameter: the Markdown plugin optionnal language file : 

```smarty
{javascripts file="assets/locale/bootstrap-markdown.{lang attr="code"}.js" source="Markdown" failsafe=true}
    <script src="{$asset_url}"></script>
{/javascripts}
```