### PR TITLE
Assets filters management improvement

### DIFF
--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -82,6 +82,7 @@
         <!-- The asset filters -->
         <service id="less.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
             <tag name="thelia.asset.filter" key="less" />
+            <tag name="kernel.event_subscriber"/>
         </service>
 
         <service id="less_legacy.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">

--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -79,34 +79,33 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <!-- The assets processors -->
-
-        <service id="less.assetic.processor" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
+        <!-- The asset filters -->
+        <service id="less.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
             <tag name="thelia.asset.filter" key="less" />
         </service>
 
-        <service id="less_legacy.assetic.processor" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
+        <service id="less_legacy.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
             <argument key="identifier">less_legacy</argument>
             <tag name="thelia.asset.filter" key="less_legacy" />
         </service>
 
-        <service id="sass.assetic.processor" class="Assetic\Filter\Sass\SassFilter">
+        <service id="sass.assetic.filter" class="Assetic\Filter\Sass\SassFilter">
             <tag name="thelia.asset.filter" key="sass"  />
         </service>
 
-        <service id="cssembed.assetic.processor" class="Assetic\Filter\PhpCssEmbedFilter">
+        <service id="cssembed.assetic.filter" class="Assetic\Filter\PhpCssEmbedFilter">
             <tag name="thelia.asset.filter" key="cssembed" />
         </service>
 
-        <service id="cssrewrite.assetic.processor" class="Assetic\Filter\CssRewriteFilter">
+        <service id="cssrewrite.assetic.filter" class="Assetic\Filter\CssRewriteFilter">
             <tag name="thelia.asset.filter" key="cssrewrite"/>
         </service>
 
-        <service id="cssimport.assetic.processor" class="Assetic\Filter\CssImportFilter">
+        <service id="cssimport.assetic.filter" class="Assetic\Filter\CssImportFilter">
             <tag name="thelia.asset.filter" key="cssimport"/>
         </service>
 
-        <service id="compass.assetic.processor" class="Assetic\Filter\CompassFilter">
+        <service id="compass.assetic.filter" class="Assetic\Filter\CompassFilter">
             <tag name="thelia.asset.filter" key="compass"/>
         </service>
 

--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -79,11 +79,42 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-		<!--
-		A ControllerResolver that supports "a:b:c", "service:method" and class::method" notations,
-		thus allowing the definition of controllers as service (see http://symfony.com/fr/doc/current/cookbook/controller/service.html)
-		We use it here to inject the service container in the admin base controller.
-		-->
+        <!-- The assets processors -->
+
+        <service id="less.assetic.processor" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
+            <tag name="thelia.asset.filter" key="less" />
+        </service>
+
+        <service id="less_legacy.assetic.processor" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
+            <argument key="identifier">less_legacy</argument>
+            <tag name="thelia.asset.filter" key="less_legacy" />
+        </service>
+
+        <service id="sass.assetic.processor" class="Assetic\Filter\Sass\SassFilter">
+            <tag name="thelia.asset.filter" key="sass"  />
+        </service>
+
+        <service id="cssembed.assetic.processor" class="Assetic\Filter\PhpCssEmbedFilter">
+            <tag name="thelia.asset.filter" key="cssembed" />
+        </service>
+
+        <service id="cssrewrite.assetic.processor" class="Assetic\Filter\CssRewriteFilter">
+            <tag name="thelia.asset.filter" key="cssrewrite"/>
+        </service>
+
+        <service id="cssimport.assetic.processor" class="Assetic\Filter\CssImportFilter">
+            <tag name="thelia.asset.filter" key="cssimport"/>
+        </service>
+
+        <service id="compass.assetic.processor" class="Assetic\Filter\CompassFilter">
+            <tag name="thelia.asset.filter" key="compass"/>
+        </service>
+
+        <!--
+        A ControllerResolver that supports "a:b:c", "service:method" and class::method" notations,
+        thus allowing the definition of controllers as service (see http://symfony.com/fr/doc/current/cookbook/controller/service.html)
+        We use it here to inject the service container in the admin base controller.
+        -->
         <service id="controller_resolver" class="Thelia\Core\Controller\ControllerResolver">
         	<argument type="service" id="service_container"/>
         </service>

--- a/core/lib/Thelia/Core/Bundle/TheliaBundle.php
+++ b/core/lib/Thelia/Core/Bundle/TheliaBundle.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Scope;
 use Thelia\Core\DependencyInjection\Compiler\CurrencyConverterProviderPass;
 use Thelia\Core\DependencyInjection\Compiler\FallbackParserPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterArchiveBuilderPass;
+use Thelia\Core\DependencyInjection\Compiler\RegisterAssetFilterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterCouponPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterFormatterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterFormExtensionPass;
@@ -62,6 +63,7 @@ class TheliaBundle extends Bundle
             ->addCompilerPass(new RegisterCouponPass())
             ->addCompilerPass(new RegisterCouponConditionPass())
             ->addCompilerPass(new RegisterArchiveBuilderPass())
+            ->addCompilerPass(new RegisterAssetFilterPass())
             ->addCompilerPass(new RegisterFormatterPass())
             ->addCompilerPass(new StackPass())
             ->addCompilerPass(new RegisterFormExtensionPass())

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterAssetFilterPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterAssetFilterPass.php
@@ -1,0 +1,73 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class RegisterAssetFilterPass
+ * @package Thelia\Core\DependencyInjection\Compiler
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class RegisterAssetFilterPass implements CompilerPassInterface
+{
+    const MANAGER_DEFINITION = "assetic.asset.manager";
+
+    const SERVICE_TAG = "thelia.asset.filter";
+
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container Container
+     *
+     * @api
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(static::MANAGER_DEFINITION)) {
+            return;
+        }
+
+        $manager = $container->getDefinition(static::MANAGER_DEFINITION);
+        $services = $container->findTaggedServiceIds(static::SERVICE_TAG);
+
+        foreach ($services as $id => $attributes) {
+            if (! isset($attributes[0]['key']) || empty($attributes[0]['key'])) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Service "%s" must define the "key" attribute on "thelia.asset.filter" tag.',
+                        $id
+                    )
+                );
+            }
+
+            $class = $container->getDefinition($id)->getClass();
+
+            if (! is_subclass_of($class, '\Assetic\Filter\FilterInterface')) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Service "%s" should implement the \Assetic\Filter\FilterInterface interface',
+                        $id
+                    )
+                );
+            }
+
+            $manager->addMethodCall(
+                'registerAssetFilter',
+                [ $attributes[0]['key'], new Reference($id) ]
+            );
+        }
+    }
+}

--- a/core/lib/Thelia/Core/Template/Assets/AssetManagerInterface.php
+++ b/core/lib/Thelia/Core/Template/Assets/AssetManagerInterface.php
@@ -59,4 +59,9 @@ interface AssetManagerInterface
      * @return bool true if the AssetManager was started in debug mode
      */
     public function isDebugMode();
+
+    /**
+     * Register an asset filter
+     */
+    public function registerAssetFilter($filterIdentifier, $filter);
 }

--- a/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
+++ b/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
@@ -217,9 +217,10 @@ class AsseticAssetManager implements AssetManagerInterface
                 foreach ($this->assetFilters as $filterIdentifier => $filterInstance) {
                     if ($filterIdentifier == $filter_name) {
                         $filterManager->set($filterIdentifier, $filterInstance);
+
+                        // No, goto is not evil.
+                        goto filterFound;
                     }
-                    // No, goto is not evil.
-                    goto filterFound;
                 }
 
                 throw new \InvalidArgumentException("Unsupported Assetic filter: '$filter_name'");

--- a/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
+++ b/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
@@ -33,6 +33,8 @@ class AsseticAssetManager implements AssetManagerInterface
 
     protected $source_file_extensions = array('less', 'js', 'coffee', 'html', 'tpl', 'htm', 'xml');
 
+    protected $assetFilters = [];
+
     public function __construct($debugMode)
     {
         $this->debugMode = $debugMode;
@@ -212,39 +214,18 @@ class AsseticAssetManager implements AssetManagerInterface
             foreach ($filter_list as $filter_name) {
                 $filter_name = trim($filter_name);
 
-                switch ($filter_name) {
-                    case 'less':
-                        $filterManager->set('less', new LessDotPhpFilter());
-                        break;
-
-                    case 'less_legacy':
-                        $filterManager->set('less_legacy', new Filter\LessphpFilter());
-                        break;
-
-                    case 'sass':
-                        $filterManager->set('sass', new Filter\Sass\SassFilter());
-                        break;
-
-                    case 'cssembed':
-                        $filterManager->set('cssembed', new Filter\PhpCssEmbedFilter());
-                        break;
-
-                    case 'cssrewrite':
-                        $filterManager->set('cssrewrite', new Filter\CssRewriteFilter());
-                        break;
-
-                    case 'cssimport':
-                        $filterManager->set('cssimport', new Filter\CssImportFilter());
-                        break;
-
-                    case 'compass':
-                        $filterManager->set('compass', new Filter\CompassFilter());
-                        break;
-
-                    default:
-                        throw new \InvalidArgumentException("Unsupported Assetic filter: '$filter_name'");
-                        break;
+                foreach ($this->assetFilters as $filterIdentifier => $filterInstance) {
+                    if ($filterIdentifier == $filter_name) {
+                        $filterManager->set($filterIdentifier, $filterInstance);
+                    }
+                    // No, goto is not evil.
+                    goto filterFound;
                 }
+
+                throw new \InvalidArgumentException("Unsupported Assetic filter: '$filter_name'");
+                break;
+
+                filterFound:
             }
         } else {
             $filter_list = array();
@@ -340,5 +321,13 @@ class AsseticAssetManager implements AssetManagerInterface
     public function isDebugMode()
     {
         return $this->debugMode;
+    }
+
+    /**
+     * Register an asset filter
+     */
+    public function registerAssetFilter($filterIdentifier, $filter)
+    {
+        $this->assetFilters[$filterIdentifier] = $filter;
     }
 }

--- a/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
+++ b/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
@@ -14,7 +14,9 @@ namespace Thelia\Core\Template\Assets\Filter;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Filter\LessphpFilter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Log\Tlog;
 
 /**
@@ -26,7 +28,7 @@ use Thelia\Log\Tlog;
  * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  * @author Franck Allimant <franck@cqfdev.fr>
  */
-class LessDotPhpFilter extends LessphpFilter
+class LessDotPhpFilter extends LessphpFilter implements EventSubscriberInterface
 {
     /** @var string the compiler cache directory */
     private $cacheDir;
@@ -71,5 +73,19 @@ class LessDotPhpFilter extends LessphpFilter
         $asset->setContent(file_get_contents($this->cacheDir . DS . $css_file_name));
 
         Tlog::getInstance()->addDebug("CSS processing done.");
+    }
+
+    public function clearCacheDir()
+    {
+        $fs = new Filesystem();
+
+        $fs->remove($this->cacheDir);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            TheliaEvents::CACHE_CLEAR => array("clearCacheDir", 128),
+        ];
     }
 }

--- a/local/modules/TheliaSmarty/Template/Plugins/Assets.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Assets.php
@@ -12,13 +12,12 @@
 
 namespace TheliaSmarty\Template\Plugins;
 
+use Thelia\Core\Template\Assets\AssetManagerInterface;
 use Thelia\Core\Template\Assets\AssetResolverInterface;
-use Thelia\Core\Template\Smarty\Plugins\an;
-use TheliaSmarty\Template\SmartyPluginDescriptor;
+use Thelia\Model\ConfigQuery;
 use TheliaSmarty\Template\AbstractSmartyPlugin;
 use TheliaSmarty\Template\Assets\SmartyAssetsManager;
-use Thelia\Model\ConfigQuery;
-use Thelia\Core\Template\Assets\AssetManagerInterface;
+use TheliaSmarty\Template\SmartyPluginDescriptor;
 
 class Assets extends AbstractSmartyPlugin
 {
@@ -28,7 +27,12 @@ class Assets extends AbstractSmartyPlugin
     {
         $asset_dir_from_web_root = ConfigQuery::read('asset_dir_from_web_root', 'assets');
 
-        $this->assetManager = new SmartyAssetsManager($assetsManager, $assetsResolver, THELIA_WEB_DIR, $asset_dir_from_web_root);
+        $this->assetManager = new SmartyAssetsManager(
+            $assetsManager,
+            $assetsResolver,
+            THELIA_WEB_DIR,
+            $asset_dir_from_web_root
+        );
     }
 
     public function declareAssets($params, \Smarty_Internal_Template $template)
@@ -62,6 +66,16 @@ class Assets extends AbstractSmartyPlugin
         return $this->assetManager->computeAssetUrl(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $template);
     }
 
+    public function functionJavascript($params, \Smarty_Internal_Template $template)
+    {
+        return $this->assetManager->computeAssetUrl(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $template);
+    }
+
+    public function functionStylesheet($params, \Smarty_Internal_Template $template)
+    {
+        return $this->assetManager->computeAssetUrl('css', $params, $template);
+    }
+
     /**
      * Define the various smarty plugins hendled by this class
      *
@@ -73,7 +87,11 @@ class Assets extends AbstractSmartyPlugin
             new SmartyPluginDescriptor('block', 'stylesheets', $this, 'blockStylesheets'),
             new SmartyPluginDescriptor('block', 'javascripts', $this, 'blockJavascripts'),
             new SmartyPluginDescriptor('block', 'images', $this, 'blockImages'),
+
             new SmartyPluginDescriptor('function', 'image', $this, 'functionImage'),
+            new SmartyPluginDescriptor('function', 'javascript', $this, 'functionJavascript'),
+            new SmartyPluginDescriptor('function', 'stylesheet', $this, 'functionStylesheet'),
+
             new SmartyPluginDescriptor('function', 'declare_assets', $this, 'declareAssets')
         );
     }

--- a/templates/frontOffice/default/layout.tpl
+++ b/templates/frontOffice/default/layout.tpl
@@ -26,17 +26,18 @@ GNU General Public License : http://www.gnu.org/licenses/
 {config_load file='variables.conf'}
 {block name="init"}{/block}
 {block name="no-return-functions"}{/block}
-{assign var="store_name" value="{config key="store_name"}"}
-{assign var="store_description" value="{config key="store_description"}"}
+{assign var="store_name" value={config key="store_name"}}
+{assign var="store_description" value={config key="store_description"}}
 {assign var="lang_code" value={lang attr="code"}}
-{if not $store_name}{assign var="store_name" value="{intl l='Thelia V2'}"}{/if}
-{if not $store_description}{assign var="store_description" value="$store_name"}{/if}
+{assign var="lang_locale" value={lang attr="locale"}}
+{if not $store_name}{assign var="store_name" value={intl l='Thelia V2'}}{/if}
+{if not $store_description}{assign var="store_description" value={$store_name}}{/if}
 
 {* paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither *}
-<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang="{$lang_code}"> <![endif]-->
-<!--[if IE 7 ]><html class="no-js oldie ie7" lang="{$lang_code}"> <![endif]-->
-<!--[if IE 8 ]><html class="no-js oldie ie8" lang="{$lang_code}"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--><html lang="{$v}" class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang={$lang_code}> <![endif]-->
+<!--[if IE 7 ]><html class="no-js oldie ie7" lang={$lang_code}> <![endif]-->
+<!--[if IE 8 ]><html class="no-js oldie ie8" lang={$lang_code}> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--><html lang={$v} class="no-js"> <!--<![endif]-->
 <head>
     {hook name="main.head-top"}
     {* Test if javascript is enabled *}
@@ -60,6 +61,18 @@ GNU General Public License : http://www.gnu.org/licenses/
         <link rel="stylesheet" href="{$asset_url}">
     {/stylesheets}
 
+    {* To use the embedded less compiler :
+       1) Comment the stylesheet function above, to prevent ce style.css to be included
+       2) Uncomment the following stylesheets function, to trigger styles.less compilation
+       3) In your back-office, set the process_assets configuration variable to 1,
+       4) Run your shop in developpement ode, usinf index_dev.php
+    *}
+    {*
+    {stylesheets file='assets/less/styles.less' filters='less'}
+        <link rel="stylesheet" href="{$asset_url}">
+    {/stylesheets}
+    *}
+
     {hook name="main.stylesheet"}
 
     {block name="stylesheet"}{/block}
@@ -69,9 +82,9 @@ GNU General Public License : http://www.gnu.org/licenses/
     {images file='assets/img/favicon.png'}<link rel="icon" type="image/png" href="{$asset_url}" />{/images}
 
     {* Feeds *}
-    <link rel="alternate" type="application/rss+xml" title="{intl l='All products'}" href="{url path="/feed/catalog/{lang attr="locale"}"}" />
-    <link rel="alternate" type="application/rss+xml" title="{intl l='All contents'}" href="{url path="/feed/content/{lang attr="locale"}"}" />
-    <link rel="alternate" type="application/rss+xml" title="{intl l='All brands'}"   href="{url path="/feed/brand/{lang attr='locale'}"}" />
+    <link rel="alternate" type="application/rss+xml" title="{intl l='All products'}" href="{url path="/feed/catalog/$lang_locale"}" />
+    <link rel="alternate" type="application/rss+xml" title="{intl l='All contents'}" href="{url path="/feed/content/$lang_locale"}" />
+    <link rel="alternate" type="application/rss+xml" title="{intl l='All brands'}"   href="{url path="/feed/brand/$lang_locale"}" />
     {block name="feeds"}{/block}
 
     {* HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries *}

--- a/templates/frontOffice/default/layout.tpl
+++ b/templates/frontOffice/default/layout.tpl
@@ -34,10 +34,10 @@ GNU General Public License : http://www.gnu.org/licenses/
 {if not $store_description}{assign var="store_description" value={$store_name}}{/if}
 
 {* paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither *}
-<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang={$lang_code}> <![endif]-->
-<!--[if IE 7 ]><html class="no-js oldie ie7" lang={$lang_code}> <![endif]-->
-<!--[if IE 8 ]><html class="no-js oldie ie8" lang={$lang_code}> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--><html lang={$v} class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7 ]><html class="no-js oldie ie6" lang="{$lang_code}"> <![endif]-->
+<!--[if IE 7 ]><html class="no-js oldie ie7" lang="{$lang_code}"> <![endif]-->
+<!--[if IE 8 ]><html class="no-js oldie ie8" lang="{$lang_code}"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--><html lang="{$lang_code}" class="no-js"> <!--<![endif]-->
 <head>
     {hook name="main.head-top"}
     {* Test if javascript is enabled *}


### PR DESCRIPTION
To provide a flexible and efficient way to manage assets filters, the asset filters are now declared in the container configuration, using the `thelia.asset.filter` tag.