### PR TITLE
Wrong test of preg_match() return value

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -276,7 +276,7 @@ class Module extends BaseI18nLoop implements PropelSearchLoopInterface
                     $configContent = @file_get_contents($module->getAbsoluteConfigPath() . DS . "config.xml");
 
                     $hasConfigurationInterface = $configContent &&
-                        preg_match('/event\s*=\s*[\'"]module.configuration[\'"]/', $configContent) !== false
+                        preg_match('/event\s*=\s*[\'"]module.configuration[\'"]/', $configContent) === 1
                     ;
 
                     if (false === $hasConfigurationInterface) {


### PR DESCRIPTION
False means error, not "no match". This PR changes the test which searches for a module configuration page in module's config.xml.