### PR TITLE
Fix incoherance between test and method

### DIFF
--- a/core/lib/Thelia/Command/ModuleGenerateCommand.php
+++ b/core/lib/Thelia/Command/ModuleGenerateCommand.php
@@ -61,7 +61,7 @@ class ModuleGenerateCommand extends BaseModuleGenerate
 
         $this->createDirectories();
         $this->createFiles();
-        if (method_exists($this, "renderBlock")) {
+        if (method_exists($output, "renderBlock")) {
             // impossible to change output class in CommandTester...
             $output->renderBlock(array(
                 '',


### PR DESCRIPTION
The tested object was ```$this``` but the method was used with ```$output```, and I couldn't figure out where ```$output=$this``` was. :trollface: 