### PR TITLE
The less.php cache is now in the current environment dir.

### DIFF
--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -86,9 +86,10 @@
         <service id="less.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
             <tag name="thelia.asset.filter" key="less" />
             <tag name="kernel.event_subscriber"/>
+            <argument>%kernel.environment%</argument>
         </service>
 
-        <service id="less_legacy.assetic.filter" class="Thelia\Core\Template\Assets\Filter\LessDotPhpFilter">
+        <service id="less_legacy.assetic.filter" class="Assetic\Filter\LessphpFilter">
             <argument key="identifier">less_legacy</argument>
             <tag name="thelia.asset.filter" key="less_legacy" />
         </service>

--- a/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
+++ b/core/lib/Thelia/Core/Template/Assets/Filter/LessDotPhpFilter.php
@@ -33,10 +33,10 @@ class LessDotPhpFilter extends LessphpFilter implements EventSubscriberInterface
     /** @var string the compiler cache directory */
     private $cacheDir;
 
-    public function __construct()
+    public function __construct($environment = 'prod')
     {
         // Assign and create the cache directory, if required.
-        $this->cacheDir = THELIA_CACHE_DIR . DS . 'less.php';
+        $this->cacheDir = THELIA_CACHE_DIR . DS . $environment . DS . 'less.php';
 
         if (! is_dir($this->cacheDir)) {
             $fs = new Filesystem();

--- a/templates/frontOffice/default/layout.tpl
+++ b/templates/frontOffice/default/layout.tpl
@@ -57,7 +57,7 @@ GNU General Public License : http://www.gnu.org/licenses/
     {/block}
 
     {* Stylesheets *}
-    <link rel="stylesheet" href="{stylesheet file='assets/css/styles.css'}">
+    {*<link rel="stylesheet" href="{stylesheet file='assets/css/styles.css'}">*}
 
     {* To use the embedded less compiler :
        1) Comment the stylesheet function above, to prevent ce style.css to be included
@@ -65,11 +65,11 @@ GNU General Public License : http://www.gnu.org/licenses/
        3) In your back-office, set the process_assets configuration variable to 1,
        4) Run your shop in developpement ode, usinf index_dev.php
     *}
-    {*
+
     {stylesheets file='assets/less/styles.less' filters='less'}
         <link rel="stylesheet" href="{$asset_url}">
     {/stylesheets}
-    *}
+
 
     {hook name="main.stylesheet"}
 


### PR DESCRIPTION
This PR is a fix for #1235.

If also fixed the class name of the legacy less compiler.