### PR TITLE
Order event should be cloned if dispatched several times

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -422,9 +422,9 @@ class Order extends BaseAction implements EventSubscriberInterface
      */
     public function orderBeforePayment(OrderEvent $event)
     {
-        $event->getDispatcher()->dispatch(TheliaEvents::ORDER_SEND_CONFIRMATION_EMAIL, $event);
+        $event->getDispatcher()->dispatch(TheliaEvents::ORDER_SEND_CONFIRMATION_EMAIL, clone $event);
 
-        $event->getDispatcher()->dispatch(TheliaEvents::ORDER_SEND_NOTIFICATION_EMAIL, $event);
+        $event->getDispatcher()->dispatch(TheliaEvents::ORDER_SEND_NOTIFICATION_EMAIL, clone $event);
     }
 
     /**


### PR DESCRIPTION
This PR fix a problem with the OrderEvent.

This event is dispatched several times by the Order action. As this is the same instance that is dispatched, if someone call stopPropagation() during the event processing, all further dispatching of the same event instance will have no effect.

In this PR, the vent is cloned before beeing dispatched again.
