### PR TITLE
We must check if we have to manage stock during manual creation order.

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -360,6 +360,11 @@ class Order extends BaseAction implements EventSubscriberInterface
      */
     public function createManual(OrderManualEvent $event)
     {
+        $paymentModule = ModuleQuery::create()->findPk($event->getOrder()->getPaymentModuleId());
+
+        /** @var \Thelia\Module\PaymentModuleInterface $paymentModuleInstance */
+        $paymentModuleInstance = $paymentModule->createInstance();
+
         $event->setPlacedOrder(
             $this->createOrder(
                 $event->getDispatcher(),
@@ -368,7 +373,7 @@ class Order extends BaseAction implements EventSubscriberInterface
                 $event->getLang(),
                 $event->getCart(),
                 $event->getCustomer(),
-                true
+                $paymentModuleInstance->manageStockOnCreation()
             )
         );
 


### PR DESCRIPTION
If we don't, stock will be impact twice.

- During manualOrderCreation
- During orderUpdateStatus (status paid)

I suggest that manualOrderCreation AND orderCreation have the same comportment