### PR TITLE
send the container during the construction of the form CartAdd

### DIFF
--- a/core/lib/Thelia/Form/Definition/FrontForm.php
+++ b/core/lib/Thelia/Form/Definition/FrontForm.php
@@ -29,4 +29,5 @@ final class FrontForm
     const ADDRESS_UPDATE = 'thelia.front.address.update';
     const CONTACT = 'thelia.front.contact';
     const NEWSLETTER = 'thelia.front.newsletter';
+    const CART_ADD = 'thelia.cart.add';
 }

--- a/local/modules/Front/Controller/CartController.php
+++ b/local/modules/Front/Controller/CartController.php
@@ -31,6 +31,7 @@ use Thelia\Core\Event\Cart\CartEvent;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Form\CartAdd;
+use Thelia\Form\Definition\FrontForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
 use Thelia\Model\AddressQuery;
@@ -182,15 +183,16 @@ class CartController extends BaseFrontController
     private function getAddCartForm(Request $request)
     {
         if ($request->isMethod("post")) {
-            $cartAdd = new CartAdd($request);
+            $cartAdd = $this->createForm(FrontForm::CART_ADD);
         } else {
-            $cartAdd = new CartAdd(
-                $request,
+            $cartAdd = $this->createForm(
+                FrontForm::CART_ADD,
                 "form",
                 array(),
                 array(
                     'csrf_protection'   => false,
-                )
+                ),
+                $this->container
             );
         }
 


### PR DESCRIPTION
This allow to use the action TheliaEvents::FORM_AFTER_BUILD.".thelia_cart_add" when you build and submit the form