### PR TITLE
Add event OrderProductEvent

### DIFF
--- a/core/lib/Thelia/Core/Event/Order/OrderEvent.php
+++ b/core/lib/Thelia/Core/Event/Order/OrderEvent.php
@@ -16,21 +16,49 @@ use Symfony\Component\HttpFoundation\Response;
 use Thelia\Core\Event\ActionEvent;
 use Thelia\Model\Order;
 
+/**
+ * Class OrderEvent
+ * @package Thelia\Core\Event\Order
+ */
 class OrderEvent extends ActionEvent
 {
+    /** @var Order */
     protected $order = null;
+
+    /** @var Order */
     protected $placedOrder = null;
+
+    /** @var null|int */
     protected $invoiceAddress = null;
+
+    /** @var null|int */
     protected $deliveryAddress = null;
+
+    /** @var null|int */
     protected $deliveryModule = null;
+
+    /** @var null|int */
     protected $paymentModule = null;
+
+    /** @var null|float */
     protected $postage = null;
+
+    /** @var float */
     protected $postageTax = 0.0;
+
+    /** @var null|string */
     protected $postageTaxRuleTitle = null;
+
+    /** @var null|string */
     protected $ref = null;
+
+    /** @var null|int */
     protected $status = null;
+
+    /** @var null|string */
     protected $deliveryRef = null;
 
+    /** @var null|int */
     protected $cartItemId = null;
 
     /**
@@ -48,14 +76,18 @@ class OrderEvent extends ActionEvent
 
     /**
      * @param Order $order
+     * @return $this
      */
     public function setOrder(Order $order)
     {
         $this->order = $order;
+
+        return $this;
     }
 
     /**
      * @param int $cartItemId
+     * @return $this
      */
     public function setCartItemId($cartItemId)
     {
@@ -74,74 +106,101 @@ class OrderEvent extends ActionEvent
 
     /**
      * @param Order $order
+     * @return $this
      */
     public function setPlacedOrder(Order $order)
     {
         $this->placedOrder = $order;
+
+        return $this;
     }
 
     /**
      * @param int $address an address ID
+     * @return $this
      */
     public function setInvoiceAddress($address)
     {
         $this->invoiceAddress = $address;
+
+        return $this;
     }
 
     /**
      * @param int $address an address ID
+     * @return $this
      */
     public function setDeliveryAddress($address)
     {
         $this->deliveryAddress = $address;
+
+        return $this;
     }
 
     /**
      * @param int $module a delivery module ID
+     * @return $this
      */
     public function setDeliveryModule($module)
     {
         $this->deliveryModule = $module;
+
+        return $this;
     }
 
     /**
      * @param int $module a payment module ID
+     * @return $this
      */
     public function setPaymentModule($module)
     {
         $this->paymentModule = $module;
+
+        return $this;
     }
 
     /**
      * @param double  $postage the postage amount
+     * @return $this
      */
     public function setPostage($postage)
     {
         $this->postage = $postage;
+
+        return $this;
     }
 
     /**
      * @param string $ref the order reference
+     * @return $this
      */
     public function setRef($ref)
     {
         $this->ref = $ref;
+
+        return $this;
     }
 
     /**
      * @param int $status the order status ID
+     * @return $this
      */
     public function setStatus($status)
     {
         $this->status = $status;
+
+        return $this;
     }
 
     /**
      * @param string $deliveryRef the delivery reference
+     * @return $this
      */
     public function setDeliveryRef($deliveryRef)
     {
         $this->deliveryRef = $deliveryRef;
+
+        return $this;
     }
 
     /**
@@ -266,6 +325,7 @@ class OrderEvent extends ActionEvent
 
     /**
      * @param null $postageTax
+     * @return $this
      */
     public function setPostageTax($postageTax)
     {
@@ -284,6 +344,7 @@ class OrderEvent extends ActionEvent
 
     /**
      * @param null $postageTaxRuleTitle
+     * @return $this
      */
     public function setPostageTaxRuleTitle($postageTaxRuleTitle)
     {

--- a/core/lib/Thelia/Core/Event/Order/OrderProductEvent.php
+++ b/core/lib/Thelia/Core/Event/Order/OrderProductEvent.php
@@ -1,0 +1,54 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Event\Order;
+
+use Thelia\Model\Order;
+
+/**
+ * Class OrderEvent
+ * @package Thelia\Core\Event\Order
+ */
+class OrderProductEvent extends OrderEvent
+{
+    /** @var int */
+    protected $id = null;
+
+    /**
+     * @param Order $order
+     * @param int $id order product id
+     */
+    public function __construct(Order $order, $id)
+    {
+        parent::__construct($order);
+        $this->setId($id);
+    }
+
+    /**
+     * @param $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/core/lib/Thelia/Model/OrderProduct.php
+++ b/core/lib/Thelia/Model/OrderProduct.php
@@ -3,7 +3,7 @@
 namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
-use Thelia\Core\Event\Order\OrderEvent;
+use Thelia\Core\Event\Order\OrderProductEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\Base\OrderProduct as BaseOrderProduct;
 
@@ -17,10 +17,12 @@ class OrderProduct extends BaseOrderProduct
      */
     protected $cartIemId;
 
+    /** @var int */
     protected $cartItemId;
 
     /**
      * @param mixed $cartItemId
+     * @return $this
      */
     public function setCartItemId($cartItemId)
     {
@@ -46,9 +48,11 @@ class OrderProduct extends BaseOrderProduct
     {
         return $this->cartItemId;
     }
+
     /**
      * @param mixed $cartItemId
      * @deprecated Since 2.1.3 because it is a typo, will be removed in 2.3
+     * @return $this|OrderProduct
      */
     public function setCartIemId($cartItemId)
     {
@@ -81,7 +85,11 @@ class OrderProduct extends BaseOrderProduct
      */
     public function preInsert(ConnectionInterface $con = null)
     {
-        $this->dispatchEvent(TheliaEvents::ORDER_PRODUCT_BEFORE_CREATE, (new OrderEvent($this->getOrder()))->setCartItemId($this->cartIemId));
+        $this->dispatchEvent(
+            TheliaEvents::ORDER_PRODUCT_BEFORE_CREATE,
+            (new OrderProductEvent($this->getOrder(), null))
+                ->setCartItemId($this->cartItemId)
+        );
 
         return true;
     }
@@ -91,6 +99,10 @@ class OrderProduct extends BaseOrderProduct
      */
     public function postInsert(ConnectionInterface $con = null)
     {
-        $this->dispatchEvent(TheliaEvents::ORDER_PRODUCT_AFTER_CREATE, (new OrderEvent($this->getOrder()))->setCartItemId($this->cartIemId));
+        $this->dispatchEvent(
+            TheliaEvents::ORDER_PRODUCT_AFTER_CREATE,
+            (new OrderProductEvent($this->getOrder(), $this->getId()))
+                ->setCartItemId($this->cartItemId)
+        );
     }
 }


### PR DESCRIPTION
Hello,

It is impossible to retrieve the OrderProductId in the event ORDER_PRODUCT_AFTER_CREATE.
This PR fix solves the problem.
- Add event OrderProductEvent
- Change event dispatched in method postInsert and preInsert in model OrderProduct

Other change : 
- Add return $this for method set in event OrderEvent
- replace cartIemId by cartItemId in method postInsert and preInsert in model OrderProduct

Cheers,


