### PR TITLE
Function isPaid

### DIFF
--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -237,9 +237,13 @@ class Order extends BaseOrder
      * if false, it will check if the order has been paid, whatever the current status is. The default is false.
      * @return bool true if this order is PAID, false otherwise.
      */
-    public function isPaid()
+    public function isPaid($exact = true)
     {
-        return $this->hasStatusHelper(OrderStatus::CODE_PAID);
+        return $this->hasStatusHelper(
+            $exact ?
+            OrderStatus::CODE_PAID :
+            [ OrderStatus::CODE_PAID] //, OrderStatus::CODE_PROCESSING, OrderStatus::CODE_SENT ]
+        );
     }
 
     /**

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -237,13 +237,9 @@ class Order extends BaseOrder
      * if false, it will check if the order has been paid, whatever the current status is. The default is false.
      * @return bool true if this order is PAID, false otherwise.
      */
-    public function isPaid($exact = false)
+    public function isPaid()
     {
-        return $this->hasStatusHelper(
-            $exact ?
-            OrderStatus::CODE_PAID :
-            [ OrderStatus::CODE_PAID, OrderStatus::CODE_PROCESSING, OrderStatus::CODE_SENT ]
-        );
+        return $this->hasStatusHelper(OrderStatus::CODE_PAID);
     }
 
     /**

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -242,7 +242,7 @@ class Order extends BaseOrder
         return $this->hasStatusHelper(
             $exact ?
             OrderStatus::CODE_PAID :
-            [ OrderStatus::CODE_PAID] //, OrderStatus::CODE_PROCESSING, OrderStatus::CODE_SENT ]
+            [ OrderStatus::CODE_PAID, OrderStatus::CODE_PROCESSING, OrderStatus::CODE_SENT ]
         );
     }
 


### PR DESCRIPTION
Je pense que la fonction isPaid doit renvoyer true seulement si on est sur le status Payee.
Sinon cela engendre des erreurs au niveau des envoies de confirmation
Si on laisse
```
    public function isPaid($exact = false)
    {
        return $this->hasStatusHelper(
            $exact ?
            OrderStatus::CODE_PAID :
            [ OrderStatus::CODE_PAID, OrderStatus::CODE_PROCESSING, OrderStatus::CODE_SENT ]
        );
    }
```
l'email de confirmation de paiement est envoye pour les status PAID, PROCESSING, SENT

il faut considerer que si le status est passe sur PROCESSING ou SENT, c'est que la commande a ete au depart sur PAID