### PR TITLE
Let generateOrderPdf be more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Module information and documentation could be viewed directly from the module list
 - Add the possibility to translate text in the sql files (insert.sql, update/sql/\*.sql). to generate sql files use command `php Thelia generate:sql`. Translation can be made in the back office, in the translation page.   
 - format_date smarty function now handle symfony form type ```date```, ```datetime``` and ```time``` view value.
+- Allow BaseController::generateOrderPdf to generate a pdf without having the rights
 
 # 2.1.3
 

--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -223,17 +223,19 @@ abstract class BaseController extends ContainerAware
     }
 
     /**
-     * @param $order_id
-     * @param $fileName
+     * @param int $order_id
+     * @param string $fileName
+     * @param bool $checkOrderStatus
+     * @param bool $checkAdminUser
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function generateOrderPdf($order_id, $fileName)
+    protected function generateOrderPdf($order_id, $fileName, $checkOrderStatus = true, $checkAdminUser = true)
     {
         $order = OrderQuery::create()->findPk($order_id);
 
         // check if the order has the paid status
-        if (!$this->getSecurityContext()->hasAdminUser()) {
-            if (!$order->isPaid()) {
+        if ($checkAdminUser && !$this->getSecurityContext()->hasAdminUser()) {
+            if ($checkOrderStatus && !$order->isPaid()) {
                 throw new NotFoundHttpException();
             }
         }


### PR DESCRIPTION
This could be used for generate some pdf of not paid order ( quotes, anything else ) without having to rewrite this function.