### PR TITLE
Added a fallback on default email template of a module when building mes...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - format_date smarty function now handle symfony form type ```date```, ```datetime``` and ```time``` view value.
 - Allow BaseController::generateOrderPdf to generate a pdf without having the rights
 - SHOW_HOOK now displays parameters
+- Add fallback for email template for mails sent from a module. If the template file does not exist in the current email template, it will use the one that comes with the module.     
 
 # 2.1.3
 

--- a/core/lib/Thelia/Model/Message.php
+++ b/core/lib/Thelia/Model/Message.php
@@ -137,10 +137,18 @@ class Message extends BaseMessage
     /**
      * Add a subject and a body (TEXT, HTML or both, depending on the message
      * configuration.
+     *
+     * @param  ParserInterface $parser
+     * @param  \Swift_Message  $messageInstance
+     * @param  bool            $useFallbackTemplate When we send mail from a module and don't use the `default` email
+     *                                              template, if the file (html/txt) is not found in the template then
+     *                                              the template file located in the module under
+     *                                              `templates/email/default/' directory is used if
+     *                                              `$useFallbackTemplate` is set to `true`.
      */
-    public function buildMessage($parser, \Swift_Message $messageInstance)
+    public function buildMessage(ParserInterface $parser, \Swift_Message $messageInstance, $useFallbackTemplate = true)
     {
-        $parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveMailTemplate());
+        $parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveMailTemplate(), $useFallbackTemplate);
         $subject     = $parser->fetch(sprintf("string:%s", $this->getSubject()));
         $htmlMessage = $this->getHtmlMessageBody($parser);
         $textMessage = $this->getTextMessageBody($parser);


### PR DESCRIPTION
...sage

When we send mails from a module and don't use the `default` email template, if the files (html/txt) are not found in the template then the template files located in the module (under `templates/email/default/' directory) are used as a fallback.
