### PR TITLE
Added capability to use translator in module functions preActivation and...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Add fallback for email template for mails sent from a module. If the template file does not exist in the current email template, it will use the one that comes with the module.
 - Add dispatch of console events
 - Refactor VirtualProductDelivery module. The email sending is now triggered from a new event to gain more flexibility. Now, email messages use smarty file templates located in `templates/email/default`.     
+- Added capability to use translator in module functions `preActivation` and `postActivation`
 
 # 2.1.3
 


### PR DESCRIPTION
The goal of this PR is to make possible to use translator in the `preActivation` and `postActivation`.
As the module is not activated, the translation catalogs of the module are not yet loaded.
So we have to add resources ~~by hand~~ manually 