### PR TITLE
Add event dispatcher to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
 - format_date smarty function now handle symfony form type ```date```, ```datetime``` and ```time``` view value.
 - Allow BaseController::generateOrderPdf to generate a pdf without having the rights
 - SHOW_HOOK now displays parameters
-- Add fallback for email template for mails sent from a module. If the template file does not exist in the current email template, it will use the one that comes with the module.     
+- Add fallback for email template for mails sent from a module. If the template file does not exist in the current email template, it will use the one that comes with the module.
+- Add dispatch of console events
 
 # 2.1.3
 

--- a/core/lib/Thelia/Core/Application.php
+++ b/core/lib/Thelia/Core/Application.php
@@ -54,6 +54,10 @@ class Application extends BaseApplication
     {
         $this->registerCommands();
 
+        /** @var \Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher $eventDispatcher */
+        $eventDispatcher = $this->getContainer()->get('event_dispatcher');
+        $this->setDispatcher($eventDispatcher);
+
         return parent::doRun($input, $output);
     }
 


### PR DESCRIPTION
That allows to automatically dispatch events available in `\Symfony\Component\Console\ConsoleEvents`

See [Symfony 2 doc](http://symfony.com/doc/2.3/components/console/events.html) for more.