### PR TITLE
Update hook_module table if hook ID is changed

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterListenersPass.php
@@ -203,6 +203,13 @@ class RegisterListenersPass implements CompilerPassInterface
                     ->setPosition(ModuleHook::MAX_POSITION)
                     ->save();
             }
+        } else {
+            // Update hook if id was changed in the definition
+            if ($moduleHook->getClassname() != $id) {
+                $moduleHook
+                    ->setClassname($id)
+                    ->save();
+            }
         }
     }
 


### PR DESCRIPTION
If a hook ID is changed in a module's config.xml file (for example because this ID is not camelizable), the module_hook table is not updated, and the first hook ID remains in the 'classname' column.

This PR fixes this problem, by updating the table when the hook ID is changed.