### PR TITLE
Use PHP upload_max_filesize config

### DIFF
--- a/templates/backOffice/default/assets/js/document-upload.js
+++ b/templates/backOffice/default/assets/js/document-upload.js
@@ -16,8 +16,7 @@ $(function($){
 
         var documentDropzone = new Dropzone("#documents-dropzone", {
             dictDefaultMessage : $('.btn-browse').html(),
-            uploadMultiple: false,
-            maxFilesize: 8
+            uploadMultiple: false
         });
 
         var totalFiles      = 0,

--- a/templates/backOffice/default/assets/js/image-upload.js
+++ b/templates/backOffice/default/assets/js/image-upload.js
@@ -16,7 +16,6 @@ $(function($){
         var imageDropzone = new Dropzone("#images-dropzone", {
             dictDefaultMessage : $('.btn-browse').html(),
             uploadMultiple: false,
-            maxFilesize: 8,
             acceptedFiles: 'image/png, image/gif, image/jpeg'
         });    
 


### PR DESCRIPTION
Do not specify max filesize into templates.
Default `Dropzone.options.maxFilesize` is set to : `256` (M)
Let PHP handle it (`upload_max_filesize`)
*Another advantage : PHP error message will be translated*

Fix a functionnal bug when the template limit is greater than PHP limit.