### PR TITLE
New thelia.template_helper service to replace TemplateHelper singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,12 @@
 - Add dispatch of console events
 - Refactor VirtualProductDelivery module. The email sending is now triggered from a new event to gain more flexibility. Now, email messages use smarty file templates located in `templates/email/default`.     
 - Added capability to use translator in module functions `preActivation` and `postActivation`
-<<<<<<< HEAD
 - Add environment aware database connection
 - new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font.
 - Imagine package is updated to 0.6.2, which provides a better support for transparency.
 - Default border color of images resized with resize_mode="border" is now transparent instead of opaque white.
-=======
 - The TemplateHelper class is deprecated. You should now use the thelia.template_helper service. TemplateHelperInterface has been introduced, so that modules may implement alternate versions
->>>>>>> TemplateHelper is now replaced with a service
+
 
 # 2.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,14 @@
 - Add dispatch of console events
 - Refactor VirtualProductDelivery module. The email sending is now triggered from a new event to gain more flexibility. Now, email messages use smarty file templates located in `templates/email/default`.     
 - Added capability to use translator in module functions `preActivation` and `postActivation`
+<<<<<<< HEAD
 - Add environment aware database connection
 - new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font.
 - Imagine package is updated to 0.6.2, which provides a better support for transparency.
 - Default border color of images resized with resize_mode="border" is now transparent instead of opaque white.
+=======
+- The TemplateHelper class is deprecated. You should now use the thelia.template_helper service. TemplateHelperInterface has been introduced, so that modules may implement alternate versions
+>>>>>>> TemplateHelper is now replaced with a service
 
 # 2.1.3
 

--- a/core/lib/Thelia/Action/HttpException.php
+++ b/core/lib/Thelia/Action/HttpException.php
@@ -13,15 +13,15 @@
 namespace Thelia\Action;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Thelia\Core\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException as BaseHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Template\ParserInterface;
+use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Exception\AdminAccessDenied;
 use Thelia\Model\ConfigQuery;
-use Thelia\Core\Template\TemplateHelper;
-use Symfony\Component\HttpKernel\Exception\HttpException as BaseHttpException;
 
 /**
  *
@@ -61,7 +61,9 @@ class HttpException extends BaseAction implements EventSubscriberInterface
     protected function displayAdminGeneralError(GetResponseForExceptionEvent $event)
     {
         // Define the template thant shoud be used
-        $this->parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveAdminTemplate());
+        $this->parser->setTemplateDefinition(
+            $this->parser->getTemplateHelper()->getActiveAdminTemplate()
+        );
 
         $message = $event->getException()->getMessage();
 
@@ -81,7 +83,9 @@ class HttpException extends BaseAction implements EventSubscriberInterface
     protected function display404(GetResponseForExceptionEvent $event)
     {
         // Define the template thant shoud be used
-        $this->parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveFrontTemplate());
+        $this->parser->setTemplateDefinition(
+            $this->parser->getTemplateHelper()->getActiveFrontTemplate()
+        );
 
         $response = new Response($this->parser->render(ConfigQuery::getPageNotFoundView()), 404);
 
@@ -92,7 +96,13 @@ class HttpException extends BaseAction implements EventSubscriberInterface
     {
         /** @var \Symfony\Component\HttpKernel\Exception\HttpException $exception */
         $exception = $event->getException();
-        $event->setResponse(new Response($exception->getMessage(), $exception->getStatusCode(), $exception->getHeaders()));
+        $event->setResponse(
+            new Response(
+                $exception->getMessage(),
+                $exception->getStatusCode(),
+                $exception->getHeaders()
+            )
+        );
     }
 
     /**

--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -22,7 +22,7 @@ use Thelia\Log\Tlog;
 /**
  * Class Translation
  * @package Thelia\Action
- * @author  Franck Allimant <franck@cqfdev.fr>
+ * @author Manuel Raynaud <manu@thelia.net>
  */
 class Translation extends BaseAction implements EventSubscriberInterface
 {

--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -20,9 +20,9 @@ use Thelia\Core\Translation\Translator;
 use Thelia\Log\Tlog;
 
 /**
- * Class Area
+ * Class Translation
  * @package Thelia\Action
- * @author Manuel Raynaud <manu@thelia.net>
+ * @author  Franck Allimant <franck@cqfdev.fr>
  */
 class Translation extends BaseAction implements EventSubscriberInterface
 {
@@ -60,16 +60,16 @@ class Translation extends BaseAction implements EventSubscriberInterface
      */
     protected function walkDir($directory, $walkMode, $currentLocale, $domain, &$strings)
     {
-        $num_texts = 0;
+        $numTexts = 0;
 
         if ($walkMode == TranslationEvent::WALK_MODE_PHP) {
             $prefix = '\-\>[\s]*trans[\s]*\([\s]*';
 
-            $allowed_exts = array('php');
+            $allowedExts = array('php');
         } elseif ($walkMode == TranslationEvent::WALK_MODE_TEMPLATE) {
             $prefix = '\{intl(?:.*?)l=[\s]*';
 
-            $allowed_exts = array('html', 'tpl', 'xml', 'txt');
+            $allowedExts = array('html', 'tpl', 'xml', 'txt');
         } else {
             throw new \InvalidArgumentException(
                 Translator::getInstance()->trans(
@@ -89,7 +89,7 @@ class Translation extends BaseAction implements EventSubscriberInterface
                 }
 
                 if ($fileInfo->isDir()) {
-                    $num_texts += $this->walkDir(
+                    $numTexts += $this->walkDir(
                         $fileInfo->getPathName(),
                         $walkMode,
                         $currentLocale,
@@ -101,7 +101,7 @@ class Translation extends BaseAction implements EventSubscriberInterface
                 if ($fileInfo->isFile()) {
                     $ext = $fileInfo->getExtension();
 
-                    if (in_array($ext, $allowed_exts)) {
+                    if (in_array($ext, $allowedExts)) {
                         if ($content = file_get_contents($fileInfo->getPathName())) {
                             $short_path = $this->normalizePath($fileInfo->getPathName());
 
@@ -126,7 +126,7 @@ class Translation extends BaseAction implements EventSubscriberInterface
                                             $strings[$hash]['files'][] = $short_path;
                                         }
                                     } else {
-                                        $num_texts++;
+                                        $numTexts++;
 
                                         // remove \' (or \"), that will prevent the translator to work properly, as
                                         // "abc \def\" ghi" will be passed as abc "def" ghi to the translator.
@@ -162,10 +162,10 @@ class Translation extends BaseAction implements EventSubscriberInterface
                 }
             }
         } catch (\UnexpectedValueException $ex) {
-            // Directory does not exists => ignore/
+            // Directory does not exists => ignore it.
         }
 
-        return $num_texts;
+        return $numTexts;
     }
 
     public function writeTranslationFile(TranslationEvent $event)

--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -1,0 +1,237 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Action;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\Translation\TranslationEvent;
+use Thelia\Core\Translation\Translator;
+use Thelia\Log\Tlog;
+
+/**
+ * Class Area
+ * @package Thelia\Action
+ * @author Manuel Raynaud <manu@thelia.net>
+ */
+class Translation extends BaseAction implements EventSubscriberInterface
+{
+    public function getTranslatableStrings(TranslationEvent $event)
+    {
+        $stringCount = $this->walkDir(
+            $event->getDirectory(),
+            $event->getMode(),
+            $event->getLocale(),
+            $event->getDomain(),
+            $strings
+        );
+
+        $event
+            ->setTranslatableStrings($strings)
+            ->setTranslatableStringCount($stringCount)
+            ;
+    }
+    /**
+     * Recursively examine files in a directory tree, and extract translatable strings.
+     *
+     * Returns an array of translatable strings, each item having with the following structure:
+     * 'files' an array of file names in which the string appears,
+     * 'text' the translatable text
+     * 'translation' => the text translation, or an empty string if none available.
+     * 'dollar'  => true if the translatable text contains a $
+     *
+     * @param  string $directory the path to the directory to examine
+     * @param  string $walkMode type of file scanning: WALK_MODE_PHP or WALK_MODE_TEMPLATE
+     * @param  string $currentLocale the current locale
+     * @param  string $domain the translation domain (fontoffice, backoffice, module, etc...)
+     * @param  array $strings the list of strings
+     * @throws \InvalidArgumentException if $walkMode contains an invalid value
+     * @return number the total number of translatable texts
+     */
+    protected function walkDir($directory, $walkMode, $currentLocale, $domain, &$strings)
+    {
+        $num_texts = 0;
+
+        if ($walkMode == TranslationEvent::WALK_MODE_PHP) {
+            $prefix = '\-\>[\s]*trans[\s]*\([\s]*';
+
+            $allowed_exts = array('php');
+        } elseif ($walkMode == TranslationEvent::WALK_MODE_TEMPLATE) {
+            $prefix = '\{intl(?:.*?)l=[\s]*';
+
+            $allowed_exts = array('html', 'tpl', 'xml', 'txt');
+        } else {
+            throw new \InvalidArgumentException(
+                Translator::getInstance()->trans(
+                    'Invalid value for walkMode parameter: %value',
+                    array('%value' => $walkMode)
+                )
+            );
+        }
+
+        try {
+            Tlog::getInstance()->debug("Walking in $directory, in mode $walkMode");
+
+            /** @var \DirectoryIterator $fileInfo */
+            foreach (new \DirectoryIterator($directory) as $fileInfo) {
+                if ($fileInfo->isDot()) {
+                    continue;
+                }
+
+                if ($fileInfo->isDir()) {
+                    $num_texts += $this->walkDir(
+                        $fileInfo->getPathName(),
+                        $walkMode,
+                        $currentLocale,
+                        $domain,
+                        $strings
+                    );
+                }
+
+                if ($fileInfo->isFile()) {
+                    $ext = $fileInfo->getExtension();
+
+                    if (in_array($ext, $allowed_exts)) {
+                        if ($content = file_get_contents($fileInfo->getPathName())) {
+                            $short_path = $this->normalizePath($fileInfo->getPathName());
+
+                            Tlog::getInstance()->debug("Examining file $short_path\n");
+
+                            $matches = array();
+
+                            if (preg_match_all(
+                                '/'.$prefix.'((?<![\\\\])[\'"])((?:.(?!(?<![\\\\])\1))*.?)*?\1/ms',
+                                $content,
+                                $matches
+                            )) {
+                                Tlog::getInstance()->debug("Strings found: ", $matches[2]);
+
+                                $idx = 0;
+
+                                foreach ($matches[2] as $match) {
+                                    $hash = md5($match);
+
+                                    if (isset($strings[$hash])) {
+                                        if (! in_array($short_path, $strings[$hash]['files'])) {
+                                            $strings[$hash]['files'][] = $short_path;
+                                        }
+                                    } else {
+                                        $num_texts++;
+
+                                        // remove \' (or \"), that will prevent the translator to work properly, as
+                                        // "abc \def\" ghi" will be passed as abc "def" ghi to the translator.
+
+                                        $quote = $matches[1][$idx];
+
+                                        $match = str_replace("\\$quote", $quote, $match);
+
+                                        // Ignore empty strings
+                                        if (strlen($match) == 0) {
+                                            continue;
+                                        }
+
+                                        $strings[$hash] = array(
+                                            'files'   => array($short_path),
+                                            'text'  => $match,
+                                            'translation' => Translator::getInstance()->trans(
+                                                $match,
+                                                [],
+                                                $domain,
+                                                $currentLocale,
+                                                false
+                                            ),
+                                            'dollar'  => strstr($match, '$') !== false
+                                        );
+                                    }
+
+                                    $idx++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (\UnexpectedValueException $ex) {
+            // Directory does not exists => ignore/
+        }
+
+        return $num_texts;
+    }
+
+    public function writeTranslationFile(TranslationEvent $event)
+    {
+        $file = $event->getTranslationFilePath();
+
+        $fs = new Filesystem();
+
+        if (! $fs->exists($file) && true === $event->isCreateFileIfNotExists()) {
+            $dir = dirname($file);
+
+            if (! $fs->exists($file)) {
+                $fs->mkdir($dir);
+            }
+        }
+
+        if ($fp = @fopen($file, 'w')) {
+            fwrite($fp, '<' . "?php\n\n");
+            fwrite($fp, "return array(\n");
+
+            $texts = $event->getTranslatableStrings();
+            $translations = $event->getTranslatedStrings();
+
+            // Sort keys alphabetically while keeping index
+            asort($texts);
+
+            foreach ($texts as $key => $text) {
+                // Write only defined (not empty) translations
+                if (! empty($translations[$key])) {
+                    $text = str_replace("'", "\'", $text);
+
+                    $translation = str_replace("'", "\'", $translations[$key]);
+
+                    fwrite($fp, sprintf("    '%s' => '%s',\n", $text, $translation));
+                }
+            }
+
+            fwrite($fp, ");\n");
+
+            @fclose($fp);
+        } else {
+            throw new \RuntimeException(
+                Translator::getInstance()->trans(
+                    'Failed to open translation file %file. Please be sure that this file is writable by your Web server',
+                    array('%file' => $file)
+                )
+            );
+        }
+    }
+
+    protected function normalizePath($path)
+    {
+        $path = str_replace(
+            str_replace('\\', '/', THELIA_ROOT),
+            '',
+            str_replace('\\', '/', realpath($path))
+        );
+
+        return ltrim($path, '/');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            TheliaEvents::TRANSLATION_GET_STRINGS => array('getTranslatableStrings', 128),
+            TheliaEvents::TRANSLATION_WRITE_FILE => array('writeTranslationFile', 128)
+        );
+    }
+}

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -122,6 +122,7 @@ return array(
     'Country title' => 'Country title',
     'Coupon' => 'Coupon',
     'Coupon %code is expired.' => 'Coupon %code is expired.',
+    'Coupon code %code is disabled.' => 'Coupon code %code is disabled.',
     'Critical' => 'Critical',
     'Curency selection page' => 'Curency selection page',
     'Currencies' => 'Currencies',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -122,6 +122,7 @@ return array(
     'Country title' => 'Nom de ce pays',
     'Coupon' => 'Code promo',
     'Coupon %code is expired.' => 'La date limite d\'utilisation du coupon %code est dépassée.',
+    'Coupon code %code is disabled.' => 'Le code promo %code est désactivé.',
     'Critical' => 'Critique',
     'Curency selection page' => 'Page du choix de la device',
     'Currencies' => 'Devises',

--- a/core/lib/Thelia/Config/Resources/action.xml
+++ b/core/lib/Thelia/Config/Resources/action.xml
@@ -177,6 +177,7 @@
         </service>
 
         <service id="thelia.action.lang" class="Thelia\Action\Lang">
+            <argument type="service" id="thelia.template_helper" />
             <tag name="kernel.event_subscriber"/>
         </service>
 
@@ -203,6 +204,10 @@
         </service>
 
         <service id="thelia.action.customer_title" class="Thelia\Action\CustomerTitle">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="thelia.action.translation" class="Thelia\Action\Translation">
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -47,6 +47,9 @@
 
     <services>
 
+        <!-- Thelia template helper -->
+        <service id="thelia.template_helper" class="Thelia\Core\Template\TheliaTemplateHelper" />
+
         <!--  URL maganement -->
         <service id="thelia.url.manager" class="Thelia\Tools\URL">
             <argument type="service" id="service_container" />

--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -20,7 +20,6 @@ use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\Exception\AuthorizationException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Form\BaseForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
@@ -202,7 +201,7 @@ class BaseAdminController extends BaseController
 
         // Define the template that should be used
         $parser->setTemplateDefinition(
-            $template ?: TemplateHelper::getInstance()->getActiveAdminTemplate(),
+            $template ?: $this->getTemplateHelper()->getActiveAdminTemplate(),
             $this->useFallbackTemplate
         );
 

--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -21,7 +21,6 @@ use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Form\Definition\AdminForm;
 use Thelia\Model\MessageQuery;
 use Thelia\Model\Module;
@@ -164,7 +163,7 @@ class MessageController extends AbstractCrudController
     {
         $list = array();
 
-        $dir = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $dir = $this->getTemplateHelper()->getActiveMailTemplate()->getAbsolutePath();
 
         $finder = Finder::create()->files()->in($dir)->ignoreDotFiles(true)->sortByName()->name("*.$requiredExtension");
 
@@ -233,7 +232,7 @@ class MessageController extends AbstractCrudController
             $this->pageNotFound();
         }
 
-        $parser = $this->getParser(TemplateHelper::getInstance()->getActiveMailTemplate());
+        $parser = $this->getParser($this->getTemplateHelper()->getActiveMailTemplate());
 
         foreach ($this->getRequest()->query->all() as $key => $value) {
             $parser->assign($key, $value);

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -76,8 +76,6 @@ class TranslationsController extends BaseAdminController
             $module_part = false;
         }
 
-        $all_strings = array();
-
         $template = $directory = $i18n_directory = false;
 
         $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
@@ -183,13 +181,8 @@ class TranslationsController extends BaseAdminController
                 case 'co':
                     $directory = THELIA_LIB;
                     $domain = 'core';
-<<<<<<< HEAD
                     $i18n_directory = THELIA_LIB . 'Config' . DS . 'I18n';
-                    $walkMode = TemplateHelper::WALK_MODE_PHP;
-=======
-                    $i18n_directory = THELIA_ROOT . 'core/lib/Thelia/Config/I18n';
                     $walkMode = TranslationEvent::WALK_MODE_PHP;
->>>>>>> TemplateHelper is now replaced with a service
                     break;
 
                 // Thelia Install
@@ -257,7 +250,10 @@ class TranslationsController extends BaseAdminController
                             $this->getDispatcher()->dispatch(TheliaEvents::TRANSLATION_WRITE_FILE, $event);
 
                             if ($save_mode == 'stay') {
-                                return $this->generateRedirectFromRoute("admin.configuration.translations", $templateArguments);
+                                return $this->generateRedirectFromRoute(
+                                    "admin.configuration.translations",
+                                    $templateArguments
+                                );
                             } else {
                                 return $this->generateRedirect(URL::getInstance()->adminViewUrl('configuration'));
                             }

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -24,33 +24,33 @@ use Thelia\Model\ModuleQuery;
 use Thelia\Tools\URL;
 
 /**
- * Class LangController
+ * Class TranslationsController
  * @package Thelia\Controller\Admin
  * @author Manuel Raynaud <manu@thelia.net>
  */
 class TranslationsController extends BaseAdminController
 {
     /**
-     * @param  string                    $item_name the modume code
+     * @param  string                    $itemName the modume code
      * @return Module                    the module object
      * @throws \InvalidArgumentException if module was not found
      */
-    protected function getModule($item_name)
+    protected function getModule($itemName)
     {
-        if (null !== $module = ModuleQuery::create()->findPk($item_name)) {
+        if (null !== $module = ModuleQuery::create()->findPk($itemName)) {
             return $module;
         }
 
         throw new \InvalidArgumentException(
-            $this->getTranslator()->trans("No module found for code '%item'", ['%item' => $item_name])
+            $this->getTranslator()->trans("No module found for code '%item'", ['%item' => $itemName])
         );
     }
 
-    protected function getModuleTemplateNames(Module $module, $template_type)
+    protected function getModuleTemplateNames(Module $module, $templateType)
     {
         $templates =
             $this->getTemplateHelper()->getList(
-                $template_type,
+                $templateType,
                 $module->getAbsoluteTemplateBasePath()
             );
 
@@ -66,72 +66,72 @@ class TranslationsController extends BaseAdminController
     protected function renderTemplate()
     {
         // Get related strings, if all input data are here
-        $item_to_translate = $this->getRequest()->get('item_to_translate');
+        $itemToTranslate = $this->getRequest()->get('item_to_translate');
 
-        $item_name = $this->getRequest()->get('item_name', '');
+        $itemName = $this->getRequest()->get('item_name', '');
 
-        if ($item_to_translate == 'mo' && ! empty($item_name)) {
-            $module_part = $this->getRequest()->get('module_part', '');
+        if ($itemToTranslate == 'mo' && ! empty($itemName)) {
+            $modulePart = $this->getRequest()->get('module_part', '');
         } else {
-            $module_part = false;
+            $modulePart = false;
         }
 
-        $template = $directory = $i18n_directory = false;
+        $template = $directory = $i18nDirectory = false;
 
         $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
 
         $templateArguments = array(
-                'item_to_translate'             => $item_to_translate,
-                'item_name'                     => $item_name,
-                'module_part'                   => $module_part,
+                'item_to_translate'             => $itemToTranslate,
+                'item_name'                     => $itemName,
+                'module_part'                   => $modulePart,
                 'view_missing_traductions_only' => $this->getRequest()->get('view_missing_traductions_only'),
                 'max_input_vars_warning'        => false,
         );
 
         // Find the i18n directory, and the directory to examine.
 
-        if (! empty($item_name) || $item_to_translate == 'co' || $item_to_translate == 'in') {
-            switch ($item_to_translate) {
+        if (! empty($itemName) || $itemToTranslate == 'co' || $itemToTranslate == 'in') {
+            switch ($itemToTranslate) {
 
                 // Module core
                 case 'mo':
-                    $module = $this->getModule($item_name);
+                    $module = $this->getModule($itemName);
 
-                    if ($module_part == 'core') {
+                    if ($modulePart == 'core') {
                         $directory = $module->getAbsoluteBaseDir();
                         $domain = $module->getTranslationDomain();
-                        $i18n_directory = $module->getAbsoluteI18nPath();
+                        $i18nDirectory = $module->getAbsoluteI18nPath();
                         $walkMode = TranslationEvent::WALK_MODE_PHP;
-                    } elseif ($module_part == 'admin-includes') {
+                    } elseif ($modulePart == 'admin-includes') {
                         $directory = $module->getAbsoluteAdminIncludesPath();
                         $domain = $module->getAdminIncludesTranslationDomain();
-                        $i18n_directory = $module->getAbsoluteAdminIncludesI18nPath();
+                        $i18nDirectory = $module->getAbsoluteAdminIncludesI18nPath();
                         $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
-                    } elseif (! empty($module_part)) {
+                    } elseif (! empty($modulePart)) {
                         // Front, back, pdf or email office template,
                         // form of $module_part is [bo|fo|pdf|email].subdir-name
-                        list($type, $subdir) = explode('.', $module_part);
+                        list($type, $subdir) = explode('.', $modulePart);
 
                         switch ($type) {
                             case 'bo':
                                 $directory = $module->getAbsoluteBackOfficeTemplatePath($subdir);
                                 $domain = $module->getBackOfficeTemplateTranslationDomain($subdir);
-                                $i18n_directory = $module->getAbsoluteBackOfficeI18nTemplatePath($subdir);
+                                $i18nDirectory = $module->getAbsoluteBackOfficeI18nTemplatePath($subdir);
                                 break;
                             case 'fo':
                                 $directory = $module->getAbsoluteFrontOfficeTemplatePath($subdir);
                                 $domain = $module->getFrontOfficeTemplateTranslationDomain($subdir);
-                                $i18n_directory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
+                                $i18nDirectory = $module->getAbsoluteFrontOfficeI18nTemplatePath($subdir);
                                 break;
                             case 'email':
                                 $directory = $module->getAbsoluteEmailTemplatePath($subdir);
                                 $domain = $module->getEmailTemplateTranslationDomain($subdir);
-                                $i18n_directory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
+                                $i18nDirectory = $module->getAbsoluteEmailI18nTemplatePath($subdir);
                                 break;
                             case 'pdf':
                                 $directory = $module->getAbsolutePdfTemplatePath($subdir);
                                 $domain = $module->getPdfTemplateTranslationDomain($subdir);
-                                $i18n_directory = $module->getAbsolutePdfI18nTemplatePath($subdir);
+                                $i18nDirectory = $module->getAbsolutePdfI18nTemplatePath($subdir);
                                 break;
                             default:
                                 throw new \InvalidArgumentException("Undefined module template type: '$type'.");
@@ -143,7 +143,7 @@ class TranslationsController extends BaseAdminController
                     // Modules translations files are in the cache, and are not always
                     // updated. Force a reload of the files to get last changes.
                     if (! empty($domain)) {
-                        $this->loadTranslation($i18n_directory, $domain);
+                        $this->loadTranslation($i18nDirectory, $domain);
                     }
 
                     // List front and back office templates defined by this module
@@ -189,51 +189,51 @@ class TranslationsController extends BaseAdminController
                 case 'in':
                     $directory = THELIA_SETUP_DIRECTORY;
                     $domain = 'install';
-                    $i18n_directory = THELIA_SETUP_DIRECTORY . '/I18n';
+                    $i18nDirectory = THELIA_SETUP_DIRECTORY . '/I18n';
                     $walkMode = TranslationEvent::WALK_MODE_TEMPLATE;
                     // resources not loaded by default
-                    $this->loadTranslation($i18n_directory, $domain);
+                    $this->loadTranslation($i18nDirectory, $domain);
                     break;
 
                 // Front-office template
                 case 'fo':
-                    $template = new TemplateDefinition($item_name, TemplateDefinition::FRONT_OFFICE);
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::FRONT_OFFICE);
                     break;
 
                 // Back-office template
                 case 'bo':
-                    $template = new TemplateDefinition($item_name, TemplateDefinition::BACK_OFFICE);
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::BACK_OFFICE);
                     break;
 
                 // PDF templates
                 case 'pf':
-                    $template = new TemplateDefinition($item_name, TemplateDefinition::PDF);
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::PDF);
                     break;
 
                 // Email templates
                 case 'ma':
-                    $template = new TemplateDefinition($item_name, TemplateDefinition::EMAIL);
+                    $template = new TemplateDefinition($itemName, TemplateDefinition::EMAIL);
                     break;
             }
 
             if ($template) {
                 $directory = $template->getAbsolutePath();
 
-                $i18n_directory = $template->getAbsoluteI18nPath();
+                $i18nDirectory = $template->getAbsoluteI18nPath();
 
                 $domain = $template->getTranslationDomain();
 
                 // Load translations files is this template is not the current template
                 // as it is not loaded in Thelia.php
                 if (! $this->getTemplateHelper()->isActive($template)) {
-                    $this->loadTranslation($i18n_directory, $domain);
+                    $this->loadTranslation($i18nDirectory, $domain);
                 }
             }
 
             // Load strings to translate
             if ($directory && ! empty($domain)) {
                 // Save the string set, if the form was submitted
-                if ($i18n_directory) {
+                if ($i18nDirectory) {
                     $save_mode = $this->getRequest()->get('save_mode', false);
 
                     if ($save_mode !== false) {
@@ -241,7 +241,7 @@ class TranslationsController extends BaseAdminController
 
                         if (! empty($texts)) {
                             $event = TranslationEvent::createWriteFileEvent(
-                                sprintf("%s".DS."%s.php", $i18n_directory, $this->getCurrentEditionLocale()),
+                                sprintf("%s".DS."%s.php", $i18nDirectory, $this->getCurrentEditionLocale()),
                                 $texts,
                                 $this->getRequest()->get('translation', []),
                                 true

--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -12,31 +12,29 @@
 
 namespace Thelia\Controller;
 
+use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Thelia\Core\Event\PdfEvent;
-use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\HttpFoundation\Response;
-use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Router;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Core\Event\DefaultActionEvent;
+use Thelia\Core\Event\PdfEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\Response;
+use Thelia\Core\Template\ParserContext;
 use Thelia\Core\Translation\Translator;
 use Thelia\Exception\TheliaProcessException;
-use Thelia\Form\FirewallForm;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\OrderQuery;
 use Thelia\Tools\Redirect;
-use Thelia\Core\Template\ParserContext;
-use Thelia\Core\Event\ActionEvent;
-use Thelia\Form\BaseForm;
-use Thelia\Form\Exception\FormValidationException;
-use Thelia\Core\Event\DefaultActionEvent;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Thelia\Tools\URL;
 
 /**
@@ -58,6 +56,8 @@ abstract class BaseController extends ContainerAware
     protected $currentRouter;
 
     protected $translator;
+
+    protected $templateHelper;
 
     /** @var bool Fallback on default template when setting the templateDefinition */
     protected $useFallbackTemplate = false;
@@ -191,6 +191,18 @@ abstract class BaseController extends ContainerAware
     }
 
     /**
+     * @return \Thelia\Core\Template\TemplateHelperInterface
+     */
+    protected function getTemplateHelper()
+    {
+        if (null === $this->templateHelper) {
+            $this->templateHelper = $this->container->get("thelia.template_helper");
+        }
+
+        return $this->templateHelper;
+    }
+
+    /**
      * Get all errors that occurred in a form
      *
      * @param  \Symfony\Component\Form\Form $form
@@ -245,7 +257,7 @@ abstract class BaseController extends ContainerAware
             array(
                 'order_id' => $order_id
             ),
-            TemplateHelper::getInstance()->getActivePdfTemplate()
+            $this->getTemplateHelper()->getActivePdfTemplate()
         );
 
         try {

--- a/core/lib/Thelia/Controller/Front/BaseFrontController.php
+++ b/core/lib/Thelia/Controller/Front/BaseFrontController.php
@@ -17,9 +17,7 @@ use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Model\AddressQuery;
-use Thelia\Model\ConfigQuery;
 use Thelia\Model\ModuleQuery;
 
 class BaseFrontController extends BaseController
@@ -84,7 +82,7 @@ class BaseFrontController extends BaseController
 
         // Define the template that should be used
         $parser->setTemplateDefinition(
-            $template ?: TemplateHelper::getInstance()->getActiveFrontTemplate(),
+            $template ?: $this->getTemplateHelper()->getActiveFrontTemplate(),
             $this->useFallbackTemplate
         );
 

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -789,6 +789,8 @@ final class TheliaEvents
     const LANG_DEFAULTBEHAVIOR                  = 'action.lang.defaultBehavior';
     const LANG_URL                              = 'action.lang.url';
 
+    const LANG_FIX_MISSING_FLAG                 = 'action.lang.fix_missing_flag';
+
     const LANG_TOGGLEDEFAULT                    = 'action.lang.toggleDefault';
 
     const BEFORE_UPDATELANG                     = 'action.lang.beforeUpdate';
@@ -879,4 +881,9 @@ final class TheliaEvents
     const CUSTOMER_TITLE_AFTER_UPDATE = "action.title.after_update";
 
     const CUSTOMER_TITLE_DELETE = "action.title.delete";
+
+    // -- Translation -------------------------------------------
+
+    const TRANSLATION_GET_STRINGS = 'action.translation.get_strings';
+    const TRANSLATION_WRITE_FILE = 'action.translation.write_file';
 }

--- a/core/lib/Thelia/Core/Event/Translation/TranslationEvent.php
+++ b/core/lib/Thelia/Core/Event/Translation/TranslationEvent.php
@@ -1,0 +1,245 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+/**
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * Creation date: 26/03/2015 16:01
+ */
+
+namespace Thelia\Core\Event\Translation;
+
+use Thelia\Core\Event\ActionEvent;
+
+class TranslationEvent extends ActionEvent
+{
+    const WALK_MODE_PHP = 'php';
+    const WALK_MODE_TEMPLATE = 'tpl';
+
+    /** @var  string */
+    protected $directory;
+
+    /** @var  string */
+    protected $mode;
+
+    /** @var  string */
+    protected $locale;
+
+    /** @var  string */
+    protected $domain;
+
+    /** @var  array */
+    protected $translatableStrings;
+
+    /** @var  int */
+    protected $translatableStringCount;
+
+    /** @var  string */
+    protected $translationFilePath;
+
+    /** @var  array */
+    protected $translatedStrings;
+
+    /** @var  bool */
+    protected $createFileIfNotExists;
+
+    public static function createGetStringsEvent($directory, $mode, $locale, $domain)
+    {
+        $event = new TranslationEvent();
+
+        $event->setDirectory($directory);
+        $event->setMode($mode);
+        $event->setLocale($locale);
+        $event->setDomain($domain);
+
+        return $event;
+    }
+
+    public static function createWriteFileEvent(
+        $translationFilePath,
+        $translatableStrings,
+        $translatedStrings,
+        $createFileIfNotExists
+    ) {
+        $event = new TranslationEvent();
+
+        $event->setTranslatableStrings($translatableStrings);
+        $event->setTranslatedStrings($translatedStrings);
+        $event->setCreateFileIfNotExists($createFileIfNotExists);
+        $event->setTranslationFilePath($translationFilePath);
+
+        return $event;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getDirectory()
+    {
+        return $this->directory;
+    }
+
+    /**
+     * @param string $directory
+     * @return $this
+     */
+    public function setDirectory($directory)
+    {
+        $this->directory = $directory;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * @param string $mode
+     * @return $this
+     */
+    public function setMode($mode)
+    {
+        $this->mode = $mode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @param string $locale
+     * @return $this
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDomain()
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @param string $domain
+     * @return $this
+     */
+    public function setDomain($domain)
+    {
+        $this->domain = $domain;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTranslatableStrings()
+    {
+        return $this->translatableStrings;
+    }
+
+    /**
+     * @param array $translatableStrings
+     * @return $this
+     */
+    public function setTranslatableStrings($translatableStrings)
+    {
+        $this->translatableStrings = $translatableStrings;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTranslatableStringCount()
+    {
+        return $this->translatableStringCount;
+    }
+
+    /**
+     * @param int $translatableStringCount
+     * @return $this
+     */
+    public function setTranslatableStringCount($translatableStringCount)
+    {
+        $this->translatableStringCount = $translatableStringCount;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTranslationFilePath()
+    {
+        return $this->translationFilePath;
+    }
+
+    /**
+     * @param string $translationFilePath
+     * @return $this
+     */
+    public function setTranslationFilePath($translationFilePath)
+    {
+        $this->translationFilePath = $translationFilePath;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTranslatedStrings()
+    {
+        return $this->translatedStrings;
+    }
+
+    /**
+     * @param array $translatedStrings
+     * @return $this
+     */
+    public function setTranslatedStrings($translatedStrings)
+    {
+        $this->translatedStrings = $translatedStrings;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isCreateFileIfNotExists()
+    {
+        return $this->createFileIfNotExists;
+    }
+
+    /**
+     * @param boolean $createFileIfNotExists
+     * @return $this
+     */
+    public function setCreateFileIfNotExists($createFileIfNotExists)
+    {
+        $this->createFileIfNotExists = $createFileIfNotExists;
+        return $this;
+    }
+
+}

--- a/core/lib/Thelia/Core/EventListener/ErrorListener.php
+++ b/core/lib/Thelia/Core/EventListener/ErrorListener.php
@@ -16,12 +16,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Template\ParserInterface;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Core\TheliaKernelEvents;
 use Thelia\Model\ConfigQuery;
 
@@ -44,8 +43,11 @@ class ErrorListener implements EventSubscriberInterface
 
     protected $env;
 
-    public function __construct($env, ParserInterface $parser, SecurityContext $securityContext)
-    {
+    public function __construct(
+        $env,
+        ParserInterface $parser,
+        SecurityContext $securityContext
+    ) {
         $this->env = $env;
 
         $this->parser = $parser;
@@ -60,8 +62,8 @@ class ErrorListener implements EventSubscriberInterface
 
         $this->parser->setTemplateDefinition(
             $this->securityContext->hasAdminUser() ?
-            TemplateHelper::getInstance()->getActiveAdminTemplate() :
-            TemplateHelper::getInstance()->getActiveFrontTemplate()
+            $this->parser->getTemplateHelper()->getActiveAdminTemplate() :
+            $this->parser->getTemplateHelper()->getActiveFrontTemplate()
         );
 
         $response = new Response(

--- a/core/lib/Thelia/Core/EventListener/ViewListener.php
+++ b/core/lib/Thelia/Core/EventListener/ViewListener.php
@@ -12,19 +12,17 @@
 
 namespace Thelia\Core\EventListener;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Thelia\Core\HttpFoundation\Response;
 use Symfony\Component\Routing\Router;
+use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Template\Exception\ResourceNotFoundException;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Exception\OrderException;
-use Thelia\Core\Security\Exception\AuthenticationException;
 
 /**
  *
@@ -63,7 +61,8 @@ class ViewListener implements EventSubscriberInterface
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
         $parser = $this->container->get('thelia.parser');
-        $parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveFrontTemplate());
+        $templateHelper = $this->container->get('thelia.template_helper');
+        $parser->setTemplateDefinition($templateHelper->getActiveFrontTemplate());
         $request = $this->container->get('request');
         $response = null;
         try {

--- a/core/lib/Thelia/Core/Template/Loop/Template.php
+++ b/core/lib/Thelia/Core/Template/Loop/Template.php
@@ -12,15 +12,14 @@
 
 namespace Thelia\Core\Template\Loop;
 
+use Thelia\Core\Template\Element\ArraySearchLoopInterface;
+use Thelia\Core\Template\Element\BaseLoop;
 use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
-use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Core\Template\Loop\Argument\Argument;
-use Thelia\Type;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Core\Template\Element\BaseLoop;
-use Thelia\Core\Template\Element\ArraySearchLoopInterface;
+use Thelia\Type;
 
 /**
  *
@@ -66,7 +65,7 @@ class Template extends BaseLoop implements ArraySearchLoopInterface
             $templateType = TemplateDefinition::EMAIL;
         }
 
-        return TemplateHelper::getInstance()->getList($templateType);
+        return $this->container->get('thelia.template_helper')->getList($templateType);
     }
 
     public function parseResults(LoopResult $loopResult)

--- a/core/lib/Thelia/Core/Template/ParserInterface.php
+++ b/core/lib/Thelia/Core/Template/ParserInterface.php
@@ -77,4 +77,9 @@ interface ParserInterface
      * @param mixed  $value    the value of the variable
      */
     public function assign($variable, $value);
+
+    /**
+     * @return \Thelia\Core\Template\TemplateHelperInterface the parser template helper instance
+     */
+    public function getTemplateHelper();
 }

--- a/core/lib/Thelia/Core/Template/TemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TemplateHelper.php
@@ -21,9 +21,7 @@ namespace Thelia\Core\Template;
  */
 class TemplateHelper implements TemplateHelperInterface
 {
-    /**
-     * This is a singleton
-     */
+    /** This is a singleton */
     private static $instance = null;
 
     /** @var TemplateHelperInterface  */
@@ -32,6 +30,8 @@ class TemplateHelper implements TemplateHelperInterface
     private function __construct(TemplateHelperInterface $templateHelper)
     {
         $this->templateHelper = $templateHelper;
+
+        self::$instance = $this;
     }
 
     /**

--- a/core/lib/Thelia/Core/Template/TemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TemplateHelper.php
@@ -26,6 +26,9 @@ class TemplateHelper implements TemplateHelperInterface
      */
     private static $instance = null;
 
+    /** @var TemplateHelperInterface  */
+    private $templateHelper;
+
     private function __construct(TemplateHelperInterface $templateHelper)
     {
         $this->templateHelper = $templateHelper;

--- a/core/lib/Thelia/Core/Template/TemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TemplateHelper.php
@@ -12,321 +12,94 @@
 
 namespace Thelia\Core\Template;
 
-use Symfony\Component\Filesystem\Filesystem;
-use Thelia\Model\ConfigQuery;
-use Thelia\Log\Tlog;
-use Thelia\Core\Translation\Translator;
-
-class TemplateHelper
+/**
+ * Class TemplateHelper
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * @package Thelia\Core\Template
+ *
+ * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead. This class will be DELETED in 2.3
+ */
+class TemplateHelper implements TemplateHelperInterface
 {
-    const WALK_MODE_PHP = 'php';
-    const WALK_MODE_TEMPLATE = 'tpl';
-
     /**
      * This is a singleton
-
      */
     private static $instance = null;
 
-    private function __construct()
+    private function __construct(TemplateHelperInterface $templateHelper)
     {
+        $this->templateHelper = $templateHelper;
     }
 
+    /**
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
+     */
     public static function getInstance()
     {
         if (self::$instance == null) {
-            self::$instance = new TemplateHelper();
+            throw new \LogicException("This class should be initialized before getInstance() call.");
         }
+
         return self::$instance;
     }
 
+    public static function init(TemplateHelperInterface $templateHelper)
+    {
+        self::$instance = new TemplateHelper($templateHelper);
+    }
     /**
-     * @return TemplateDefinition
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getActiveMailTemplate()
     {
-        return new TemplateDefinition(
-            ConfigQuery::read('active-mail-template', 'default'),
-            TemplateDefinition::EMAIL
-        );
+        return $this->templateHelper->getActiveMailTemplate();
     }
 
     /**
-     * Check if a template definition is the current active template
-     *
-     * @param  TemplateDefinition $tplDefinition
-     * @return bool               true is the given template is the active template
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function isActive(TemplateDefinition $tplDefinition)
     {
-        switch ($tplDefinition->getType()) {
-            case TemplateDefinition::FRONT_OFFICE:
-                $tplVar = 'active-front-template';
-                break;
-            case TemplateDefinition::BACK_OFFICE:
-                $tplVar = 'active-admin-template';
-                break;
-            case TemplateDefinition::PDF:
-                $tplVar = 'active-pdf-template';
-                break;
-            case TemplateDefinition::EMAIL:
-                $tplVar = 'active-mail-template';
-                break;
-        }
-
-        return $tplDefinition->getName() == ConfigQuery::read($tplVar, 'default');
+        return $this->templateHelper->isActive($tplDefinition);
     }
+
     /**
-     * @return TemplateDefinition
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getActivePdfTemplate()
     {
-        return new TemplateDefinition(
-            ConfigQuery::read('active-pdf-template', 'default'),
-            TemplateDefinition::PDF
-        );
+        return $this->templateHelper->getActivePdfTemplate();
     }
 
     /**
-     * @return TemplateDefinition
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getActiveAdminTemplate()
     {
-        return new TemplateDefinition(
-            ConfigQuery::read('active-admin-template', 'default'),
-            TemplateDefinition::BACK_OFFICE
-        );
+        return $this->templateHelper->getActiveAdminTemplate();
     }
 
     /**
-     * @return TemplateDefinition
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getActiveFrontTemplate()
     {
-        return new TemplateDefinition(
-            ConfigQuery::read('active-front-template', 'default'),
-            TemplateDefinition::FRONT_OFFICE
-        );
+        return $this->templateHelper->getActiveFrontTemplate();
     }
 
     /**
-     * Returns an array which contains all standard template definitions
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getStandardTemplateDefinitions()
     {
-        return array(
-                $this->getActiveFrontTemplate(),
-                $this->getActiveAdminTemplate(),
-                $this->getActivePdfTemplate(),
-                $this->getActiveMailTemplate(),
-        );
+        return $this->templateHelper->getStandardTemplateDefinitions();
     }
 
     /**
-     * Return a list of existing templates for a given template type
-     *
-     * @param  int                  $templateType the template type
-     * @param string the template base (module or core, default to core).
-     * @return TemplateDefinition[] of \Thelia\Core\Template\TemplateDefinition
+     * @deprecated use TheliaTemplateHelper service (thelia.template_helper) instead.
      */
     public function getList($templateType, $base = THELIA_TEMPLATE_DIR)
     {
-        $list = $exclude = array();
-
-        $tplIterator = TemplateDefinition::getStandardTemplatesSubdirsIterator();
-
-        foreach ($tplIterator as $type => $subdir) {
-            if ($templateType == $type) {
-                $baseDir = rtrim($base, DS).DS.$subdir;
-
-                try {
-                    // Every subdir of the basedir is supposed to be a template.
-                    $di = new \DirectoryIterator($baseDir);
-
-                    /** @var \DirectoryIterator $file */
-                    foreach ($di as $file) {
-                        // Ignore 'dot' elements
-                        if ($file->isDot() || ! $file->isDir()) {
-                            continue;
-                        }
-
-                        // Ignore reserved directory names
-                        if (in_array($file->getFilename(), $exclude)) {
-                            continue;
-                        }
-
-                        $list[] = new TemplateDefinition($file->getFilename(), $templateType);
-                    }
-                } catch (\UnexpectedValueException $ex) {
-                    // Ignore the exception and continue
-                }
-            }
-        }
-
-        return $list;
-    }
-
-    protected function normalizePath($path)
-    {
-        $path = str_replace(
-            str_replace('\\', '/', THELIA_ROOT),
-            '',
-            str_replace('\\', '/', realpath($path))
-        );
-
-        return ltrim($path, '/');
-    }
-
-    /**
-     * Recursively examine files in a directory tree, and extract translatable strings.
-     *
-     * Returns an array of translatable strings, each item having with the following structure:
-     * 'files' an array of file names in which the string appears,
-     * 'text' the translatable text
-     * 'translation' => the text translation, or an empty string if none available.
-     * 'dollar'  => true if the translatable text contains a $
-     *
-     * @param  string                              $directory     the path to the directory to examine
-     * @param  string                              $walkMode      type of file scanning: WALK_MODE_PHP or WALK_MODE_TEMPLATE
-     * @param  \Thelia\Core\Translation\Translator $translator    the current translator
-     * @param  string                              $currentLocale the current locale
-     * @param  string                              $domain        the translation domain (fontoffice, backoffice, module, etc...)
-     * @param  array                               $strings       the list of strings
-     * @throws \InvalidArgumentException           if $walkMode contains an invalid value
-     * @return number                              the total number of translatable texts
-     */
-    public function walkDir($directory, $walkMode, Translator $translator, $currentLocale, $domain, &$strings)
-    {
-        $num_texts = 0;
-
-        if ($walkMode == self::WALK_MODE_PHP) {
-            $prefix = '\-\>[\s]*trans[\s]*\([\s]*';
-
-            $allowed_exts = array('php');
-        } elseif ($walkMode == self::WALK_MODE_TEMPLATE) {
-            $prefix = '\{intl(?:.*?)l=[\s]*';
-
-            $allowed_exts = array('html', 'tpl', 'xml', 'txt');
-        } else {
-            throw new \InvalidArgumentException(
-                Translator::getInstance()->trans('Invalid value for walkMode parameter: %value', array('%value' => $walkMode))
-            );
-        }
-
-        try {
-            Tlog::getInstance()->debug("Walking in $directory, in mode $walkMode");
-
-            /** @var \DirectoryIterator $fileInfo */
-            foreach (new \DirectoryIterator($directory) as $fileInfo) {
-                if ($fileInfo->isDot()) {
-                    continue;
-                }
-
-                if ($fileInfo->isDir()) {
-                    $num_texts += $this->walkDir($fileInfo->getPathName(), $walkMode, $translator, $currentLocale, $domain, $strings);
-                }
-
-                if ($fileInfo->isFile()) {
-                    $ext = $fileInfo->getExtension();
-
-                    if (in_array($ext, $allowed_exts)) {
-                        if ($content = file_get_contents($fileInfo->getPathName())) {
-                            $short_path = $this->normalizePath($fileInfo->getPathName());
-
-                            Tlog::getInstance()->debug("Examining file $short_path\n");
-
-                            $matches = array();
-
-                            if (preg_match_all('/'.$prefix.'((?<![\\\\])[\'"])((?:.(?!(?<![\\\\])\1))*.?)*?\1/ms', $content, $matches)) {
-                                Tlog::getInstance()->debug("Strings found: ", $matches[2]);
-
-                                $idx = 0;
-
-                                foreach ($matches[2] as $match) {
-                                    $hash = md5($match);
-
-                                    if (isset($strings[$hash])) {
-                                        if (! in_array($short_path, $strings[$hash]['files'])) {
-                                            $strings[$hash]['files'][] = $short_path;
-                                        }
-                                    } else {
-                                        $num_texts++;
-
-                                        // remove \' (or \"), that will prevent the translator to work properly, as
-                                        // "abc \def\" ghi" will be passed as abc "def" ghi to the translator.
-
-                                        $quote = $matches[1][$idx];
-
-                                        $match = str_replace("\\$quote", $quote, $match);
-
-                                        // Ignore empty strings
-                                        if (strlen($match) == 0) {
-                                            continue;
-                                        }
-
-                                        $strings[$hash] = array(
-                                                'files'   => array($short_path),
-                                                'text'  => $match,
-                                                'translation' => $translator->trans($match, array(), $domain, $currentLocale, false),
-                                                'dollar'  => strstr($match, '$') !== false
-                                        );
-                                    }
-
-                                    $idx++;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            return $num_texts;
-        } catch (\UnexpectedValueException $ex) {
-            // Directory does not exists => ignore/
-        }
-    }
-
-
-    public function writeTranslation($file, $texts, $translations, $createIfNotExists = false)
-    {
-        $fs = new Filesystem();
-
-        if (! $fs->exists($file) && true === $createIfNotExists) {
-            $dir = dirname($file);
-
-            if (! $fs->exists($file)) {
-                $fs->mkdir($dir);
-            }
-        }
-
-        if ($fp = @fopen($file, 'w')) {
-            fwrite($fp, '<' . "?php\n\n");
-            fwrite($fp, "return array(\n");
-
-            // Sort keys alphabetically while keeping index
-            asort($texts);
-
-            foreach ($texts as $key => $text) {
-                // Write only defined (not empty) translations
-                if (! empty($translations[$key])) {
-                    $text = str_replace("'", "\'", $text);
-
-                    $translation = str_replace("'", "\'", $translations[$key]);
-
-                    fwrite($fp, sprintf("    '%s' => '%s',\n", $text, $translation));
-                }
-            }
-
-            fwrite($fp, ");\n");
-
-            @fclose($fp);
-        } else {
-            throw new \RuntimeException(
-                Translator::getInstance()->trans(
-                    'Failed to open translation file %file. Please be sure that this file is writable by your Web server',
-                    array('%file' => $file)
-                )
-            );
-        }
+        return $this->templateHelper->getList($templateType, $base);
     }
 }

--- a/core/lib/Thelia/Core/Template/TemplateHelperInterface.php
+++ b/core/lib/Thelia/Core/Template/TemplateHelperInterface.php
@@ -1,0 +1,63 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Model\ConfigQuery;
+use Thelia\Log\Tlog;
+use Thelia\Core\Translation\Translator;
+
+interface TemplateHelperInterface
+{
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveMailTemplate();
+
+    /**
+     * Check if a template definition is the current active template
+     *
+     * @param  TemplateDefinition $tplDefinition
+     * @return bool               true is the given template is the active template
+     */
+    public function isActive(TemplateDefinition $tplDefinition);
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActivePdfTemplate();
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveAdminTemplate();
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveFrontTemplate();
+
+    /**
+     * Returns an array which contains all standard template definitions
+     */
+    public function getStandardTemplateDefinitions();
+
+    /**
+     * Return a list of existing templates for a given template type
+     *
+     * @param int  $templateType the template type
+     * @param string $base the template base (module or core, default to core).
+     * @return TemplateDefinition[] of \Thelia\Core\Template\TemplateDefinition
+     */
+    public function getList($templateType, $base = THELIA_TEMPLATE_DIR);
+}

--- a/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
@@ -1,0 +1,157 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+/**
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * Creation date: 26/03/2015 16:36
+ */
+
+namespace Thelia\Core\Template;
+
+use Thelia\Model\ConfigQuery;
+
+class TheliaTemplateHelper implements TemplateHelperInterface
+{
+    public function __construct()
+    {
+        // Initialize the deprecated TemplateHelper class to ensure backward compatibility
+        TemplateHelper::init($this);
+    }
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveMailTemplate()
+    {
+        return new TemplateDefinition(
+            ConfigQuery::read('active-mail-template', 'default'),
+            TemplateDefinition::EMAIL
+        );
+    }
+
+    /**
+     * Check if a template definition is the current active template
+     *
+     * @param  TemplateDefinition $tplDefinition
+     * @return bool               true is the given template is the active template
+     */
+    public function isActive(TemplateDefinition $tplDefinition)
+    {
+        $tplVar = '';
+
+        switch ($tplDefinition->getType()) {
+            case TemplateDefinition::FRONT_OFFICE:
+                $tplVar = 'active-front-template';
+                break;
+            case TemplateDefinition::BACK_OFFICE:
+                $tplVar = 'active-admin-template';
+                break;
+            case TemplateDefinition::PDF:
+                $tplVar = 'active-pdf-template';
+                break;
+            case TemplateDefinition::EMAIL:
+                $tplVar = 'active-mail-template';
+                break;
+        }
+
+        return $tplDefinition->getName() == ConfigQuery::read($tplVar, 'default');
+    }
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActivePdfTemplate()
+    {
+        return new TemplateDefinition(
+            ConfigQuery::read('active-pdf-template', 'default'),
+            TemplateDefinition::PDF
+        );
+    }
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveAdminTemplate()
+    {
+        return new TemplateDefinition(
+            ConfigQuery::read('active-admin-template', 'default'),
+            TemplateDefinition::BACK_OFFICE
+        );
+    }
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getActiveFrontTemplate()
+    {
+        return new TemplateDefinition(
+            ConfigQuery::read('active-front-template', 'default'),
+            TemplateDefinition::FRONT_OFFICE
+        );
+    }
+
+    /**
+     * Returns an array which contains all standard template definitions
+     */
+    public function getStandardTemplateDefinitions()
+    {
+        return array(
+            $this->getActiveFrontTemplate(),
+            $this->getActiveAdminTemplate(),
+            $this->getActivePdfTemplate(),
+            $this->getActiveMailTemplate(),
+        );
+    }
+
+    /**
+     * Return a list of existing templates for a given template type
+     *
+     * @param  int $templateType the template type
+     * @param string $base the template base (module or core, default to core).
+     * @return TemplateDefinition[] of \Thelia\Core\Template\TemplateDefinition
+     */
+    public function getList($templateType, $base = THELIA_TEMPLATE_DIR)
+    {
+        $list = $exclude = array();
+
+        $tplIterator = TemplateDefinition::getStandardTemplatesSubdirsIterator();
+
+        foreach ($tplIterator as $type => $subdir) {
+            if ($templateType == $type) {
+                $baseDir = rtrim($base, DS).DS.$subdir;
+
+                try {
+                    // Every subdir of the basedir is supposed to be a template.
+                    $di = new \DirectoryIterator($baseDir);
+
+                    /** @var \DirectoryIterator $file */
+                    foreach ($di as $file) {
+                        // Ignore 'dot' elements
+                        if ($file->isDot() || ! $file->isDir()) {
+                            continue;
+                        }
+
+                        // Ignore reserved directory names
+                        if (in_array($file->getFilename(), $exclude)) {
+                            continue;
+                        }
+
+                        $list[] = new TemplateDefinition($file->getFilename(), $templateType);
+                    }
+                } catch (\UnexpectedValueException $ex) {
+                    // Ignore the exception and continue
+                }
+            }
+        }
+
+        return $list;
+    }
+}

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -42,7 +42,6 @@ use Thelia\Core\DependencyInjection\Loader\XmlFileLoader;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Log\Tlog;
 use Thelia\Model\Map\ProductTableMap;
 use Thelia\Model\Module;
@@ -271,10 +270,13 @@ class Thelia extends Kernel
             /** @var ParserInterface $parser */
             $parser = $container->getDefinition('thelia.parser');
 
+            /** @var \Thelia\Core\Template\TemplateHelperInterface $templateHelper */
+            $templateHelper = $container->get('thelia.template_helper');
+
             /** @var Module $module */
             foreach ($modules as $module) {
                 try {
-                    $this->loadModuleTranslationDirectories($module, $translationDirs);
+                    $this->loadModuleTranslationDirectories($module, $translationDirs, $templateHelper);
 
                     $this->addStandardModuleTemplatesToParserEnvironment($parser, $module);
                 } catch (\Exception $e) {
@@ -289,10 +291,9 @@ class Thelia extends Kernel
             $translationDirs['core'] = THELIA_LIB . 'Config' . DS . 'I18n';
 
             // Standard templates (front, back, pdf, mail)
-            $th = TemplateHelper::getInstance();
 
             /** @var TemplateDefinition $templateDefinition */
-            foreach ($th->getStandardTemplateDefinitions() as $templateDefinition) {
+            foreach ($templateHelper->getStandardTemplateDefinitions() as $templateDefinition) {
                 if (is_dir($dir = $templateDefinition->getAbsoluteI18nPath())) {
                     $translationDirs[$templateDefinition->getTranslationDomain()] = $dir;
                 }
@@ -304,7 +305,7 @@ class Thelia extends Kernel
         }
     }
 
-    private function loadModuleTranslationDirectories(Module $module, array &$translationDirs)
+    private function loadModuleTranslationDirectories(Module $module, array &$translationDirs, $templateHelper)
     {
         // Core module translation
         if (is_dir($dir = $module->getAbsoluteI18nPath())) {
@@ -318,7 +319,7 @@ class Thelia extends Kernel
 
         // Module back-office template, if any
         $templates =
-            TemplateHelper::getInstance()->getList(
+            $templateHelper->getList(
                 TemplateDefinition::BACK_OFFICE,
                 $module->getAbsoluteTemplateBasePath()
             );
@@ -330,7 +331,7 @@ class Thelia extends Kernel
 
         // Module front-office template, if any
         $templates =
-            TemplateHelper::getInstance()->getList(
+            $templateHelper->getList(
                 TemplateDefinition::FRONT_OFFICE,
                 $module->getAbsoluteTemplateBasePath()
             );
@@ -342,7 +343,7 @@ class Thelia extends Kernel
 
         // Module pdf template, if any
         $templates =
-            TemplateHelper::getInstance()->getList(
+            $templateHelper->getList(
                 TemplateDefinition::PDF,
                 $module->getAbsoluteTemplateBasePath()
             );
@@ -354,7 +355,7 @@ class Thelia extends Kernel
 
         // Module email template, if any
         $templates =
-            TemplateHelper::getInstance()->getList(
+            $templateHelper->getList(
                 TemplateDefinition::EMAIL,
                 $module->getAbsoluteTemplateBasePath()
             );

--- a/core/lib/Thelia/Coupon/BaseFacade.php
+++ b/core/lib/Thelia/Coupon/BaseFacade.php
@@ -19,7 +19,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Thelia\Condition\ConditionEvaluator;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Template\ParserInterface;
-use Thelia\Core\Template\TemplateHelper;
 use Thelia\Log\Tlog;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\Country;
@@ -74,7 +73,9 @@ class BaseFacade implements FacadeInterface
     public function getDeliveryAddress()
     {
         try {
-            return AddressQuery::create()->findPk($this->getRequest()->getSession()->getOrder()->getChoosenDeliveryAddress());
+            return AddressQuery::create()->findPk(
+                $this->getRequest()->getSession()->getOrder()->getChoosenDeliveryAddress()
+            );
         } catch (\Exception $ex) {
             throw new \LogicException("Failed to get delivery address (" . $ex->getMessage() . ")");
         }
@@ -255,7 +256,9 @@ class BaseFacade implements FacadeInterface
             $this->parser = $this->container->get('thelia.parser');
 
             // Define the current back-office template that should be used
-            $this->parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveAdminTemplate());
+            $this->parser->setTemplateDefinition(
+                $this->parser->getTemplateHelper()->getActiveAdminTemplate()
+            );
         }
 
         return $this->parser;

--- a/core/lib/Thelia/Model/Lang.php
+++ b/core/lib/Thelia/Model/Lang.php
@@ -5,11 +5,8 @@ namespace Thelia\Model;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
-use Symfony\Component\Filesystem\Filesystem;
 use Thelia\Core\Event\Lang\LangEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Template\TemplateHelper;
-use Thelia\Core\Translation\Translator;
 use Thelia\Model\Base\Lang as BaseLang;
 use Thelia\Model\Map\LangTableMap;
 
@@ -64,34 +61,6 @@ class Lang extends BaseLang
         }
     }
 
-    protected function fixMissingFlag()
-    {
-        // Be sure that a lang have a flag, otherwise copy the
-        // "unknown" flag
-        $adminTemplate = TemplateHelper::getInstance()->getActiveAdminTemplate();
-        $unknownFlag = ConfigQuery::getUnknownFlagPath();
-
-        $unknownFlagPath = $adminTemplate->getAbsolutePath().DS.$unknownFlag;
-
-        if (! file_exists($unknownFlagPath)) {
-            throw new \RuntimeException(
-                Translator::getInstance()->trans(
-                    "The image which replaces an undefined country flag (%file) was not found. Please check unknown-flag-path configuration variable, and check that the image exists.",
-                    array("%file" => $unknownFlag)
-                )
-            );
-        }
-
-        // Check if the country flag exists
-        $countryFlag = rtrim(dirname($unknownFlagPath), DS).DS.$this->getCode().'.png';
-
-        if (! file_exists($countryFlag)) {
-            $fs = new Filesystem();
-
-            $fs->copy($unknownFlagPath, $countryFlag);
-        }
-    }
-
     public function preInsert(ConnectionInterface $con = null)
     {
         $this->dispatchEvent(TheliaEvents::BEFORE_CREATELANG, new LangEvent($this));
@@ -103,7 +72,7 @@ class Lang extends BaseLang
     {
         $this->dispatchEvent(TheliaEvents::AFTER_CREATELANG, new LangEvent($this));
 
-        $this->fixMissingFlag();
+        $this->dispatchEvent(TheliaEvents::LANG_FIX_MISSING_FLAG, new LangEvent($this));
     }
 
     public function preUpdate(ConnectionInterface $con = null)
@@ -117,7 +86,7 @@ class Lang extends BaseLang
     {
         $this->dispatchEvent(TheliaEvents::AFTER_UPDATELANG, new LangEvent($this));
 
-        $this->fixMissingFlag();
+        $this->dispatchEvent(TheliaEvents::LANG_FIX_MISSING_FLAG, new LangEvent($this));
     }
 
     public function preDelete(ConnectionInterface $con = null)

--- a/core/lib/Thelia/Model/Map/AttributeTableMap.php
+++ b/core/lib/Thelia/Model/Map/AttributeTableMap.php
@@ -165,7 +165,7 @@ class AttributeTableMap extends TableMap
         $this->addRelation('AttributeCombination', '\\Thelia\\Model\\AttributeCombination', RelationMap::ONE_TO_MANY, array('id' => 'attribute_id', ), 'CASCADE', 'RESTRICT', 'AttributeCombinations');
         $this->addRelation('AttributeTemplate', '\\Thelia\\Model\\AttributeTemplate', RelationMap::ONE_TO_MANY, array('id' => 'attribute_id', ), 'CASCADE', 'RESTRICT', 'AttributeTemplates');
         $this->addRelation('AttributeI18n', '\\Thelia\\Model\\AttributeI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'AttributeI18ns');
-        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_MANY, array(), null, null, 'Templates');
+        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_MANY, array(), 'CASCADE', 'RESTRICT', 'Templates');
     } // buildRelations()
 
     /**

--- a/core/lib/Thelia/Model/Map/AttributeTemplateTableMap.php
+++ b/core/lib/Thelia/Model/Map/AttributeTemplateTableMap.php
@@ -166,7 +166,7 @@ class AttributeTemplateTableMap extends TableMap
     public function buildRelations()
     {
         $this->addRelation('Attribute', '\\Thelia\\Model\\Attribute', RelationMap::MANY_TO_ONE, array('attribute_id' => 'id', ), 'CASCADE', 'RESTRICT');
-        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_ONE, array('template_id' => 'id', ), null, null);
+        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_ONE, array('template_id' => 'id', ), 'CASCADE', 'RESTRICT');
     } // buildRelations()
 
     /**

--- a/core/lib/Thelia/Model/Map/FeatureTableMap.php
+++ b/core/lib/Thelia/Model/Map/FeatureTableMap.php
@@ -171,7 +171,7 @@ class FeatureTableMap extends TableMap
         $this->addRelation('FeatureProduct', '\\Thelia\\Model\\FeatureProduct', RelationMap::ONE_TO_MANY, array('id' => 'feature_id', ), 'CASCADE', 'RESTRICT', 'FeatureProducts');
         $this->addRelation('FeatureTemplate', '\\Thelia\\Model\\FeatureTemplate', RelationMap::ONE_TO_MANY, array('id' => 'feature_id', ), 'CASCADE', 'RESTRICT', 'FeatureTemplates');
         $this->addRelation('FeatureI18n', '\\Thelia\\Model\\FeatureI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'FeatureI18ns');
-        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_MANY, array(), null, null, 'Templates');
+        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_MANY, array(), 'CASCADE', 'RESTRICT', 'Templates');
     } // buildRelations()
 
     /**

--- a/core/lib/Thelia/Model/Map/FeatureTemplateTableMap.php
+++ b/core/lib/Thelia/Model/Map/FeatureTemplateTableMap.php
@@ -166,7 +166,7 @@ class FeatureTemplateTableMap extends TableMap
     public function buildRelations()
     {
         $this->addRelation('Feature', '\\Thelia\\Model\\Feature', RelationMap::MANY_TO_ONE, array('feature_id' => 'id', ), 'CASCADE', 'RESTRICT');
-        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_ONE, array('template_id' => 'id', ), null, null);
+        $this->addRelation('Template', '\\Thelia\\Model\\Template', RelationMap::MANY_TO_ONE, array('template_id' => 'id', ), 'CASCADE', 'RESTRICT');
     } // buildRelations()
 
     /**

--- a/core/lib/Thelia/Model/Map/TemplateTableMap.php
+++ b/core/lib/Thelia/Model/Map/TemplateTableMap.php
@@ -156,8 +156,8 @@ class TemplateTableMap extends TableMap
     public function buildRelations()
     {
         $this->addRelation('Product', '\\Thelia\\Model\\Product', RelationMap::ONE_TO_MANY, array('id' => 'template_id', ), 'SET NULL', null, 'Products');
-        $this->addRelation('FeatureTemplate', '\\Thelia\\Model\\FeatureTemplate', RelationMap::ONE_TO_MANY, array('id' => 'template_id', ), null, null, 'FeatureTemplates');
-        $this->addRelation('AttributeTemplate', '\\Thelia\\Model\\AttributeTemplate', RelationMap::ONE_TO_MANY, array('id' => 'template_id', ), null, null, 'AttributeTemplates');
+        $this->addRelation('FeatureTemplate', '\\Thelia\\Model\\FeatureTemplate', RelationMap::ONE_TO_MANY, array('id' => 'template_id', ), 'CASCADE', 'RESTRICT', 'FeatureTemplates');
+        $this->addRelation('AttributeTemplate', '\\Thelia\\Model\\AttributeTemplate', RelationMap::ONE_TO_MANY, array('id' => 'template_id', ), 'CASCADE', 'RESTRICT', 'AttributeTemplates');
         $this->addRelation('TemplateI18n', '\\Thelia\\Model\\TemplateI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'TemplateI18ns');
         $this->addRelation('Feature', '\\Thelia\\Model\\Feature', RelationMap::MANY_TO_MANY, array(), 'CASCADE', 'RESTRICT', 'Features');
         $this->addRelation('Attribute', '\\Thelia\\Model\\Attribute', RelationMap::MANY_TO_MANY, array(), 'CASCADE', 'RESTRICT', 'Attributes');
@@ -184,6 +184,8 @@ class TemplateTableMap extends TableMap
         // Invalidate objects in ".$this->getClassNameFromBuilder($joinedTableTableMapBuilder)." instance pool,
         // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
                 ProductTableMap::clearInstancePool();
+                FeatureTemplateTableMap::clearInstancePool();
+                AttributeTemplateTableMap::clearInstancePool();
                 TemplateI18nTableMap::clearInstancePool();
             }
 

--- a/core/lib/Thelia/Model/Message.php
+++ b/core/lib/Thelia/Model/Message.php
@@ -2,13 +2,12 @@
 
 namespace Thelia\Model;
 
-use Thelia\Core\Template\Exception\ResourceNotFoundException;
-use Thelia\Model\Base\Message as BaseMessage;
 use Propel\Runtime\Connection\ConnectionInterface;
-use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\Message\MessageEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserInterface;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Model\Base\Message as BaseMessage;
 
 class Message extends BaseMessage
 {
@@ -148,7 +147,11 @@ class Message extends BaseMessage
      */
     public function buildMessage(ParserInterface $parser, \Swift_Message $messageInstance, $useFallbackTemplate = true)
     {
-        $parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveMailTemplate(), $useFallbackTemplate);
+        $parser->setTemplateDefinition(
+            $parser->getTemplateHelper()->getActiveMailTemplate(),
+            $useFallbackTemplate
+        );
+
         $subject     = $parser->fetch(sprintf("string:%s", $this->getSubject()));
         $htmlMessage = $this->getHtmlMessageBody($parser);
         $textMessage = $this->getTextMessageBody($parser);

--- a/core/lib/Thelia/Module/AbstractPaymentModule.php
+++ b/core/lib/Thelia/Module/AbstractPaymentModule.php
@@ -15,7 +15,7 @@ namespace Thelia\Module;
 use Symfony\Component\Routing\Router;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Template\ParserInterface;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Model\Order;
 use Thelia\Tools\URL;
 
@@ -33,9 +33,11 @@ abstract class AbstractPaymentModule extends BaseModule implements PaymentModule
     public function generateGatewayFormResponse($order, $gateway_url, $form_data)
     {
         /** @var ParserInterface $parser */
-        $parser = $this->container->get("thelia.parser");
+        $parser = $this->getContainer()->get("thelia.parser");
 
-        $parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveFrontTemplate());
+        $parser->setTemplateDefinition(
+            $$parser->getTemplateHelper()->getActiveFrontTemplate()
+        );
 
         $renderedTemplate = $parser->render(
             "order-payment-gateway.html",

--- a/local/modules/TheliaSmarty/Config/config.xml
+++ b/local/modules/TheliaSmarty/Config/config.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="request" />
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="thelia.parser.context"/>
+            <argument type="service" id="thelia.template_helper"/>
             <argument >%kernel.environment%</argument>
             <argument >%kernel.debug%</argument>
         </service>
@@ -117,6 +118,7 @@
         <service id="smarty.plugin.adminUtilities" class="TheliaSmarty\Template\Plugins\AdminUtilities" scope="request">
             <tag name="thelia.parser.register_plugin"/>
             <argument type="service" id="thelia.securityContext" />
+            <argument type="service" id="thelia.template_helper" />
         </service>
 
         <service id="smarty.plugin.flashMessage" class="TheliaSmarty\Template\Plugins\FlashMessage" scope="request">

--- a/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
@@ -12,11 +12,11 @@
 
 namespace TheliaSmarty\Template\Plugins;
 
-use TheliaSmarty\Template\SmartyPluginDescriptor;
-use TheliaSmarty\Template\AbstractSmartyPlugin;
-use Thelia\Tools\URL;
 use Thelia\Core\Security\SecurityContext;
-use Thelia\Core\Template\TemplateHelper;
+use Thelia\Core\Template\TemplateHelperInterface;
+use Thelia\Tools\URL;
+use TheliaSmarty\Template\AbstractSmartyPlugin;
+use TheliaSmarty\Template\SmartyPluginDescriptor;
 
 /**
  * This class implements variour admin template utilities
@@ -26,10 +26,12 @@ use Thelia\Core\Template\TemplateHelper;
 class AdminUtilities extends AbstractSmartyPlugin
 {
     private $securityContext;
+    private $templateHelper;
 
-    public function __construct(SecurityContext $securityContext)
+    public function __construct(SecurityContext $securityContext, TemplateHelperInterface $templateHelper)
     {
         $this->securityContext = $securityContext;
+        $this->templateHelper = $templateHelper;
     }
 
     protected function fetchSnippet($smarty, $templateName, $variablesArray)
@@ -39,7 +41,7 @@ class AdminUtilities extends AbstractSmartyPlugin
         $snippet_path = sprintf(
             '%s/%s/%s.html',
             THELIA_TEMPLATE_DIR,
-            TemplateHelper::getInstance()->getActiveAdminTemplate()->getPath(),
+            $this->templateHelper->getActiveAdminTemplate()->getPath(),
             $templateName
         );
 

--- a/local/modules/TheliaSmarty/Template/SmartyParser.php
+++ b/local/modules/TheliaSmarty/Template/SmartyParser.php
@@ -21,6 +21,7 @@ use Thelia\Core\Template\ParserInterface;
 
 use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TemplateHelperInterface;
 use TheliaSmarty\Template\AbstractSmartyPlugin;
 use TheliaSmarty\Template\SmartyPluginDescriptor;
 use Thelia\Core\Template\TemplateDefinition;
@@ -41,6 +42,7 @@ class SmartyParser extends Smarty implements ParserInterface
     protected $request;
     protected $dispatcher;
     protected $parserContext;
+    protected $templateHelper;
 
     protected $backOfficeTemplateDirectories = array();
     protected $frontOfficeTemplateDirectories = array();
@@ -60,6 +62,7 @@ class SmartyParser extends Smarty implements ParserInterface
      * @param Request                  $request
      * @param EventDispatcherInterface $dispatcher
      * @param ParserContext            $parserContext
+     * @param TemplateHelperInterface  $templateHelper
      * @param string                   $env
      * @param bool                     $debug
      */
@@ -67,6 +70,7 @@ class SmartyParser extends Smarty implements ParserInterface
         Request $request,
         EventDispatcherInterface $dispatcher,
         ParserContext $parserContext,
+        TemplateHelperInterface $templateHelper,
         $env = "prod",
         $debug = false
     ) {
@@ -75,6 +79,7 @@ class SmartyParser extends Smarty implements ParserInterface
         $this->request = $request;
         $this->dispatcher = $dispatcher;
         $this->parserContext = $parserContext;
+        $this->templateHelper = $templateHelper;
 
         // Configure basic Smarty parameters
 
@@ -467,5 +472,13 @@ class SmartyParser extends Smarty implements ParserInterface
                 );
             }
         }
+    }
+
+    /**
+     * @return \Thelia\Core\Template\TemplateHelperInterface the parser template helper instance
+     */
+    public function getTemplateHelper()
+    {
+        return $this->templateHelper;
     }
 }

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
@@ -14,6 +14,7 @@ namespace TheliaSmarty\Tests\Template\Plugin;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TheliaTemplateHelper;
 use Thelia\Tests\ContainerAwareTestCase;
 use TheliaSmarty\Template\SmartyParser;
 
@@ -35,7 +36,8 @@ abstract class SmartyPluginTestCase extends ContainerAwareTestCase
         $this->smarty = new SmartyParser(
             $container->get("request"),
             $container->get("event_dispatcher"),
-            $parserContext = new ParserContext($container->get("request"))
+            $parserContext = new ParserContext($container->get("request")),
+            $templateHelper = new TheliaTemplateHelper()
         );
 
         $container->set("thelia.parser", $this->smarty);

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -286,6 +286,8 @@ CREATE TABLE `feature_template`
     CONSTRAINT `fk_feature_template`
         FOREIGN KEY (`template_id`)
         REFERENCES `template` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------
@@ -414,6 +416,8 @@ CREATE TABLE `attribute_template`
     CONSTRAINT `fk_attribute_template`
         FOREIGN KEY (`template_id`)
         REFERENCES `template` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------

--- a/tests/phpunit/Thelia/Tests/Action/LangTest.php
+++ b/tests/phpunit/Thelia/Tests/Action/LangTest.php
@@ -17,6 +17,7 @@ use Thelia\Action\Lang;
 use Thelia\Core\Event\Lang\LangDeleteEvent;
 use Thelia\Core\Event\Lang\LangToggleDefaultEvent;
 use Thelia\Core\Event\Lang\LangUpdateEvent;
+use Thelia\Core\Template\TheliaTemplateHelper;
 use Thelia\Model\LangQuery;
 use Thelia\Model\Lang as LangModel;
 use Thelia\Core\Event\Lang\LangCreateEvent;
@@ -64,7 +65,7 @@ class LangTest extends ContainerAwareTestCase
             ->setDispatcher($this->dispatcher)
         ;
 
-        $action = new Lang();
+        $action = new Lang(new TheliaTemplateHelper());
         $action->create($event);
 
         $createdLang = $event->getLang();
@@ -106,7 +107,7 @@ class LangTest extends ContainerAwareTestCase
             ->setDispatcher($this->dispatcher)
         ;
 
-        $action = new Lang();
+        $action = new Lang(new TheliaTemplateHelper());
         $action->update($event);
 
         $updatedLang = $event->getLang();
@@ -135,7 +136,7 @@ class LangTest extends ContainerAwareTestCase
         $event = new LangToggleDefaultEvent($lang->getId());
         $event->setDispatcher($this->dispatcher);
 
-        $action = new Lang();
+        $action = new Lang(new TheliaTemplateHelper());
         $action->toggleDefault($event);
 
         $updatedLang = $event->getLang();
@@ -161,7 +162,7 @@ class LangTest extends ContainerAwareTestCase
         $event = new LangDeleteEvent($lang->getId());
         $event->setDispatcher($this->dispatcher);
 
-        $action = new Lang();
+        $action = new Lang(new TheliaTemplateHelper());
         $action->delete($event);
 
         $deletedLang = $event->getLang();
@@ -183,7 +184,7 @@ class LangTest extends ContainerAwareTestCase
         $event = new LangDeleteEvent($lang->getId());
         $event->setDispatcher($this->dispatcher);
 
-        $action = new Lang();
+        $action = new Lang(new TheliaTemplateHelper());
         $action->delete($event);
     }
 

--- a/tests/phpunit/Thelia/Tests/Model/MessageTest.php
+++ b/tests/phpunit/Thelia/Tests/Model/MessageTest.php
@@ -12,16 +12,16 @@
 
 namespace Thelia\Tests\Model;
 
-use Thelia\Model\ConfigQuery;
-use Symfony\Component\Filesystem\Filesystem;
-use Thelia\Model\Message as ModelMessage;
-use TheliaSmarty\Template\SmartyParser;
-use Thelia\Core\Template\ParserContext;
-use Thelia\Core\Template\TemplateHelper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TheliaTemplateHelper;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Message as ModelMessage;
+use TheliaSmarty\Template\SmartyParser;
 
 /**
  * Class CustomerTest
@@ -35,6 +35,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
      */
     protected $container;
     protected $parser;
+    protected $templateHelper;
 
     private $backup_mail_template = 'undefined';
 
@@ -44,7 +45,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         ConfigQuery::write('active-mail-template', 'test');
 
-        @mkdir(TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath(), 0777, true);
+        $this->templateHelper = new TheliaTemplateHelper();
+
+        @mkdir($this->templateHelper->getActiveMailTemplate()->getAbsolutePath(), 0777, true);
 
         $container = new ContainerBuilder();
 
@@ -63,8 +66,8 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $container->set("event_dispatcher", $dispatcher);
         $container->set('request', $request);
 
-        $this->parser = new SmartyParser($request, $dispatcher, new ParserContext($request), 'dev', true);
-        $this->parser->setTemplateDefinition(TemplateHelper::getInstance()->getActiveMailTemplate());
+        $this->parser = new SmartyParser($request, $dispatcher, new ParserContext($request), $this->templateHelper, 'dev', true);
+        $this->parser->setTemplateDefinition($this->templateHelper->getActiveMailTemplate());
 
         $container->set('thelia.parser', $this->parser);
 
@@ -131,7 +134,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->setHtmlLayoutFileName('layout.html.tpl');
         $message->setTextLayoutFileName('layout.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         file_put_contents($path.DS.'layout.html.tpl', 'HTML Layout: {$message_body nofilter}');
         file_put_contents($path.DS.'layout.text.tpl', 'TEXT Layout: {$message_body nofilter}');
@@ -160,7 +163,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $message->setTextLayoutFileName('layout3.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         file_put_contents($path.DS.'layout3.text.tpl', 'TEXT Layout 3: {$message_body nofilter} :-) <>');
 
@@ -189,7 +192,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $message->setTextLayoutFileName('layout3.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         file_put_contents($path.DS.'layout3.text.tpl', 'TEXT Layout 3: {$message_body nofilter} :-) <>');
 
@@ -222,7 +225,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->setHtmlLayoutFileName('layout4.html.tpl');
         $message->setTextLayoutFileName('layout4.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         $this->parser->assign('myvar', 'my-value');
 
@@ -261,7 +264,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         //$message->setHtmlLayoutFileName('layout5.html.tpl');
         //$message->setTextLayoutFileName('layout5.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         $this->parser->assign('myvar', 'my-value');
 
@@ -297,7 +300,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->setHtmlLayoutFileName('layout6.html.tpl');
         $message->setTextLayoutFileName('layout6.text.tpl');
 
-        $path = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         $this->parser->assign('myvar', 'my-value');
 
@@ -315,7 +318,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        $dir = TemplateHelper::getInstance()->getActiveMailTemplate()->getAbsolutePath();
+        $dir = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
 
         ConfigQuery::write('active-mail-template', $this->backup_mail_template);
 


### PR DESCRIPTION
To allow modules to change the way current templates are set, this PR introduces the `thelia.template_helper` service, which offer the same services as the `TemplateHelper` singleton, in a more dynamic way. 
A TemplateHelperInterface is introduced as well, to define `thelia.template_helper` interface. The default implementation of this interface is the TheliaTemplateHelper class.

TemplateHelper singleton is now deprecated, and is just a (more or less) static facade for the `thelia.template_helper` service, to provide backward compatibility.

Some translation specific features that were previously located in TemplateHelper have been moved to a specific Translation action, triggered by two new events.