### PR TITLE
Accès au formulaire par les champs supplémentaires de celui-ci

### DIFF
--- a/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
+++ b/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
@@ -63,7 +63,7 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
      * @param float  $discount
      * @param string $company
      * @param string $ref
-     * @param array $other
+     * @param array $other Additional fields
      */
     public function __construct($title, $firstname, $lastname, $address1, $address2, $address3, $phone, $cellphone, $zipcode, $city, $country, $email, $password, $lang, $reseller, $sponsor, $discount, $company, $ref, array $other = array())
     {
@@ -292,7 +292,8 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
     /**
      * @return array
      */
-    public function getOther() {
+    public function getOther()
+    {
         return $this->other;
     }
 }

--- a/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
+++ b/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
@@ -41,6 +41,7 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
     protected $ref;
     protected $emailUpdateAllowed;
     protected $notifyCustomerOfAccountCreation;
+    protected $other;
 
     /**
      * @param int    $title     the title customer id
@@ -62,8 +63,9 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
      * @param float  $discount
      * @param string $company
      * @param string $ref
+     * @param array $other
      */
-    public function __construct($title, $firstname, $lastname, $address1, $address2, $address3, $phone, $cellphone, $zipcode, $city, $country, $email, $password, $lang, $reseller, $sponsor, $discount, $company, $ref)
+    public function __construct($title, $firstname, $lastname, $address1, $address2, $address3, $phone, $cellphone, $zipcode, $city, $country, $email, $password, $lang, $reseller, $sponsor, $discount, $company, $ref, array $other = array())
     {
         $this->address1 = $address1;
         $this->address2 = $address2;
@@ -84,6 +86,7 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
         $this->discount = $discount;
         $this->company = $company;
         $this->ref = $ref;
+        $this->other = $other;
     }
     /**
      * @return mixed
@@ -284,5 +287,12 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
     public function getNotifyCustomerOfAccountCreation()
     {
         return $this->notifyCustomerOfAccountCreation;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOther() {
+        return $this->other;
     }
 }

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -507,7 +507,7 @@ class CustomerController extends BaseFrontController
      */
     private function createEventInstance($data)
     {
-        $other = clone $data;
+        $other = $data;
         unset($other['title']);
         unset($other['firstname']);
         unset($other['lastname']);

--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -507,6 +507,25 @@ class CustomerController extends BaseFrontController
      */
     private function createEventInstance($data)
     {
+        $other = clone $data;
+        unset($other['title']);
+        unset($other['firstname']);
+        unset($other['lastname']);
+        unset($other['address1']);
+        unset($other['address2']);
+        unset($other['address3']);
+        unset($other['phone']);
+        unset($other['cellphone']);
+        unset($other['zipcode']);
+        unset($other['city']);
+        unset($other['country']);
+        unset($other['email']);
+        unset($other['password']);
+        unset($other['reseller']);
+        unset($other['sponsor']);
+        unset($other['discount']);
+        unset($other['company']);
+
         $customerCreateEvent = new CustomerCreateOrUpdateEvent(
             isset($data["title"])?$data["title"]:null,
             isset($data["firstname"])?$data["firstname"]:null,
@@ -526,7 +545,8 @@ class CustomerController extends BaseFrontController
             isset($data["sponsor"])?$data["sponsor"]:null,
             isset($data["discount"])?$data["discount"]:null,
             isset($data["company"])?$data["company"]:null,
-            null
+            null,
+            $other
         );
 
         return $customerCreateEvent;

--- a/templates/frontOffice/default/account-update.html
+++ b/templates/frontOffice/default/account-update.html
@@ -139,7 +139,7 @@
                 </div><!--/.form-group-->
                 {/form_field}
 
-                {hook name="account-update.form-bottom"}
+                {hook name="account-update.form-bottom" form=$form }
 
                 <div class="form-group group-btn">
                     <div class="control-btn">

--- a/templates/frontOffice/default/register.html
+++ b/templates/frontOffice/default/register.html
@@ -293,7 +293,7 @@
             </form>
             {/form}
 
-            {hook name="register.bottom"}
+            {hook name="register.bottom" form=$form }
         </article>
 
     </div><!-- /.layout -->


### PR DESCRIPTION
Lors de mon travail sur notre module Thelia CustomerFamily ( https://github.com/thelia-modules/CustomerFamily/pull/1 ), j'ai dû apporter des modifications à Thelia afin que celui-ci puisse fonctionner avec Thelia >= 2.1.0. Je reporte ces modifications pour le fonctionnement du module Customer Family avec les versions de Thelia à venir et aussi parce que c'est suffisamment générique pour être utilisé par d'autres modules.

La PR rajoute un paramètre `form` aux hooks "register.form-bottom" et "account-update.form-bottom" de Thelia afin que les champs additionnels puissent utiliser le formulaire dans leurs templates. La PR ajoute également un champ `other` aux events `CustomerCreateOrUpdateEvent`. Ce champ contient les données du formulaire non utilisées par le formulaire "de base" (sans ce que les hooks peuvent rajouter). Ces données "`other`" peuvent par exemple contenir les valeurs des champs additionnels afin que les modules utilisant les hooks "register.form-bottom" et "account-update.form-bottom" puissent exploiter les données de leurs champs supplémentaires, en écoutant les évènements qui sont dispatchés après la création d'un customer.

NB : j'en ai parlé avec Julien plus tôt dans le semaine.