### PR TITLE
Add paths for thelia project

### DIFF
--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -31,6 +31,14 @@ if (!defined('THELIA_ROOT')) {
     define('THELIA_ROOT', rtrim(realpath(dirname(__DIR__)), DS) . DS);
 }
 
+if (!defined('THELIA_LIB')) {
+    define('THELIA_LIB', THELIA_ROOT . 'core' . DS . 'lib' . DS . 'Thelia' . DS);
+}
+
+if (!defined('THELIA_VENDOR')) {
+    define('THELIA_VENDOR', THELIA_ROOT . 'core' . DS . 'vendor' . DS);
+}
+
 if (!defined('THELIA_LOCAL_DIR')) {
     define('THELIA_LOCAL_DIR', THELIA_ROOT . 'local' . DS);
 }

--- a/core/lib/Thelia/Command/ModuleGenerateCommand.php
+++ b/core/lib/Thelia/Command/ModuleGenerateCommand.php
@@ -176,6 +176,14 @@ class ModuleGenerateCommand extends BaseModuleGenerate
                 $schemaContent = file_get_contents($skeletonDir . "schema.xml");
 
                 $schemaContent = str_replace("%%NAMESPACE%%", $this->module, $schemaContent);
+                $schemaContent = str_replace(
+                    '%%XSD_LOCATION%%',
+                    $fs->makePathRelative(
+                        THELIA_VENDOR . 'propel/propel/resources/xsd/',
+                        $this->moduleDirectory
+                    ) . 'database.xsd',
+                    $schemaContent
+                );
 
                 file_put_contents($filename, $schemaContent);
             }

--- a/core/lib/Thelia/Command/Skeleton/Module/schema.xml
+++ b/core/lib/Thelia/Command/Skeleton/Module/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <database defaultIdMethod="native" name="thelia"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="../../../../core/vendor/propel/propel/resources/xsd/database.xsd" >
+          xsi:noNamespaceSchemaLocation="%%XSD_LOCATION%%" >
     <!--
     See propel documentation on http://propelorm.org for all information about schema file
 

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -180,9 +180,9 @@ class TranslationsController extends BaseAdminController
 
                 // Thelia Core
                 case 'co':
-                    $directory = THELIA_ROOT . 'core/lib/Thelia';
+                    $directory = THELIA_LIB;
                     $domain = 'core';
-                    $i18n_directory = THELIA_ROOT . 'core/lib/Thelia/Config/I18n';
+                    $i18n_directory = THELIA_LIB . 'Config' . DS . 'I18n';
                     $walkMode = TemplateHelper::WALK_MODE_PHP;
                     break;
 

--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -64,10 +64,10 @@ class RequestListener implements EventSubscriberInterface
         /** @var \Thelia\Core\HttpFoundation\Request $request */
         $request = $event->getRequest();
         $lang = $request->getSession()->getLang();
-        $vendorDir = THELIA_ROOT.'core'.DS.'vendor';
-        $vendorFormDir = $vendorDir.DS.'symfony'.DS.'form'.DS.'Symfony'.DS.'Component'.DS.'Form';
+
+        $vendorFormDir = THELIA_VENDOR . 'symfony' . DS . 'form' . DS . 'Symfony' . DS . 'Component' . DS . 'Form';
         $vendorValidatorDir =
-            $vendorDir.DS.'symfony'.DS.'validator'.DS.'Symfony'.DS.'Component'.DS.'Validator';
+            THELIA_VENDOR . 'symfony' . DS . 'validator' . DS . 'Symfony' . DS . 'Component' . DS . 'Validator';
 
         $this->translator->addResource(
             'xlf',

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -282,7 +282,7 @@ class Thelia extends Kernel
             }
 
             // Load core translation
-            $translationDirs['core'] = realpath(__DIR__ . DS . ".." . DS ."Config".DS.'I18n');
+            $translationDirs['core'] = THELIA_LIB . 'Config' . DS . 'I18n';
 
             // Standard templates (front, back, pdf, mail)
             $th = TemplateHelper::getInstance();


### PR DESCRIPTION
Add two runtime constants that can be override in thelia-project bootstrap file.

These constants are used to properly load the core translations