### PR TITLE
Imagine library updated to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@
 - Refactor VirtualProductDelivery module. The email sending is now triggered from a new event to gain more flexibility. Now, email messages use smarty file templates located in `templates/email/default`.     
 - Added capability to use translator in module functions `preActivation` and `postActivation`
 - Add environment aware database connection
-- new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font. 
+- new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font.
+- Imagine package is updated to 0.6.2, which provides a better support for transparency.
+- Default border color of images resized with resize_mode="border" is now transparent instead of opaque white.
 
 # 2.1.3
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ptachoire/cssembed": "1.0.*",
         "doctrine/cache": "v1.3.0",
         "simplepie/simplepie": "1.3.*",
-        "imagine/imagine": "v0.5.0",
+        "imagine/imagine": "v0.6.2",
         "symfony/icu": "1.0",
         "swiftmailer/swiftmailer": "5.2.*",
         "symfony/serializer": "2.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e4a7dca0a6a8ea12eea1a1e79419186d",
+    "hash": "47a0fd24517c10b3e194758ac16e57b5",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -186,16 +186,16 @@
         },
         {
             "name": "imagine/imagine",
-            "version": "v0.5.0",
+            "version": "0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "f64ec666baaa800edcbf237db41121a569230709"
+                "reference": "83ca8babede0e54f935ec09d55a726bf4b0a3f7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/f64ec666baaa800edcbf237db41121a569230709",
-                "reference": "f64ec666baaa800edcbf237db41121a569230709",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/83ca8babede0e54f935ec09d55a726bf4b0a3f7c",
+                "reference": "83ca8babede0e54f935ec09d55a726bf4b0a3f7c",
                 "shasum": ""
             },
             "require": {
@@ -210,6 +210,11 @@
                 "ext-imagick": "to use the Imagick implementation"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.7-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Imagine": "lib/"
@@ -234,7 +239,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2013-07-10 17:25:36"
+            "time": "2014-11-11 11:36:02"
         },
         {
             "name": "ircmaxell/password-compat",

--- a/core/lib/Thelia/Action/Image.php
+++ b/core/lib/Thelia/Action/Image.php
@@ -13,9 +13,9 @@
 namespace Thelia\Action;
 
 use Imagine\Image\Box;
-use Imagine\Image\Color;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
+use Imagine\Image\Palette\RGB;
 use Imagine\Image\Point;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Thelia\Core\Event\Image\ImageEvent;
@@ -138,10 +138,13 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
 
                     $background_color = $event->getBackgroundColor();
 
+                    $palette = new RGB();
+
                     if ($background_color != null) {
-                        $bg_color = new Color($background_color);
+                        $bg_color = $palette->color($background_color);
                     } else {
-                        $bg_color = null;
+                        // Define a fully transparent white background color
+                        $bg_color = $palette->color('fff', 0);
                     }
 
                     // Apply resize
@@ -202,7 +205,7 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
                             case 'colorize':
                                 // Syntax: colorize:couleur. Exemple: colorize:#ff00cc
                                 if (isset($params[1])) {
-                                    $the_color = new Color($params[1]);
+                                    $the_color = $palette->color($params[1]);
 
                                     $image->effects()->colorize($the_color);
                                 }

--- a/setup/faker.php
+++ b/setup/faker.php
@@ -880,11 +880,13 @@ function generate_image($image, $typeobj, $id)
         ->save()
     ;
 
+    $palette = new \Imagine\Image\Palette\RGB();
+
     // Generate images
     $imagine = new Imagine\Gd\Imagine();
-    $image   = $imagine->create(new Imagine\Image\Box(320,240), new Imagine\Image\Color('#E9730F'));
+    $image   = $imagine->create(new Imagine\Image\Box(320, 240), $palette->color('#E9730F'));
 
-    $white = new Imagine\Image\Color('#FFF');
+    $white = $palette->color('#FFF');
 
     $font = $imagine->font(__DIR__.'/faker-assets/FreeSans.ttf', 14, $white);
 


### PR DESCRIPTION
- Imagine library is updated to 0.6.2, which provides a better support for transparency.
- Default border colour of images resized with resize_mode="border" is now transparent instead of opaque white.