### PR TITLE
Added a new 'asset' Smarty function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Refactor VirtualProductDelivery module. The email sending is now triggered from a new event to gain more flexibility. Now, email messages use smarty file templates located in `templates/email/default`.     
 - Added capability to use translator in module functions `preActivation` and `postActivation`
 - Add environment aware database connection
+- new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font. 
 
 # 2.1.3
 

--- a/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsManager.php
+++ b/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsManager.php
@@ -128,19 +128,19 @@ class SmartyAssetsManager
     /**
      * Retrieve asset URL
      *
-     * @param string                    $assetType js|css|image
-     * @param array                     $params    Parameters
+     * @param string $assetType js|css|image
+     * @param array $params Parameters
      *                                             - file File path in the default template
      *                                             - source module asset
      *                                             - filters filter to apply
      *                                             - debug
      *                                             - template if you want to load asset from another template
-     * @param \Smarty_Internal_Template $template  Smarty Template
+     * @param \Smarty_Internal_Template $template Smarty Template
      *
+     * @param bool $allowFilters if false, the 'filters' parameter is ignored
      * @return string
-     * @throws \Exception
      */
-    public function computeAssetUrl($assetType, $params, \Smarty_Internal_Template $template)
+    public function computeAssetUrl($assetType, $params, \Smarty_Internal_Template $template, $allowFilters = true)
     {
         $assetUrl = "";
 
@@ -154,7 +154,7 @@ class SmartyAssetsManager
         }
 
         $assetOrigin  = isset($params['source']) ? $params['source'] : SmartyParser::TEMPLATE_ASSETS_KEY;
-        $filters      = isset($params['filters']) ? $params['filters'] : '';
+        $filters      = $allowFilters && isset($params['filters']) ? $params['filters'] : '';
         $debug        = isset($params['debug']) ? trim(strtolower($params['debug'])) == 'true' : false;
         $templateName = isset($params['template']) ? $params['template'] : false;
         $failsafe     = isset($params['failsafe']) ? $params['failsafe'] : false;
@@ -223,10 +223,14 @@ class SmartyAssetsManager
     ) {
         // Opening tag (first call only)
         if ($repeat) {
+            $isfailsafe = false;
+
             $url = '';
             try {
                 // Check if we're in failsafe mode
-                $isfailsafe = isset($params['failsafe']) ? $params['failsafe'] : false;
+                if (isset($params['failsafe'])) {
+                    $isfailsafe = $params['failsafe'];
+                }
 
                 $url = $this->computeAssetUrl($assetType, $params, $template);
 

--- a/local/modules/TheliaSmarty/Template/Plugins/Assets.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Assets.php
@@ -53,7 +53,9 @@ class Assets extends AbstractSmartyPlugin
 
     public function blockImages($params, $content, \Smarty_Internal_Template $template, &$repeat)
     {
-        return $this->assetManager->processSmartyPluginCall(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $content, $template, $repeat);
+        return $this
+            ->assetManager
+            ->processSmartyPluginCall(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $content, $template, $repeat);
     }
 
     public function blockStylesheets($params, $content, \Smarty_Internal_Template $template, &$repeat)
@@ -64,6 +66,11 @@ class Assets extends AbstractSmartyPlugin
     public function functionImage($params, \Smarty_Internal_Template $template)
     {
         return $this->assetManager->computeAssetUrl(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $template);
+    }
+
+    public function functionAsset($params, \Smarty_Internal_Template $template)
+    {
+        return $this->assetManager->computeAssetUrl(SmartyAssetsManager::ASSET_TYPE_AUTO, $params, $template, false);
     }
 
     public function functionJavascript($params, \Smarty_Internal_Template $template)
@@ -79,7 +86,7 @@ class Assets extends AbstractSmartyPlugin
     /**
      * Define the various smarty plugins hendled by this class
      *
-     * @return an array of smarty plugin descriptors
+     * @return array an array of smarty plugin descriptors
      */
     public function getPluginDescriptors()
     {
@@ -88,6 +95,7 @@ class Assets extends AbstractSmartyPlugin
             new SmartyPluginDescriptor('block', 'javascripts', $this, 'blockJavascripts'),
             new SmartyPluginDescriptor('block', 'images', $this, 'blockImages'),
 
+            new SmartyPluginDescriptor('function', 'asset', $this, 'functionAsset'),
             new SmartyPluginDescriptor('function', 'image', $this, 'functionImage'),
             new SmartyPluginDescriptor('function', 'javascript', $this, 'functionJavascript'),
             new SmartyPluginDescriptor('function', 'stylesheet', $this, 'functionStylesheet'),


### PR DESCRIPTION
This PR introduces a new 'asset' Smarty function, to get the URL of an arbitrary file from template assets, such as a video or a font:

```
<video>
    <source type="video/mp4" src="{asset file='assets/video/video-accueil.mp4'}" />
    <img title="{config key='store_description'}" alt="{config key='store_name'}" src="{image file='assets/video/landing-video.jpg'}">
</video>
```