### PR TITLE
Ignore FK constraint on cart

### DIFF
--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -737,10 +737,7 @@ CREATE TABLE `order`
         FOREIGN KEY (`lang_id`)
         REFERENCES `lang` (`id`)
         ON UPDATE RESTRICT
-        ON DELETE RESTRICT,
-    CONSTRAINT `fk_order_cart_id`
-        FOREIGN KEY (`cart_id`)
-        REFERENCES `cart` (`id`)
+        ON DELETE RESTRICT
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
apparemment la mise à jour vers la version 2.0.5 est corrigé seulement si on fait une mise à jours vers la 2.0.5 et pas ailleurs donc en installant une version supérieur le problème suivant persiste suite à certaine navigation : 
PropelException: Unable to execute DELETE statement [DELETE FROM `cart` WHERE cart.ID=:p1]