### PR TITLE
Ignore FK constraint on cart

### DIFF
--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
 <database defaultIdMethod="native" name="thelia">
   <vendor type="mysql">
     <parameter name="Engine" value="InnoDB"/>
@@ -603,9 +604,6 @@
     </foreign-key>
     <foreign-key foreignTable="lang" name="fk_order_lang_id" onDelete="RESTRICT" onUpdate="RESTRICT">
       <reference foreign="id" local="lang_id" />
-    </foreign-key>
-    <foreign-key foreignTable="cart" name="fk_order_cart_id">
-      <reference foreign="id" local="cart_id" />
     </foreign-key>
     <index name="idx_order_currency_id">
       <index-column name="currency_id" />


### PR DESCRIPTION
Correction vers la version 2.0.5 pas corrigé dans les version supérieur, j'ai du appliqué le correctif 
SET FOREIGN_KEY_CHECKS = 0;
ALTER TABLE `order` DROP FOREIGN KEY `fk_order_cart_id`;
Donc je suppose qu'il faut supprimer ça : 
    <foreign-key foreignTable="cart" name="fk_order_cart_id">
      <reference foreign="id" local="cart_id" />
    </foreign-key>

pour ne plus avoir le problème sur une nouvelle installation.