### PR TITLE
Fix session sleep

### DIFF
--- a/core/lib/Thelia/Model/Tools/ModelEventDispatcherTrait.php
+++ b/core/lib/Thelia/Model/Tools/ModelEventDispatcherTrait.php
@@ -53,4 +53,16 @@ trait ModelEventDispatcherTrait
             $this->dispatcher->dispatch($eventName, $event);
         }
     }
+
+    public function __sleep()
+    {
+        $data = parent::__sleep();
+        $key = array_search("dispatcher", $data);
+
+        if (isset($data[$key])) {
+            unset($data[$key]);
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Well ... We don't need to serialize the dispatcher ( and the container ).... as it was with the customer.

With that fix, my logged in customer session went from ~398ko to 5.4ko. 
:kissing_heart: 

You can cherry pick it on 2.0 and 2.1 with no conflict :heart: 