### PR TITLE
Remove order cart id constraint on 2.1

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -226,7 +226,7 @@ class Order extends BaseAction implements EventSubscriberInterface
             OrderStatusQuery::getNotPaidStatus()->getId()
         );
 
-        $placedOrder->setCart($cart);
+        $placedOrder->setCartId($cart->getId());
 
         /* memorize discount */
         $placedOrder->setDiscount(

--- a/core/lib/Thelia/Model/Base/Cart.php
+++ b/core/lib/Thelia/Model/Base/Cart.php
@@ -27,8 +27,6 @@ use Thelia\Model\Currency as ChildCurrency;
 use Thelia\Model\CurrencyQuery as ChildCurrencyQuery;
 use Thelia\Model\Customer as ChildCustomer;
 use Thelia\Model\CustomerQuery as ChildCustomerQuery;
-use Thelia\Model\Order as ChildOrder;
-use Thelia\Model\OrderQuery as ChildOrderQuery;
 use Thelia\Model\Map\CartTableMap;
 
 abstract class Cart implements ActiveRecordInterface
@@ -141,12 +139,6 @@ abstract class Cart implements ActiveRecordInterface
     protected $aCurrency;
 
     /**
-     * @var        ObjectCollection|ChildOrder[] Collection to store aggregation of ChildOrder objects.
-     */
-    protected $collOrders;
-    protected $collOrdersPartial;
-
-    /**
      * @var        ObjectCollection|ChildCartItem[] Collection to store aggregation of ChildCartItem objects.
      */
     protected $collCartItems;
@@ -159,12 +151,6 @@ abstract class Cart implements ActiveRecordInterface
      * @var boolean
      */
     protected $alreadyInSave = false;
-
-    /**
-     * An array of objects scheduled for deletion.
-     * @var ObjectCollection
-     */
-    protected $ordersScheduledForDeletion = null;
 
     /**
      * An array of objects scheduled for deletion.
@@ -923,8 +909,6 @@ abstract class Cart implements ActiveRecordInterface
             $this->aAddressRelatedByAddressDeliveryId = null;
             $this->aAddressRelatedByAddressInvoiceId = null;
             $this->aCurrency = null;
-            $this->collOrders = null;
-
             $this->collCartItems = null;
 
         } // if (deep)
@@ -1091,23 +1075,6 @@ abstract class Cart implements ActiveRecordInterface
                 }
                 $affectedRows += 1;
                 $this->resetModified();
-            }
-
-            if ($this->ordersScheduledForDeletion !== null) {
-                if (!$this->ordersScheduledForDeletion->isEmpty()) {
-                    \Thelia\Model\OrderQuery::create()
-                        ->filterByPrimaryKeys($this->ordersScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
-                    $this->ordersScheduledForDeletion = null;
-                }
-            }
-
-                if ($this->collOrders !== null) {
-            foreach ($this->collOrders as $referrerFK) {
-                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
-                        $affectedRows += $referrerFK->save($con);
-                    }
-                }
             }
 
             if ($this->cartItemsScheduledForDeletion !== null) {
@@ -1364,9 +1331,6 @@ abstract class Cart implements ActiveRecordInterface
             if (null !== $this->aCurrency) {
                 $result['Currency'] = $this->aCurrency->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
             }
-            if (null !== $this->collOrders) {
-                $result['Orders'] = $this->collOrders->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
-            }
             if (null !== $this->collCartItems) {
                 $result['CartItems'] = $this->collCartItems->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
             }
@@ -1560,12 +1524,6 @@ abstract class Cart implements ActiveRecordInterface
             // important: temporarily setNew(false) because this affects the behavior of
             // the getter/setter methods for fkey referrer objects.
             $copyObj->setNew(false);
-
-            foreach ($this->getOrders() as $relObj) {
-                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
-                    $copyObj->addOrder($relObj->copy($deepCopy));
-                }
-            }
 
             foreach ($this->getCartItems() as $relObj) {
                 if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
@@ -1818,430 +1776,9 @@ abstract class Cart implements ActiveRecordInterface
      */
     public function initRelation($relationName)
     {
-        if ('Order' == $relationName) {
-            return $this->initOrders();
-        }
         if ('CartItem' == $relationName) {
             return $this->initCartItems();
         }
-    }
-
-    /**
-     * Clears out the collOrders collection
-     *
-     * This does not modify the database; however, it will remove any associated objects, causing
-     * them to be refetched by subsequent calls to accessor method.
-     *
-     * @return void
-     * @see        addOrders()
-     */
-    public function clearOrders()
-    {
-        $this->collOrders = null; // important to set this to NULL since that means it is uninitialized
-    }
-
-    /**
-     * Reset is the collOrders collection loaded partially.
-     */
-    public function resetPartialOrders($v = true)
-    {
-        $this->collOrdersPartial = $v;
-    }
-
-    /**
-     * Initializes the collOrders collection.
-     *
-     * By default this just sets the collOrders collection to an empty array (like clearcollOrders());
-     * however, you may wish to override this method in your stub class to provide setting appropriate
-     * to your application -- for example, setting the initial array to the values stored in database.
-     *
-     * @param      boolean $overrideExisting If set to true, the method call initializes
-     *                                        the collection even if it is not empty
-     *
-     * @return void
-     */
-    public function initOrders($overrideExisting = true)
-    {
-        if (null !== $this->collOrders && !$overrideExisting) {
-            return;
-        }
-        $this->collOrders = new ObjectCollection();
-        $this->collOrders->setModel('\Thelia\Model\Order');
-    }
-
-    /**
-     * Gets an array of ChildOrder objects which contain a foreign key that references this object.
-     *
-     * If the $criteria is not null, it is used to always fetch the results from the database.
-     * Otherwise the results are fetched from the database the first time, then cached.
-     * Next time the same method is called without $criteria, the cached collection is returned.
-     * If this ChildCart is new, it will return
-     * an empty collection or the current collection; the criteria is ignored on a new object.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     * @throws PropelException
-     */
-    public function getOrders($criteria = null, ConnectionInterface $con = null)
-    {
-        $partial = $this->collOrdersPartial && !$this->isNew();
-        if (null === $this->collOrders || null !== $criteria  || $partial) {
-            if ($this->isNew() && null === $this->collOrders) {
-                // return empty collection
-                $this->initOrders();
-            } else {
-                $collOrders = ChildOrderQuery::create(null, $criteria)
-                    ->filterByCart($this)
-                    ->find($con);
-
-                if (null !== $criteria) {
-                    if (false !== $this->collOrdersPartial && count($collOrders)) {
-                        $this->initOrders(false);
-
-                        foreach ($collOrders as $obj) {
-                            if (false == $this->collOrders->contains($obj)) {
-                                $this->collOrders->append($obj);
-                            }
-                        }
-
-                        $this->collOrdersPartial = true;
-                    }
-
-                    reset($collOrders);
-
-                    return $collOrders;
-                }
-
-                if ($partial && $this->collOrders) {
-                    foreach ($this->collOrders as $obj) {
-                        if ($obj->isNew()) {
-                            $collOrders[] = $obj;
-                        }
-                    }
-                }
-
-                $this->collOrders = $collOrders;
-                $this->collOrdersPartial = false;
-            }
-        }
-
-        return $this->collOrders;
-    }
-
-    /**
-     * Sets a collection of Order objects related by a one-to-many relationship
-     * to the current object.
-     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
-     * and new objects from the given Propel collection.
-     *
-     * @param      Collection $orders A Propel collection.
-     * @param      ConnectionInterface $con Optional connection object
-     * @return   ChildCart The current object (for fluent API support)
-     */
-    public function setOrders(Collection $orders, ConnectionInterface $con = null)
-    {
-        $ordersToDelete = $this->getOrders(new Criteria(), $con)->diff($orders);
-
-
-        $this->ordersScheduledForDeletion = $ordersToDelete;
-
-        foreach ($ordersToDelete as $orderRemoved) {
-            $orderRemoved->setCart(null);
-        }
-
-        $this->collOrders = null;
-        foreach ($orders as $order) {
-            $this->addOrder($order);
-        }
-
-        $this->collOrders = $orders;
-        $this->collOrdersPartial = false;
-
-        return $this;
-    }
-
-    /**
-     * Returns the number of related Order objects.
-     *
-     * @param      Criteria $criteria
-     * @param      boolean $distinct
-     * @param      ConnectionInterface $con
-     * @return int             Count of related Order objects.
-     * @throws PropelException
-     */
-    public function countOrders(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
-    {
-        $partial = $this->collOrdersPartial && !$this->isNew();
-        if (null === $this->collOrders || null !== $criteria || $partial) {
-            if ($this->isNew() && null === $this->collOrders) {
-                return 0;
-            }
-
-            if ($partial && !$criteria) {
-                return count($this->getOrders());
-            }
-
-            $query = ChildOrderQuery::create(null, $criteria);
-            if ($distinct) {
-                $query->distinct();
-            }
-
-            return $query
-                ->filterByCart($this)
-                ->count($con);
-        }
-
-        return count($this->collOrders);
-    }
-
-    /**
-     * Method called to associate a ChildOrder object to this object
-     * through the ChildOrder foreign key attribute.
-     *
-     * @param    ChildOrder $l ChildOrder
-     * @return   \Thelia\Model\Cart The current object (for fluent API support)
-     */
-    public function addOrder(ChildOrder $l)
-    {
-        if ($this->collOrders === null) {
-            $this->initOrders();
-            $this->collOrdersPartial = true;
-        }
-
-        if (!in_array($l, $this->collOrders->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
-            $this->doAddOrder($l);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param Order $order The order object to add.
-     */
-    protected function doAddOrder($order)
-    {
-        $this->collOrders[]= $order;
-        $order->setCart($this);
-    }
-
-    /**
-     * @param  Order $order The order object to remove.
-     * @return ChildCart The current object (for fluent API support)
-     */
-    public function removeOrder($order)
-    {
-        if ($this->getOrders()->contains($order)) {
-            $this->collOrders->remove($this->collOrders->search($order));
-            if (null === $this->ordersScheduledForDeletion) {
-                $this->ordersScheduledForDeletion = clone $this->collOrders;
-                $this->ordersScheduledForDeletion->clear();
-            }
-            $this->ordersScheduledForDeletion[]= clone $order;
-            $order->setCart(null);
-        }
-
-        return $this;
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCurrency($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Currency', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCustomer($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Customer', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinOrderAddressRelatedByInvoiceOrderAddressId($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('OrderAddressRelatedByInvoiceOrderAddressId', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinOrderAddressRelatedByDeliveryOrderAddressId($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('OrderAddressRelatedByDeliveryOrderAddressId', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinOrderStatus($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('OrderStatus', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinModuleRelatedByPaymentModuleId($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('ModuleRelatedByPaymentModuleId', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinModuleRelatedByDeliveryModuleId($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('ModuleRelatedByDeliveryModuleId', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Cart is new, it will return
-     * an empty collection; or if this Cart has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Cart.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinLang($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Lang', $joinBehavior);
-
-        return $this->getOrders($query, $con);
     }
 
     /**
@@ -2546,11 +2083,6 @@ abstract class Cart implements ActiveRecordInterface
     public function clearAllReferences($deep = false)
     {
         if ($deep) {
-            if ($this->collOrders) {
-                foreach ($this->collOrders as $o) {
-                    $o->clearAllReferences($deep);
-                }
-            }
             if ($this->collCartItems) {
                 foreach ($this->collCartItems as $o) {
                     $o->clearAllReferences($deep);
@@ -2558,7 +2090,6 @@ abstract class Cart implements ActiveRecordInterface
             }
         } // if ($deep)
 
-        $this->collOrders = null;
         $this->collCartItems = null;
         $this->aCustomer = null;
         $this->aAddressRelatedByAddressDeliveryId = null;

--- a/core/lib/Thelia/Model/Base/CartQuery.php
+++ b/core/lib/Thelia/Model/Base/CartQuery.php
@@ -61,10 +61,6 @@ use Thelia\Model\Map\CartTableMap;
  * @method     ChildCartQuery rightJoinCurrency($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Currency relation
  * @method     ChildCartQuery innerJoinCurrency($relationAlias = null) Adds a INNER JOIN clause to the query using the Currency relation
  *
- * @method     ChildCartQuery leftJoinOrder($relationAlias = null) Adds a LEFT JOIN clause to the query using the Order relation
- * @method     ChildCartQuery rightJoinOrder($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Order relation
- * @method     ChildCartQuery innerJoinOrder($relationAlias = null) Adds a INNER JOIN clause to the query using the Order relation
- *
  * @method     ChildCartQuery leftJoinCartItem($relationAlias = null) Adds a LEFT JOIN clause to the query using the CartItem relation
  * @method     ChildCartQuery rightJoinCartItem($relationAlias = null) Adds a RIGHT JOIN clause to the query using the CartItem relation
  * @method     ChildCartQuery innerJoinCartItem($relationAlias = null) Adds a INNER JOIN clause to the query using the CartItem relation
@@ -935,79 +931,6 @@ abstract class CartQuery extends ModelCriteria
         return $this
             ->joinCurrency($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'Currency', '\Thelia\Model\CurrencyQuery');
-    }
-
-    /**
-     * Filter the query by a related \Thelia\Model\Order object
-     *
-     * @param \Thelia\Model\Order|ObjectCollection $order  the related object to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildCartQuery The current query, for fluid interface
-     */
-    public function filterByOrder($order, $comparison = null)
-    {
-        if ($order instanceof \Thelia\Model\Order) {
-            return $this
-                ->addUsingAlias(CartTableMap::ID, $order->getCartId(), $comparison);
-        } elseif ($order instanceof ObjectCollection) {
-            return $this
-                ->useOrderQuery()
-                ->filterByPrimaryKeys($order->getPrimaryKeys())
-                ->endUse();
-        } else {
-            throw new PropelException('filterByOrder() only accepts arguments of type \Thelia\Model\Order or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the Order relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildCartQuery The current query, for fluid interface
-     */
-    public function joinOrder($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('Order');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'Order');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the Order relation Order object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Thelia\Model\OrderQuery A secondary query class using the current class as primary query
-     */
-    public function useOrderQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinOrder($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'Order', '\Thelia\Model\OrderQuery');
     }
 
     /**

--- a/core/lib/Thelia/Model/Base/Currency.php
+++ b/core/lib/Thelia/Model/Base/Currency.php
@@ -1986,31 +1986,6 @@ abstract class Currency implements ActiveRecordInterface
         return $this->getOrders($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Currency is new, it will return
-     * an empty collection; or if this Currency has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Currency.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
     /**
      * Clears out the collCarts collection
      *

--- a/core/lib/Thelia/Model/Base/Customer.php
+++ b/core/lib/Thelia/Model/Base/Customer.php
@@ -3042,31 +3042,6 @@ abstract class Customer implements ActiveRecordInterface
         return $this->getOrders($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Customer is new, it will return
-     * an empty collection; or if this Customer has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Customer.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
     /**
      * Clears out the collCarts collection
      *

--- a/core/lib/Thelia/Model/Base/Lang.php
+++ b/core/lib/Thelia/Model/Base/Lang.php
@@ -2191,31 +2191,6 @@ abstract class Lang implements ActiveRecordInterface
         return $this->getOrders($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Lang is new, it will return
-     * an empty collection; or if this Lang has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Lang.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
     /**
      * Clears the current object and sets all attributes to their default values
      */

--- a/core/lib/Thelia/Model/Base/Module.php
+++ b/core/lib/Thelia/Model/Base/Module.php
@@ -2490,31 +2490,6 @@ abstract class Module implements ActiveRecordInterface
         return $this->getOrdersRelatedByPaymentModuleId($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Module is new, it will return
-     * an empty collection; or if this Module has previously
-     * been saved, it will retrieve related OrdersRelatedByPaymentModuleId from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Module.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersRelatedByPaymentModuleIdJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrdersRelatedByPaymentModuleId($query, $con);
-    }
-
     /**
      * Clears out the collOrdersRelatedByDeliveryModuleId collection
      *
@@ -2879,31 +2854,6 @@ abstract class Module implements ActiveRecordInterface
     {
         $query = ChildOrderQuery::create(null, $criteria);
         $query->joinWith('Lang', $joinBehavior);
-
-        return $this->getOrdersRelatedByDeliveryModuleId($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this Module is new, it will return
-     * an empty collection; or if this Module has previously
-     * been saved, it will retrieve related OrdersRelatedByDeliveryModuleId from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in Module.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersRelatedByDeliveryModuleIdJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
 
         return $this->getOrdersRelatedByDeliveryModuleId($query, $con);
     }

--- a/core/lib/Thelia/Model/Base/Order.php
+++ b/core/lib/Thelia/Model/Base/Order.php
@@ -17,8 +17,6 @@ use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Parser\AbstractParser;
 use Propel\Runtime\Util\PropelDateTime;
-use Thelia\Model\Cart as ChildCart;
-use Thelia\Model\CartQuery as ChildCartQuery;
 use Thelia\Model\Currency as ChildCurrency;
 use Thelia\Model\CurrencyQuery as ChildCurrencyQuery;
 use Thelia\Model\Customer as ChildCustomer;
@@ -268,11 +266,6 @@ abstract class Order implements ActiveRecordInterface
      * @var        Lang
      */
     protected $aLang;
-
-    /**
-     * @var        Cart
-     */
-    protected $aCart;
 
     /**
      * @var        ObjectCollection|ChildOrderProduct[] Collection to store aggregation of ChildOrderProduct objects.
@@ -1357,10 +1350,6 @@ abstract class Order implements ActiveRecordInterface
             $this->modifiedColumns[OrderTableMap::CART_ID] = true;
         }
 
-        if ($this->aCart !== null && $this->aCart->getId() !== $v) {
-            $this->aCart = null;
-        }
-
 
         return $this;
     } // setCartId()
@@ -1655,9 +1644,6 @@ abstract class Order implements ActiveRecordInterface
         if ($this->aLang !== null && $this->lang_id !== $this->aLang->getId()) {
             $this->aLang = null;
         }
-        if ($this->aCart !== null && $this->cart_id !== $this->aCart->getId()) {
-            $this->aCart = null;
-        }
     } // ensureConsistency
 
     /**
@@ -1705,7 +1691,6 @@ abstract class Order implements ActiveRecordInterface
             $this->aModuleRelatedByPaymentModuleId = null;
             $this->aModuleRelatedByDeliveryModuleId = null;
             $this->aLang = null;
-            $this->aCart = null;
             $this->collOrderProducts = null;
 
             $this->collOrderCoupons = null;
@@ -1905,13 +1890,6 @@ abstract class Order implements ActiveRecordInterface
                     $affectedRows += $this->aLang->save($con);
                 }
                 $this->setLang($this->aLang);
-            }
-
-            if ($this->aCart !== null) {
-                if ($this->aCart->isModified() || $this->aCart->isNew()) {
-                    $affectedRows += $this->aCart->save($con);
-                }
-                $this->setCart($this->aCart);
             }
 
             if ($this->isNew() || $this->isModified()) {
@@ -2384,9 +2362,6 @@ abstract class Order implements ActiveRecordInterface
             }
             if (null !== $this->aLang) {
                 $result['Lang'] = $this->aLang->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
-            }
-            if (null !== $this->aCart) {
-                $result['Cart'] = $this->aCart->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
             }
             if (null !== $this->collOrderProducts) {
                 $result['OrderProducts'] = $this->collOrderProducts->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
@@ -3138,57 +3113,6 @@ abstract class Order implements ActiveRecordInterface
         }
 
         return $this->aLang;
-    }
-
-    /**
-     * Declares an association between this object and a ChildCart object.
-     *
-     * @param                  ChildCart $v
-     * @return                 \Thelia\Model\Order The current object (for fluent API support)
-     * @throws PropelException
-     */
-    public function setCart(ChildCart $v = null)
-    {
-        if ($v === null) {
-            $this->setCartId(NULL);
-        } else {
-            $this->setCartId($v->getId());
-        }
-
-        $this->aCart = $v;
-
-        // Add binding for other direction of this n:n relationship.
-        // If this object has already been added to the ChildCart object, it will not be re-added.
-        if ($v !== null) {
-            $v->addOrder($this);
-        }
-
-
-        return $this;
-    }
-
-
-    /**
-     * Get the associated ChildCart object
-     *
-     * @param      ConnectionInterface $con Optional Connection object.
-     * @return                 ChildCart The associated ChildCart object.
-     * @throws PropelException
-     */
-    public function getCart(ConnectionInterface $con = null)
-    {
-        if ($this->aCart === null && ($this->cart_id !== null)) {
-            $this->aCart = ChildCartQuery::create()->findPk($this->cart_id, $con);
-            /* The following can be used additionally to
-                guarantee the related object contains a reference
-                to this object.  This level of coupling may, however, be
-                undesirable since it could result in an only partially populated collection
-                in the referenced object.
-                $this->aCart->addOrders($this);
-             */
-        }
-
-        return $this->aCart;
     }
 
 
@@ -3948,7 +3872,6 @@ abstract class Order implements ActiveRecordInterface
         $this->aModuleRelatedByPaymentModuleId = null;
         $this->aModuleRelatedByDeliveryModuleId = null;
         $this->aLang = null;
-        $this->aCart = null;
     }
 
     /**

--- a/core/lib/Thelia/Model/Base/OrderAddress.php
+++ b/core/lib/Thelia/Model/Base/OrderAddress.php
@@ -2309,31 +2309,6 @@ abstract class OrderAddress implements ActiveRecordInterface
         return $this->getOrdersRelatedByInvoiceOrderAddressId($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this OrderAddress is new, it will return
-     * an empty collection; or if this OrderAddress has previously
-     * been saved, it will retrieve related OrdersRelatedByInvoiceOrderAddressId from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in OrderAddress.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersRelatedByInvoiceOrderAddressIdJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrdersRelatedByInvoiceOrderAddressId($query, $con);
-    }
-
     /**
      * Clears out the collOrdersRelatedByDeliveryOrderAddressId collection
      *
@@ -2698,31 +2673,6 @@ abstract class OrderAddress implements ActiveRecordInterface
     {
         $query = ChildOrderQuery::create(null, $criteria);
         $query->joinWith('Lang', $joinBehavior);
-
-        return $this->getOrdersRelatedByDeliveryOrderAddressId($query, $con);
-    }
-
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this OrderAddress is new, it will return
-     * an empty collection; or if this OrderAddress has previously
-     * been saved, it will retrieve related OrdersRelatedByDeliveryOrderAddressId from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in OrderAddress.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersRelatedByDeliveryOrderAddressIdJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
 
         return $this->getOrdersRelatedByDeliveryOrderAddressId($query, $con);
     }

--- a/core/lib/Thelia/Model/Base/OrderQuery.php
+++ b/core/lib/Thelia/Model/Base/OrderQuery.php
@@ -109,10 +109,6 @@ use Thelia\Model\Map\OrderTableMap;
  * @method     ChildOrderQuery rightJoinLang($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Lang relation
  * @method     ChildOrderQuery innerJoinLang($relationAlias = null) Adds a INNER JOIN clause to the query using the Lang relation
  *
- * @method     ChildOrderQuery leftJoinCart($relationAlias = null) Adds a LEFT JOIN clause to the query using the Cart relation
- * @method     ChildOrderQuery rightJoinCart($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Cart relation
- * @method     ChildOrderQuery innerJoinCart($relationAlias = null) Adds a INNER JOIN clause to the query using the Cart relation
- *
  * @method     ChildOrderQuery leftJoinOrderProduct($relationAlias = null) Adds a LEFT JOIN clause to the query using the OrderProduct relation
  * @method     ChildOrderQuery rightJoinOrderProduct($relationAlias = null) Adds a RIGHT JOIN clause to the query using the OrderProduct relation
  * @method     ChildOrderQuery innerJoinOrderProduct($relationAlias = null) Adds a INNER JOIN clause to the query using the OrderProduct relation
@@ -1110,8 +1106,6 @@ abstract class OrderQuery extends ModelCriteria
      * $query->filterByCartId(array('min' => 12)); // WHERE cart_id > 12
      * </code>
      *
-     * @see       filterByCart()
-     *
      * @param     mixed $cartId The value to use as filter.
      *              Use scalar values for equality.
      *              Use array values for in_array() equivalent.
@@ -1940,81 +1934,6 @@ abstract class OrderQuery extends ModelCriteria
         return $this
             ->joinLang($relationAlias, $joinType)
             ->useQuery($relationAlias ? $relationAlias : 'Lang', '\Thelia\Model\LangQuery');
-    }
-
-    /**
-     * Filter the query by a related \Thelia\Model\Cart object
-     *
-     * @param \Thelia\Model\Cart|ObjectCollection $cart The related object(s) to use as filter
-     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
-     *
-     * @return ChildOrderQuery The current query, for fluid interface
-     */
-    public function filterByCart($cart, $comparison = null)
-    {
-        if ($cart instanceof \Thelia\Model\Cart) {
-            return $this
-                ->addUsingAlias(OrderTableMap::CART_ID, $cart->getId(), $comparison);
-        } elseif ($cart instanceof ObjectCollection) {
-            if (null === $comparison) {
-                $comparison = Criteria::IN;
-            }
-
-            return $this
-                ->addUsingAlias(OrderTableMap::CART_ID, $cart->toKeyValue('PrimaryKey', 'Id'), $comparison);
-        } else {
-            throw new PropelException('filterByCart() only accepts arguments of type \Thelia\Model\Cart or Collection');
-        }
-    }
-
-    /**
-     * Adds a JOIN clause to the query using the Cart relation
-     *
-     * @param     string $relationAlias optional alias for the relation
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return ChildOrderQuery The current query, for fluid interface
-     */
-    public function joinCart($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        $tableMap = $this->getTableMap();
-        $relationMap = $tableMap->getRelation('Cart');
-
-        // create a ModelJoin object for this join
-        $join = new ModelJoin();
-        $join->setJoinType($joinType);
-        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
-        if ($previousJoin = $this->getPreviousJoin()) {
-            $join->setPreviousJoin($previousJoin);
-        }
-
-        // add the ModelJoin to the current object
-        if ($relationAlias) {
-            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
-            $this->addJoinObject($join, $relationAlias);
-        } else {
-            $this->addJoinObject($join, 'Cart');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Use the Cart relation Cart object
-     *
-     * @see useQuery()
-     *
-     * @param     string $relationAlias optional alias for the relation,
-     *                                   to be used as main alias in the secondary query
-     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
-     *
-     * @return   \Thelia\Model\CartQuery A secondary query class using the current class as primary query
-     */
-    public function useCartQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
-    {
-        return $this
-            ->joinCart($relationAlias, $joinType)
-            ->useQuery($relationAlias ? $relationAlias : 'Cart', '\Thelia\Model\CartQuery');
     }
 
     /**

--- a/core/lib/Thelia/Model/Base/OrderStatus.php
+++ b/core/lib/Thelia/Model/Base/OrderStatus.php
@@ -1623,31 +1623,6 @@ abstract class OrderStatus implements ActiveRecordInterface
         return $this->getOrders($query, $con);
     }
 
-
-    /**
-     * If this collection has already been initialized with
-     * an identical criteria, it returns the collection.
-     * Otherwise if this OrderStatus is new, it will return
-     * an empty collection; or if this OrderStatus has previously
-     * been saved, it will retrieve related Orders from storage.
-     *
-     * This method is protected by default in order to keep the public
-     * api reasonable.  You can provide public methods for those you
-     * actually need in OrderStatus.
-     *
-     * @param      Criteria $criteria optional Criteria object to narrow the query
-     * @param      ConnectionInterface $con optional connection object
-     * @param      string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
-     * @return Collection|ChildOrder[] List of ChildOrder objects
-     */
-    public function getOrdersJoinCart($criteria = null, $con = null, $joinBehavior = Criteria::LEFT_JOIN)
-    {
-        $query = ChildOrderQuery::create(null, $criteria);
-        $query->joinWith('Cart', $joinBehavior);
-
-        return $this->getOrders($query, $con);
-    }
-
     /**
      * Clears out the collOrderStatusI18ns collection
      *

--- a/core/lib/Thelia/Model/Map/CartTableMap.php
+++ b/core/lib/Thelia/Model/Map/CartTableMap.php
@@ -186,7 +186,6 @@ class CartTableMap extends TableMap
         $this->addRelation('AddressRelatedByAddressDeliveryId', '\\Thelia\\Model\\Address', RelationMap::MANY_TO_ONE, array('address_delivery_id' => 'id', ), 'RESTRICT', 'RESTRICT');
         $this->addRelation('AddressRelatedByAddressInvoiceId', '\\Thelia\\Model\\Address', RelationMap::MANY_TO_ONE, array('address_invoice_id' => 'id', ), 'RESTRICT', 'RESTRICT');
         $this->addRelation('Currency', '\\Thelia\\Model\\Currency', RelationMap::MANY_TO_ONE, array('currency_id' => 'id', ), 'CASCADE', 'RESTRICT');
-        $this->addRelation('Order', '\\Thelia\\Model\\Order', RelationMap::ONE_TO_MANY, array('id' => 'cart_id', ), null, null, 'Orders');
         $this->addRelation('CartItem', '\\Thelia\\Model\\CartItem', RelationMap::ONE_TO_MANY, array('id' => 'cart_id', ), 'CASCADE', 'RESTRICT', 'CartItems');
     } // buildRelations()
 

--- a/core/lib/Thelia/Model/Map/OrderTableMap.php
+++ b/core/lib/Thelia/Model/Map/OrderTableMap.php
@@ -265,7 +265,7 @@ class OrderTableMap extends TableMap
         $this->addForeignKey('DELIVERY_MODULE_ID', 'DeliveryModuleId', 'INTEGER', 'module', 'ID', true, null, null);
         $this->addForeignKey('STATUS_ID', 'StatusId', 'INTEGER', 'order_status', 'ID', true, null, null);
         $this->addForeignKey('LANG_ID', 'LangId', 'INTEGER', 'lang', 'ID', true, null, null);
-        $this->addForeignKey('CART_ID', 'CartId', 'INTEGER', 'cart', 'ID', true, null, null);
+        $this->addColumn('CART_ID', 'CartId', 'INTEGER', true, null, null);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('VERSION', 'Version', 'INTEGER', false, null, 0);
@@ -286,7 +286,6 @@ class OrderTableMap extends TableMap
         $this->addRelation('ModuleRelatedByPaymentModuleId', '\\Thelia\\Model\\Module', RelationMap::MANY_TO_ONE, array('payment_module_id' => 'id', ), 'RESTRICT', 'RESTRICT');
         $this->addRelation('ModuleRelatedByDeliveryModuleId', '\\Thelia\\Model\\Module', RelationMap::MANY_TO_ONE, array('delivery_module_id' => 'id', ), 'RESTRICT', 'RESTRICT');
         $this->addRelation('Lang', '\\Thelia\\Model\\Lang', RelationMap::MANY_TO_ONE, array('lang_id' => 'id', ), 'RESTRICT', 'RESTRICT');
-        $this->addRelation('Cart', '\\Thelia\\Model\\Cart', RelationMap::MANY_TO_ONE, array('cart_id' => 'id', ), null, null);
         $this->addRelation('OrderProduct', '\\Thelia\\Model\\OrderProduct', RelationMap::ONE_TO_MANY, array('id' => 'order_id', ), 'CASCADE', 'RESTRICT', 'OrderProducts');
         $this->addRelation('OrderCoupon', '\\Thelia\\Model\\OrderCoupon', RelationMap::ONE_TO_MANY, array('id' => 'order_id', ), 'CASCADE', 'RESTRICT', 'OrderCoupons');
         $this->addRelation('OrderVersion', '\\Thelia\\Model\\OrderVersion', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'OrderVersions');

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -624,9 +624,6 @@
     <foreign-key foreignTable="lang" name="fk_order_lang_id" onDelete="RESTRICT" onUpdate="RESTRICT">
       <reference foreign="id" local="lang_id" />
     </foreign-key>
-    <foreign-key foreignTable="cart" name="fk_order_cart_id">
-      <reference foreign="id" local="cart_id" />
-    </foreign-key>
     <index name="idx_order_currency_id">
       <index-column name="currency_id" />
     </index>

--- a/setup/faker.php
+++ b/setup/faker.php
@@ -681,7 +681,7 @@ try {
                     ->findOne()
             )
             ->setPostage(mt_rand(1, 50))
-            ->setCart($cart)
+            ->setCartId($cart->getId())
         ;
 
         $placedOrder->save($con);

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -762,10 +762,7 @@ CREATE TABLE `order`
         FOREIGN KEY (`lang_id`)
         REFERENCES `lang` (`id`)
         ON UPDATE RESTRICT
-        ON DELETE RESTRICT,
-    CONSTRAINT `fk_order_cart_id`
-        FOREIGN KEY (`cart_id`)
-        REFERENCES `cart` (`id`)
+        ON DELETE RESTRICT
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
I do it here because we have to apply that patch on 2.1 too, and because you have to generate the model after modify it.