### PR TITLE
A Template Context to ease form error processing

### DIFF
--- a/core/lib/Thelia/Core/Template/ParserContext.php
+++ b/core/lib/Thelia/Core/Template/ParserContext.php
@@ -12,6 +12,7 @@
 
 namespace Thelia\Core\Template;
 
+use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Thelia;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Form\BaseForm;
@@ -28,10 +29,38 @@ class ParserContext implements \IteratorAggregate
     private $formStore = array();
     private $store = array();
 
+    /** @var Session */
+    protected $session;
+
     public function __construct(Request $request)
     {
         // Setup basic variables
         $this->set('THELIA_VERSION', Thelia::THELIA_VERSION);
+
+        $this->session = $request->getSession();
+    }
+
+    /**
+     * Store the current template info
+     *
+     * @param TemplateContext $context the template context
+     * @return $this
+     */
+    public function setCurrentTemplateContext(TemplateContext $context)
+    {
+        $templateInfo = $this->session->get('thelia.template-information', []);
+
+        $this->session->set('thelia.template-context', $context);
+
+        return $this;
+    }
+
+    /**
+     * @return TemplateContext|null the current template context.
+     */
+    public function getCurrentTemplateContext()
+    {
+        return $this->session->get('thelia.template-context');
     }
 
     /**

--- a/core/lib/Thelia/Core/Template/ParserContext.php
+++ b/core/lib/Thelia/Core/Template/ParserContext.php
@@ -48,8 +48,6 @@ class ParserContext implements \IteratorAggregate
      */
     public function setCurrentTemplateContext(TemplateContext $context)
     {
-        $templateInfo = $this->session->get('thelia.template-information', []);
-
         $this->session->set('thelia.template-context', $context);
 
         return $this;

--- a/core/lib/Thelia/Core/Template/TemplateContext.php
+++ b/core/lib/Thelia/Core/Template/TemplateContext.php
@@ -1,0 +1,55 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+/**
+ * This class stores the last rendered template information.
+ *
+ * @author Franck Allimant <franck@cqfdev.fr>
+ * Creation date: 15/04/2015 10:35
+ */
+
+namespace Thelia\Core\Template;
+
+class TemplateContext
+{
+    /** @var String  */
+    protected $name;
+
+    /** @var array */
+    protected $parameters;
+
+    /**
+     * @param string $name the template name, as passed to ParserInterface::render()
+     * @param array $parameters the template parameters, as passed to ParserInterface::render()
+     */
+    public function __construct($name, $parameters)
+    {
+        $this->name = preg_replace('/\.html$/', '', $name);
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return array the template parameters
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return string the template name, without the final '.html' extension.
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/local/modules/TheliaSmarty/Template/SmartyParser.php
+++ b/local/modules/TheliaSmarty/Template/SmartyParser.php
@@ -21,6 +21,7 @@ use Thelia\Core\Template\ParserInterface;
 
 use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserContext;
+use Thelia\Core\Template\TemplateContext;
 use Thelia\Core\Template\TemplateHelperInterface;
 use TheliaSmarty\Template\AbstractSmartyPlugin;
 use TheliaSmarty\Template\SmartyPluginDescriptor;
@@ -390,6 +391,13 @@ class SmartyParser extends Smarty implements ParserInterface
         if (false === $this->templateExists($realTemplateName) || false === $this->checkTemplate($realTemplateName)) {
             throw new ResourceNotFoundException(Translator::getInstance()->trans("Template file %file cannot be found.", array('%file' => $realTemplateName)));
         }
+
+        $this->parserContext->setCurrentTemplateContext(
+            new TemplateContext(
+                $realTemplateName,
+                $parameters
+            )
+        );
 
         return $this->internalRenderer('file', $realTemplateName, $parameters, $compressOutput);
     }


### PR DESCRIPTION
This PR introduces a template context, stored in the parser context, so that a controller may get `the last rendered template, and its parameters.

This is very useful to process form errors, where the current template should be redisplayed without redirecting.

```
return $this->render(
    $this->getParserContext()->getCurrentTemplateContext()->getName(),
    $this->getParserContext()->getCurrentTemplateContext()->getParameters()
);
```