### PR TITLE
Use HttpKernel RegisterListenerPass instead of a hand written one

### DIFF
--- a/core/lib/Thelia/Core/Bundle/TheliaBundle.php
+++ b/core/lib/Thelia/Core/Bundle/TheliaBundle.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Scope;
+use Symfony\Component\HttpKernel\DependencyInjection\RegisterListenersPass;
 use Thelia\Core\DependencyInjection\Compiler\CurrencyConverterProviderPass;
 use Thelia\Core\DependencyInjection\Compiler\FallbackParserPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterArchiveBuilderPass;
@@ -23,7 +24,7 @@ use Thelia\Core\DependencyInjection\Compiler\RegisterAssetFilterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterCouponPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterFormatterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterFormExtensionPass;
-use Thelia\Core\DependencyInjection\Compiler\RegisterListenersPass;
+use Thelia\Core\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterRouterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterCouponConditionPass;
 use Thelia\Core\DependencyInjection\Compiler\StackPass;
@@ -58,7 +59,7 @@ class TheliaBundle extends Bundle
         $container
             ->addCompilerPass(new FallbackParserPass())
             ->addCompilerPass(new TranslatorPass())
-            ->addCompilerPass(new RegisterListenersPass(), PassConfig::TYPE_AFTER_REMOVING)
+            ->addCompilerPass(new RegisterHookListenersPass(), PassConfig::TYPE_AFTER_REMOVING)
             ->addCompilerPass(new RegisterRouterPass())
             ->addCompilerPass(new RegisterCouponPass())
             ->addCompilerPass(new RegisterCouponConditionPass())
@@ -68,6 +69,7 @@ class TheliaBundle extends Bundle
             ->addCompilerPass(new StackPass())
             ->addCompilerPass(new RegisterFormExtensionPass())
             ->addCompilerPass(new CurrencyConverterProviderPass())
+            ->addCompilerPass(new RegisterListenersPass())
         ;
     }
 }


### PR DESCRIPTION
Well ... Without that patch, if you try to register a listener with a class name that is a parameter, you get an error.

Example:
```
<parameters>
  <parameter key="foo.class">Foo\Bar</parameter>
</parameters>
<services>
  <service id="foo.bar" class="%foo.class%">
    <tag name="kernel.event_subscriber" />
  </service>
</services>
```
Here, you get a beautiful ```The class "%foo.class%" doesn't exist```