### PR TITLE
More explicit filenames for exports

### DIFF
--- a/core/lib/Thelia/Controller/Admin/ExportController.php
+++ b/core/lib/Thelia/Controller/Admin/ExportController.php
@@ -164,7 +164,7 @@ class ExportController extends BaseAdminController
 
         $event = new ImportExportEvent($formatter, $handler);
 
-        $filename = $formatter::FILENAME . "." . $formatter->getExtension();
+        $filename = $handler->getFilename() . "." . $formatter->getExtension();
 
         if ($archiveBuilder === null) {
             $data = $handler->buildData($lang);
@@ -223,7 +223,7 @@ class ExportController extends BaseAdminController
                 $filename
             );
 
-            return $archiveBuilder->buildArchiveResponse($formatter::FILENAME);
+            return $archiveBuilder->buildArchiveResponse($handler->getFilename());
         }
     }
 

--- a/core/lib/Thelia/ImportExport/Export/ExportHandler.php
+++ b/core/lib/Thelia/ImportExport/Export/ExportHandler.php
@@ -29,6 +29,9 @@ use Thelia\ImportExport\AbstractHandler;
  */
 abstract class ExportHandler extends AbstractHandler
 {
+    /** @var string Default filename. */
+    const DEFAULT_FILENAME = "data";
+
     protected $locale;
 
     /** @var  array */
@@ -195,6 +198,16 @@ abstract class ExportHandler extends AbstractHandler
     public function isImageExport()
     {
         return $this->isImageExport;
+    }
+
+    /**
+     * Get filename
+     *
+     * @return string
+     */
+    public function getFilename()
+    {
+        return static::DEFAULT_FILENAME;
     }
 
     /**


### PR DESCRIPTION
Thelia's current default behavior for naming exports files (in the `Admin\ExportController`) consists in naming them "*data*", regardless of what the export consists in (customer, products, prices or other things depending on what should be exported). This PR consists in giving to the exports the possibility to have more explicit file names, depending on what they consist in.

Technically, the file name (without the extension) is now built in the `ExportHandler` instead of the formatter (where the "*data*" file name is a constant). It is now built in a method called `getFilename();` which returns the file name without its extension. The base `Thelia/ImportExport/Export/ExportHandler` class for ExportHandlers have a default `getFilename();` method which consists in naming the file "*data*", just like before in order to avoid breaking Thelia.