### PR TITLE
Improved data encoding in exports

### DIFF
--- a/core/lib/Thelia/Controller/Admin/ExportController.php
+++ b/core/lib/Thelia/Controller/Admin/ExportController.php
@@ -208,6 +208,7 @@ class ExportController extends BaseAdminController
                 ->setLang($lang)
             ;
 
+            $event->setData($data);
             $this->dispatch(TheliaEvents::EXPORT_BEFORE_ENCODE, $event);
 
             $formattedContent = $formatter

--- a/core/lib/Thelia/Controller/Admin/ExportController.php
+++ b/core/lib/Thelia/Controller/Admin/ExportController.php
@@ -174,7 +174,7 @@ class ExportController extends BaseAdminController
 
             $formattedContent = $formatter
                 ->setOrder($handler->getOrder())
-                ->encode($data)
+                ->encode($event->getData())
             ;
 
             $this->dispatch(TheliaEvents::EXPORT_AFTER_ENCODE, $event->setContent($formattedContent));
@@ -212,7 +212,7 @@ class ExportController extends BaseAdminController
 
             $formattedContent = $formatter
                 ->setOrder($handler->getOrder())
-                ->encode($data)
+                ->encode($event->getData())
             ;
 
             $this->dispatch(TheliaEvents::EXPORT_AFTER_ENCODE, $event->setContent($formattedContent));


### PR DESCRIPTION
This PR deals with encoding data in exports.

In the `Admin/ExportController`, data to export are built and set in a `ImportExportEvent` for encoding purposes. Then the `TheliaEvents::EXPORT_BEFORE_ENCODE` event is dispatched. In this event, data to export might be altered. After that, Thelia should logically use data altered by the event instead of original data, but it uses original data. This PR consists in bringing back logic in Thelia, making it using data altered by the `TheliaEvents::EXPORT_BEFORE_ENCODE` event instead of original data.