### PR TITLE
Column naming in CSV Exports more understandable for non-developer people

### DIFF
--- a/core/lib/Thelia/Action/Export.php
+++ b/core/lib/Thelia/Action/Export.php
@@ -75,15 +75,13 @@ class Export extends BaseAction implements EventSubscriberInterface
         $handler = $event->getHandler();
         $formatter = $event->getFormatter();
 
-        if ($handler instanceof ExportHandler &&
-            $formatter instanceof CSVFormatter
-        ) {
+        if ($formatter instanceof CSVFormatter) {
             // Get existing data
             $formatterData = $event->getData();
             $data = $formatterData->getData();
 
             // Get heading labels
-            $heading = $handler->getHeading();
+            $heading = $handler->getTranslatedHeading();
 
             // Complete heading row (with all keys)
             // - Use label if possible

--- a/core/lib/Thelia/ImportExport/Export/ExportHandler.php
+++ b/core/lib/Thelia/ImportExport/Export/ExportHandler.php
@@ -54,7 +54,7 @@ abstract class ExportHandler extends AbstractHandler
     {
         parent::__construct($container);
 
-        $this->translator = $container->get('thelia.translator');
+        $this->translator = Translator::getInstance();
     }
 
     /**

--- a/core/lib/Thelia/ImportExport/Export/ExportHandler.php
+++ b/core/lib/Thelia/ImportExport/Export/ExportHandler.php
@@ -14,6 +14,7 @@ namespace Thelia\ImportExport\Export;
 
 use Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Thelia\Core\FileFormat\Formatting\FormatterData;
 use Thelia\Core\Template\Element\BaseLoop;
 use Thelia\Core\Template\Element\Exception\LoopException;
@@ -31,12 +32,27 @@ abstract class ExportHandler extends AbstractHandler
 {
     protected $locale;
 
+    /** @var  Translator */
+    protected $translator;
+
+    /**
+     * Translation domain to use for translating headers. Set it to null in extended classes if you do not want to translate.
+     */
+    const TRANSLATION_DOMAIN = null;
+
     /** @var  array */
     protected $order = array();
 
     protected $isImageExport = false;
 
     protected $isDocumentExport = false;
+
+    public function __construct(ContainerInterface $container)
+    {
+        parent::__construct($container);
+
+        $this->translator = $container->get('thelia.translator');
+    }
 
     /**
      * @return array
@@ -215,5 +231,24 @@ abstract class ExportHandler extends AbstractHandler
     {
         $indexHeaders = $this->getOrder();
         return array_combine($indexHeaders, $indexHeaders);
+    }
+
+    protected function trans($key)
+    {
+        return is_null($this::TRANSLATION_DOMAIN) ? $key : $this->translator->trans($key, [], $this::TRANSLATION_DOMAIN);
+    }
+
+    /**
+     * @return array Heading row with translated values to display.
+     */
+    public function getTranslatedHeading()
+    {
+        $translatedHeading = array();
+
+        foreach ($this->getHeading() as $alias => $header) {
+            $translatedHeading[$alias] = $this->trans($header);
+        }
+
+        return $translatedHeading;
     }
 }

--- a/core/lib/Thelia/ImportExport/Export/ExportHandler.php
+++ b/core/lib/Thelia/ImportExport/Export/ExportHandler.php
@@ -202,4 +202,18 @@ abstract class ExportHandler extends AbstractHandler
      * @return ModelCriteria|array|BaseLoop
      */
     abstract public function buildDataSet(Lang $lang);
+
+    /**
+     * Customize heading row
+     *
+     * Set values to each columns of your export
+     * instead of using aliases
+     *
+     * @return array
+     */
+    public function getHeading()
+    {
+        $indexHeaders = $this->getOrder();
+        return array_combine($indexHeaders, $indexHeaders);
+    }
 }


### PR DESCRIPTION
A Thelia current behavior in CSV exports consists in naming columns with aliases. These column names could not be suitable for non developer people who might be easier with explicit names, especially if the name is in a lang they understand. With this PR, it is now possible to give to the columns other names than aliases which might not be understood by some people.

Technically, a heading row with the column names is added to data to export through a `TheliaEvents::EXPORT_BEFORE_ENCODE` event. Then, datas are encoded and an unexpected heading row containing aliases is added to data to export. This unexpected heading row with aliases is then removed through the `TheliaEvents::EXPORT_AFTER_ENCODE` event. The methods used to do such a thing are located in `Thelia\Action\Export`, the Thelia's action dedicated to exports.

The header names could be translated too. It happens in the `Thelia/ImportExport/Export/ExportHandler` class. There is now a method called `getHeading();` which returns an array whose keys are aliases and whose values are i18n keys for names that should be displayed. There is also a `getTranslatedHeading();` method which returns an array with translated keys. As for the translation itself, the `Thelia/ImportExport/Export/ExportHandler` class now have a protected `Thelia\Core\Translation\Translator $translator` attribute and a `TRANSLATION_DOMAIN` constant containing the domain for translations. The `TRANSLATION_DOMAIN` constant can be overriden in extended classes and setting it to `null` disables translations. The `Thelia/ImportExport/Export/ExportHandler` class have a default behaviour which consists in using aliases. For this, it disables translations and uses headers whose names are aliases. This default behavior is also here in order to avoid breaking Thelia.