### PR TITLE
Set FO / BO to default language if current language is deleted

### DIFF
--- a/core/lib/Thelia/Config/Resources/action.xml
+++ b/core/lib/Thelia/Config/Resources/action.xml
@@ -176,8 +176,9 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
-        <service id="thelia.action.lang" class="Thelia\Action\Lang">
+        <service id="thelia.action.lang" class="Thelia\Action\Lang" scope="request">
             <argument type="service" id="thelia.template_helper" />
+            <argument type="service" id="request"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
@@ -41,7 +41,7 @@ use Thelia\Tools\URL;
 class Session extends BaseSession
 {
     /**
-     * @param bool $forceDefault
+     * @param bool $forceDefault if true, the default language will be returned if no current language is defined.
      *
      * @return \Thelia\Model\Lang|null
      */
@@ -70,7 +70,7 @@ class Session extends BaseSession
     /**
      * Return current currency
      *
-     * @param bool $forceDefault If default currency forced
+     * @param bool $forceDefault if true, the default currency will be returned if no current currency is defined.
      *
      * @return Currency
      */
@@ -105,6 +105,9 @@ class Session extends BaseSession
         return $this;
     }
 
+    /**
+     * @return Lang the current edition language in the back-office
+     */
     public function getAdminEditionLang()
     {
         $lang = $this->get('thelia.admin.edition.lang');
@@ -116,7 +119,11 @@ class Session extends BaseSession
         return $lang;
     }
 
-    public function setAdminEditionLang($lang)
+    /**
+     * @param Lang $lang the current edition language to set in the back-office
+     * @return $this
+     */
+    public function setAdminEditionLang(Lang $lang)
     {
         $this->set('thelia.admin.edition.lang', $lang);
 


### PR DESCRIPTION
When a language is deleted from the B.O, the current FO / BO language and/or the edition language are set to the default language if they're the same as the deleted language, thus preventing the B.O to fail with `Incorrect lang argument given : lang `X not found`.