### PR TITLE
Set dispatcher to newly created content

### DIFF
--- a/core/lib/Thelia/Action/Content.php
+++ b/core/lib/Thelia/Action/Content.php
@@ -39,9 +39,8 @@ class Content extends BaseAction implements EventSubscriberInterface
 {
     public function create(ContentCreateEvent $event)
     {
-        $content = new ContentModel();
-
-        $content
+        $content = (new ContentModel)
+            ->setDispatcher($event->getDispatcher())
             ->setVisible($event->getVisible())
             ->setLocale($event->getLocale())
             ->setTitle($event->getTitle())

--- a/core/lib/Thelia/Model/Content.php
+++ b/core/lib/Thelia/Model/Content.php
@@ -149,8 +149,7 @@ class Content extends BaseContent implements FileModelParentInterface
             throw $ex;
         }
 
-
-       return $this;
+        return $this;
     }
 
     public function preUpdate(ConnectionInterface $con = null)

--- a/core/lib/Thelia/Model/Content.php
+++ b/core/lib/Thelia/Model/Content.php
@@ -116,7 +116,10 @@ class Content extends BaseContent implements FileModelParentInterface
      * Here pre and post insert event are fired
      *
      * @param $defaultFolderId
+     *
      * @throws \Exception
+     *
+     * @return $this Return $this, allow chaining
      */
     public function create($defaultFolderId)
     {
@@ -145,6 +148,9 @@ class Content extends BaseContent implements FileModelParentInterface
 
             throw $ex;
         }
+
+
+       return $this;
     }
 
     public function preUpdate(ConnectionInterface $con = null)


### PR DESCRIPTION
that allow to dispatch `TheliaEvents::BEFORE_CREATECONTENT` and `TheliaEvents::AFTER_CREATECONTENT` events.