### PR TITLE
force locale in session when loading a rewriten url

### DIFF
--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -274,7 +274,7 @@ class BaseAdminController extends BaseController
     protected function getUrlLanguage($locale = null)
     {
         // Check if the functionality is activated
-        if (!ConfigQuery::read("one_domain_foreach_lang", false)) {
+        if (!ConfigQuery::isMultiDomainActivated()) {
             return null;
         }
 

--- a/core/lib/Thelia/Controller/Admin/LangController.php
+++ b/core/lib/Thelia/Controller/Admin/LangController.php
@@ -55,7 +55,7 @@ class LangController extends BaseAdminController
 
         return $this->render('languages', array_merge($param, array(
             'lang_without_translation' => ConfigQuery::getDefaultLangWhenNoTranslationAvailable(),
-            'one_domain_per_lang' => ConfigQuery::read("one_domain_foreach_lang", false)
+            'one_domain_per_lang' => ConfigQuery::isMultiDomainActivated()
         )));
     }
 

--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -243,7 +243,7 @@ class RequestListener implements EventSubscriberInterface
             if (null !== $referrer) {
                 $session = $request->getSession();
 
-                if (ConfigQuery::read("one_domain_foreach_lang", false) == 1) {
+                if (ConfigQuery::isMultiDomainActivated()) {
                     $components = parse_url($referrer);
                     $lang = LangQuery::create()
                         ->filterByUrl(sprintf("%s://%s", $components["scheme"], $components["host"]), ModelCriteria::LIKE)

--- a/core/lib/Thelia/Core/Routing/RewritingRouter.php
+++ b/core/lib/Thelia/Core/Routing/RewritingRouter.php
@@ -26,6 +26,9 @@ use Thelia\Core\HttpFoundation\Request as TheliaRequest;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Exception\UrlRewritingException;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Model\RewritingUrlQuery;
+use Thelia\Rewriting\RewritingResolver;
 use Thelia\Tools\URL;
 
 /**
@@ -184,9 +187,11 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
                     $request->query->set($rewrittenUrlData->view . '_id', $rewrittenUrlData->viewId);
                 }
             }
+
             if (null !== $rewrittenUrlData->locale) {
-                $request->query->set('locale', $rewrittenUrlData->locale);
+                $this->manageLocale($rewrittenUrlData, $request);
             }
+
 
             foreach ($rewrittenUrlData->otherParameters as $parameter => $value) {
                 $request->query->set($parameter, $value);
@@ -199,6 +204,24 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
             );
         }
         throw new ResourceNotFoundException();
+    }
+
+    protected function manageLocale(RewritingResolver $rewrittenUrlData, Request $request)
+    {
+        $lang = LangQuery::create()
+            ->findOneByLocale($rewrittenUrlData->locale);
+
+        $langSession = $request->getSession()->getLang();
+
+        if ($lang != $langSession) {
+            if (ConfigQuery::isMultiDomainActivated()) {
+                $this->redirect(
+                    sprintf("%s/%s", $lang->getUrl(), $rewrittenUrlData->rewrittenUrl)
+                );
+            } else {
+                $request->getSession()->setLang($lang);
+            }
+        }
     }
 
     protected function redirect($url, $status = 302)

--- a/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
+++ b/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
@@ -143,8 +143,8 @@ class ParamInitMiddleware implements HttpKernelInterface
                 return Lang::getDefaultLanguage();
             }
 
-            //if each lang had is own domain, we redirect the user to the good one.
-            if (ConfigQuery::read("one_domain_foreach_lang", false) == 1) {
+            //if each lang has its own domain, we redirect the user to the good one.
+            if (ConfigQuery::isMultiDomainActivated()) {
                 //if lang domain is different from actuel domain, redirect to the good one
                 if (rtrim($lang->getUrl(), "/") != $request->getSchemeAndHttpHost()) {
                     // TODO : search if http status 302 is the good one.
@@ -162,7 +162,7 @@ class ParamInitMiddleware implements HttpKernelInterface
 
         //check if lang is not defined. If not we have to search the good one.
         if (null === $request->getSession()->getLang(false)) {
-            if (ConfigQuery::read("one_domain_foreach_lang", false) == 1) {
+            if (ConfigQuery::isMultiDomainActivated()) {
                 //find lang with domain
                 return LangQuery::create()->filterByUrl($request->getSchemeAndHttpHost(), ModelCriteria::LIKE)->findOne();
             }

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -284,5 +284,15 @@ class ConfigQuery extends BaseConfigQuery
     {
         return intval(static::read("admin_cache_home_stats_ttl", 600));
     }
+
+    /**
+     * check if Thelia multi domain is activated. (Means one domain for each language)
+     *
+     * @return bool
+     */
+    public static function isMultiDomainActivated()
+    {
+        return (bool) self::read("one_domain_foreach_lang", false);
+    }
 }
 // ConfigQuery

--- a/core/lib/Thelia/Rewriting/RewritingResolver.php
+++ b/core/lib/Thelia/Rewriting/RewritingResolver.php
@@ -32,6 +32,7 @@ class RewritingResolver
     public $locale;
     public $otherParameters;
     public $redirectedToUrl;
+    public $rewrittenUrl;
 
     public function __construct($url = null)
     {
@@ -46,6 +47,7 @@ class RewritingResolver
     {
         $rewrittenUrl = ltrim($rewrittenUrl, '/');
         $rewrittenUrl = urldecode($rewrittenUrl);
+        $this->rewrittenUrl = $rewrittenUrl;
         $this->search = $this->rewritingUrlQuery->getResolverSearch($rewrittenUrl);
 
         if ($this->search->count() == 0) {

--- a/core/lib/Thelia/Rewriting/RewritingRetriever.php
+++ b/core/lib/Thelia/Rewriting/RewritingRetriever.php
@@ -49,7 +49,7 @@ class RewritingRetriever
         $this->search = $this->rewritingUrlQuery->getViewUrlQuery($view, $viewLocale, $viewId);
 
         $allParametersWithoutView = array();
-        if (null !== $viewId) {
+        if (null !== $viewLocale) {
             $allParametersWithoutView['locale'] = $viewLocale;
         }
         if (null !== $viewId) {

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -55,6 +55,14 @@ class URL
     }
 
     /**
+     * @param RequestContext $requestContext
+     */
+    public function setRequestContext(RequestContext $requestContext)
+    {
+        $this->requestContext = $requestContext;
+    }
+
+    /**
      * Return this class instance, only once instanciated.
      *
      * @throws \RuntimeException if the class has not been instanciated.

--- a/tests/phpunit/Thelia/Tests/Core/Routing/RewritingRouterTest.php
+++ b/tests/phpunit/Thelia/Tests/Core/Routing/RewritingRouterTest.php
@@ -1,0 +1,210 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Tests\Core\Routing;
+
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\RequestContext;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\HttpKernel\Exception\RedirectException;
+use Thelia\Core\Routing\RewritingRouter;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\RewritingUrlQuery;
+use Thelia\Tools\URL;
+
+/**
+ * Class RewritingRouterTest
+ * @package Thelia\Tests\Core\Routing
+ * @author Manuel Raynaud <manu@thelia.net>
+ */
+class RewritingRouterTest extends \PHPUnit_Framework_TestCase
+{
+
+    public static function setUpBeforeClass()
+    {
+        $url = new URL();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\RouteNotFoundException
+     * @covers RewritingRouter::generate
+     */
+    public function testGenerate()
+    {
+        $rewritingRouter = new RewritingRouter();
+        $rewritingRouter->generate('foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * @covers RewritingRouter::match
+     */
+    public function testMatch()
+    {
+        $rewritingRouter = new RewritingRouter();
+        $rewritingRouter->match('foo');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * covers RewritingRouter::matchRequest
+     */
+    public function testMatchRequestWithNoRewriting()
+    {
+        ConfigQuery::write('rewriting_enable', 0);
+        $request = new Request();
+
+        $rewritingRouter = new RewritingRouter();
+        $rewritingRouter->matchRequest($request);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * covers RewritingRouter::matchRequest
+     */
+    public function testMatchRequestWithNonExistingUrl()
+    {
+        ConfigQuery::write('rewriting_enable', 1);
+        $request = Request::create('http://test.com/foo');
+
+        $rewritingRouter = new RewritingRouter();
+        $rewritingRouter->matchRequest($request);
+    }
+
+    /**
+     * covers RewritingRouter::matchRequest
+     */
+    public function testMatchRequestWithSameLocale()
+    {
+        ConfigQuery::write('rewriting_enable', 1);
+        ConfigQuery::write('one_domain_foreach_lang', 0);
+
+        $defaultLang = LangQuery::create()->findOneByByDefault(1);
+        $product = ProductQuery::create()->findOne();
+        $product->setLocale($defaultLang->getLocale());
+
+        $rewriting = RewritingUrlQuery::create()
+            ->filterByView('product')
+            ->filterByViewId($product->getId())
+            ->filterByViewLocale($defaultLang->getLocale())
+            ->filterByRedirected(null)
+            ->findOne();
+
+        $request = Request::create('http://test.com/'.$rewriting->getUrl());
+        $session = new Session(new MockArraySessionStorage());
+        $session->setLang($defaultLang);
+        $request->setSession($session);
+        $url = new URL();
+        $requestContext = new RequestContext();
+        $requestContext->fromRequest($request);
+        $url->setRequestContext($requestContext);
+
+        $rewritingRouter = new RewritingRouter();
+        $parameters = $rewritingRouter->matchRequest($request);
+
+        $this->assertEquals('Thelia\\Controller\\Front\\DefaultController::noAction', $parameters['_controller']);
+        $this->assertEquals('rewrite', $parameters['_route']);
+        $this->assertTrue($parameters['_rewritten']);
+
+        $this->assertEquals($product->getId(), $request->query->get('product_id'));
+        $this->assertEquals('product', $request->attributes->get('_view'));
+    }
+
+    /**
+     * covers RewritingRouter::matchRequest
+     */
+    public function testMatchRequestWithDifferentLocale()
+    {
+        ConfigQuery::write('rewriting_enable', 1);
+        ConfigQuery::write('one_domain_foreach_lang', 0);
+
+        $defaultLang = LangQuery::create()->findOneByLocale('en_US');
+        $product = ProductQuery::create()->findOne();
+        $product->setLocale($defaultLang->getLocale());
+
+        $rewriting = RewritingUrlQuery::create()
+            ->filterByView('product')
+            ->filterByViewId($product->getId())
+            ->filterByViewLocale('fr_FR')
+            ->filterByRedirected(null)
+            ->findOne();
+
+        $request = Request::create('http://test.com/'.$rewriting->getUrl());
+        $session = new Session(new MockArraySessionStorage());
+        $session->setLang($defaultLang);
+        $request->setSession($session);
+        $url = new URL();
+        $requestContext = new RequestContext();
+        $requestContext->fromRequest($request);
+        $url->setRequestContext($requestContext);
+
+        $rewritingRouter = new RewritingRouter();
+        $parameters = $rewritingRouter->matchRequest($request);
+
+        $this->assertEquals('Thelia\\Controller\\Front\\DefaultController::noAction', $parameters['_controller']);
+        $this->assertEquals('rewrite', $parameters['_route']);
+        $this->assertTrue($parameters['_rewritten']);
+
+        $this->assertEquals($product->getId(), $request->query->get('product_id'));
+        $this->assertEquals('product', $request->attributes->get('_view'));
+        $this->assertNotEquals($defaultLang, $request->getSession()->getLang());
+    }
+
+    /**
+     * covers RewritingRouter::matchRequest
+     */
+    public function testMatchRequestWithDifferentLocaleAndDomain()
+    {
+        ConfigQuery::write('rewriting_enable', 1);
+        ConfigQuery::write('one_domain_foreach_lang', 1);
+
+        $defaultLang = LangQuery::create()->findOneByLocale('en_US');
+        $defaultLang->setUrl('http://test_en.com');
+
+        $frenchLang = LangQuery::create()->findOneByLocale('fr_FR');
+        $saveUrl = $frenchLang->getUrl();
+        $frenchLang->setUrl('http://test.com')->save();
+
+        $product = ProductQuery::create()->findOne();
+        $product->setLocale($defaultLang->getLocale());
+
+        $rewriting = RewritingUrlQuery::create()
+            ->filterByView('product')
+            ->filterByViewId($product->getId())
+            ->filterByViewLocale('fr_FR')
+            ->filterByRedirected(null)
+            ->findOne();
+
+        $request = Request::create('http://test_en.com/'.$rewriting->getUrl());
+        $session = new Session(new MockArraySessionStorage());
+        $session->setLang($defaultLang);
+        $request->setSession($session);
+        $url = new URL();
+        $requestContext = new RequestContext();
+        $requestContext->fromRequest($request);
+        $url->setRequestContext($requestContext);
+
+        try {
+            $rewritingRouter = new RewritingRouter();
+            $parameters = $rewritingRouter->matchRequest($request);
+        } catch (RedirectException $e) {
+            $this->assertRegExp("/http:\/\/test\.com\/.*/", $e->getUrl());
+            return;
+        }
+
+        $this->fail('->matchRequest must throw a RedirectException');
+
+    }
+}


### PR DESCRIPTION
For now, a rewriten URL doesn't have any effect on the locale. If an English URL is loaded and the current locale is french, the website is still loaded in french but with the english URL