### PR TITLE
Add & processing in {navigate} function

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -139,7 +139,7 @@ class UrlGenerator extends AbstractSmartyPlugin
 
         $toMethod = $this->getNavigateToMethod($to);
 
-        return $this->$toMethod();
+        return $this->applyNoAmpAndTarget($params, $this->$toMethod());
     }
 
     protected function generateViewUrlFunction($params, $forAdmin)

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -138,8 +138,14 @@ class UrlGenerator extends AbstractSmartyPlugin
         $to = $this->getParam($params, 'to', null);
 
         $toMethod = $this->getNavigateToMethod($to);
+     
+        $url = URL::getInstance()->absoluteUrl(
+            $this->$toMethod(),
+            $this->getArgsFromParam($params, ['noamp', 'to', 'target']),
+            URL::WITH_INDEX_PAGE
+        );
 
-        return $this->applyNoAmpAndTarget($params, $this->$toMethod());
+        return $this->applyNoAmpAndTarget($params, $url);
     }
 
     protected function generateViewUrlFunction($params, $forAdmin)


### PR DESCRIPTION
The {navigate} function leaves & as-is in the generated URLs. The `applyNoAmpAndTarget()` is now used to process & like in other URL generation functions.