### PR TITLE
Change default param of the isPaid function.

### DIFF
--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -237,7 +237,7 @@ class Order extends BaseOrder
      * if false, it will check if the order has been paid, whatever the current status is. The default is false.
      * @return bool true if this order is PAID, false otherwise.
      */
-    public function isPaid($exact = false)
+    public function isPaid($exact = true)
     {
         return $this->hasStatusHelper(
             $exact ?


### PR DESCRIPTION
By default, the paid order in Thelia must have only one status (OrderStatus::CODE_PAID)