### PR TITLE
Fixed error 404 on mini_src image

### DIFF
--- a/local/modules/Tinymce/Resources/js/tinymce/filemanager/dialog.php
+++ b/local/modules/Tinymce/Resources/js/tinymce/filemanager/dialog.php
@@ -720,6 +720,7 @@ if(isset($_POST['submit'])){
         $src = $base_url . $cur_dir . rawurlencode($file);
         $mini_src = $src_thumb = $thumbs_path.$subdir. $file;
         $src_thumb_url = $base_url . $cur_thumbs_dir.$subdir. $file;
+        $mini_src_url = $base_url .$thumbs_dir.$subdir. $file;
         //add in thumbs folder if not exist
         if(!file_exists($src_thumb)){
             try {
@@ -739,6 +740,7 @@ if(isset($_POST['submit'])){
 
         if($img_width<45 && $img_height<38){
             $mini_src=$current_path.$rfm_subfolder.$subdir.$file;
+            $mini_src_url= $base_url.$upload_dir.$rfm_subfolder.$subdir.$file;
             $show_original_mini=true;
         }
     }
@@ -802,7 +804,7 @@ if(isset($_POST['submit'])){
                     <div class="img-container-mini">
                         <span></span>
                         <?php if($mini_src!=""){ ?>
-                            <img alt="<?php echo $filename." thumbnails";?>" class="<?php echo $show_original_mini ? "original" : "" ?> <?php echo $is_icon_thumb_mini ? "icon" : "" ?>" src="<?php echo $mini_src; ?>">
+                            <img alt="<?php echo $filename." thumbnails";?>" class="<?php echo $show_original_mini ? "original" : "" ?> <?php echo $is_icon_thumb_mini ? "icon" : "" ?>" src="<?php echo $mini_src_url; ?>">
                         <?php } ?>
                     </div>
                 </div>

--- a/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
+++ b/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
@@ -86,6 +86,7 @@
 
         convert_urls: false,
         relative_urls : false,
-        document_base_url : "{url path="/"}"
+        // Use file to get an url without index.php or index_dev.php
+        document_base_url : "{url file="/"}"
     });
 </script>


### PR DESCRIPTION
This PR fixed the tinymce  `document_base_url`, which should not contains index.php or index_dev.php.

It also fixes a 404 error on the `$mini_src` image (not sure what it is used for...) in the file manager dialog.