### PR TITLE
Fix currency creation and update rates actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0-beta1
+
+- Fix currency create action to set the by_default field properly. 
+
 # 2.2.0-alpha2
 
 - Add a front office way to make an address the default one

--- a/core/lib/Thelia/Action/Currency.php
+++ b/core/lib/Thelia/Action/Currency.php
@@ -49,6 +49,8 @@ class Currency extends BaseAction implements EventSubscriberInterface
     {
         $currency = new CurrencyModel();
 
+        $isDefault = CurrencyQuery::create()->count() === 0;
+
         $currency
             ->setDispatcher($event->getDispatcher())
             ->setLocale($event->getLocale())
@@ -56,6 +58,7 @@ class Currency extends BaseAction implements EventSubscriberInterface
             ->setSymbol($event->getSymbol())
             ->setRate($event->getRate())
             ->setCode(strtoupper($event->getCode()))
+            ->setByDefault($isDefault)
             ->save()
         ;
 

--- a/setup/update/sql/2.2.0-beta1.sql
+++ b/setup/update/sql/2.2.0-beta1.sql
@@ -1,0 +1,12 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+UPDATE `config` SET `value`='2.2.0-beta1' WHERE `name`='thelia_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_major_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_minus_version';
+UPDATE `config` SET `value`='0' WHERE `name`='thelia_release_version';
+UPDATE `config` SET `value`='beta1' WHERE `name`='thelia_extra_version';
+
+-- fix currency already created
+update currency set by_default = 0 where by_default is NULL;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.2.0-beta1.sql.tpl
+++ b/setup/update/tpl/2.2.0-beta1.sql.tpl
@@ -1,0 +1,12 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+UPDATE `config` SET `value`='2.2.0-beta1' WHERE `name`='thelia_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_major_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_minus_version';
+UPDATE `config` SET `value`='0' WHERE `name`='thelia_release_version';
+UPDATE `config` SET `value`='beta1' WHERE `name`='thelia_extra_version';
+
+-- fix currency already created
+update currency set by_default = 0 where by_default is NULL;
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Fixes currency create action to set the by_default field properly. 
Now, update rates action works also for new currencies.