### PR TITLE
Feature value loop improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fix currency create action to set the by_default field properly.
 - Add missing column default_template_id in category_version table
+- The product parameter of the feature_value loop is no longer mandatory
+- The product parameter new $PRODUCT variable is deprecated. $PRODUCT_ID should be used instead.
 
 # 2.2.0-alpha2
 

--- a/core/lib/Thelia/Core/Template/Loop/FeatureValue.php
+++ b/core/lib/Thelia/Core/Template/Loop/FeatureValue.php
@@ -44,7 +44,7 @@ class FeatureValue extends BaseI18nLoop implements PropelSearchLoopInterface
     {
         return new ArgumentCollection(
             Argument::createIntTypeArgument('feature', null, true),
-            Argument::createIntTypeArgument('product', null, true),
+            Argument::createIntTypeArgument('product'),
             Argument::createIntListTypeArgument('feature_availability'),
             Argument::createBooleanTypeArgument('exclude_feature_availability', 0),
             Argument::createBooleanTypeArgument('exclude_free_text', 0),
@@ -81,19 +81,15 @@ class FeatureValue extends BaseI18nLoop implements PropelSearchLoopInterface
 
         $search->filterByFeatureId($feature, Criteria::EQUAL);
 
-        $product = $this->getProduct();
+        if (null !== $product = $this->getProduct()) {
+            $search->filterByProductId($product, Criteria::EQUAL);
+        }
 
-        $search->filterByProductId($product, Criteria::EQUAL);
-
-        $featureAvailability = $this->getFeature_availability();
-
-        if (null !== $featureAvailability) {
+        if (null !== $featureAvailability = $this->getFeature_availability()) {
             $search->filterByFeatureAvId($featureAvailability, Criteria::IN);
         }
 
-        $excludeFeatureAvailability = $this->getExclude_feature_availability();
-
-        if ($excludeFeatureAvailability == true) {
+        if (true === $excludeFeatureAvailability = $this->getExclude_feature_availability()) {
             $search->filterByFeatureAvId(null, Criteria::ISNULL);
         }
 
@@ -128,6 +124,7 @@ class FeatureValue extends BaseI18nLoop implements PropelSearchLoopInterface
             $loopResultRow
                 ->set("ID", $featureValue->getId())
                 ->set("PRODUCT", $featureValue->getProductId())
+                ->set("PRODUCT_ID", $featureValue->getProductId())
                 ->set("FEATURE_AV_ID", $featureValue->getFeatureAvId())
                 ->set("FREE_TEXT_VALUE", $featureValue->getFreeTextValue())
                 ->set("IS_FREE_TEXT", is_null($featureValue->getFeatureAvId()) ? 1 : 0)


### PR DESCRIPTION
The `product` parameter is now optional.

The `PRODUCT_ID` variable has been added, as an (better) alias of `PRODUCT`