### PR TITLE
getModuleHookClassnames() no longer add null to result array

### DIFF
--- a/core/lib/Thelia/Controller/Admin/ModuleHookController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleHookController.php
@@ -344,7 +344,7 @@ class ModuleHookController extends AbstractCrudController
         /** @var IgnoredModuleHook $moduleHook */
         foreach ($ignoredModuleHooks as $moduleHook) {
             $className = $moduleHook->getClassname();
-            if (! in_array($className, $result)) {
+            if (null !== $className && ! in_array($className, $result)) {
                 $result[] = $className;
             }
         }


### PR DESCRIPTION
This PR fixes this problem :

![img-2015-06-12 19 03 23](https://cloud.githubusercontent.com/assets/2197734/8135236/f6171cb2-1135-11e5-9a2d-c9aea5959df6.png)
