### PR TITLE
solution for issue #1108

### DIFF
--- a/core/lib/Thelia/Core/Security/SecurityContext.php
+++ b/core/lib/Thelia/Core/Security/SecurityContext.php
@@ -183,6 +183,24 @@ class SecurityContext
     final public function isGranted(array $roles, array $resources, array $modules, array $accesses)
     {
         // Find a user which matches the required roles.
+        $user = $this->checkRole($roles);
+
+        if (null === $user) {
+            return false;
+        } else {
+            return $this->isUserGranted($roles, $resources, $modules, $accesses, $user);
+        }
+    }
+
+    /**
+     * look if a user has the required role.
+     *
+     * @param array $roles
+     * @return null|UserInterface
+     */
+    public function checkRole(array $roles)
+    {
+        // Find a user which matches the required roles.
         $user = $this->getCustomerUser();
 
         if (! $this->hasRequiredRole($user, $roles)) {
@@ -193,11 +211,7 @@ class SecurityContext
             }
         }
 
-        if (null === $user) {
-            return false;
-        } else {
-            return $this->isUserGranted($roles, $resources, $modules, $accesses, $user);
-        }
+        return $user;
     }
 
     /**

--- a/local/modules/TheliaSmarty/Template/Plugins/Security.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Security.php
@@ -52,7 +52,7 @@ class Security extends AbstractSmartyPlugin
         $accesses = $this->explode($this->getParam($params, 'access'));
 
         if (! $this->securityContext->isGranted($roles, $resources, $modules, $accesses)) {
-            if (! $this->securityContext->hasLoggedInUser()) {
+            if (null === $this->securityContext->checkRole($roles)) {
                 // The current user is not logged-in.
                 $ex = new AuthenticationException(
                     sprintf(
@@ -68,8 +68,7 @@ class Security extends AbstractSmartyPlugin
                 if (null != $loginTpl) {
                     $ex->setLoginTemplate($loginTpl);
                 }
-            }
-            else {
+            } else {
                 // We have a logged-in user, who do not have the proper permission. Issue an AuthorizationException.
                 $ex = new AuthorizationException(
                     sprintf(


### PR DESCRIPTION
The security module check only if a user is logged if the securityContext tells a user is not granted.

This information is not enough because we only know if a use is logged in buit this user can be an admin or a customer.

Now only the role is checked if a user is not granted.

Fix issue #1108 