### PR TITLE
add a customer page parameter for the order loop on the customer page

### DIFF
--- a/core/lib/Thelia/Controller/Admin/CustomerController.php
+++ b/core/lib/Thelia/Controller/Admin/CustomerController.php
@@ -173,7 +173,8 @@ class CustomerController extends AbstractCrudController
     {
         return array(
                 'customer_id' => $this->getRequest()->get('customer_id', 0),
-                'page'        => $this->getRequest()->get('page', 1)
+                'page'        => $this->getRequest()->get('page', 1),
+                'page_order'  => $this->getRequest()->get('page_order', 1)
         );
     }
 

--- a/templates/backOffice/default/customer-edit.html
+++ b/templates/backOffice/default/customer-edit.html
@@ -289,7 +289,7 @@
                                         </tr>
                                         </thead>
                                         <tbody>
-                                        {loop type="order" name="order-list" customer="{$customer_id}" backend_context="1" status='*' page={$page} limit=10}
+                                        {loop type="order" name="order-list" customer="{$customer_id}" backend_context="1" status='*' page={$page_order} limit=10}
                                         {loop type="order-status" name="order-status" id=$STATUS}
                                         {assign "orderStatus" $TITLE}
                                         {assign "orderStatusLabel" "order_$CODE"}
@@ -325,6 +325,7 @@
                                                 loop_ref       = "order-list"
                                                 max_page_count = 10
                                                 page_url       = "{url path="/admin/customer/update" customer_id=$customer_id page=$page}"
+                                                page_param_name = "page_order"
                                                 }
                                             </td>
                                         </tr>


### PR DESCRIPTION
If you go on /admin/customers?page=2 and you visit a customer profile, the parameter page is still 2 and is used in the order loop.