### PR TITLE
Fix index form error information session cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The product parameter new $PRODUCT variable is deprecated. $PRODUCT_ID should be used instead.
 - Fix smarty `format_date` function to use consistent format when `locale` attribute is used.
 - A product and all it's dependencies can now be cloned
+- Fix index form error information session cleaning
 
 # 2.2.0-alpha2
 

--- a/core/lib/Thelia/Core/Template/ParserContext.php
+++ b/core/lib/Thelia/Core/Template/ParserContext.php
@@ -181,7 +181,7 @@ class ParserContext implements \IteratorAggregate
     {
         $formErrorInformation = $this->request->getSession()->getFormErrorInformation();
 
-        $formClass = get_class($form);
+        $formClass = get_class($form) . ':' . $form->getType();
 
         if (isset($formErrorInformation[$formClass])) {
             unset($formErrorInformation[$formClass]);


### PR DESCRIPTION
Add `:<formType>` to index to remove from session error form