### PR TITLE
Changed useless prod trace level to debug

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -428,7 +428,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
     public function buildModelCriteria()
     {
-        Tlog::getInstance()->addInfo("-- Starting new product build criteria");
+        Tlog::getInstance()->debug("-- Starting new product build criteria");
 
         $currencyId = $this->getCurrency();
         if (null !== $currencyId) {


### PR DESCRIPTION
This PR changes the level of an INFO trace to DEBUG, to prevent the log file to be saturated with endless useless messages : 

```
10: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
11: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
12: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
13: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
14: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
15: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
16: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
17: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
18: 2015-06-25 8:02:47 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
19: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
20: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
21: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
22: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
23: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
24: 2015-06-25 8:02:48 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
25: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
26: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
27: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
28: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
29: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
30: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
31: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
32: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
33: 2015-06-25 8:02:49 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
34: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
35: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
36: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
37: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
38: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
39: 2015-06-25 8:02:50 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
40: 2015-06-25 8:02:51 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
41: 2015-06-25 8:02:51 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
42: 2015-06-25 8:02:51 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
43: 2015-06-25 8:02:51 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
44: 2015-06-25 8:02:51 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
45: 2015-06-25 8:02:52 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria
46: 2015-06-25 8:02:52 : INFO [Product.php:buildModelCriteria()] {418} : -- Starting new product build criteria

ad nauseam
```

