### PR TITLE
Ability to remove arguments in a loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Feature's free text values now handle i18n
 - URLs now have no problem with accents or case
 - Add order by ```weight``` and ```weight_reverse``` in  product sale elements loop
+- Add the ability to remove arguments in loops.
 
 # 2.2.0-alpha2
 

--- a/core/lib/Thelia/Core/Template/Loop/Argument/ArgumentCollection.php
+++ b/core/lib/Thelia/Core/Template/Loop/Argument/ArgumentCollection.php
@@ -74,6 +74,34 @@ class ArgumentCollection implements \Iterator
         return $this;
     }
 
+    /**
+     * @param array $argumentNames Array with names of arguments to remove.
+     *
+     * @return ArgumentCollection
+     */
+    public function removeArguments(array $argumentNames)
+    {
+        foreach ($argumentNames as $argumentName) {
+            $this->removeArgument($argumentName);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $argumentName Name of the argument to remove.
+     *
+     * @return ArgumentCollection
+     */
+    public function removeArgument($argumentName)
+    {
+        if (isset($this->arguments[$argumentName])) {
+            unset($this->arguments[$argumentName]);
+        }
+
+        return $this;
+    }
+
     public function getCount()
     {
         return count($this->arguments);

--- a/core/lib/Thelia/Core/Template/Loop/Argument/ArgumentCollection.php
+++ b/core/lib/Thelia/Core/Template/Loop/Argument/ArgumentCollection.php
@@ -78,6 +78,7 @@ class ArgumentCollection implements \Iterator
      * @param array $argumentNames Array with names of arguments to remove.
      *
      * @return ArgumentCollection
+     * @since 2.2.0-beta1
      */
     public function removeArguments(array $argumentNames)
     {
@@ -92,6 +93,7 @@ class ArgumentCollection implements \Iterator
      * @param string $argumentName Name of the argument to remove.
      *
      * @return ArgumentCollection
+     * @since 2.2.0-beta1
      */
     public function removeArgument($argumentName)
     {


### PR DESCRIPTION
It is possible to add arguments for a loop but it is not possible to remove them, just like for forms. This PR enables Thelia to do such a thing.