### PR TITLE
WIP : Suggestion : Image, other sources

### DIFF
--- a/core/lib/Thelia/Model/Base/Image.php
+++ b/core/lib/Thelia/Model/Base/Image.php
@@ -1,0 +1,2137 @@
+<?php
+
+namespace Thelia\Model\Base;
+
+use \DateTime;
+use \Exception;
+use \PDO;
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\BadMethodCallException;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\TableMap;
+use Propel\Runtime\Parser\AbstractParser;
+use Propel\Runtime\Util\PropelDateTime;
+use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\DefaultTranslator;
+use Symfony\Component\Validator\Validator;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
+use Thelia\Model\Image as ChildImage;
+use Thelia\Model\ImageI18n as ChildImageI18n;
+use Thelia\Model\ImageI18nQuery as ChildImageI18nQuery;
+use Thelia\Model\ImageQuery as ChildImageQuery;
+use Thelia\Model\Map\ImageTableMap;
+
+abstract class Image implements ActiveRecordInterface
+{
+    /**
+     * TableMap class name
+     */
+    const TABLE_MAP = '\\Thelia\\Model\\Map\\ImageTableMap';
+
+
+    /**
+     * attribute to determine if this object has previously been saved.
+     * @var boolean
+     */
+    protected $new = true;
+
+    /**
+     * attribute to determine whether this object has been deleted.
+     * @var boolean
+     */
+    protected $deleted = false;
+
+    /**
+     * The columns that have been modified in current object.
+     * Tracking modified columns allows us to only update modified columns.
+     * @var array
+     */
+    protected $modifiedColumns = array();
+
+    /**
+     * The (virtual) columns that are added at runtime
+     * The formatters can add supplementary columns based on a resultset
+     * @var array
+     */
+    protected $virtualColumns = array();
+
+    /**
+     * The value for the id field.
+     * @var        int
+     */
+    protected $id;
+
+    /**
+     * The value for the source field.
+     * @var        string
+     */
+    protected $source;
+
+    /**
+     * The value for the source_id field.
+     * @var        int
+     */
+    protected $source_id;
+
+    /**
+     * The value for the file field.
+     * @var        string
+     */
+    protected $file;
+
+    /**
+     * The value for the visible field.
+     * Note: this column has a database default value of: 1
+     * @var        int
+     */
+    protected $visible;
+
+    /**
+     * The value for the position field.
+     * @var        int
+     */
+    protected $position;
+
+    /**
+     * The value for the created_at field.
+     * @var        string
+     */
+    protected $created_at;
+
+    /**
+     * The value for the updated_at field.
+     * @var        string
+     */
+    protected $updated_at;
+
+    /**
+     * @var        ObjectCollection|ChildImageI18n[] Collection to store aggregation of ChildImageI18n objects.
+     */
+    protected $collImageI18ns;
+    protected $collImageI18nsPartial;
+
+    /**
+     * Flag to prevent endless save loop, if this object is referenced
+     * by another object which falls in this transaction.
+     *
+     * @var boolean
+     */
+    protected $alreadyInSave = false;
+
+    // validate behavior
+
+    /**
+     * Flag to prevent endless validation loop, if this object is referenced
+     * by another object which falls in this transaction.
+     * @var        boolean
+     */
+    protected $alreadyInValidation = false;
+
+    /**
+     * ConstraintViolationList object
+     *
+     * @see     http://api.symfony.com/2.0/Symfony/Component/Validator/ConstraintViolationList.html
+     * @var     ConstraintViolationList
+     */
+    protected $validationFailures;
+
+    // i18n behavior
+
+    /**
+     * Current locale
+     * @var        string
+     */
+    protected $currentLocale = 'en_US';
+
+    /**
+     * Current translation objects
+     * @var        array[ChildImageI18n]
+     */
+    protected $currentTranslations;
+
+    /**
+     * An array of objects scheduled for deletion.
+     * @var ObjectCollection
+     */
+    protected $imageI18nsScheduledForDeletion = null;
+
+    /**
+     * Applies default values to this object.
+     * This method should be called from the object's constructor (or
+     * equivalent initialization method).
+     * @see __construct()
+     */
+    public function applyDefaultValues()
+    {
+        $this->visible = 1;
+    }
+
+    /**
+     * Initializes internal state of Thelia\Model\Base\Image object.
+     * @see applyDefaults()
+     */
+    public function __construct()
+    {
+        $this->applyDefaultValues();
+    }
+
+    /**
+     * Returns whether the object has been modified.
+     *
+     * @return boolean True if the object has been modified.
+     */
+    public function isModified()
+    {
+        return !!$this->modifiedColumns;
+    }
+
+    /**
+     * Has specified column been modified?
+     *
+     * @param  string  $col column fully qualified name (TableMap::TYPE_COLNAME), e.g. Book::AUTHOR_ID
+     * @return boolean True if $col has been modified.
+     */
+    public function isColumnModified($col)
+    {
+        return $this->modifiedColumns && isset($this->modifiedColumns[$col]);
+    }
+
+    /**
+     * Get the columns that have been modified in this object.
+     * @return array A unique list of the modified column names for this object.
+     */
+    public function getModifiedColumns()
+    {
+        return $this->modifiedColumns ? array_keys($this->modifiedColumns) : [];
+    }
+
+    /**
+     * Returns whether the object has ever been saved.  This will
+     * be false, if the object was retrieved from storage or was created
+     * and then saved.
+     *
+     * @return boolean true, if the object has never been persisted.
+     */
+    public function isNew()
+    {
+        return $this->new;
+    }
+
+    /**
+     * Setter for the isNew attribute.  This method will be called
+     * by Propel-generated children and objects.
+     *
+     * @param boolean $b the state of the object.
+     */
+    public function setNew($b)
+    {
+        $this->new = (Boolean) $b;
+    }
+
+    /**
+     * Whether this object has been deleted.
+     * @return boolean The deleted state of this object.
+     */
+    public function isDeleted()
+    {
+        return $this->deleted;
+    }
+
+    /**
+     * Specify whether this object has been deleted.
+     * @param  boolean $b The deleted state of this object.
+     * @return void
+     */
+    public function setDeleted($b)
+    {
+        $this->deleted = (Boolean) $b;
+    }
+
+    /**
+     * Sets the modified state for the object to be false.
+     * @param  string $col If supplied, only the specified column is reset.
+     * @return void
+     */
+    public function resetModified($col = null)
+    {
+        if (null !== $col) {
+            if (isset($this->modifiedColumns[$col])) {
+                unset($this->modifiedColumns[$col]);
+            }
+        } else {
+            $this->modifiedColumns = array();
+        }
+    }
+
+    /**
+     * Compares this with another <code>Image</code> instance.  If
+     * <code>obj</code> is an instance of <code>Image</code>, delegates to
+     * <code>equals(Image)</code>.  Otherwise, returns <code>false</code>.
+     *
+     * @param  mixed   $obj The object to compare to.
+     * @return boolean Whether equal to the object specified.
+     */
+    public function equals($obj)
+    {
+        $thisclazz = get_class($this);
+        if (!is_object($obj) || !($obj instanceof $thisclazz)) {
+            return false;
+        }
+
+        if ($this === $obj) {
+            return true;
+        }
+
+        if (null === $this->getPrimaryKey()
+            || null === $obj->getPrimaryKey())  {
+            return false;
+        }
+
+        return $this->getPrimaryKey() === $obj->getPrimaryKey();
+    }
+
+    /**
+     * If the primary key is not null, return the hashcode of the
+     * primary key. Otherwise, return the hash code of the object.
+     *
+     * @return int Hashcode
+     */
+    public function hashCode()
+    {
+        if (null !== $this->getPrimaryKey()) {
+            return crc32(serialize($this->getPrimaryKey()));
+        }
+
+        return crc32(serialize(clone $this));
+    }
+
+    /**
+     * Get the associative array of the virtual columns in this object
+     *
+     * @return array
+     */
+    public function getVirtualColumns()
+    {
+        return $this->virtualColumns;
+    }
+
+    /**
+     * Checks the existence of a virtual column in this object
+     *
+     * @param  string  $name The virtual column name
+     * @return boolean
+     */
+    public function hasVirtualColumn($name)
+    {
+        return array_key_exists($name, $this->virtualColumns);
+    }
+
+    /**
+     * Get the value of a virtual column in this object
+     *
+     * @param  string $name The virtual column name
+     * @return mixed
+     *
+     * @throws PropelException
+     */
+    public function getVirtualColumn($name)
+    {
+        if (!$this->hasVirtualColumn($name)) {
+            throw new PropelException(sprintf('Cannot get value of inexistent virtual column %s.', $name));
+        }
+
+        return $this->virtualColumns[$name];
+    }
+
+    /**
+     * Set the value of a virtual column in this object
+     *
+     * @param string $name  The virtual column name
+     * @param mixed  $value The value to give to the virtual column
+     *
+     * @return Image The current object, for fluid interface
+     */
+    public function setVirtualColumn($name, $value)
+    {
+        $this->virtualColumns[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Logs a message using Propel::log().
+     *
+     * @param  string  $msg
+     * @param  int     $priority One of the Propel::LOG_* logging levels
+     * @return boolean
+     */
+    protected function log($msg, $priority = Propel::LOG_INFO)
+    {
+        return Propel::log(get_class($this) . ': ' . $msg, $priority);
+    }
+
+    /**
+     * Populate the current object from a string, using a given parser format
+     * <code>
+     * $book = new Book();
+     * $book->importFrom('JSON', '{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678}');
+     * </code>
+     *
+     * @param mixed $parser A AbstractParser instance,
+     *                       or a format name ('XML', 'YAML', 'JSON', 'CSV')
+     * @param string $data The source data to import from
+     *
+     * @return Image The current object, for fluid interface
+     */
+    public function importFrom($parser, $data)
+    {
+        if (!$parser instanceof AbstractParser) {
+            $parser = AbstractParser::getParser($parser);
+        }
+
+        $this->fromArray($parser->toArray($data), TableMap::TYPE_PHPNAME);
+
+        return $this;
+    }
+
+    /**
+     * Export the current object properties to a string, using a given parser format
+     * <code>
+     * $book = BookQuery::create()->findPk(9012);
+     * echo $book->exportTo('JSON');
+     *  => {"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678}');
+     * </code>
+     *
+     * @param  mixed   $parser                 A AbstractParser instance, or a format name ('XML', 'YAML', 'JSON', 'CSV')
+     * @param  boolean $includeLazyLoadColumns (optional) Whether to include lazy load(ed) columns. Defaults to TRUE.
+     * @return string  The exported data
+     */
+    public function exportTo($parser, $includeLazyLoadColumns = true)
+    {
+        if (!$parser instanceof AbstractParser) {
+            $parser = AbstractParser::getParser($parser);
+        }
+
+        return $parser->fromArray($this->toArray(TableMap::TYPE_PHPNAME, $includeLazyLoadColumns, array(), true));
+    }
+
+    /**
+     * Clean up internal collections prior to serializing
+     * Avoids recursive loops that turn into segmentation faults when serializing
+     */
+    public function __sleep()
+    {
+        $this->clearAllReferences();
+
+        return array_keys(get_object_vars($this));
+    }
+
+    /**
+     * Get the [id] column value.
+     *
+     * @return   int
+     */
+    public function getId()
+    {
+
+        return $this->id;
+    }
+
+    /**
+     * Get the [source] column value.
+     *
+     * @return   string
+     */
+    public function getSource()
+    {
+
+        return $this->source;
+    }
+
+    /**
+     * Get the [source_id] column value.
+     *
+     * @return   int
+     */
+    public function getSourceId()
+    {
+
+        return $this->source_id;
+    }
+
+    /**
+     * Get the [file] column value.
+     *
+     * @return   string
+     */
+    public function getFile()
+    {
+
+        return $this->file;
+    }
+
+    /**
+     * Get the [visible] column value.
+     *
+     * @return   int
+     */
+    public function getVisible()
+    {
+
+        return $this->visible;
+    }
+
+    /**
+     * Get the [position] column value.
+     *
+     * @return   int
+     */
+    public function getPosition()
+    {
+
+        return $this->position;
+    }
+
+    /**
+     * Get the [optionally formatted] temporal [created_at] column value.
+     *
+     *
+     * @param      string $format The date/time format string (either date()-style or strftime()-style).
+     *                            If format is NULL, then the raw \DateTime object will be returned.
+     *
+     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
+     *
+     * @throws PropelException - if unable to parse/validate the date/time value.
+     */
+    public function getCreatedAt($format = NULL)
+    {
+        if ($format === null) {
+            return $this->created_at;
+        } else {
+            return $this->created_at instanceof \DateTime ? $this->created_at->format($format) : null;
+        }
+    }
+
+    /**
+     * Get the [optionally formatted] temporal [updated_at] column value.
+     *
+     *
+     * @param      string $format The date/time format string (either date()-style or strftime()-style).
+     *                            If format is NULL, then the raw \DateTime object will be returned.
+     *
+     * @return mixed Formatted date/time value as string or \DateTime object (if format is NULL), NULL if column is NULL, and 0 if column value is 0000-00-00 00:00:00
+     *
+     * @throws PropelException - if unable to parse/validate the date/time value.
+     */
+    public function getUpdatedAt($format = NULL)
+    {
+        if ($format === null) {
+            return $this->updated_at;
+        } else {
+            return $this->updated_at instanceof \DateTime ? $this->updated_at->format($format) : null;
+        }
+    }
+
+    /**
+     * Set the value of [id] column.
+     *
+     * @param      int $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->id !== $v) {
+            $this->id = $v;
+            $this->modifiedColumns[ImageTableMap::ID] = true;
+        }
+
+
+        return $this;
+    } // setId()
+
+    /**
+     * Set the value of [source] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setSource($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->source !== $v) {
+            $this->source = $v;
+            $this->modifiedColumns[ImageTableMap::SOURCE] = true;
+        }
+
+
+        return $this;
+    } // setSource()
+
+    /**
+     * Set the value of [source_id] column.
+     *
+     * @param      int $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setSourceId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->source_id !== $v) {
+            $this->source_id = $v;
+            $this->modifiedColumns[ImageTableMap::SOURCE_ID] = true;
+        }
+
+
+        return $this;
+    } // setSourceId()
+
+    /**
+     * Set the value of [file] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setFile($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->file !== $v) {
+            $this->file = $v;
+            $this->modifiedColumns[ImageTableMap::FILE] = true;
+        }
+
+
+        return $this;
+    } // setFile()
+
+    /**
+     * Set the value of [visible] column.
+     *
+     * @param      int $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setVisible($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->visible !== $v) {
+            $this->visible = $v;
+            $this->modifiedColumns[ImageTableMap::VISIBLE] = true;
+        }
+
+
+        return $this;
+    } // setVisible()
+
+    /**
+     * Set the value of [position] column.
+     *
+     * @param      int $v new value
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setPosition($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->position !== $v) {
+            $this->position = $v;
+            $this->modifiedColumns[ImageTableMap::POSITION] = true;
+        }
+
+
+        return $this;
+    } // setPosition()
+
+    /**
+     * Sets the value of [created_at] column to a normalized version of the date/time value specified.
+     *
+     * @param      mixed $v string, integer (timestamp), or \DateTime value.
+     *               Empty strings are treated as NULL.
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setCreatedAt($v)
+    {
+        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
+        if ($this->created_at !== null || $dt !== null) {
+            if ($dt !== $this->created_at) {
+                $this->created_at = $dt;
+                $this->modifiedColumns[ImageTableMap::CREATED_AT] = true;
+            }
+        } // if either are not null
+
+
+        return $this;
+    } // setCreatedAt()
+
+    /**
+     * Sets the value of [updated_at] column to a normalized version of the date/time value specified.
+     *
+     * @param      mixed $v string, integer (timestamp), or \DateTime value.
+     *               Empty strings are treated as NULL.
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function setUpdatedAt($v)
+    {
+        $dt = PropelDateTime::newInstance($v, null, '\DateTime');
+        if ($this->updated_at !== null || $dt !== null) {
+            if ($dt !== $this->updated_at) {
+                $this->updated_at = $dt;
+                $this->modifiedColumns[ImageTableMap::UPDATED_AT] = true;
+            }
+        } // if either are not null
+
+
+        return $this;
+    } // setUpdatedAt()
+
+    /**
+     * Indicates whether the columns in this object are only set to default values.
+     *
+     * This method can be used in conjunction with isModified() to indicate whether an object is both
+     * modified _and_ has some values set which are non-default.
+     *
+     * @return boolean Whether the columns in this object are only been set with default values.
+     */
+    public function hasOnlyDefaultValues()
+    {
+            if ($this->visible !== 1) {
+                return false;
+            }
+
+        // otherwise, everything was equal, so return TRUE
+        return true;
+    } // hasOnlyDefaultValues()
+
+    /**
+     * Hydrates (populates) the object variables with values from the database resultset.
+     *
+     * An offset (0-based "start column") is specified so that objects can be hydrated
+     * with a subset of the columns in the resultset rows.  This is needed, for example,
+     * for results of JOIN queries where the resultset row includes columns from two or
+     * more tables.
+     *
+     * @param array   $row       The row returned by DataFetcher->fetch().
+     * @param int     $startcol  0-based offset column which indicates which restultset column to start with.
+     * @param boolean $rehydrate Whether this object is being re-hydrated from the database.
+     * @param string  $indexType The index type of $row. Mostly DataFetcher->getIndexType().
+                                  One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                            TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *
+     * @return int             next starting column
+     * @throws PropelException - Any caught Exception will be rewrapped as a PropelException.
+     */
+    public function hydrate($row, $startcol = 0, $rehydrate = false, $indexType = TableMap::TYPE_NUM)
+    {
+        try {
+
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : ImageTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : ImageTableMap::translateFieldName('Source', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->source = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : ImageTableMap::translateFieldName('SourceId', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->source_id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : ImageTableMap::translateFieldName('File', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->file = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : ImageTableMap::translateFieldName('Visible', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->visible = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : ImageTableMap::translateFieldName('Position', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->position = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : ImageTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            if ($col === '0000-00-00 00:00:00') {
+                $col = null;
+            }
+            $this->created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : ImageTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            if ($col === '0000-00-00 00:00:00') {
+                $col = null;
+            }
+            $this->updated_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
+            $this->resetModified();
+
+            $this->setNew(false);
+
+            if ($rehydrate) {
+                $this->ensureConsistency();
+            }
+
+            return $startcol + 8; // 8 = ImageTableMap::NUM_HYDRATE_COLUMNS.
+
+        } catch (Exception $e) {
+            throw new PropelException("Error populating \Thelia\Model\Image object", 0, $e);
+        }
+    }
+
+    /**
+     * Checks and repairs the internal consistency of the object.
+     *
+     * This method is executed after an already-instantiated object is re-hydrated
+     * from the database.  It exists to check any foreign keys to make sure that
+     * the objects related to the current object are correct based on foreign key.
+     *
+     * You can override this method in the stub class, but you should always invoke
+     * the base method from the overridden method (i.e. parent::ensureConsistency()),
+     * in case your model changes.
+     *
+     * @throws PropelException
+     */
+    public function ensureConsistency()
+    {
+    } // ensureConsistency
+
+    /**
+     * Reloads this object from datastore based on primary key and (optionally) resets all associated objects.
+     *
+     * This will only work if the object has been saved and has a valid primary key set.
+     *
+     * @param      boolean $deep (optional) Whether to also de-associated any related objects.
+     * @param      ConnectionInterface $con (optional) The ConnectionInterface connection to use.
+     * @return void
+     * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
+     */
+    public function reload($deep = false, ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("Cannot reload a deleted object.");
+        }
+
+        if ($this->isNew()) {
+            throw new PropelException("Cannot reload an unsaved object.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getReadConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        // We don't need to alter the object instance pool; we're just modifying this instance
+        // already in the pool.
+
+        $dataFetcher = ChildImageQuery::create(null, $this->buildPkeyCriteria())->setFormatter(ModelCriteria::FORMAT_STATEMENT)->find($con);
+        $row = $dataFetcher->fetch();
+        $dataFetcher->close();
+        if (!$row) {
+            throw new PropelException('Cannot find matching row in the database to reload object values.');
+        }
+        $this->hydrate($row, 0, true, $dataFetcher->getIndexType()); // rehydrate
+
+        if ($deep) {  // also de-associate any related objects?
+
+            $this->collImageI18ns = null;
+
+        } // if (deep)
+    }
+
+    /**
+     * Removes this object from datastore and sets delete attribute.
+     *
+     * @param      ConnectionInterface $con
+     * @return void
+     * @throws PropelException
+     * @see Image::setDeleted()
+     * @see Image::isDeleted()
+     */
+    public function delete(ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("This object has already been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        $con->beginTransaction();
+        try {
+            $deleteQuery = ChildImageQuery::create()
+                ->filterByPrimaryKey($this->getPrimaryKey());
+            $ret = $this->preDelete($con);
+            if ($ret) {
+                $deleteQuery->delete($con);
+                $this->postDelete($con);
+                $con->commit();
+                $this->setDeleted(true);
+            } else {
+                $con->commit();
+            }
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Persists this object to the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All modified related objects will also be persisted in the doSave()
+     * method.  This method wraps all precipitate database operations in a
+     * single transaction.
+     *
+     * @param      ConnectionInterface $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @see doSave()
+     */
+    public function save(ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("You cannot save an object that has been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        $con->beginTransaction();
+        $isInsert = $this->isNew();
+        try {
+            $ret = $this->preSave($con);
+            if ($isInsert) {
+                $ret = $ret && $this->preInsert($con);
+                // timestampable behavior
+                if (!$this->isColumnModified(ImageTableMap::CREATED_AT)) {
+                    $this->setCreatedAt(time());
+                }
+                if (!$this->isColumnModified(ImageTableMap::UPDATED_AT)) {
+                    $this->setUpdatedAt(time());
+                }
+            } else {
+                $ret = $ret && $this->preUpdate($con);
+                // timestampable behavior
+                if ($this->isModified() && !$this->isColumnModified(ImageTableMap::UPDATED_AT)) {
+                    $this->setUpdatedAt(time());
+                }
+            }
+            if ($ret) {
+                $affectedRows = $this->doSave($con);
+                if ($isInsert) {
+                    $this->postInsert($con);
+                } else {
+                    $this->postUpdate($con);
+                }
+                $this->postSave($con);
+                ImageTableMap::addInstanceToPool($this);
+            } else {
+                $affectedRows = 0;
+            }
+            $con->commit();
+
+            return $affectedRows;
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Performs the work of inserting or updating the row in the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All related objects are also updated in this method.
+     *
+     * @param      ConnectionInterface $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @see save()
+     */
+    protected function doSave(ConnectionInterface $con)
+    {
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        if (!$this->alreadyInSave) {
+            $this->alreadyInSave = true;
+
+            if ($this->isNew() || $this->isModified()) {
+                // persist changes
+                if ($this->isNew()) {
+                    $this->doInsert($con);
+                } else {
+                    $this->doUpdate($con);
+                }
+                $affectedRows += 1;
+                $this->resetModified();
+            }
+
+            if ($this->imageI18nsScheduledForDeletion !== null) {
+                if (!$this->imageI18nsScheduledForDeletion->isEmpty()) {
+                    \Thelia\Model\ImageI18nQuery::create()
+                        ->filterByPrimaryKeys($this->imageI18nsScheduledForDeletion->getPrimaryKeys(false))
+                        ->delete($con);
+                    $this->imageI18nsScheduledForDeletion = null;
+                }
+            }
+
+                if ($this->collImageI18ns !== null) {
+            foreach ($this->collImageI18ns as $referrerFK) {
+                    if (!$referrerFK->isDeleted() && ($referrerFK->isNew() || $referrerFK->isModified())) {
+                        $affectedRows += $referrerFK->save($con);
+                    }
+                }
+            }
+
+            $this->alreadyInSave = false;
+
+        }
+
+        return $affectedRows;
+    } // doSave()
+
+    /**
+     * Insert the row in the database.
+     *
+     * @param      ConnectionInterface $con
+     *
+     * @throws PropelException
+     * @see doSave()
+     */
+    protected function doInsert(ConnectionInterface $con)
+    {
+        $modifiedColumns = array();
+        $index = 0;
+
+        $this->modifiedColumns[ImageTableMap::ID] = true;
+        if (null !== $this->id) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key (' . ImageTableMap::ID . ')');
+        }
+
+         // check the columns in natural order for more readable SQL queries
+        if ($this->isColumnModified(ImageTableMap::ID)) {
+            $modifiedColumns[':p' . $index++]  = '`ID`';
+        }
+        if ($this->isColumnModified(ImageTableMap::SOURCE)) {
+            $modifiedColumns[':p' . $index++]  = '`SOURCE`';
+        }
+        if ($this->isColumnModified(ImageTableMap::SOURCE_ID)) {
+            $modifiedColumns[':p' . $index++]  = '`SOURCE_ID`';
+        }
+        if ($this->isColumnModified(ImageTableMap::FILE)) {
+            $modifiedColumns[':p' . $index++]  = '`FILE`';
+        }
+        if ($this->isColumnModified(ImageTableMap::VISIBLE)) {
+            $modifiedColumns[':p' . $index++]  = '`VISIBLE`';
+        }
+        if ($this->isColumnModified(ImageTableMap::POSITION)) {
+            $modifiedColumns[':p' . $index++]  = '`POSITION`';
+        }
+        if ($this->isColumnModified(ImageTableMap::CREATED_AT)) {
+            $modifiedColumns[':p' . $index++]  = '`CREATED_AT`';
+        }
+        if ($this->isColumnModified(ImageTableMap::UPDATED_AT)) {
+            $modifiedColumns[':p' . $index++]  = '`UPDATED_AT`';
+        }
+
+        $sql = sprintf(
+            'INSERT INTO `image` (%s) VALUES (%s)',
+            implode(', ', $modifiedColumns),
+            implode(', ', array_keys($modifiedColumns))
+        );
+
+        try {
+            $stmt = $con->prepare($sql);
+            foreach ($modifiedColumns as $identifier => $columnName) {
+                switch ($columnName) {
+                    case '`ID`':
+                        $stmt->bindValue($identifier, $this->id, PDO::PARAM_INT);
+                        break;
+                    case '`SOURCE`':
+                        $stmt->bindValue($identifier, $this->source, PDO::PARAM_STR);
+                        break;
+                    case '`SOURCE_ID`':
+                        $stmt->bindValue($identifier, $this->source_id, PDO::PARAM_INT);
+                        break;
+                    case '`FILE`':
+                        $stmt->bindValue($identifier, $this->file, PDO::PARAM_STR);
+                        break;
+                    case '`VISIBLE`':
+                        $stmt->bindValue($identifier, $this->visible, PDO::PARAM_INT);
+                        break;
+                    case '`POSITION`':
+                        $stmt->bindValue($identifier, $this->position, PDO::PARAM_INT);
+                        break;
+                    case '`CREATED_AT`':
+                        $stmt->bindValue($identifier, $this->created_at ? $this->created_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
+                        break;
+                    case '`UPDATED_AT`':
+                        $stmt->bindValue($identifier, $this->updated_at ? $this->updated_at->format("Y-m-d H:i:s") : null, PDO::PARAM_STR);
+                        break;
+                }
+            }
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute INSERT statement [%s]', $sql), 0, $e);
+        }
+
+        try {
+            $pk = $con->lastInsertId();
+        } catch (Exception $e) {
+            throw new PropelException('Unable to get autoincrement id.', 0, $e);
+        }
+        $this->setId($pk);
+
+        $this->setNew(false);
+    }
+
+    /**
+     * Update the row in the database.
+     *
+     * @param      ConnectionInterface $con
+     *
+     * @return Integer Number of updated rows
+     * @see doSave()
+     */
+    protected function doUpdate(ConnectionInterface $con)
+    {
+        $selectCriteria = $this->buildPkeyCriteria();
+        $valuesCriteria = $this->buildCriteria();
+
+        return $selectCriteria->doUpdate($valuesCriteria, $con);
+    }
+
+    /**
+     * Retrieves a field from the object by name passed in as a string.
+     *
+     * @param      string $name name
+     * @param      string $type The type of fieldname the $name is of:
+     *                     one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                     TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                     Defaults to TableMap::TYPE_PHPNAME.
+     * @return mixed Value of field.
+     */
+    public function getByName($name, $type = TableMap::TYPE_PHPNAME)
+    {
+        $pos = ImageTableMap::translateFieldName($name, $type, TableMap::TYPE_NUM);
+        $field = $this->getByPosition($pos);
+
+        return $field;
+    }
+
+    /**
+     * Retrieves a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param      int $pos position in xml schema
+     * @return mixed Value of field at $pos
+     */
+    public function getByPosition($pos)
+    {
+        switch ($pos) {
+            case 0:
+                return $this->getId();
+                break;
+            case 1:
+                return $this->getSource();
+                break;
+            case 2:
+                return $this->getSourceId();
+                break;
+            case 3:
+                return $this->getFile();
+                break;
+            case 4:
+                return $this->getVisible();
+                break;
+            case 5:
+                return $this->getPosition();
+                break;
+            case 6:
+                return $this->getCreatedAt();
+                break;
+            case 7:
+                return $this->getUpdatedAt();
+                break;
+            default:
+                return null;
+                break;
+        } // switch()
+    }
+
+    /**
+     * Exports the object as an array.
+     *
+     * You can specify the key type of the array by passing one of the class
+     * type constants.
+     *
+     * @param     string  $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME,
+     *                    TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                    Defaults to TableMap::TYPE_PHPNAME.
+     * @param     boolean $includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
+     * @param     array $alreadyDumpedObjects List of objects to skip to avoid recursion
+     * @param     boolean $includeForeignObjects (optional) Whether to include hydrated related objects. Default to FALSE.
+     *
+     * @return array an associative array containing the field names (as keys) and field values
+     */
+    public function toArray($keyType = TableMap::TYPE_PHPNAME, $includeLazyLoadColumns = true, $alreadyDumpedObjects = array(), $includeForeignObjects = false)
+    {
+        if (isset($alreadyDumpedObjects['Image'][$this->getPrimaryKey()])) {
+            return '*RECURSION*';
+        }
+        $alreadyDumpedObjects['Image'][$this->getPrimaryKey()] = true;
+        $keys = ImageTableMap::getFieldNames($keyType);
+        $result = array(
+            $keys[0] => $this->getId(),
+            $keys[1] => $this->getSource(),
+            $keys[2] => $this->getSourceId(),
+            $keys[3] => $this->getFile(),
+            $keys[4] => $this->getVisible(),
+            $keys[5] => $this->getPosition(),
+            $keys[6] => $this->getCreatedAt(),
+            $keys[7] => $this->getUpdatedAt(),
+        );
+        $virtualColumns = $this->virtualColumns;
+        foreach ($virtualColumns as $key => $virtualColumn) {
+            $result[$key] = $virtualColumn;
+        }
+
+        if ($includeForeignObjects) {
+            if (null !== $this->collImageI18ns) {
+                $result['ImageI18ns'] = $this->collImageI18ns->toArray(null, true, $keyType, $includeLazyLoadColumns, $alreadyDumpedObjects);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sets a field from the object by name passed in as a string.
+     *
+     * @param      string $name
+     * @param      mixed  $value field value
+     * @param      string $type The type of fieldname the $name is of:
+     *                     one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                     TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                     Defaults to TableMap::TYPE_PHPNAME.
+     * @return void
+     */
+    public function setByName($name, $value, $type = TableMap::TYPE_PHPNAME)
+    {
+        $pos = ImageTableMap::translateFieldName($name, $type, TableMap::TYPE_NUM);
+
+        return $this->setByPosition($pos, $value);
+    }
+
+    /**
+     * Sets a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param      int $pos position in xml schema
+     * @param      mixed $value field value
+     * @return void
+     */
+    public function setByPosition($pos, $value)
+    {
+        switch ($pos) {
+            case 0:
+                $this->setId($value);
+                break;
+            case 1:
+                $this->setSource($value);
+                break;
+            case 2:
+                $this->setSourceId($value);
+                break;
+            case 3:
+                $this->setFile($value);
+                break;
+            case 4:
+                $this->setVisible($value);
+                break;
+            case 5:
+                $this->setPosition($value);
+                break;
+            case 6:
+                $this->setCreatedAt($value);
+                break;
+            case 7:
+                $this->setUpdatedAt($value);
+                break;
+        } // switch()
+    }
+
+    /**
+     * Populates the object using an array.
+     *
+     * This is particularly useful when populating an object from one of the
+     * request arrays (e.g. $_POST).  This method goes through the column
+     * names, checking to see whether a matching key exists in populated
+     * array. If so the setByName() method is called for that column.
+     *
+     * You can specify the key type of the array by additionally passing one
+     * of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME,
+     * TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     * The default key type is the column's TableMap::TYPE_PHPNAME.
+     *
+     * @param      array  $arr     An array to populate the object from.
+     * @param      string $keyType The type of keys the array uses.
+     * @return void
+     */
+    public function fromArray($arr, $keyType = TableMap::TYPE_PHPNAME)
+    {
+        $keys = ImageTableMap::getFieldNames($keyType);
+
+        if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
+        if (array_key_exists($keys[1], $arr)) $this->setSource($arr[$keys[1]]);
+        if (array_key_exists($keys[2], $arr)) $this->setSourceId($arr[$keys[2]]);
+        if (array_key_exists($keys[3], $arr)) $this->setFile($arr[$keys[3]]);
+        if (array_key_exists($keys[4], $arr)) $this->setVisible($arr[$keys[4]]);
+        if (array_key_exists($keys[5], $arr)) $this->setPosition($arr[$keys[5]]);
+        if (array_key_exists($keys[6], $arr)) $this->setCreatedAt($arr[$keys[6]]);
+        if (array_key_exists($keys[7], $arr)) $this->setUpdatedAt($arr[$keys[7]]);
+    }
+
+    /**
+     * Build a Criteria object containing the values of all modified columns in this object.
+     *
+     * @return Criteria The Criteria object containing all modified values.
+     */
+    public function buildCriteria()
+    {
+        $criteria = new Criteria(ImageTableMap::DATABASE_NAME);
+
+        if ($this->isColumnModified(ImageTableMap::ID)) $criteria->add(ImageTableMap::ID, $this->id);
+        if ($this->isColumnModified(ImageTableMap::SOURCE)) $criteria->add(ImageTableMap::SOURCE, $this->source);
+        if ($this->isColumnModified(ImageTableMap::SOURCE_ID)) $criteria->add(ImageTableMap::SOURCE_ID, $this->source_id);
+        if ($this->isColumnModified(ImageTableMap::FILE)) $criteria->add(ImageTableMap::FILE, $this->file);
+        if ($this->isColumnModified(ImageTableMap::VISIBLE)) $criteria->add(ImageTableMap::VISIBLE, $this->visible);
+        if ($this->isColumnModified(ImageTableMap::POSITION)) $criteria->add(ImageTableMap::POSITION, $this->position);
+        if ($this->isColumnModified(ImageTableMap::CREATED_AT)) $criteria->add(ImageTableMap::CREATED_AT, $this->created_at);
+        if ($this->isColumnModified(ImageTableMap::UPDATED_AT)) $criteria->add(ImageTableMap::UPDATED_AT, $this->updated_at);
+
+        return $criteria;
+    }
+
+    /**
+     * Builds a Criteria object containing the primary key for this object.
+     *
+     * Unlike buildCriteria() this method includes the primary key values regardless
+     * of whether or not they have been modified.
+     *
+     * @return Criteria The Criteria object containing value(s) for primary key(s).
+     */
+    public function buildPkeyCriteria()
+    {
+        $criteria = new Criteria(ImageTableMap::DATABASE_NAME);
+        $criteria->add(ImageTableMap::ID, $this->id);
+
+        return $criteria;
+    }
+
+    /**
+     * Returns the primary key for this object (row).
+     * @return   int
+     */
+    public function getPrimaryKey()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * Generic method to set the primary key (id column).
+     *
+     * @param       int $key Primary key.
+     * @return void
+     */
+    public function setPrimaryKey($key)
+    {
+        $this->setId($key);
+    }
+
+    /**
+     * Returns true if the primary key for this object is null.
+     * @return boolean
+     */
+    public function isPrimaryKeyNull()
+    {
+
+        return null === $this->getId();
+    }
+
+    /**
+     * Sets contents of passed object to values from current object.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param      object $copyObj An object of \Thelia\Model\Image (or compatible) type.
+     * @param      boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @param      boolean $makeNew Whether to reset autoincrement PKs and make the object new.
+     * @throws PropelException
+     */
+    public function copyInto($copyObj, $deepCopy = false, $makeNew = true)
+    {
+        $copyObj->setSource($this->getSource());
+        $copyObj->setSourceId($this->getSourceId());
+        $copyObj->setFile($this->getFile());
+        $copyObj->setVisible($this->getVisible());
+        $copyObj->setPosition($this->getPosition());
+        $copyObj->setCreatedAt($this->getCreatedAt());
+        $copyObj->setUpdatedAt($this->getUpdatedAt());
+
+        if ($deepCopy) {
+            // important: temporarily setNew(false) because this affects the behavior of
+            // the getter/setter methods for fkey referrer objects.
+            $copyObj->setNew(false);
+
+            foreach ($this->getImageI18ns() as $relObj) {
+                if ($relObj !== $this) {  // ensure that we don't try to copy a reference to ourselves
+                    $copyObj->addImageI18n($relObj->copy($deepCopy));
+                }
+            }
+
+        } // if ($deepCopy)
+
+        if ($makeNew) {
+            $copyObj->setNew(true);
+            $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
+        }
+    }
+
+    /**
+     * Makes a copy of this object that will be inserted as a new row in table when saved.
+     * It creates a new object filling in the simple attributes, but skipping any primary
+     * keys that are defined for the table.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param      boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @return                 \Thelia\Model\Image Clone of current object.
+     * @throws PropelException
+     */
+    public function copy($deepCopy = false)
+    {
+        // we use get_class(), because this might be a subclass
+        $clazz = get_class($this);
+        $copyObj = new $clazz();
+        $this->copyInto($copyObj, $deepCopy);
+
+        return $copyObj;
+    }
+
+
+    /**
+     * Initializes a collection based on the name of a relation.
+     * Avoids crafting an 'init[$relationName]s' method name
+     * that wouldn't work when StandardEnglishPluralizer is used.
+     *
+     * @param      string $relationName The name of the relation to initialize
+     * @return void
+     */
+    public function initRelation($relationName)
+    {
+        if ('ImageI18n' == $relationName) {
+            return $this->initImageI18ns();
+        }
+    }
+
+    /**
+     * Clears out the collImageI18ns collection
+     *
+     * This does not modify the database; however, it will remove any associated objects, causing
+     * them to be refetched by subsequent calls to accessor method.
+     *
+     * @return void
+     * @see        addImageI18ns()
+     */
+    public function clearImageI18ns()
+    {
+        $this->collImageI18ns = null; // important to set this to NULL since that means it is uninitialized
+    }
+
+    /**
+     * Reset is the collImageI18ns collection loaded partially.
+     */
+    public function resetPartialImageI18ns($v = true)
+    {
+        $this->collImageI18nsPartial = $v;
+    }
+
+    /**
+     * Initializes the collImageI18ns collection.
+     *
+     * By default this just sets the collImageI18ns collection to an empty array (like clearcollImageI18ns());
+     * however, you may wish to override this method in your stub class to provide setting appropriate
+     * to your application -- for example, setting the initial array to the values stored in database.
+     *
+     * @param      boolean $overrideExisting If set to true, the method call initializes
+     *                                        the collection even if it is not empty
+     *
+     * @return void
+     */
+    public function initImageI18ns($overrideExisting = true)
+    {
+        if (null !== $this->collImageI18ns && !$overrideExisting) {
+            return;
+        }
+        $this->collImageI18ns = new ObjectCollection();
+        $this->collImageI18ns->setModel('\Thelia\Model\ImageI18n');
+    }
+
+    /**
+     * Gets an array of ChildImageI18n objects which contain a foreign key that references this object.
+     *
+     * If the $criteria is not null, it is used to always fetch the results from the database.
+     * Otherwise the results are fetched from the database the first time, then cached.
+     * Next time the same method is called without $criteria, the cached collection is returned.
+     * If this ChildImage is new, it will return
+     * an empty collection or the current collection; the criteria is ignored on a new object.
+     *
+     * @param      Criteria $criteria optional Criteria object to narrow the query
+     * @param      ConnectionInterface $con optional connection object
+     * @return Collection|ChildImageI18n[] List of ChildImageI18n objects
+     * @throws PropelException
+     */
+    public function getImageI18ns($criteria = null, ConnectionInterface $con = null)
+    {
+        $partial = $this->collImageI18nsPartial && !$this->isNew();
+        if (null === $this->collImageI18ns || null !== $criteria  || $partial) {
+            if ($this->isNew() && null === $this->collImageI18ns) {
+                // return empty collection
+                $this->initImageI18ns();
+            } else {
+                $collImageI18ns = ChildImageI18nQuery::create(null, $criteria)
+                    ->filterByImage($this)
+                    ->find($con);
+
+                if (null !== $criteria) {
+                    if (false !== $this->collImageI18nsPartial && count($collImageI18ns)) {
+                        $this->initImageI18ns(false);
+
+                        foreach ($collImageI18ns as $obj) {
+                            if (false == $this->collImageI18ns->contains($obj)) {
+                                $this->collImageI18ns->append($obj);
+                            }
+                        }
+
+                        $this->collImageI18nsPartial = true;
+                    }
+
+                    reset($collImageI18ns);
+
+                    return $collImageI18ns;
+                }
+
+                if ($partial && $this->collImageI18ns) {
+                    foreach ($this->collImageI18ns as $obj) {
+                        if ($obj->isNew()) {
+                            $collImageI18ns[] = $obj;
+                        }
+                    }
+                }
+
+                $this->collImageI18ns = $collImageI18ns;
+                $this->collImageI18nsPartial = false;
+            }
+        }
+
+        return $this->collImageI18ns;
+    }
+
+    /**
+     * Sets a collection of ImageI18n objects related by a one-to-many relationship
+     * to the current object.
+     * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
+     * and new objects from the given Propel collection.
+     *
+     * @param      Collection $imageI18ns A Propel collection.
+     * @param      ConnectionInterface $con Optional connection object
+     * @return   ChildImage The current object (for fluent API support)
+     */
+    public function setImageI18ns(Collection $imageI18ns, ConnectionInterface $con = null)
+    {
+        $imageI18nsToDelete = $this->getImageI18ns(new Criteria(), $con)->diff($imageI18ns);
+
+
+        //since at least one column in the foreign key is at the same time a PK
+        //we can not just set a PK to NULL in the lines below. We have to store
+        //a backup of all values, so we are able to manipulate these items based on the onDelete value later.
+        $this->imageI18nsScheduledForDeletion = clone $imageI18nsToDelete;
+
+        foreach ($imageI18nsToDelete as $imageI18nRemoved) {
+            $imageI18nRemoved->setImage(null);
+        }
+
+        $this->collImageI18ns = null;
+        foreach ($imageI18ns as $imageI18n) {
+            $this->addImageI18n($imageI18n);
+        }
+
+        $this->collImageI18ns = $imageI18ns;
+        $this->collImageI18nsPartial = false;
+
+        return $this;
+    }
+
+    /**
+     * Returns the number of related ImageI18n objects.
+     *
+     * @param      Criteria $criteria
+     * @param      boolean $distinct
+     * @param      ConnectionInterface $con
+     * @return int             Count of related ImageI18n objects.
+     * @throws PropelException
+     */
+    public function countImageI18ns(Criteria $criteria = null, $distinct = false, ConnectionInterface $con = null)
+    {
+        $partial = $this->collImageI18nsPartial && !$this->isNew();
+        if (null === $this->collImageI18ns || null !== $criteria || $partial) {
+            if ($this->isNew() && null === $this->collImageI18ns) {
+                return 0;
+            }
+
+            if ($partial && !$criteria) {
+                return count($this->getImageI18ns());
+            }
+
+            $query = ChildImageI18nQuery::create(null, $criteria);
+            if ($distinct) {
+                $query->distinct();
+            }
+
+            return $query
+                ->filterByImage($this)
+                ->count($con);
+        }
+
+        return count($this->collImageI18ns);
+    }
+
+    /**
+     * Method called to associate a ChildImageI18n object to this object
+     * through the ChildImageI18n foreign key attribute.
+     *
+     * @param    ChildImageI18n $l ChildImageI18n
+     * @return   \Thelia\Model\Image The current object (for fluent API support)
+     */
+    public function addImageI18n(ChildImageI18n $l)
+    {
+        if ($l && $locale = $l->getLocale()) {
+            $this->setLocale($locale);
+            $this->currentTranslations[$locale] = $l;
+        }
+        if ($this->collImageI18ns === null) {
+            $this->initImageI18ns();
+            $this->collImageI18nsPartial = true;
+        }
+
+        if (!in_array($l, $this->collImageI18ns->getArrayCopy(), true)) { // only add it if the **same** object is not already associated
+            $this->doAddImageI18n($l);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param ImageI18n $imageI18n The imageI18n object to add.
+     */
+    protected function doAddImageI18n($imageI18n)
+    {
+        $this->collImageI18ns[]= $imageI18n;
+        $imageI18n->setImage($this);
+    }
+
+    /**
+     * @param  ImageI18n $imageI18n The imageI18n object to remove.
+     * @return ChildImage The current object (for fluent API support)
+     */
+    public function removeImageI18n($imageI18n)
+    {
+        if ($this->getImageI18ns()->contains($imageI18n)) {
+            $this->collImageI18ns->remove($this->collImageI18ns->search($imageI18n));
+            if (null === $this->imageI18nsScheduledForDeletion) {
+                $this->imageI18nsScheduledForDeletion = clone $this->collImageI18ns;
+                $this->imageI18nsScheduledForDeletion->clear();
+            }
+            $this->imageI18nsScheduledForDeletion[]= clone $imageI18n;
+            $imageI18n->setImage(null);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clears the current object and sets all attributes to their default values
+     */
+    public function clear()
+    {
+        $this->id = null;
+        $this->source = null;
+        $this->source_id = null;
+        $this->file = null;
+        $this->visible = null;
+        $this->position = null;
+        $this->created_at = null;
+        $this->updated_at = null;
+        $this->alreadyInSave = false;
+        $this->clearAllReferences();
+        $this->applyDefaultValues();
+        $this->resetModified();
+        $this->setNew(true);
+        $this->setDeleted(false);
+    }
+
+    /**
+     * Resets all references to other model objects or collections of model objects.
+     *
+     * This method is a user-space workaround for PHP's inability to garbage collect
+     * objects with circular references (even in PHP 5.3). This is currently necessary
+     * when using Propel in certain daemon or large-volume/high-memory operations.
+     *
+     * @param      boolean $deep Whether to also clear the references on all referrer objects.
+     */
+    public function clearAllReferences($deep = false)
+    {
+        if ($deep) {
+            if ($this->collImageI18ns) {
+                foreach ($this->collImageI18ns as $o) {
+                    $o->clearAllReferences($deep);
+                }
+            }
+        } // if ($deep)
+
+        // i18n behavior
+        $this->currentLocale = 'en_US';
+        $this->currentTranslations = null;
+
+        $this->collImageI18ns = null;
+    }
+
+    /**
+     * Return the string representation of this object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->exportTo(ImageTableMap::DEFAULT_STRING_FORMAT);
+    }
+
+    // validate behavior
+
+    /**
+     * Configure validators constraints. The Validator object uses this method
+     * to perform object validation.
+     *
+     * @param ClassMetadata $metadata
+     */
+    static public function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('source', new Regex(array ('pattern' => '/[a-z0-9\\-]{3,50}/',)));
+    }
+
+    /**
+     * Validates the object and all objects related to this table.
+     *
+     * @see        getValidationFailures()
+     * @param      object $validator A Validator class instance
+     * @return     boolean Whether all objects pass validation.
+     */
+    public function validate(Validator $validator = null)
+    {
+        if (null === $validator) {
+            $validator = new Validator(new ClassMetadataFactory(new StaticMethodLoader()), new ConstraintValidatorFactory(), new DefaultTranslator());
+        }
+
+        $failureMap = new ConstraintViolationList();
+
+        if (!$this->alreadyInValidation) {
+            $this->alreadyInValidation = true;
+            $retval = null;
+
+
+            $retval = $validator->validate($this);
+            if (count($retval) > 0) {
+                $failureMap->addAll($retval);
+            }
+
+            if (null !== $this->collImageI18ns) {
+                foreach ($this->collImageI18ns as $referrerFK) {
+                    if (method_exists($referrerFK, 'validate')) {
+                        if (!$referrerFK->validate($validator)) {
+                            $failureMap->addAll($referrerFK->getValidationFailures());
+                        }
+                    }
+                }
+            }
+
+            $this->alreadyInValidation = false;
+        }
+
+        $this->validationFailures = $failureMap;
+
+        return (Boolean) (!(count($this->validationFailures) > 0));
+
+    }
+
+    /**
+     * Gets any ConstraintViolation objects that resulted from last call to validate().
+     *
+     *
+     * @return     object ConstraintViolationList
+     * @see        validate()
+     */
+    public function getValidationFailures()
+    {
+        return $this->validationFailures;
+    }
+
+    // timestampable behavior
+
+    /**
+     * Mark the current object so that the update date doesn't get updated during next save
+     *
+     * @return     ChildImage The current object (for fluent API support)
+     */
+    public function keepUpdateDateUnchanged()
+    {
+        $this->modifiedColumns[ImageTableMap::UPDATED_AT] = true;
+
+        return $this;
+    }
+
+    // i18n behavior
+
+    /**
+     * Sets the locale for translations
+     *
+     * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
+     *
+     * @return    ChildImage The current object (for fluent API support)
+     */
+    public function setLocale($locale = 'en_US')
+    {
+        $this->currentLocale = $locale;
+
+        return $this;
+    }
+
+    /**
+     * Gets the locale for translations
+     *
+     * @return    string $locale Locale to use for the translation, e.g. 'fr_FR'
+     */
+    public function getLocale()
+    {
+        return $this->currentLocale;
+    }
+
+    /**
+     * Returns the current translation for a given locale
+     *
+     * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
+     * @param     ConnectionInterface $con an optional connection object
+     *
+     * @return ChildImageI18n */
+    public function getTranslation($locale = 'en_US', ConnectionInterface $con = null)
+    {
+        if (!isset($this->currentTranslations[$locale])) {
+            if (null !== $this->collImageI18ns) {
+                foreach ($this->collImageI18ns as $translation) {
+                    if ($translation->getLocale() == $locale) {
+                        $this->currentTranslations[$locale] = $translation;
+
+                        return $translation;
+                    }
+                }
+            }
+            if ($this->isNew()) {
+                $translation = new ChildImageI18n();
+                $translation->setLocale($locale);
+            } else {
+                $translation = ChildImageI18nQuery::create()
+                    ->filterByPrimaryKey(array($this->getPrimaryKey(), $locale))
+                    ->findOneOrCreate($con);
+                $this->currentTranslations[$locale] = $translation;
+            }
+            $this->addImageI18n($translation);
+        }
+
+        return $this->currentTranslations[$locale];
+    }
+
+    /**
+     * Remove the translation for a given locale
+     *
+     * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
+     * @param     ConnectionInterface $con an optional connection object
+     *
+     * @return    ChildImage The current object (for fluent API support)
+     */
+    public function removeTranslation($locale = 'en_US', ConnectionInterface $con = null)
+    {
+        if (!$this->isNew()) {
+            ChildImageI18nQuery::create()
+                ->filterByPrimaryKey(array($this->getPrimaryKey(), $locale))
+                ->delete($con);
+        }
+        if (isset($this->currentTranslations[$locale])) {
+            unset($this->currentTranslations[$locale]);
+        }
+        foreach ($this->collImageI18ns as $key => $translation) {
+            if ($translation->getLocale() == $locale) {
+                unset($this->collImageI18ns[$key]);
+                break;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns the current translation
+     *
+     * @param     ConnectionInterface $con an optional connection object
+     *
+     * @return ChildImageI18n */
+    public function getCurrentTranslation(ConnectionInterface $con = null)
+    {
+        return $this->getTranslation($this->getLocale(), $con);
+    }
+
+
+        /**
+         * Get the [title] column value.
+         *
+         * @return   string
+         */
+        public function getTitle()
+        {
+        return $this->getCurrentTranslation()->getTitle();
+    }
+
+
+        /**
+         * Set the value of [title] column.
+         *
+         * @param      string $v new value
+         * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+         */
+        public function setTitle($v)
+        {    $this->getCurrentTranslation()->setTitle($v);
+
+        return $this;
+    }
+
+
+        /**
+         * Get the [description] column value.
+         *
+         * @return   string
+         */
+        public function getDescription()
+        {
+        return $this->getCurrentTranslation()->getDescription();
+    }
+
+
+        /**
+         * Set the value of [description] column.
+         *
+         * @param      string $v new value
+         * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+         */
+        public function setDescription($v)
+        {    $this->getCurrentTranslation()->setDescription($v);
+
+        return $this;
+    }
+
+
+        /**
+         * Get the [chapo] column value.
+         *
+         * @return   string
+         */
+        public function getChapo()
+        {
+        return $this->getCurrentTranslation()->getChapo();
+    }
+
+
+        /**
+         * Set the value of [chapo] column.
+         *
+         * @param      string $v new value
+         * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+         */
+        public function setChapo($v)
+        {    $this->getCurrentTranslation()->setChapo($v);
+
+        return $this;
+    }
+
+
+        /**
+         * Get the [postscriptum] column value.
+         *
+         * @return   string
+         */
+        public function getPostscriptum()
+        {
+        return $this->getCurrentTranslation()->getPostscriptum();
+    }
+
+
+        /**
+         * Set the value of [postscriptum] column.
+         *
+         * @param      string $v new value
+         * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+         */
+        public function setPostscriptum($v)
+        {    $this->getCurrentTranslation()->setPostscriptum($v);
+
+        return $this;
+    }
+
+    /**
+     * Code to be run before persisting the object
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preSave(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after persisting the object
+     * @param ConnectionInterface $con
+     */
+    public function postSave(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before inserting to database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preInsert(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after inserting to database
+     * @param ConnectionInterface $con
+     */
+    public function postInsert(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before updating the object in database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preUpdate(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after updating the object in database
+     * @param ConnectionInterface $con
+     */
+    public function postUpdate(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before deleting the object in database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preDelete(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after deleting the object in database
+     * @param ConnectionInterface $con
+     */
+    public function postDelete(ConnectionInterface $con = null)
+    {
+
+    }
+
+
+    /**
+     * Derived method to catches calls to undefined methods.
+     *
+     * Provides magic import/export method support (fromXML()/toXML(), fromYAML()/toYAML(), etc.).
+     * Allows to define default __call() behavior if you overwrite __call()
+     *
+     * @param string $name
+     * @param mixed  $params
+     *
+     * @return array|string
+     */
+    public function __call($name, $params)
+    {
+        if (0 === strpos($name, 'get')) {
+            $virtualColumn = substr($name, 3);
+            if ($this->hasVirtualColumn($virtualColumn)) {
+                return $this->getVirtualColumn($virtualColumn);
+            }
+
+            $virtualColumn = lcfirst($virtualColumn);
+            if ($this->hasVirtualColumn($virtualColumn)) {
+                return $this->getVirtualColumn($virtualColumn);
+            }
+        }
+
+        if (0 === strpos($name, 'from')) {
+            $format = substr($name, 4);
+
+            return $this->importFrom($format, reset($params));
+        }
+
+        if (0 === strpos($name, 'to')) {
+            $format = substr($name, 2);
+            $includeLazyLoadColumns = isset($params[0]) ? $params[0] : true;
+
+            return $this->exportTo($format, $includeLazyLoadColumns);
+        }
+
+        throw new BadMethodCallException(sprintf('Call to undefined method: %s.', $name));
+    }
+
+}

--- a/core/lib/Thelia/Model/Base/ImageI18n.php
+++ b/core/lib/Thelia/Model/Base/ImageI18n.php
@@ -1,0 +1,1442 @@
+<?php
+
+namespace Thelia\Model\Base;
+
+use \Exception;
+use \PDO;
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\BadMethodCallException;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\TableMap;
+use Propel\Runtime\Parser\AbstractParser;
+use Thelia\Model\Image as ChildImage;
+use Thelia\Model\ImageI18nQuery as ChildImageI18nQuery;
+use Thelia\Model\ImageQuery as ChildImageQuery;
+use Thelia\Model\Map\ImageI18nTableMap;
+
+abstract class ImageI18n implements ActiveRecordInterface
+{
+    /**
+     * TableMap class name
+     */
+    const TABLE_MAP = '\\Thelia\\Model\\Map\\ImageI18nTableMap';
+
+
+    /**
+     * attribute to determine if this object has previously been saved.
+     * @var boolean
+     */
+    protected $new = true;
+
+    /**
+     * attribute to determine whether this object has been deleted.
+     * @var boolean
+     */
+    protected $deleted = false;
+
+    /**
+     * The columns that have been modified in current object.
+     * Tracking modified columns allows us to only update modified columns.
+     * @var array
+     */
+    protected $modifiedColumns = array();
+
+    /**
+     * The (virtual) columns that are added at runtime
+     * The formatters can add supplementary columns based on a resultset
+     * @var array
+     */
+    protected $virtualColumns = array();
+
+    /**
+     * The value for the id field.
+     * @var        int
+     */
+    protected $id;
+
+    /**
+     * The value for the locale field.
+     * Note: this column has a database default value of: 'en_US'
+     * @var        string
+     */
+    protected $locale;
+
+    /**
+     * The value for the title field.
+     * @var        string
+     */
+    protected $title;
+
+    /**
+     * The value for the description field.
+     * @var        string
+     */
+    protected $description;
+
+    /**
+     * The value for the chapo field.
+     * @var        string
+     */
+    protected $chapo;
+
+    /**
+     * The value for the postscriptum field.
+     * @var        string
+     */
+    protected $postscriptum;
+
+    /**
+     * @var        Image
+     */
+    protected $aImage;
+
+    /**
+     * Flag to prevent endless save loop, if this object is referenced
+     * by another object which falls in this transaction.
+     *
+     * @var boolean
+     */
+    protected $alreadyInSave = false;
+
+    /**
+     * Applies default values to this object.
+     * This method should be called from the object's constructor (or
+     * equivalent initialization method).
+     * @see __construct()
+     */
+    public function applyDefaultValues()
+    {
+        $this->locale = 'en_US';
+    }
+
+    /**
+     * Initializes internal state of Thelia\Model\Base\ImageI18n object.
+     * @see applyDefaults()
+     */
+    public function __construct()
+    {
+        $this->applyDefaultValues();
+    }
+
+    /**
+     * Returns whether the object has been modified.
+     *
+     * @return boolean True if the object has been modified.
+     */
+    public function isModified()
+    {
+        return !!$this->modifiedColumns;
+    }
+
+    /**
+     * Has specified column been modified?
+     *
+     * @param  string  $col column fully qualified name (TableMap::TYPE_COLNAME), e.g. Book::AUTHOR_ID
+     * @return boolean True if $col has been modified.
+     */
+    public function isColumnModified($col)
+    {
+        return $this->modifiedColumns && isset($this->modifiedColumns[$col]);
+    }
+
+    /**
+     * Get the columns that have been modified in this object.
+     * @return array A unique list of the modified column names for this object.
+     */
+    public function getModifiedColumns()
+    {
+        return $this->modifiedColumns ? array_keys($this->modifiedColumns) : [];
+    }
+
+    /**
+     * Returns whether the object has ever been saved.  This will
+     * be false, if the object was retrieved from storage or was created
+     * and then saved.
+     *
+     * @return boolean true, if the object has never been persisted.
+     */
+    public function isNew()
+    {
+        return $this->new;
+    }
+
+    /**
+     * Setter for the isNew attribute.  This method will be called
+     * by Propel-generated children and objects.
+     *
+     * @param boolean $b the state of the object.
+     */
+    public function setNew($b)
+    {
+        $this->new = (Boolean) $b;
+    }
+
+    /**
+     * Whether this object has been deleted.
+     * @return boolean The deleted state of this object.
+     */
+    public function isDeleted()
+    {
+        return $this->deleted;
+    }
+
+    /**
+     * Specify whether this object has been deleted.
+     * @param  boolean $b The deleted state of this object.
+     * @return void
+     */
+    public function setDeleted($b)
+    {
+        $this->deleted = (Boolean) $b;
+    }
+
+    /**
+     * Sets the modified state for the object to be false.
+     * @param  string $col If supplied, only the specified column is reset.
+     * @return void
+     */
+    public function resetModified($col = null)
+    {
+        if (null !== $col) {
+            if (isset($this->modifiedColumns[$col])) {
+                unset($this->modifiedColumns[$col]);
+            }
+        } else {
+            $this->modifiedColumns = array();
+        }
+    }
+
+    /**
+     * Compares this with another <code>ImageI18n</code> instance.  If
+     * <code>obj</code> is an instance of <code>ImageI18n</code>, delegates to
+     * <code>equals(ImageI18n)</code>.  Otherwise, returns <code>false</code>.
+     *
+     * @param  mixed   $obj The object to compare to.
+     * @return boolean Whether equal to the object specified.
+     */
+    public function equals($obj)
+    {
+        $thisclazz = get_class($this);
+        if (!is_object($obj) || !($obj instanceof $thisclazz)) {
+            return false;
+        }
+
+        if ($this === $obj) {
+            return true;
+        }
+
+        if (null === $this->getPrimaryKey()
+            || null === $obj->getPrimaryKey())  {
+            return false;
+        }
+
+        return $this->getPrimaryKey() === $obj->getPrimaryKey();
+    }
+
+    /**
+     * If the primary key is not null, return the hashcode of the
+     * primary key. Otherwise, return the hash code of the object.
+     *
+     * @return int Hashcode
+     */
+    public function hashCode()
+    {
+        if (null !== $this->getPrimaryKey()) {
+            return crc32(serialize($this->getPrimaryKey()));
+        }
+
+        return crc32(serialize(clone $this));
+    }
+
+    /**
+     * Get the associative array of the virtual columns in this object
+     *
+     * @return array
+     */
+    public function getVirtualColumns()
+    {
+        return $this->virtualColumns;
+    }
+
+    /**
+     * Checks the existence of a virtual column in this object
+     *
+     * @param  string  $name The virtual column name
+     * @return boolean
+     */
+    public function hasVirtualColumn($name)
+    {
+        return array_key_exists($name, $this->virtualColumns);
+    }
+
+    /**
+     * Get the value of a virtual column in this object
+     *
+     * @param  string $name The virtual column name
+     * @return mixed
+     *
+     * @throws PropelException
+     */
+    public function getVirtualColumn($name)
+    {
+        if (!$this->hasVirtualColumn($name)) {
+            throw new PropelException(sprintf('Cannot get value of inexistent virtual column %s.', $name));
+        }
+
+        return $this->virtualColumns[$name];
+    }
+
+    /**
+     * Set the value of a virtual column in this object
+     *
+     * @param string $name  The virtual column name
+     * @param mixed  $value The value to give to the virtual column
+     *
+     * @return ImageI18n The current object, for fluid interface
+     */
+    public function setVirtualColumn($name, $value)
+    {
+        $this->virtualColumns[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Logs a message using Propel::log().
+     *
+     * @param  string  $msg
+     * @param  int     $priority One of the Propel::LOG_* logging levels
+     * @return boolean
+     */
+    protected function log($msg, $priority = Propel::LOG_INFO)
+    {
+        return Propel::log(get_class($this) . ': ' . $msg, $priority);
+    }
+
+    /**
+     * Populate the current object from a string, using a given parser format
+     * <code>
+     * $book = new Book();
+     * $book->importFrom('JSON', '{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678}');
+     * </code>
+     *
+     * @param mixed $parser A AbstractParser instance,
+     *                       or a format name ('XML', 'YAML', 'JSON', 'CSV')
+     * @param string $data The source data to import from
+     *
+     * @return ImageI18n The current object, for fluid interface
+     */
+    public function importFrom($parser, $data)
+    {
+        if (!$parser instanceof AbstractParser) {
+            $parser = AbstractParser::getParser($parser);
+        }
+
+        $this->fromArray($parser->toArray($data), TableMap::TYPE_PHPNAME);
+
+        return $this;
+    }
+
+    /**
+     * Export the current object properties to a string, using a given parser format
+     * <code>
+     * $book = BookQuery::create()->findPk(9012);
+     * echo $book->exportTo('JSON');
+     *  => {"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678}');
+     * </code>
+     *
+     * @param  mixed   $parser                 A AbstractParser instance, or a format name ('XML', 'YAML', 'JSON', 'CSV')
+     * @param  boolean $includeLazyLoadColumns (optional) Whether to include lazy load(ed) columns. Defaults to TRUE.
+     * @return string  The exported data
+     */
+    public function exportTo($parser, $includeLazyLoadColumns = true)
+    {
+        if (!$parser instanceof AbstractParser) {
+            $parser = AbstractParser::getParser($parser);
+        }
+
+        return $parser->fromArray($this->toArray(TableMap::TYPE_PHPNAME, $includeLazyLoadColumns, array(), true));
+    }
+
+    /**
+     * Clean up internal collections prior to serializing
+     * Avoids recursive loops that turn into segmentation faults when serializing
+     */
+    public function __sleep()
+    {
+        $this->clearAllReferences();
+
+        return array_keys(get_object_vars($this));
+    }
+
+    /**
+     * Get the [id] column value.
+     *
+     * @return   int
+     */
+    public function getId()
+    {
+
+        return $this->id;
+    }
+
+    /**
+     * Get the [locale] column value.
+     *
+     * @return   string
+     */
+    public function getLocale()
+    {
+
+        return $this->locale;
+    }
+
+    /**
+     * Get the [title] column value.
+     *
+     * @return   string
+     */
+    public function getTitle()
+    {
+
+        return $this->title;
+    }
+
+    /**
+     * Get the [description] column value.
+     *
+     * @return   string
+     */
+    public function getDescription()
+    {
+
+        return $this->description;
+    }
+
+    /**
+     * Get the [chapo] column value.
+     *
+     * @return   string
+     */
+    public function getChapo()
+    {
+
+        return $this->chapo;
+    }
+
+    /**
+     * Get the [postscriptum] column value.
+     *
+     * @return   string
+     */
+    public function getPostscriptum()
+    {
+
+        return $this->postscriptum;
+    }
+
+    /**
+     * Set the value of [id] column.
+     *
+     * @param      int $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->id !== $v) {
+            $this->id = $v;
+            $this->modifiedColumns[ImageI18nTableMap::ID] = true;
+        }
+
+        if ($this->aImage !== null && $this->aImage->getId() !== $v) {
+            $this->aImage = null;
+        }
+
+
+        return $this;
+    } // setId()
+
+    /**
+     * Set the value of [locale] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setLocale($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->locale !== $v) {
+            $this->locale = $v;
+            $this->modifiedColumns[ImageI18nTableMap::LOCALE] = true;
+        }
+
+
+        return $this;
+    } // setLocale()
+
+    /**
+     * Set the value of [title] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setTitle($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->title !== $v) {
+            $this->title = $v;
+            $this->modifiedColumns[ImageI18nTableMap::TITLE] = true;
+        }
+
+
+        return $this;
+    } // setTitle()
+
+    /**
+     * Set the value of [description] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setDescription($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->description !== $v) {
+            $this->description = $v;
+            $this->modifiedColumns[ImageI18nTableMap::DESCRIPTION] = true;
+        }
+
+
+        return $this;
+    } // setDescription()
+
+    /**
+     * Set the value of [chapo] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setChapo($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->chapo !== $v) {
+            $this->chapo = $v;
+            $this->modifiedColumns[ImageI18nTableMap::CHAPO] = true;
+        }
+
+
+        return $this;
+    } // setChapo()
+
+    /**
+     * Set the value of [postscriptum] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ImageI18n The current object (for fluent API support)
+     */
+    public function setPostscriptum($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->postscriptum !== $v) {
+            $this->postscriptum = $v;
+            $this->modifiedColumns[ImageI18nTableMap::POSTSCRIPTUM] = true;
+        }
+
+
+        return $this;
+    } // setPostscriptum()
+
+    /**
+     * Indicates whether the columns in this object are only set to default values.
+     *
+     * This method can be used in conjunction with isModified() to indicate whether an object is both
+     * modified _and_ has some values set which are non-default.
+     *
+     * @return boolean Whether the columns in this object are only been set with default values.
+     */
+    public function hasOnlyDefaultValues()
+    {
+            if ($this->locale !== 'en_US') {
+                return false;
+            }
+
+        // otherwise, everything was equal, so return TRUE
+        return true;
+    } // hasOnlyDefaultValues()
+
+    /**
+     * Hydrates (populates) the object variables with values from the database resultset.
+     *
+     * An offset (0-based "start column") is specified so that objects can be hydrated
+     * with a subset of the columns in the resultset rows.  This is needed, for example,
+     * for results of JOIN queries where the resultset row includes columns from two or
+     * more tables.
+     *
+     * @param array   $row       The row returned by DataFetcher->fetch().
+     * @param int     $startcol  0-based offset column which indicates which restultset column to start with.
+     * @param boolean $rehydrate Whether this object is being re-hydrated from the database.
+     * @param string  $indexType The index type of $row. Mostly DataFetcher->getIndexType().
+                                  One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                            TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *
+     * @return int             next starting column
+     * @throws PropelException - Any caught Exception will be rewrapped as a PropelException.
+     */
+    public function hydrate($row, $startcol = 0, $rehydrate = false, $indexType = TableMap::TYPE_NUM)
+    {
+        try {
+
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : ImageI18nTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : ImageI18nTableMap::translateFieldName('Locale', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->locale = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : ImageI18nTableMap::translateFieldName('Title', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->title = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : ImageI18nTableMap::translateFieldName('Description', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->description = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : ImageI18nTableMap::translateFieldName('Chapo', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->chapo = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : ImageI18nTableMap::translateFieldName('Postscriptum', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->postscriptum = (null !== $col) ? (string) $col : null;
+            $this->resetModified();
+
+            $this->setNew(false);
+
+            if ($rehydrate) {
+                $this->ensureConsistency();
+            }
+
+            return $startcol + 6; // 6 = ImageI18nTableMap::NUM_HYDRATE_COLUMNS.
+
+        } catch (Exception $e) {
+            throw new PropelException("Error populating \Thelia\Model\ImageI18n object", 0, $e);
+        }
+    }
+
+    /**
+     * Checks and repairs the internal consistency of the object.
+     *
+     * This method is executed after an already-instantiated object is re-hydrated
+     * from the database.  It exists to check any foreign keys to make sure that
+     * the objects related to the current object are correct based on foreign key.
+     *
+     * You can override this method in the stub class, but you should always invoke
+     * the base method from the overridden method (i.e. parent::ensureConsistency()),
+     * in case your model changes.
+     *
+     * @throws PropelException
+     */
+    public function ensureConsistency()
+    {
+        if ($this->aImage !== null && $this->id !== $this->aImage->getId()) {
+            $this->aImage = null;
+        }
+    } // ensureConsistency
+
+    /**
+     * Reloads this object from datastore based on primary key and (optionally) resets all associated objects.
+     *
+     * This will only work if the object has been saved and has a valid primary key set.
+     *
+     * @param      boolean $deep (optional) Whether to also de-associated any related objects.
+     * @param      ConnectionInterface $con (optional) The ConnectionInterface connection to use.
+     * @return void
+     * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
+     */
+    public function reload($deep = false, ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("Cannot reload a deleted object.");
+        }
+
+        if ($this->isNew()) {
+            throw new PropelException("Cannot reload an unsaved object.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getReadConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        // We don't need to alter the object instance pool; we're just modifying this instance
+        // already in the pool.
+
+        $dataFetcher = ChildImageI18nQuery::create(null, $this->buildPkeyCriteria())->setFormatter(ModelCriteria::FORMAT_STATEMENT)->find($con);
+        $row = $dataFetcher->fetch();
+        $dataFetcher->close();
+        if (!$row) {
+            throw new PropelException('Cannot find matching row in the database to reload object values.');
+        }
+        $this->hydrate($row, 0, true, $dataFetcher->getIndexType()); // rehydrate
+
+        if ($deep) {  // also de-associate any related objects?
+
+            $this->aImage = null;
+        } // if (deep)
+    }
+
+    /**
+     * Removes this object from datastore and sets delete attribute.
+     *
+     * @param      ConnectionInterface $con
+     * @return void
+     * @throws PropelException
+     * @see ImageI18n::setDeleted()
+     * @see ImageI18n::isDeleted()
+     */
+    public function delete(ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("This object has already been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        $con->beginTransaction();
+        try {
+            $deleteQuery = ChildImageI18nQuery::create()
+                ->filterByPrimaryKey($this->getPrimaryKey());
+            $ret = $this->preDelete($con);
+            if ($ret) {
+                $deleteQuery->delete($con);
+                $this->postDelete($con);
+                $con->commit();
+                $this->setDeleted(true);
+            } else {
+                $con->commit();
+            }
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Persists this object to the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All modified related objects will also be persisted in the doSave()
+     * method.  This method wraps all precipitate database operations in a
+     * single transaction.
+     *
+     * @param      ConnectionInterface $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @see doSave()
+     */
+    public function save(ConnectionInterface $con = null)
+    {
+        if ($this->isDeleted()) {
+            throw new PropelException("You cannot save an object that has been deleted.");
+        }
+
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        $con->beginTransaction();
+        $isInsert = $this->isNew();
+        try {
+            $ret = $this->preSave($con);
+            if ($isInsert) {
+                $ret = $ret && $this->preInsert($con);
+            } else {
+                $ret = $ret && $this->preUpdate($con);
+            }
+            if ($ret) {
+                $affectedRows = $this->doSave($con);
+                if ($isInsert) {
+                    $this->postInsert($con);
+                } else {
+                    $this->postUpdate($con);
+                }
+                $this->postSave($con);
+                ImageI18nTableMap::addInstanceToPool($this);
+            } else {
+                $affectedRows = 0;
+            }
+            $con->commit();
+
+            return $affectedRows;
+        } catch (Exception $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Performs the work of inserting or updating the row in the database.
+     *
+     * If the object is new, it inserts it; otherwise an update is performed.
+     * All related objects are also updated in this method.
+     *
+     * @param      ConnectionInterface $con
+     * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
+     * @throws PropelException
+     * @see save()
+     */
+    protected function doSave(ConnectionInterface $con)
+    {
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        if (!$this->alreadyInSave) {
+            $this->alreadyInSave = true;
+
+            // We call the save method on the following object(s) if they
+            // were passed to this object by their corresponding set
+            // method.  This object relates to these object(s) by a
+            // foreign key reference.
+
+            if ($this->aImage !== null) {
+                if ($this->aImage->isModified() || $this->aImage->isNew()) {
+                    $affectedRows += $this->aImage->save($con);
+                }
+                $this->setImage($this->aImage);
+            }
+
+            if ($this->isNew() || $this->isModified()) {
+                // persist changes
+                if ($this->isNew()) {
+                    $this->doInsert($con);
+                } else {
+                    $this->doUpdate($con);
+                }
+                $affectedRows += 1;
+                $this->resetModified();
+            }
+
+            $this->alreadyInSave = false;
+
+        }
+
+        return $affectedRows;
+    } // doSave()
+
+    /**
+     * Insert the row in the database.
+     *
+     * @param      ConnectionInterface $con
+     *
+     * @throws PropelException
+     * @see doSave()
+     */
+    protected function doInsert(ConnectionInterface $con)
+    {
+        $modifiedColumns = array();
+        $index = 0;
+
+
+         // check the columns in natural order for more readable SQL queries
+        if ($this->isColumnModified(ImageI18nTableMap::ID)) {
+            $modifiedColumns[':p' . $index++]  = '`ID`';
+        }
+        if ($this->isColumnModified(ImageI18nTableMap::LOCALE)) {
+            $modifiedColumns[':p' . $index++]  = '`LOCALE`';
+        }
+        if ($this->isColumnModified(ImageI18nTableMap::TITLE)) {
+            $modifiedColumns[':p' . $index++]  = '`TITLE`';
+        }
+        if ($this->isColumnModified(ImageI18nTableMap::DESCRIPTION)) {
+            $modifiedColumns[':p' . $index++]  = '`DESCRIPTION`';
+        }
+        if ($this->isColumnModified(ImageI18nTableMap::CHAPO)) {
+            $modifiedColumns[':p' . $index++]  = '`CHAPO`';
+        }
+        if ($this->isColumnModified(ImageI18nTableMap::POSTSCRIPTUM)) {
+            $modifiedColumns[':p' . $index++]  = '`POSTSCRIPTUM`';
+        }
+
+        $sql = sprintf(
+            'INSERT INTO `image_i18n` (%s) VALUES (%s)',
+            implode(', ', $modifiedColumns),
+            implode(', ', array_keys($modifiedColumns))
+        );
+
+        try {
+            $stmt = $con->prepare($sql);
+            foreach ($modifiedColumns as $identifier => $columnName) {
+                switch ($columnName) {
+                    case '`ID`':
+                        $stmt->bindValue($identifier, $this->id, PDO::PARAM_INT);
+                        break;
+                    case '`LOCALE`':
+                        $stmt->bindValue($identifier, $this->locale, PDO::PARAM_STR);
+                        break;
+                    case '`TITLE`':
+                        $stmt->bindValue($identifier, $this->title, PDO::PARAM_STR);
+                        break;
+                    case '`DESCRIPTION`':
+                        $stmt->bindValue($identifier, $this->description, PDO::PARAM_STR);
+                        break;
+                    case '`CHAPO`':
+                        $stmt->bindValue($identifier, $this->chapo, PDO::PARAM_STR);
+                        break;
+                    case '`POSTSCRIPTUM`':
+                        $stmt->bindValue($identifier, $this->postscriptum, PDO::PARAM_STR);
+                        break;
+                }
+            }
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute INSERT statement [%s]', $sql), 0, $e);
+        }
+
+        $this->setNew(false);
+    }
+
+    /**
+     * Update the row in the database.
+     *
+     * @param      ConnectionInterface $con
+     *
+     * @return Integer Number of updated rows
+     * @see doSave()
+     */
+    protected function doUpdate(ConnectionInterface $con)
+    {
+        $selectCriteria = $this->buildPkeyCriteria();
+        $valuesCriteria = $this->buildCriteria();
+
+        return $selectCriteria->doUpdate($valuesCriteria, $con);
+    }
+
+    /**
+     * Retrieves a field from the object by name passed in as a string.
+     *
+     * @param      string $name name
+     * @param      string $type The type of fieldname the $name is of:
+     *                     one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                     TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                     Defaults to TableMap::TYPE_PHPNAME.
+     * @return mixed Value of field.
+     */
+    public function getByName($name, $type = TableMap::TYPE_PHPNAME)
+    {
+        $pos = ImageI18nTableMap::translateFieldName($name, $type, TableMap::TYPE_NUM);
+        $field = $this->getByPosition($pos);
+
+        return $field;
+    }
+
+    /**
+     * Retrieves a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param      int $pos position in xml schema
+     * @return mixed Value of field at $pos
+     */
+    public function getByPosition($pos)
+    {
+        switch ($pos) {
+            case 0:
+                return $this->getId();
+                break;
+            case 1:
+                return $this->getLocale();
+                break;
+            case 2:
+                return $this->getTitle();
+                break;
+            case 3:
+                return $this->getDescription();
+                break;
+            case 4:
+                return $this->getChapo();
+                break;
+            case 5:
+                return $this->getPostscriptum();
+                break;
+            default:
+                return null;
+                break;
+        } // switch()
+    }
+
+    /**
+     * Exports the object as an array.
+     *
+     * You can specify the key type of the array by passing one of the class
+     * type constants.
+     *
+     * @param     string  $keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME,
+     *                    TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                    Defaults to TableMap::TYPE_PHPNAME.
+     * @param     boolean $includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
+     * @param     array $alreadyDumpedObjects List of objects to skip to avoid recursion
+     * @param     boolean $includeForeignObjects (optional) Whether to include hydrated related objects. Default to FALSE.
+     *
+     * @return array an associative array containing the field names (as keys) and field values
+     */
+    public function toArray($keyType = TableMap::TYPE_PHPNAME, $includeLazyLoadColumns = true, $alreadyDumpedObjects = array(), $includeForeignObjects = false)
+    {
+        if (isset($alreadyDumpedObjects['ImageI18n'][serialize($this->getPrimaryKey())])) {
+            return '*RECURSION*';
+        }
+        $alreadyDumpedObjects['ImageI18n'][serialize($this->getPrimaryKey())] = true;
+        $keys = ImageI18nTableMap::getFieldNames($keyType);
+        $result = array(
+            $keys[0] => $this->getId(),
+            $keys[1] => $this->getLocale(),
+            $keys[2] => $this->getTitle(),
+            $keys[3] => $this->getDescription(),
+            $keys[4] => $this->getChapo(),
+            $keys[5] => $this->getPostscriptum(),
+        );
+        $virtualColumns = $this->virtualColumns;
+        foreach ($virtualColumns as $key => $virtualColumn) {
+            $result[$key] = $virtualColumn;
+        }
+
+        if ($includeForeignObjects) {
+            if (null !== $this->aImage) {
+                $result['Image'] = $this->aImage->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sets a field from the object by name passed in as a string.
+     *
+     * @param      string $name
+     * @param      mixed  $value field value
+     * @param      string $type The type of fieldname the $name is of:
+     *                     one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                     TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *                     Defaults to TableMap::TYPE_PHPNAME.
+     * @return void
+     */
+    public function setByName($name, $value, $type = TableMap::TYPE_PHPNAME)
+    {
+        $pos = ImageI18nTableMap::translateFieldName($name, $type, TableMap::TYPE_NUM);
+
+        return $this->setByPosition($pos, $value);
+    }
+
+    /**
+     * Sets a field from the object by Position as specified in the xml schema.
+     * Zero-based.
+     *
+     * @param      int $pos position in xml schema
+     * @param      mixed $value field value
+     * @return void
+     */
+    public function setByPosition($pos, $value)
+    {
+        switch ($pos) {
+            case 0:
+                $this->setId($value);
+                break;
+            case 1:
+                $this->setLocale($value);
+                break;
+            case 2:
+                $this->setTitle($value);
+                break;
+            case 3:
+                $this->setDescription($value);
+                break;
+            case 4:
+                $this->setChapo($value);
+                break;
+            case 5:
+                $this->setPostscriptum($value);
+                break;
+        } // switch()
+    }
+
+    /**
+     * Populates the object using an array.
+     *
+     * This is particularly useful when populating an object from one of the
+     * request arrays (e.g. $_POST).  This method goes through the column
+     * names, checking to see whether a matching key exists in populated
+     * array. If so the setByName() method is called for that column.
+     *
+     * You can specify the key type of the array by additionally passing one
+     * of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME,
+     * TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     * The default key type is the column's TableMap::TYPE_PHPNAME.
+     *
+     * @param      array  $arr     An array to populate the object from.
+     * @param      string $keyType The type of keys the array uses.
+     * @return void
+     */
+    public function fromArray($arr, $keyType = TableMap::TYPE_PHPNAME)
+    {
+        $keys = ImageI18nTableMap::getFieldNames($keyType);
+
+        if (array_key_exists($keys[0], $arr)) $this->setId($arr[$keys[0]]);
+        if (array_key_exists($keys[1], $arr)) $this->setLocale($arr[$keys[1]]);
+        if (array_key_exists($keys[2], $arr)) $this->setTitle($arr[$keys[2]]);
+        if (array_key_exists($keys[3], $arr)) $this->setDescription($arr[$keys[3]]);
+        if (array_key_exists($keys[4], $arr)) $this->setChapo($arr[$keys[4]]);
+        if (array_key_exists($keys[5], $arr)) $this->setPostscriptum($arr[$keys[5]]);
+    }
+
+    /**
+     * Build a Criteria object containing the values of all modified columns in this object.
+     *
+     * @return Criteria The Criteria object containing all modified values.
+     */
+    public function buildCriteria()
+    {
+        $criteria = new Criteria(ImageI18nTableMap::DATABASE_NAME);
+
+        if ($this->isColumnModified(ImageI18nTableMap::ID)) $criteria->add(ImageI18nTableMap::ID, $this->id);
+        if ($this->isColumnModified(ImageI18nTableMap::LOCALE)) $criteria->add(ImageI18nTableMap::LOCALE, $this->locale);
+        if ($this->isColumnModified(ImageI18nTableMap::TITLE)) $criteria->add(ImageI18nTableMap::TITLE, $this->title);
+        if ($this->isColumnModified(ImageI18nTableMap::DESCRIPTION)) $criteria->add(ImageI18nTableMap::DESCRIPTION, $this->description);
+        if ($this->isColumnModified(ImageI18nTableMap::CHAPO)) $criteria->add(ImageI18nTableMap::CHAPO, $this->chapo);
+        if ($this->isColumnModified(ImageI18nTableMap::POSTSCRIPTUM)) $criteria->add(ImageI18nTableMap::POSTSCRIPTUM, $this->postscriptum);
+
+        return $criteria;
+    }
+
+    /**
+     * Builds a Criteria object containing the primary key for this object.
+     *
+     * Unlike buildCriteria() this method includes the primary key values regardless
+     * of whether or not they have been modified.
+     *
+     * @return Criteria The Criteria object containing value(s) for primary key(s).
+     */
+    public function buildPkeyCriteria()
+    {
+        $criteria = new Criteria(ImageI18nTableMap::DATABASE_NAME);
+        $criteria->add(ImageI18nTableMap::ID, $this->id);
+        $criteria->add(ImageI18nTableMap::LOCALE, $this->locale);
+
+        return $criteria;
+    }
+
+    /**
+     * Returns the composite primary key for this object.
+     * The array elements will be in same order as specified in XML.
+     * @return array
+     */
+    public function getPrimaryKey()
+    {
+        $pks = array();
+        $pks[0] = $this->getId();
+        $pks[1] = $this->getLocale();
+
+        return $pks;
+    }
+
+    /**
+     * Set the [composite] primary key.
+     *
+     * @param      array $keys The elements of the composite key (order must match the order in XML file).
+     * @return void
+     */
+    public function setPrimaryKey($keys)
+    {
+        $this->setId($keys[0]);
+        $this->setLocale($keys[1]);
+    }
+
+    /**
+     * Returns true if the primary key for this object is null.
+     * @return boolean
+     */
+    public function isPrimaryKeyNull()
+    {
+
+        return (null === $this->getId()) && (null === $this->getLocale());
+    }
+
+    /**
+     * Sets contents of passed object to values from current object.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param      object $copyObj An object of \Thelia\Model\ImageI18n (or compatible) type.
+     * @param      boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @param      boolean $makeNew Whether to reset autoincrement PKs and make the object new.
+     * @throws PropelException
+     */
+    public function copyInto($copyObj, $deepCopy = false, $makeNew = true)
+    {
+        $copyObj->setId($this->getId());
+        $copyObj->setLocale($this->getLocale());
+        $copyObj->setTitle($this->getTitle());
+        $copyObj->setDescription($this->getDescription());
+        $copyObj->setChapo($this->getChapo());
+        $copyObj->setPostscriptum($this->getPostscriptum());
+        if ($makeNew) {
+            $copyObj->setNew(true);
+        }
+    }
+
+    /**
+     * Makes a copy of this object that will be inserted as a new row in table when saved.
+     * It creates a new object filling in the simple attributes, but skipping any primary
+     * keys that are defined for the table.
+     *
+     * If desired, this method can also make copies of all associated (fkey referrers)
+     * objects.
+     *
+     * @param      boolean $deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @return                 \Thelia\Model\ImageI18n Clone of current object.
+     * @throws PropelException
+     */
+    public function copy($deepCopy = false)
+    {
+        // we use get_class(), because this might be a subclass
+        $clazz = get_class($this);
+        $copyObj = new $clazz();
+        $this->copyInto($copyObj, $deepCopy);
+
+        return $copyObj;
+    }
+
+    /**
+     * Declares an association between this object and a ChildImage object.
+     *
+     * @param                  ChildImage $v
+     * @return                 \Thelia\Model\ImageI18n The current object (for fluent API support)
+     * @throws PropelException
+     */
+    public function setImage(ChildImage $v = null)
+    {
+        if ($v === null) {
+            $this->setId(NULL);
+        } else {
+            $this->setId($v->getId());
+        }
+
+        $this->aImage = $v;
+
+        // Add binding for other direction of this n:n relationship.
+        // If this object has already been added to the ChildImage object, it will not be re-added.
+        if ($v !== null) {
+            $v->addImageI18n($this);
+        }
+
+
+        return $this;
+    }
+
+
+    /**
+     * Get the associated ChildImage object
+     *
+     * @param      ConnectionInterface $con Optional Connection object.
+     * @return                 ChildImage The associated ChildImage object.
+     * @throws PropelException
+     */
+    public function getImage(ConnectionInterface $con = null)
+    {
+        if ($this->aImage === null && ($this->id !== null)) {
+            $this->aImage = ChildImageQuery::create()->findPk($this->id, $con);
+            /* The following can be used additionally to
+                guarantee the related object contains a reference
+                to this object.  This level of coupling may, however, be
+                undesirable since it could result in an only partially populated collection
+                in the referenced object.
+                $this->aImage->addImageI18ns($this);
+             */
+        }
+
+        return $this->aImage;
+    }
+
+    /**
+     * Clears the current object and sets all attributes to their default values
+     */
+    public function clear()
+    {
+        $this->id = null;
+        $this->locale = null;
+        $this->title = null;
+        $this->description = null;
+        $this->chapo = null;
+        $this->postscriptum = null;
+        $this->alreadyInSave = false;
+        $this->clearAllReferences();
+        $this->applyDefaultValues();
+        $this->resetModified();
+        $this->setNew(true);
+        $this->setDeleted(false);
+    }
+
+    /**
+     * Resets all references to other model objects or collections of model objects.
+     *
+     * This method is a user-space workaround for PHP's inability to garbage collect
+     * objects with circular references (even in PHP 5.3). This is currently necessary
+     * when using Propel in certain daemon or large-volume/high-memory operations.
+     *
+     * @param      boolean $deep Whether to also clear the references on all referrer objects.
+     */
+    public function clearAllReferences($deep = false)
+    {
+        if ($deep) {
+        } // if ($deep)
+
+        $this->aImage = null;
+    }
+
+    /**
+     * Return the string representation of this object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->exportTo(ImageI18nTableMap::DEFAULT_STRING_FORMAT);
+    }
+
+    /**
+     * Code to be run before persisting the object
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preSave(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after persisting the object
+     * @param ConnectionInterface $con
+     */
+    public function postSave(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before inserting to database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preInsert(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after inserting to database
+     * @param ConnectionInterface $con
+     */
+    public function postInsert(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before updating the object in database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preUpdate(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after updating the object in database
+     * @param ConnectionInterface $con
+     */
+    public function postUpdate(ConnectionInterface $con = null)
+    {
+
+    }
+
+    /**
+     * Code to be run before deleting the object in database
+     * @param  ConnectionInterface $con
+     * @return boolean
+     */
+    public function preDelete(ConnectionInterface $con = null)
+    {
+        return true;
+    }
+
+    /**
+     * Code to be run after deleting the object in database
+     * @param ConnectionInterface $con
+     */
+    public function postDelete(ConnectionInterface $con = null)
+    {
+
+    }
+
+
+    /**
+     * Derived method to catches calls to undefined methods.
+     *
+     * Provides magic import/export method support (fromXML()/toXML(), fromYAML()/toYAML(), etc.).
+     * Allows to define default __call() behavior if you overwrite __call()
+     *
+     * @param string $name
+     * @param mixed  $params
+     *
+     * @return array|string
+     */
+    public function __call($name, $params)
+    {
+        if (0 === strpos($name, 'get')) {
+            $virtualColumn = substr($name, 3);
+            if ($this->hasVirtualColumn($virtualColumn)) {
+                return $this->getVirtualColumn($virtualColumn);
+            }
+
+            $virtualColumn = lcfirst($virtualColumn);
+            if ($this->hasVirtualColumn($virtualColumn)) {
+                return $this->getVirtualColumn($virtualColumn);
+            }
+        }
+
+        if (0 === strpos($name, 'from')) {
+            $format = substr($name, 4);
+
+            return $this->importFrom($format, reset($params));
+        }
+
+        if (0 === strpos($name, 'to')) {
+            $format = substr($name, 2);
+            $includeLazyLoadColumns = isset($params[0]) ? $params[0] : true;
+
+            return $this->exportTo($format, $includeLazyLoadColumns);
+        }
+
+        throw new BadMethodCallException(sprintf('Call to undefined method: %s.', $name));
+    }
+
+}

--- a/core/lib/Thelia/Model/Base/ImageI18nQuery.php
+++ b/core/lib/Thelia/Model/Base/ImageI18nQuery.php
@@ -1,0 +1,607 @@
+<?php
+
+namespace Thelia\Model\Base;
+
+use \Exception;
+use \PDO;
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveQuery\ModelJoin;
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
+use Thelia\Model\ImageI18n as ChildImageI18n;
+use Thelia\Model\ImageI18nQuery as ChildImageI18nQuery;
+use Thelia\Model\Map\ImageI18nTableMap;
+
+/**
+ * Base class that represents a query for the 'image_i18n' table.
+ *
+ *
+ *
+ * @method     ChildImageI18nQuery orderById($order = Criteria::ASC) Order by the id column
+ * @method     ChildImageI18nQuery orderByLocale($order = Criteria::ASC) Order by the locale column
+ * @method     ChildImageI18nQuery orderByTitle($order = Criteria::ASC) Order by the title column
+ * @method     ChildImageI18nQuery orderByDescription($order = Criteria::ASC) Order by the description column
+ * @method     ChildImageI18nQuery orderByChapo($order = Criteria::ASC) Order by the chapo column
+ * @method     ChildImageI18nQuery orderByPostscriptum($order = Criteria::ASC) Order by the postscriptum column
+ *
+ * @method     ChildImageI18nQuery groupById() Group by the id column
+ * @method     ChildImageI18nQuery groupByLocale() Group by the locale column
+ * @method     ChildImageI18nQuery groupByTitle() Group by the title column
+ * @method     ChildImageI18nQuery groupByDescription() Group by the description column
+ * @method     ChildImageI18nQuery groupByChapo() Group by the chapo column
+ * @method     ChildImageI18nQuery groupByPostscriptum() Group by the postscriptum column
+ *
+ * @method     ChildImageI18nQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
+ * @method     ChildImageI18nQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
+ * @method     ChildImageI18nQuery innerJoin($relation) Adds a INNER JOIN clause to the query
+ *
+ * @method     ChildImageI18nQuery leftJoinImage($relationAlias = null) Adds a LEFT JOIN clause to the query using the Image relation
+ * @method     ChildImageI18nQuery rightJoinImage($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Image relation
+ * @method     ChildImageI18nQuery innerJoinImage($relationAlias = null) Adds a INNER JOIN clause to the query using the Image relation
+ *
+ * @method     ChildImageI18n findOne(ConnectionInterface $con = null) Return the first ChildImageI18n matching the query
+ * @method     ChildImageI18n findOneOrCreate(ConnectionInterface $con = null) Return the first ChildImageI18n matching the query, or a new ChildImageI18n object populated from the query conditions when no match is found
+ *
+ * @method     ChildImageI18n findOneById(int $id) Return the first ChildImageI18n filtered by the id column
+ * @method     ChildImageI18n findOneByLocale(string $locale) Return the first ChildImageI18n filtered by the locale column
+ * @method     ChildImageI18n findOneByTitle(string $title) Return the first ChildImageI18n filtered by the title column
+ * @method     ChildImageI18n findOneByDescription(string $description) Return the first ChildImageI18n filtered by the description column
+ * @method     ChildImageI18n findOneByChapo(string $chapo) Return the first ChildImageI18n filtered by the chapo column
+ * @method     ChildImageI18n findOneByPostscriptum(string $postscriptum) Return the first ChildImageI18n filtered by the postscriptum column
+ *
+ * @method     array findById(int $id) Return ChildImageI18n objects filtered by the id column
+ * @method     array findByLocale(string $locale) Return ChildImageI18n objects filtered by the locale column
+ * @method     array findByTitle(string $title) Return ChildImageI18n objects filtered by the title column
+ * @method     array findByDescription(string $description) Return ChildImageI18n objects filtered by the description column
+ * @method     array findByChapo(string $chapo) Return ChildImageI18n objects filtered by the chapo column
+ * @method     array findByPostscriptum(string $postscriptum) Return ChildImageI18n objects filtered by the postscriptum column
+ *
+ */
+abstract class ImageI18nQuery extends ModelCriteria
+{
+
+    /**
+     * Initializes internal state of \Thelia\Model\Base\ImageI18nQuery object.
+     *
+     * @param     string $dbName The database name
+     * @param     string $modelName The phpName of a model, e.g. 'Book'
+     * @param     string $modelAlias The alias for the model in this query, e.g. 'b'
+     */
+    public function __construct($dbName = 'thelia', $modelName = '\\Thelia\\Model\\ImageI18n', $modelAlias = null)
+    {
+        parent::__construct($dbName, $modelName, $modelAlias);
+    }
+
+    /**
+     * Returns a new ChildImageI18nQuery object.
+     *
+     * @param     string $modelAlias The alias of a model in the query
+     * @param     Criteria $criteria Optional Criteria to build the query from
+     *
+     * @return ChildImageI18nQuery
+     */
+    public static function create($modelAlias = null, $criteria = null)
+    {
+        if ($criteria instanceof \Thelia\Model\ImageI18nQuery) {
+            return $criteria;
+        }
+        $query = new \Thelia\Model\ImageI18nQuery();
+        if (null !== $modelAlias) {
+            $query->setModelAlias($modelAlias);
+        }
+        if ($criteria instanceof Criteria) {
+            $query->mergeWith($criteria);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Find object by primary key.
+     * Propel uses the instance pool to skip the database if the object exists.
+     * Go fast if the query is untouched.
+     *
+     * <code>
+     * $obj = $c->findPk(array(12, 34), $con);
+     * </code>
+     *
+     * @param array[$id, $locale] $key Primary key to use for the query
+     * @param ConnectionInterface $con an optional connection object
+     *
+     * @return ChildImageI18n|array|mixed the result, formatted by the current formatter
+     */
+    public function findPk($key, $con = null)
+    {
+        if ($key === null) {
+            return null;
+        }
+        if ((null !== ($obj = ImageI18nTableMap::getInstanceFromPool(serialize(array((string) $key[0], (string) $key[1]))))) && !$this->formatter) {
+            // the object is already in the instance pool
+            return $obj;
+        }
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getReadConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+        $this->basePreSelect($con);
+        if ($this->formatter || $this->modelAlias || $this->with || $this->select
+         || $this->selectColumns || $this->asColumns || $this->selectModifiers
+         || $this->map || $this->having || $this->joins) {
+            return $this->findPkComplex($key, $con);
+        } else {
+            return $this->findPkSimple($key, $con);
+        }
+    }
+
+    /**
+     * Find object by primary key using raw SQL to go fast.
+     * Bypass doSelect() and the object formatter by using generated code.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     ConnectionInterface $con A connection object
+     *
+     * @return   ChildImageI18n A model object, or null if the key is not found
+     */
+    protected function findPkSimple($key, $con)
+    {
+        $sql = 'SELECT `ID`, `LOCALE`, `TITLE`, `DESCRIPTION`, `CHAPO`, `POSTSCRIPTUM` FROM `image_i18n` WHERE `ID` = :p0 AND `LOCALE` = :p1';
+        try {
+            $stmt = $con->prepare($sql);
+            $stmt->bindValue(':p0', $key[0], PDO::PARAM_INT);
+            $stmt->bindValue(':p1', $key[1], PDO::PARAM_STR);
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute SELECT statement [%s]', $sql), 0, $e);
+        }
+        $obj = null;
+        if ($row = $stmt->fetch(\PDO::FETCH_NUM)) {
+            $obj = new ChildImageI18n();
+            $obj->hydrate($row);
+            ImageI18nTableMap::addInstanceToPool($obj, serialize(array((string) $key[0], (string) $key[1])));
+        }
+        $stmt->closeCursor();
+
+        return $obj;
+    }
+
+    /**
+     * Find object by primary key.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     ConnectionInterface $con A connection object
+     *
+     * @return ChildImageI18n|array|mixed the result, formatted by the current formatter
+     */
+    protected function findPkComplex($key, $con)
+    {
+        // As the query uses a PK condition, no limit(1) is necessary.
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $dataFetcher = $criteria
+            ->filterByPrimaryKey($key)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->formatOne($dataFetcher);
+    }
+
+    /**
+     * Find objects by primary key
+     * <code>
+     * $objs = $c->findPks(array(array(12, 56), array(832, 123), array(123, 456)), $con);
+     * </code>
+     * @param     array $keys Primary keys to use for the query
+     * @param     ConnectionInterface $con an optional connection object
+     *
+     * @return ObjectCollection|array|mixed the list of results, formatted by the current formatter
+     */
+    public function findPks($keys, $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
+        }
+        $this->basePreSelect($con);
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $dataFetcher = $criteria
+            ->filterByPrimaryKeys($keys)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->format($dataFetcher);
+    }
+
+    /**
+     * Filter the query by primary key
+     *
+     * @param     mixed $key Primary key to use for the query
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKey($key)
+    {
+        $this->addUsingAlias(ImageI18nTableMap::ID, $key[0], Criteria::EQUAL);
+        $this->addUsingAlias(ImageI18nTableMap::LOCALE, $key[1], Criteria::EQUAL);
+
+        return $this;
+    }
+
+    /**
+     * Filter the query by a list of primary keys
+     *
+     * @param     array $keys The list of primary key to use for the query
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKeys($keys)
+    {
+        if (empty($keys)) {
+            return $this->add(null, '1<>1', Criteria::CUSTOM);
+        }
+        foreach ($keys as $key) {
+            $cton0 = $this->getNewCriterion(ImageI18nTableMap::ID, $key[0], Criteria::EQUAL);
+            $cton1 = $this->getNewCriterion(ImageI18nTableMap::LOCALE, $key[1], Criteria::EQUAL);
+            $cton0->addAnd($cton1);
+            $this->addOr($cton0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Filter the query on the id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterById(1234); // WHERE id = 1234
+     * $query->filterById(array(12, 34)); // WHERE id IN (12, 34)
+     * $query->filterById(array('min' => 12)); // WHERE id > 12
+     * </code>
+     *
+     * @see       filterByImage()
+     *
+     * @param     mixed $id The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterById($id = null, $comparison = null)
+    {
+        if (is_array($id)) {
+            $useMinMax = false;
+            if (isset($id['min'])) {
+                $this->addUsingAlias(ImageI18nTableMap::ID, $id['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($id['max'])) {
+                $this->addUsingAlias(ImageI18nTableMap::ID, $id['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::ID, $id, $comparison);
+    }
+
+    /**
+     * Filter the query on the locale column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByLocale('fooValue');   // WHERE locale = 'fooValue'
+     * $query->filterByLocale('%fooValue%'); // WHERE locale LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $locale The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByLocale($locale = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($locale)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $locale)) {
+                $locale = str_replace('*', '%', $locale);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::LOCALE, $locale, $comparison);
+    }
+
+    /**
+     * Filter the query on the title column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByTitle('fooValue');   // WHERE title = 'fooValue'
+     * $query->filterByTitle('%fooValue%'); // WHERE title LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $title The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByTitle($title = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($title)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $title)) {
+                $title = str_replace('*', '%', $title);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::TITLE, $title, $comparison);
+    }
+
+    /**
+     * Filter the query on the description column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByDescription('fooValue');   // WHERE description = 'fooValue'
+     * $query->filterByDescription('%fooValue%'); // WHERE description LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $description The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByDescription($description = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($description)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $description)) {
+                $description = str_replace('*', '%', $description);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::DESCRIPTION, $description, $comparison);
+    }
+
+    /**
+     * Filter the query on the chapo column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByChapo('fooValue');   // WHERE chapo = 'fooValue'
+     * $query->filterByChapo('%fooValue%'); // WHERE chapo LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $chapo The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByChapo($chapo = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($chapo)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $chapo)) {
+                $chapo = str_replace('*', '%', $chapo);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::CHAPO, $chapo, $comparison);
+    }
+
+    /**
+     * Filter the query on the postscriptum column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByPostscriptum('fooValue');   // WHERE postscriptum = 'fooValue'
+     * $query->filterByPostscriptum('%fooValue%'); // WHERE postscriptum LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $postscriptum The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByPostscriptum($postscriptum = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($postscriptum)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $postscriptum)) {
+                $postscriptum = str_replace('*', '%', $postscriptum);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageI18nTableMap::POSTSCRIPTUM, $postscriptum, $comparison);
+    }
+
+    /**
+     * Filter the query by a related \Thelia\Model\Image object
+     *
+     * @param \Thelia\Model\Image|ObjectCollection $image The related object(s) to use as filter
+     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function filterByImage($image, $comparison = null)
+    {
+        if ($image instanceof \Thelia\Model\Image) {
+            return $this
+                ->addUsingAlias(ImageI18nTableMap::ID, $image->getId(), $comparison);
+        } elseif ($image instanceof ObjectCollection) {
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+
+            return $this
+                ->addUsingAlias(ImageI18nTableMap::ID, $image->toKeyValue('PrimaryKey', 'Id'), $comparison);
+        } else {
+            throw new PropelException('filterByImage() only accepts arguments of type \Thelia\Model\Image or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Image relation
+     *
+     * @param     string $relationAlias optional alias for the relation
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function joinImage($relationAlias = null, $joinType = 'LEFT JOIN')
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Image');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Image');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Image relation Image object
+     *
+     * @see useQuery()
+     *
+     * @param     string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return   \Thelia\Model\ImageQuery A secondary query class using the current class as primary query
+     */
+    public function useImageQuery($relationAlias = null, $joinType = 'LEFT JOIN')
+    {
+        return $this
+            ->joinImage($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Image', '\Thelia\Model\ImageQuery');
+    }
+
+    /**
+     * Exclude object from result
+     *
+     * @param   ChildImageI18n $imageI18n Object to remove from the list of results
+     *
+     * @return ChildImageI18nQuery The current query, for fluid interface
+     */
+    public function prune($imageI18n = null)
+    {
+        if ($imageI18n) {
+            $this->addCond('pruneCond0', $this->getAliasedColName(ImageI18nTableMap::ID), $imageI18n->getId(), Criteria::NOT_EQUAL);
+            $this->addCond('pruneCond1', $this->getAliasedColName(ImageI18nTableMap::LOCALE), $imageI18n->getLocale(), Criteria::NOT_EQUAL);
+            $this->combine(array('pruneCond0', 'pruneCond1'), Criteria::LOGICAL_OR);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Deletes all rows from the image_i18n table.
+     *
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).
+     */
+    public function doDeleteAll(ConnectionInterface $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+            $affectedRows += parent::doDeleteAll($con);
+            // Because this db requires some delete cascade/set null emulation, we have to
+            // clear the cached instance *after* the emulation has happened (since
+            // instances get re-added by the select statement contained therein).
+            ImageI18nTableMap::clearInstancePool();
+            ImageI18nTableMap::clearRelatedInstancePool();
+
+            $con->commit();
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+
+        return $affectedRows;
+    }
+
+    /**
+     * Performs a DELETE on the database, given a ChildImageI18n or Criteria object OR a primary key value.
+     *
+     * @param mixed               $values Criteria or ChildImageI18n object or primary key or array of primary keys
+     *              which is used to create the DELETE statement
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
+     *                if supported by native driver or if emulated using Propel.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+     public function delete(ConnectionInterface $con = null)
+     {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        $criteria = $this;
+
+        // Set the correct dbName
+        $criteria->setDbName(ImageI18nTableMap::DATABASE_NAME);
+
+        $affectedRows = 0; // initialize var to track total num of affected rows
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+
+
+        ImageI18nTableMap::removeInstanceFromPool($criteria);
+
+            $affectedRows += ModelCriteria::delete($con);
+            ImageI18nTableMap::clearRelatedInstancePool();
+            $con->commit();
+
+            return $affectedRows;
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+} // ImageI18nQuery

--- a/core/lib/Thelia/Model/Base/ImageQuery.php
+++ b/core/lib/Thelia/Model/Base/ImageQuery.php
@@ -1,0 +1,843 @@
+<?php
+
+namespace Thelia\Model\Base;
+
+use \Exception;
+use \PDO;
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\ActiveQuery\ModelJoin;
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
+use Thelia\Model\Image as ChildImage;
+use Thelia\Model\ImageI18nQuery as ChildImageI18nQuery;
+use Thelia\Model\ImageQuery as ChildImageQuery;
+use Thelia\Model\Map\ImageTableMap;
+
+/**
+ * Base class that represents a query for the 'image' table.
+ *
+ *
+ *
+ * @method     ChildImageQuery orderById($order = Criteria::ASC) Order by the id column
+ * @method     ChildImageQuery orderBySource($order = Criteria::ASC) Order by the source column
+ * @method     ChildImageQuery orderBySourceId($order = Criteria::ASC) Order by the source_id column
+ * @method     ChildImageQuery orderByFile($order = Criteria::ASC) Order by the file column
+ * @method     ChildImageQuery orderByVisible($order = Criteria::ASC) Order by the visible column
+ * @method     ChildImageQuery orderByPosition($order = Criteria::ASC) Order by the position column
+ * @method     ChildImageQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
+ * @method     ChildImageQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
+ *
+ * @method     ChildImageQuery groupById() Group by the id column
+ * @method     ChildImageQuery groupBySource() Group by the source column
+ * @method     ChildImageQuery groupBySourceId() Group by the source_id column
+ * @method     ChildImageQuery groupByFile() Group by the file column
+ * @method     ChildImageQuery groupByVisible() Group by the visible column
+ * @method     ChildImageQuery groupByPosition() Group by the position column
+ * @method     ChildImageQuery groupByCreatedAt() Group by the created_at column
+ * @method     ChildImageQuery groupByUpdatedAt() Group by the updated_at column
+ *
+ * @method     ChildImageQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
+ * @method     ChildImageQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
+ * @method     ChildImageQuery innerJoin($relation) Adds a INNER JOIN clause to the query
+ *
+ * @method     ChildImageQuery leftJoinImageI18n($relationAlias = null) Adds a LEFT JOIN clause to the query using the ImageI18n relation
+ * @method     ChildImageQuery rightJoinImageI18n($relationAlias = null) Adds a RIGHT JOIN clause to the query using the ImageI18n relation
+ * @method     ChildImageQuery innerJoinImageI18n($relationAlias = null) Adds a INNER JOIN clause to the query using the ImageI18n relation
+ *
+ * @method     ChildImage findOne(ConnectionInterface $con = null) Return the first ChildImage matching the query
+ * @method     ChildImage findOneOrCreate(ConnectionInterface $con = null) Return the first ChildImage matching the query, or a new ChildImage object populated from the query conditions when no match is found
+ *
+ * @method     ChildImage findOneById(int $id) Return the first ChildImage filtered by the id column
+ * @method     ChildImage findOneBySource(string $source) Return the first ChildImage filtered by the source column
+ * @method     ChildImage findOneBySourceId(int $source_id) Return the first ChildImage filtered by the source_id column
+ * @method     ChildImage findOneByFile(string $file) Return the first ChildImage filtered by the file column
+ * @method     ChildImage findOneByVisible(int $visible) Return the first ChildImage filtered by the visible column
+ * @method     ChildImage findOneByPosition(int $position) Return the first ChildImage filtered by the position column
+ * @method     ChildImage findOneByCreatedAt(string $created_at) Return the first ChildImage filtered by the created_at column
+ * @method     ChildImage findOneByUpdatedAt(string $updated_at) Return the first ChildImage filtered by the updated_at column
+ *
+ * @method     array findById(int $id) Return ChildImage objects filtered by the id column
+ * @method     array findBySource(string $source) Return ChildImage objects filtered by the source column
+ * @method     array findBySourceId(int $source_id) Return ChildImage objects filtered by the source_id column
+ * @method     array findByFile(string $file) Return ChildImage objects filtered by the file column
+ * @method     array findByVisible(int $visible) Return ChildImage objects filtered by the visible column
+ * @method     array findByPosition(int $position) Return ChildImage objects filtered by the position column
+ * @method     array findByCreatedAt(string $created_at) Return ChildImage objects filtered by the created_at column
+ * @method     array findByUpdatedAt(string $updated_at) Return ChildImage objects filtered by the updated_at column
+ *
+ */
+abstract class ImageQuery extends ModelCriteria
+{
+
+    /**
+     * Initializes internal state of \Thelia\Model\Base\ImageQuery object.
+     *
+     * @param     string $dbName The database name
+     * @param     string $modelName The phpName of a model, e.g. 'Book'
+     * @param     string $modelAlias The alias for the model in this query, e.g. 'b'
+     */
+    public function __construct($dbName = 'thelia', $modelName = '\\Thelia\\Model\\Image', $modelAlias = null)
+    {
+        parent::__construct($dbName, $modelName, $modelAlias);
+    }
+
+    /**
+     * Returns a new ChildImageQuery object.
+     *
+     * @param     string $modelAlias The alias of a model in the query
+     * @param     Criteria $criteria Optional Criteria to build the query from
+     *
+     * @return ChildImageQuery
+     */
+    public static function create($modelAlias = null, $criteria = null)
+    {
+        if ($criteria instanceof \Thelia\Model\ImageQuery) {
+            return $criteria;
+        }
+        $query = new \Thelia\Model\ImageQuery();
+        if (null !== $modelAlias) {
+            $query->setModelAlias($modelAlias);
+        }
+        if ($criteria instanceof Criteria) {
+            $query->mergeWith($criteria);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Find object by primary key.
+     * Propel uses the instance pool to skip the database if the object exists.
+     * Go fast if the query is untouched.
+     *
+     * <code>
+     * $obj  = $c->findPk(12, $con);
+     * </code>
+     *
+     * @param mixed $key Primary key to use for the query
+     * @param ConnectionInterface $con an optional connection object
+     *
+     * @return ChildImage|array|mixed the result, formatted by the current formatter
+     */
+    public function findPk($key, $con = null)
+    {
+        if ($key === null) {
+            return null;
+        }
+        if ((null !== ($obj = ImageTableMap::getInstanceFromPool((string) $key))) && !$this->formatter) {
+            // the object is already in the instance pool
+            return $obj;
+        }
+        if ($con === null) {
+            $con = Propel::getServiceContainer()->getReadConnection(ImageTableMap::DATABASE_NAME);
+        }
+        $this->basePreSelect($con);
+        if ($this->formatter || $this->modelAlias || $this->with || $this->select
+         || $this->selectColumns || $this->asColumns || $this->selectModifiers
+         || $this->map || $this->having || $this->joins) {
+            return $this->findPkComplex($key, $con);
+        } else {
+            return $this->findPkSimple($key, $con);
+        }
+    }
+
+    /**
+     * Find object by primary key using raw SQL to go fast.
+     * Bypass doSelect() and the object formatter by using generated code.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     ConnectionInterface $con A connection object
+     *
+     * @return   ChildImage A model object, or null if the key is not found
+     */
+    protected function findPkSimple($key, $con)
+    {
+        $sql = 'SELECT `ID`, `SOURCE`, `SOURCE_ID`, `FILE`, `VISIBLE`, `POSITION`, `CREATED_AT`, `UPDATED_AT` FROM `image` WHERE `ID` = :p0';
+        try {
+            $stmt = $con->prepare($sql);
+            $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
+            $stmt->execute();
+        } catch (Exception $e) {
+            Propel::log($e->getMessage(), Propel::LOG_ERR);
+            throw new PropelException(sprintf('Unable to execute SELECT statement [%s]', $sql), 0, $e);
+        }
+        $obj = null;
+        if ($row = $stmt->fetch(\PDO::FETCH_NUM)) {
+            $obj = new ChildImage();
+            $obj->hydrate($row);
+            ImageTableMap::addInstanceToPool($obj, (string) $key);
+        }
+        $stmt->closeCursor();
+
+        return $obj;
+    }
+
+    /**
+     * Find object by primary key.
+     *
+     * @param     mixed $key Primary key to use for the query
+     * @param     ConnectionInterface $con A connection object
+     *
+     * @return ChildImage|array|mixed the result, formatted by the current formatter
+     */
+    protected function findPkComplex($key, $con)
+    {
+        // As the query uses a PK condition, no limit(1) is necessary.
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $dataFetcher = $criteria
+            ->filterByPrimaryKey($key)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->formatOne($dataFetcher);
+    }
+
+    /**
+     * Find objects by primary key
+     * <code>
+     * $objs = $c->findPks(array(12, 56, 832), $con);
+     * </code>
+     * @param     array $keys Primary keys to use for the query
+     * @param     ConnectionInterface $con an optional connection object
+     *
+     * @return ObjectCollection|array|mixed the list of results, formatted by the current formatter
+     */
+    public function findPks($keys, $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
+        }
+        $this->basePreSelect($con);
+        $criteria = $this->isKeepQuery() ? clone $this : $this;
+        $dataFetcher = $criteria
+            ->filterByPrimaryKeys($keys)
+            ->doSelect($con);
+
+        return $criteria->getFormatter()->init($criteria)->format($dataFetcher);
+    }
+
+    /**
+     * Filter the query by primary key
+     *
+     * @param     mixed $key Primary key to use for the query
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKey($key)
+    {
+
+        return $this->addUsingAlias(ImageTableMap::ID, $key, Criteria::EQUAL);
+    }
+
+    /**
+     * Filter the query by a list of primary keys
+     *
+     * @param     array $keys The list of primary key to use for the query
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByPrimaryKeys($keys)
+    {
+
+        return $this->addUsingAlias(ImageTableMap::ID, $keys, Criteria::IN);
+    }
+
+    /**
+     * Filter the query on the id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterById(1234); // WHERE id = 1234
+     * $query->filterById(array(12, 34)); // WHERE id IN (12, 34)
+     * $query->filterById(array('min' => 12)); // WHERE id > 12
+     * </code>
+     *
+     * @param     mixed $id The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterById($id = null, $comparison = null)
+    {
+        if (is_array($id)) {
+            $useMinMax = false;
+            if (isset($id['min'])) {
+                $this->addUsingAlias(ImageTableMap::ID, $id['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($id['max'])) {
+                $this->addUsingAlias(ImageTableMap::ID, $id['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::ID, $id, $comparison);
+    }
+
+    /**
+     * Filter the query on the source column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterBySource('fooValue');   // WHERE source = 'fooValue'
+     * $query->filterBySource('%fooValue%'); // WHERE source LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $source The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterBySource($source = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($source)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $source)) {
+                $source = str_replace('*', '%', $source);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::SOURCE, $source, $comparison);
+    }
+
+    /**
+     * Filter the query on the source_id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterBySourceId(1234); // WHERE source_id = 1234
+     * $query->filterBySourceId(array(12, 34)); // WHERE source_id IN (12, 34)
+     * $query->filterBySourceId(array('min' => 12)); // WHERE source_id > 12
+     * </code>
+     *
+     * @param     mixed $sourceId The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterBySourceId($sourceId = null, $comparison = null)
+    {
+        if (is_array($sourceId)) {
+            $useMinMax = false;
+            if (isset($sourceId['min'])) {
+                $this->addUsingAlias(ImageTableMap::SOURCE_ID, $sourceId['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($sourceId['max'])) {
+                $this->addUsingAlias(ImageTableMap::SOURCE_ID, $sourceId['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::SOURCE_ID, $sourceId, $comparison);
+    }
+
+    /**
+     * Filter the query on the file column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByFile('fooValue');   // WHERE file = 'fooValue'
+     * $query->filterByFile('%fooValue%'); // WHERE file LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $file The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByFile($file = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($file)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $file)) {
+                $file = str_replace('*', '%', $file);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::FILE, $file, $comparison);
+    }
+
+    /**
+     * Filter the query on the visible column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByVisible(1234); // WHERE visible = 1234
+     * $query->filterByVisible(array(12, 34)); // WHERE visible IN (12, 34)
+     * $query->filterByVisible(array('min' => 12)); // WHERE visible > 12
+     * </code>
+     *
+     * @param     mixed $visible The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByVisible($visible = null, $comparison = null)
+    {
+        if (is_array($visible)) {
+            $useMinMax = false;
+            if (isset($visible['min'])) {
+                $this->addUsingAlias(ImageTableMap::VISIBLE, $visible['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($visible['max'])) {
+                $this->addUsingAlias(ImageTableMap::VISIBLE, $visible['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::VISIBLE, $visible, $comparison);
+    }
+
+    /**
+     * Filter the query on the position column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByPosition(1234); // WHERE position = 1234
+     * $query->filterByPosition(array(12, 34)); // WHERE position IN (12, 34)
+     * $query->filterByPosition(array('min' => 12)); // WHERE position > 12
+     * </code>
+     *
+     * @param     mixed $position The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByPosition($position = null, $comparison = null)
+    {
+        if (is_array($position)) {
+            $useMinMax = false;
+            if (isset($position['min'])) {
+                $this->addUsingAlias(ImageTableMap::POSITION, $position['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($position['max'])) {
+                $this->addUsingAlias(ImageTableMap::POSITION, $position['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::POSITION, $position, $comparison);
+    }
+
+    /**
+     * Filter the query on the created_at column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByCreatedAt('2011-03-14'); // WHERE created_at = '2011-03-14'
+     * $query->filterByCreatedAt('now'); // WHERE created_at = '2011-03-14'
+     * $query->filterByCreatedAt(array('max' => 'yesterday')); // WHERE created_at > '2011-03-13'
+     * </code>
+     *
+     * @param     mixed $createdAt The value to use as filter.
+     *              Values can be integers (unix timestamps), DateTime objects, or strings.
+     *              Empty strings are treated as NULL.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByCreatedAt($createdAt = null, $comparison = null)
+    {
+        if (is_array($createdAt)) {
+            $useMinMax = false;
+            if (isset($createdAt['min'])) {
+                $this->addUsingAlias(ImageTableMap::CREATED_AT, $createdAt['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($createdAt['max'])) {
+                $this->addUsingAlias(ImageTableMap::CREATED_AT, $createdAt['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::CREATED_AT, $createdAt, $comparison);
+    }
+
+    /**
+     * Filter the query on the updated_at column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByUpdatedAt('2011-03-14'); // WHERE updated_at = '2011-03-14'
+     * $query->filterByUpdatedAt('now'); // WHERE updated_at = '2011-03-14'
+     * $query->filterByUpdatedAt(array('max' => 'yesterday')); // WHERE updated_at > '2011-03-13'
+     * </code>
+     *
+     * @param     mixed $updatedAt The value to use as filter.
+     *              Values can be integers (unix timestamps), DateTime objects, or strings.
+     *              Empty strings are treated as NULL.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByUpdatedAt($updatedAt = null, $comparison = null)
+    {
+        if (is_array($updatedAt)) {
+            $useMinMax = false;
+            if (isset($updatedAt['min'])) {
+                $this->addUsingAlias(ImageTableMap::UPDATED_AT, $updatedAt['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($updatedAt['max'])) {
+                $this->addUsingAlias(ImageTableMap::UPDATED_AT, $updatedAt['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        return $this->addUsingAlias(ImageTableMap::UPDATED_AT, $updatedAt, $comparison);
+    }
+
+    /**
+     * Filter the query by a related \Thelia\Model\ImageI18n object
+     *
+     * @param \Thelia\Model\ImageI18n|ObjectCollection $imageI18n  the related object to use as filter
+     * @param string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function filterByImageI18n($imageI18n, $comparison = null)
+    {
+        if ($imageI18n instanceof \Thelia\Model\ImageI18n) {
+            return $this
+                ->addUsingAlias(ImageTableMap::ID, $imageI18n->getId(), $comparison);
+        } elseif ($imageI18n instanceof ObjectCollection) {
+            return $this
+                ->useImageI18nQuery()
+                ->filterByPrimaryKeys($imageI18n->getPrimaryKeys())
+                ->endUse();
+        } else {
+            throw new PropelException('filterByImageI18n() only accepts arguments of type \Thelia\Model\ImageI18n or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the ImageI18n relation
+     *
+     * @param     string $relationAlias optional alias for the relation
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function joinImageI18n($relationAlias = null, $joinType = 'LEFT JOIN')
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('ImageI18n');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'ImageI18n');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the ImageI18n relation ImageI18n object
+     *
+     * @see useQuery()
+     *
+     * @param     string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return   \Thelia\Model\ImageI18nQuery A secondary query class using the current class as primary query
+     */
+    public function useImageI18nQuery($relationAlias = null, $joinType = 'LEFT JOIN')
+    {
+        return $this
+            ->joinImageI18n($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'ImageI18n', '\Thelia\Model\ImageI18nQuery');
+    }
+
+    /**
+     * Exclude object from result
+     *
+     * @param   ChildImage $image Object to remove from the list of results
+     *
+     * @return ChildImageQuery The current query, for fluid interface
+     */
+    public function prune($image = null)
+    {
+        if ($image) {
+            $this->addUsingAlias(ImageTableMap::ID, $image->getId(), Criteria::NOT_EQUAL);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Deletes all rows from the image table.
+     *
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).
+     */
+    public function doDeleteAll(ConnectionInterface $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+        $affectedRows = 0; // initialize var to track total num of affected rows
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+            $affectedRows += parent::doDeleteAll($con);
+            // Because this db requires some delete cascade/set null emulation, we have to
+            // clear the cached instance *after* the emulation has happened (since
+            // instances get re-added by the select statement contained therein).
+            ImageTableMap::clearInstancePool();
+            ImageTableMap::clearRelatedInstancePool();
+
+            $con->commit();
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+
+        return $affectedRows;
+    }
+
+    /**
+     * Performs a DELETE on the database, given a ChildImage or Criteria object OR a primary key value.
+     *
+     * @param mixed               $values Criteria or ChildImage object or primary key or array of primary keys
+     *              which is used to create the DELETE statement
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
+     *                if supported by native driver or if emulated using Propel.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+     public function delete(ConnectionInterface $con = null)
+     {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        $criteria = $this;
+
+        // Set the correct dbName
+        $criteria->setDbName(ImageTableMap::DATABASE_NAME);
+
+        $affectedRows = 0; // initialize var to track total num of affected rows
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table or we could emulating ON DELETE CASCADE, etc.
+            $con->beginTransaction();
+
+
+        ImageTableMap::removeInstanceFromPool($criteria);
+
+            $affectedRows += ModelCriteria::delete($con);
+            ImageTableMap::clearRelatedInstancePool();
+            $con->commit();
+
+            return $affectedRows;
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+    }
+
+    // timestampable behavior
+
+    /**
+     * Filter by the latest updated
+     *
+     * @param      int $nbDays Maximum age of the latest update in days
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function recentlyUpdated($nbDays = 7)
+    {
+        return $this->addUsingAlias(ImageTableMap::UPDATED_AT, time() - $nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
+    }
+
+    /**
+     * Filter by the latest created
+     *
+     * @param      int $nbDays Maximum age of in days
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function recentlyCreated($nbDays = 7)
+    {
+        return $this->addUsingAlias(ImageTableMap::CREATED_AT, time() - $nbDays * 24 * 60 * 60, Criteria::GREATER_EQUAL);
+    }
+
+    /**
+     * Order by update date desc
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function lastUpdatedFirst()
+    {
+        return $this->addDescendingOrderByColumn(ImageTableMap::UPDATED_AT);
+    }
+
+    /**
+     * Order by update date asc
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function firstUpdatedFirst()
+    {
+        return $this->addAscendingOrderByColumn(ImageTableMap::UPDATED_AT);
+    }
+
+    /**
+     * Order by create date desc
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function lastCreatedFirst()
+    {
+        return $this->addDescendingOrderByColumn(ImageTableMap::CREATED_AT);
+    }
+
+    /**
+     * Order by create date asc
+     *
+     * @return     ChildImageQuery The current query, for fluid interface
+     */
+    public function firstCreatedFirst()
+    {
+        return $this->addAscendingOrderByColumn(ImageTableMap::CREATED_AT);
+    }
+
+    // i18n behavior
+
+    /**
+     * Adds a JOIN clause to the query using the i18n relation
+     *
+     * @param     string $locale Locale to use for the join condition, e.g. 'fr_FR'
+     * @param     string $relationAlias optional alias for the relation
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+     *
+     * @return    ChildImageQuery The current query, for fluid interface
+     */
+    public function joinI18n($locale = 'en_US', $relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        $relationName = $relationAlias ? $relationAlias : 'ImageI18n';
+
+        return $this
+            ->joinImageI18n($relationAlias, $joinType)
+            ->addJoinCondition($relationName, $relationName . '.Locale = ?', $locale);
+    }
+
+    /**
+     * Adds a JOIN clause to the query and hydrates the related I18n object.
+     * Shortcut for $c->joinI18n($locale)->with()
+     *
+     * @param     string $locale Locale to use for the join condition, e.g. 'fr_FR'
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+     *
+     * @return    ChildImageQuery The current query, for fluid interface
+     */
+    public function joinWithI18n($locale = 'en_US', $joinType = Criteria::LEFT_JOIN)
+    {
+        $this
+            ->joinI18n($locale, null, $joinType)
+            ->with('ImageI18n');
+        $this->with['ImageI18n']->setIsWithOneToMany(false);
+
+        return $this;
+    }
+
+    /**
+     * Use the I18n relation query object
+     *
+     * @see       useQuery()
+     *
+     * @param     string $locale Locale to use for the join condition, e.g. 'fr_FR'
+     * @param     string $relationAlias optional alias for the relation
+     * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
+     *
+     * @return    ChildImageI18nQuery A secondary query class using the current class as primary query
+     */
+    public function useI18nQuery($locale = 'en_US', $relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinI18n($locale, $relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'ImageI18n', '\Thelia\Model\ImageI18nQuery');
+    }
+
+} // ImageQuery

--- a/core/lib/Thelia/Model/Image.php
+++ b/core/lib/Thelia/Model/Image.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\Image as BaseImage;
+
+class Image extends BaseImage
+{
+
+}

--- a/core/lib/Thelia/Model/ImageI18n.php
+++ b/core/lib/Thelia/Model/ImageI18n.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\ImageI18n as BaseImageI18n;
+
+class ImageI18n extends BaseImageI18n
+{
+
+}

--- a/core/lib/Thelia/Model/ImageI18nQuery.php
+++ b/core/lib/Thelia/Model/ImageI18nQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\ImageI18nQuery as BaseImageI18nQuery;
+
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'image_i18n' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ *
+ */
+class ImageI18nQuery extends BaseImageI18nQuery
+{
+
+} // ImageI18nQuery

--- a/core/lib/Thelia/Model/ImageQuery.php
+++ b/core/lib/Thelia/Model/ImageQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\ImageQuery as BaseImageQuery;
+
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'image' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ *
+ */
+class ImageQuery extends BaseImageQuery
+{
+
+} // ImageQuery

--- a/core/lib/Thelia/Model/Map/ImageI18nTableMap.php
+++ b/core/lib/Thelia/Model/Map/ImageI18nTableMap.php
@@ -1,0 +1,498 @@
+<?php
+
+namespace Thelia\Model\Map;
+
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\InstancePoolTrait;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\RelationMap;
+use Propel\Runtime\Map\TableMap;
+use Propel\Runtime\Map\TableMapTrait;
+use Thelia\Model\ImageI18n;
+use Thelia\Model\ImageI18nQuery;
+
+
+/**
+ * This class defines the structure of the 'image_i18n' table.
+ *
+ *
+ *
+ * This map class is used by Propel to do runtime db structure discovery.
+ * For example, the createSelectSql() method checks the type of a given column used in an
+ * ORDER BY clause to know whether it needs to apply SQL to make the ORDER BY case-insensitive
+ * (i.e. if it's a text column type).
+ *
+ */
+class ImageI18nTableMap extends TableMap
+{
+    use InstancePoolTrait;
+    use TableMapTrait;
+    /**
+     * The (dot-path) name of this class
+     */
+    const CLASS_NAME = 'Thelia.Model.Map.ImageI18nTableMap';
+
+    /**
+     * The default database name for this class
+     */
+    const DATABASE_NAME = 'thelia';
+
+    /**
+     * The table name for this class
+     */
+    const TABLE_NAME = 'image_i18n';
+
+    /**
+     * The related Propel class for this table
+     */
+    const OM_CLASS = '\\Thelia\\Model\\ImageI18n';
+
+    /**
+     * A class that can be returned by this tableMap
+     */
+    const CLASS_DEFAULT = 'Thelia.Model.ImageI18n';
+
+    /**
+     * The total number of columns
+     */
+    const NUM_COLUMNS = 6;
+
+    /**
+     * The number of lazy-loaded columns
+     */
+    const NUM_LAZY_LOAD_COLUMNS = 0;
+
+    /**
+     * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
+     */
+    const NUM_HYDRATE_COLUMNS = 6;
+
+    /**
+     * the column name for the ID field
+     */
+    const ID = 'image_i18n.ID';
+
+    /**
+     * the column name for the LOCALE field
+     */
+    const LOCALE = 'image_i18n.LOCALE';
+
+    /**
+     * the column name for the TITLE field
+     */
+    const TITLE = 'image_i18n.TITLE';
+
+    /**
+     * the column name for the DESCRIPTION field
+     */
+    const DESCRIPTION = 'image_i18n.DESCRIPTION';
+
+    /**
+     * the column name for the CHAPO field
+     */
+    const CHAPO = 'image_i18n.CHAPO';
+
+    /**
+     * the column name for the POSTSCRIPTUM field
+     */
+    const POSTSCRIPTUM = 'image_i18n.POSTSCRIPTUM';
+
+    /**
+     * The default string format for model objects of the related table
+     */
+    const DEFAULT_STRING_FORMAT = 'YAML';
+
+    /**
+     * holds an array of fieldnames
+     *
+     * first dimension keys are the type constants
+     * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
+     */
+    protected static $fieldNames = array (
+        self::TYPE_PHPNAME       => array('Id', 'Locale', 'Title', 'Description', 'Chapo', 'Postscriptum', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'locale', 'title', 'description', 'chapo', 'postscriptum', ),
+        self::TYPE_COLNAME       => array(ImageI18nTableMap::ID, ImageI18nTableMap::LOCALE, ImageI18nTableMap::TITLE, ImageI18nTableMap::DESCRIPTION, ImageI18nTableMap::CHAPO, ImageI18nTableMap::POSTSCRIPTUM, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'LOCALE', 'TITLE', 'DESCRIPTION', 'CHAPO', 'POSTSCRIPTUM', ),
+        self::TYPE_FIELDNAME     => array('id', 'locale', 'title', 'description', 'chapo', 'postscriptum', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+    );
+
+    /**
+     * holds an array of keys for quick access to the fieldnames array
+     *
+     * first dimension keys are the type constants
+     * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
+     */
+    protected static $fieldKeys = array (
+        self::TYPE_PHPNAME       => array('Id' => 0, 'Locale' => 1, 'Title' => 2, 'Description' => 3, 'Chapo' => 4, 'Postscriptum' => 5, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'locale' => 1, 'title' => 2, 'description' => 3, 'chapo' => 4, 'postscriptum' => 5, ),
+        self::TYPE_COLNAME       => array(ImageI18nTableMap::ID => 0, ImageI18nTableMap::LOCALE => 1, ImageI18nTableMap::TITLE => 2, ImageI18nTableMap::DESCRIPTION => 3, ImageI18nTableMap::CHAPO => 4, ImageI18nTableMap::POSTSCRIPTUM => 5, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'LOCALE' => 1, 'TITLE' => 2, 'DESCRIPTION' => 3, 'CHAPO' => 4, 'POSTSCRIPTUM' => 5, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'locale' => 1, 'title' => 2, 'description' => 3, 'chapo' => 4, 'postscriptum' => 5, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, )
+    );
+
+    /**
+     * Initialize the table attributes and columns
+     * Relations are not initialized by this method since they are lazy loaded
+     *
+     * @return void
+     * @throws PropelException
+     */
+    public function initialize()
+    {
+        // attributes
+        $this->setName('image_i18n');
+        $this->setPhpName('ImageI18n');
+        $this->setClassName('\\Thelia\\Model\\ImageI18n');
+        $this->setPackage('Thelia.Model');
+        $this->setUseIdGenerator(false);
+        // columns
+        $this->addForeignPrimaryKey('ID', 'Id', 'INTEGER' , 'image', 'ID', true, null, null);
+        $this->addPrimaryKey('LOCALE', 'Locale', 'VARCHAR', true, 5, 'en_US');
+        $this->addColumn('TITLE', 'Title', 'VARCHAR', false, 255, null);
+        $this->addColumn('DESCRIPTION', 'Description', 'CLOB', false, null, null);
+        $this->addColumn('CHAPO', 'Chapo', 'LONGVARCHAR', false, null, null);
+        $this->addColumn('POSTSCRIPTUM', 'Postscriptum', 'LONGVARCHAR', false, null, null);
+    } // initialize()
+
+    /**
+     * Build the RelationMap objects for this table relationships
+     */
+    public function buildRelations()
+    {
+        $this->addRelation('Image', '\\Thelia\\Model\\Image', RelationMap::MANY_TO_ONE, array('id' => 'id', ), 'CASCADE', null);
+    } // buildRelations()
+
+    /**
+     * Adds an object to the instance pool.
+     *
+     * Propel keeps cached copies of objects in an instance pool when they are retrieved
+     * from the database. In some cases you may need to explicitly add objects
+     * to the cache in order to ensure that the same objects are always returned by find*()
+     * and findPk*() calls.
+     *
+     * @param \Thelia\Model\ImageI18n $obj A \Thelia\Model\ImageI18n object.
+     * @param string $key             (optional) key to use for instance map (for performance boost if key was already calculated externally).
+     */
+    public static function addInstanceToPool($obj, $key = null)
+    {
+        if (Propel::isInstancePoolingEnabled()) {
+            if (null === $key) {
+                $key = serialize(array((string) $obj->getId(), (string) $obj->getLocale()));
+            } // if key === null
+            self::$instances[$key] = $obj;
+        }
+    }
+
+    /**
+     * Removes an object from the instance pool.
+     *
+     * Propel keeps cached copies of objects in an instance pool when they are retrieved
+     * from the database.  In some cases -- especially when you override doDelete
+     * methods in your stub classes -- you may need to explicitly remove objects
+     * from the cache in order to prevent returning objects that no longer exist.
+     *
+     * @param mixed $value A \Thelia\Model\ImageI18n object or a primary key value.
+     */
+    public static function removeInstanceFromPool($value)
+    {
+        if (Propel::isInstancePoolingEnabled() && null !== $value) {
+            if (is_object($value) && $value instanceof \Thelia\Model\ImageI18n) {
+                $key = serialize(array((string) $value->getId(), (string) $value->getLocale()));
+
+            } elseif (is_array($value) && count($value) === 2) {
+                // assume we've been passed a primary key";
+                $key = serialize(array((string) $value[0], (string) $value[1]));
+            } elseif ($value instanceof Criteria) {
+                self::$instances = [];
+
+                return;
+            } else {
+                $e = new PropelException("Invalid value passed to removeInstanceFromPool().  Expected primary key or \Thelia\Model\ImageI18n object; got " . (is_object($value) ? get_class($value) . ' object.' : var_export($value, true)));
+                throw $e;
+            }
+
+            unset(self::$instances[$key]);
+        }
+    }
+
+    /**
+     * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
+     *
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, a serialize()d version of the primary key will be returned.
+     *
+     * @param array  $row       resultset row.
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM
+     */
+    public static function getPrimaryKeyHashFromRow($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+        // If the PK cannot be derived from the row, return NULL.
+        if ($row[TableMap::TYPE_NUM == $indexType ? 0 + $offset : static::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)] === null && $row[TableMap::TYPE_NUM == $indexType ? 1 + $offset : static::translateFieldName('Locale', TableMap::TYPE_PHPNAME, $indexType)] === null) {
+            return null;
+        }
+
+        return serialize(array((string) $row[TableMap::TYPE_NUM == $indexType ? 0 + $offset : static::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)], (string) $row[TableMap::TYPE_NUM == $indexType ? 1 + $offset : static::translateFieldName('Locale', TableMap::TYPE_PHPNAME, $indexType)]));
+    }
+
+    /**
+     * Retrieves the primary key from the DB resultset row
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, an array of the primary key columns will be returned.
+     *
+     * @param array  $row       resultset row.
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM
+     *
+     * @return mixed The primary key of the row
+     */
+    public static function getPrimaryKeyFromRow($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+
+            return $pks;
+    }
+
+    /**
+     * The class that the tableMap will make instances of.
+     *
+     * If $withPrefix is true, the returned path
+     * uses a dot-path notation which is translated into a path
+     * relative to a location on the PHP include_path.
+     * (e.g. path.to.MyClass -> 'path/to/MyClass.php')
+     *
+     * @param boolean $withPrefix Whether or not to return the path with the class name
+     * @return string path.to.ClassName
+     */
+    public static function getOMClass($withPrefix = true)
+    {
+        return $withPrefix ? ImageI18nTableMap::CLASS_DEFAULT : ImageI18nTableMap::OM_CLASS;
+    }
+
+    /**
+     * Populates an object of the default type or an object that inherit from the default.
+     *
+     * @param array  $row       row returned by DataFetcher->fetch().
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType The index type of $row. Mostly DataFetcher->getIndexType().
+                                 One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     * @return array (ImageI18n object, last column rank)
+     */
+    public static function populateObject($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+        $key = ImageI18nTableMap::getPrimaryKeyHashFromRow($row, $offset, $indexType);
+        if (null !== ($obj = ImageI18nTableMap::getInstanceFromPool($key))) {
+            // We no longer rehydrate the object, since this can cause data loss.
+            // See http://www.propelorm.org/ticket/509
+            // $obj->hydrate($row, $offset, true); // rehydrate
+            $col = $offset + ImageI18nTableMap::NUM_HYDRATE_COLUMNS;
+        } else {
+            $cls = ImageI18nTableMap::OM_CLASS;
+            $obj = new $cls();
+            $col = $obj->hydrate($row, $offset, false, $indexType);
+            ImageI18nTableMap::addInstanceToPool($obj, $key);
+        }
+
+        return array($obj, $col);
+    }
+
+    /**
+     * The returned array will contain objects of the default type or
+     * objects that inherit from the default.
+     *
+     * @param DataFetcherInterface $dataFetcher
+     * @return array
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function populateObjects(DataFetcherInterface $dataFetcher)
+    {
+        $results = array();
+
+        // set the class once to avoid overhead in the loop
+        $cls = static::getOMClass(false);
+        // populate the object(s)
+        while ($row = $dataFetcher->fetch()) {
+            $key = ImageI18nTableMap::getPrimaryKeyHashFromRow($row, 0, $dataFetcher->getIndexType());
+            if (null !== ($obj = ImageI18nTableMap::getInstanceFromPool($key))) {
+                // We no longer rehydrate the object, since this can cause data loss.
+                // See http://www.propelorm.org/ticket/509
+                // $obj->hydrate($row, 0, true); // rehydrate
+                $results[] = $obj;
+            } else {
+                $obj = new $cls();
+                $obj->hydrate($row);
+                $results[] = $obj;
+                ImageI18nTableMap::addInstanceToPool($obj, $key);
+            } // if key exists
+        }
+
+        return $results;
+    }
+    /**
+     * Add all the columns needed to create a new object.
+     *
+     * Note: any columns that were marked with lazyLoad="true" in the
+     * XML schema will not be added to the select list and only loaded
+     * on demand.
+     *
+     * @param Criteria $criteria object containing the columns to add.
+     * @param string   $alias    optional table alias
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function addSelectColumns(Criteria $criteria, $alias = null)
+    {
+        if (null === $alias) {
+            $criteria->addSelectColumn(ImageI18nTableMap::ID);
+            $criteria->addSelectColumn(ImageI18nTableMap::LOCALE);
+            $criteria->addSelectColumn(ImageI18nTableMap::TITLE);
+            $criteria->addSelectColumn(ImageI18nTableMap::DESCRIPTION);
+            $criteria->addSelectColumn(ImageI18nTableMap::CHAPO);
+            $criteria->addSelectColumn(ImageI18nTableMap::POSTSCRIPTUM);
+        } else {
+            $criteria->addSelectColumn($alias . '.ID');
+            $criteria->addSelectColumn($alias . '.LOCALE');
+            $criteria->addSelectColumn($alias . '.TITLE');
+            $criteria->addSelectColumn($alias . '.DESCRIPTION');
+            $criteria->addSelectColumn($alias . '.CHAPO');
+            $criteria->addSelectColumn($alias . '.POSTSCRIPTUM');
+        }
+    }
+
+    /**
+     * Returns the TableMap related to this object.
+     * This method is not needed for general use but a specific application could have a need.
+     * @return TableMap
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function getTableMap()
+    {
+        return Propel::getServiceContainer()->getDatabaseMap(ImageI18nTableMap::DATABASE_NAME)->getTable(ImageI18nTableMap::TABLE_NAME);
+    }
+
+    /**
+     * Add a TableMap instance to the database for this tableMap class.
+     */
+    public static function buildTableMap()
+    {
+      $dbMap = Propel::getServiceContainer()->getDatabaseMap(ImageI18nTableMap::DATABASE_NAME);
+      if (!$dbMap->hasTable(ImageI18nTableMap::TABLE_NAME)) {
+        $dbMap->addTableObject(new ImageI18nTableMap());
+      }
+    }
+
+    /**
+     * Performs a DELETE on the database, given a ImageI18n or Criteria object OR a primary key value.
+     *
+     * @param mixed               $values Criteria or ImageI18n object or primary key or array of primary keys
+     *              which is used to create the DELETE statement
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
+     *                if supported by native driver or if emulated using Propel.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+     public static function doDelete($values, ConnectionInterface $con = null)
+     {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        if ($values instanceof Criteria) {
+            // rename for clarity
+            $criteria = $values;
+        } elseif ($values instanceof \Thelia\Model\ImageI18n) { // it's a model object
+            // create criteria based on pk values
+            $criteria = $values->buildPkeyCriteria();
+        } else { // it's a primary key, or an array of pks
+            $criteria = new Criteria(ImageI18nTableMap::DATABASE_NAME);
+            // primary key is composite; we therefore, expect
+            // the primary key passed to be an array of pkey values
+            if (count($values) == count($values, COUNT_RECURSIVE)) {
+                // array is not multi-dimensional
+                $values = array($values);
+            }
+            foreach ($values as $value) {
+                $criterion = $criteria->getNewCriterion(ImageI18nTableMap::ID, $value[0]);
+                $criterion->addAnd($criteria->getNewCriterion(ImageI18nTableMap::LOCALE, $value[1]));
+                $criteria->addOr($criterion);
+            }
+        }
+
+        $query = ImageI18nQuery::create()->mergeWith($criteria);
+
+        if ($values instanceof Criteria) { ImageI18nTableMap::clearInstancePool();
+        } elseif (!is_object($values)) { // it's a primary key, or an array of pks
+            foreach ((array) $values as $singleval) { ImageI18nTableMap::removeInstanceFromPool($singleval);
+            }
+        }
+
+        return $query->delete($con);
+    }
+
+    /**
+     * Deletes all rows from the image_i18n table.
+     *
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).
+     */
+    public static function doDeleteAll(ConnectionInterface $con = null)
+    {
+        return ImageI18nQuery::create()->doDeleteAll($con);
+    }
+
+    /**
+     * Performs an INSERT on the database, given a ImageI18n or Criteria object.
+     *
+     * @param mixed               $criteria Criteria or ImageI18n object containing data that is used to create the INSERT statement.
+     * @param ConnectionInterface $con the ConnectionInterface connection to use
+     * @return mixed           The new primary key.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function doInsert($criteria, ConnectionInterface $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageI18nTableMap::DATABASE_NAME);
+        }
+
+        if ($criteria instanceof Criteria) {
+            $criteria = clone $criteria; // rename for clarity
+        } else {
+            $criteria = $criteria->buildCriteria(); // build Criteria from ImageI18n object
+        }
+
+
+        // Set the correct dbName
+        $query = ImageI18nQuery::create()->mergeWith($criteria);
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table (I guess, conceivably)
+            $con->beginTransaction();
+            $pk = $query->doInsert($con);
+            $con->commit();
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+
+        return $pk;
+    }
+
+} // ImageI18nTableMap
+// This is the static code needed to register the TableMap for this table with the main Propel class.
+//
+ImageI18nTableMap::buildTableMap();

--- a/core/lib/Thelia/Model/Map/ImageTableMap.php
+++ b/core/lib/Thelia/Model/Map/ImageTableMap.php
@@ -1,0 +1,492 @@
+<?php
+
+namespace Thelia\Model\Map;
+
+use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\InstancePoolTrait;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\RelationMap;
+use Propel\Runtime\Map\TableMap;
+use Propel\Runtime\Map\TableMapTrait;
+use Thelia\Model\Image;
+use Thelia\Model\ImageQuery;
+
+
+/**
+ * This class defines the structure of the 'image' table.
+ *
+ *
+ *
+ * This map class is used by Propel to do runtime db structure discovery.
+ * For example, the createSelectSql() method checks the type of a given column used in an
+ * ORDER BY clause to know whether it needs to apply SQL to make the ORDER BY case-insensitive
+ * (i.e. if it's a text column type).
+ *
+ */
+class ImageTableMap extends TableMap
+{
+    use InstancePoolTrait;
+    use TableMapTrait;
+    /**
+     * The (dot-path) name of this class
+     */
+    const CLASS_NAME = 'Thelia.Model.Map.ImageTableMap';
+
+    /**
+     * The default database name for this class
+     */
+    const DATABASE_NAME = 'thelia';
+
+    /**
+     * The table name for this class
+     */
+    const TABLE_NAME = 'image';
+
+    /**
+     * The related Propel class for this table
+     */
+    const OM_CLASS = '\\Thelia\\Model\\Image';
+
+    /**
+     * A class that can be returned by this tableMap
+     */
+    const CLASS_DEFAULT = 'Thelia.Model.Image';
+
+    /**
+     * The total number of columns
+     */
+    const NUM_COLUMNS = 8;
+
+    /**
+     * The number of lazy-loaded columns
+     */
+    const NUM_LAZY_LOAD_COLUMNS = 0;
+
+    /**
+     * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
+     */
+    const NUM_HYDRATE_COLUMNS = 8;
+
+    /**
+     * the column name for the ID field
+     */
+    const ID = 'image.ID';
+
+    /**
+     * the column name for the SOURCE field
+     */
+    const SOURCE = 'image.SOURCE';
+
+    /**
+     * the column name for the SOURCE_ID field
+     */
+    const SOURCE_ID = 'image.SOURCE_ID';
+
+    /**
+     * the column name for the FILE field
+     */
+    const FILE = 'image.FILE';
+
+    /**
+     * the column name for the VISIBLE field
+     */
+    const VISIBLE = 'image.VISIBLE';
+
+    /**
+     * the column name for the POSITION field
+     */
+    const POSITION = 'image.POSITION';
+
+    /**
+     * the column name for the CREATED_AT field
+     */
+    const CREATED_AT = 'image.CREATED_AT';
+
+    /**
+     * the column name for the UPDATED_AT field
+     */
+    const UPDATED_AT = 'image.UPDATED_AT';
+
+    /**
+     * The default string format for model objects of the related table
+     */
+    const DEFAULT_STRING_FORMAT = 'YAML';
+
+    // i18n behavior
+
+    /**
+     * The default locale to use for translations.
+     *
+     * @var string
+     */
+    const DEFAULT_LOCALE = 'en_US';
+
+    /**
+     * holds an array of fieldnames
+     *
+     * first dimension keys are the type constants
+     * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
+     */
+    protected static $fieldNames = array (
+        self::TYPE_PHPNAME       => array('Id', 'Source', 'SourceId', 'File', 'Visible', 'Position', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'source', 'sourceId', 'file', 'visible', 'position', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(ImageTableMap::ID, ImageTableMap::SOURCE, ImageTableMap::SOURCE_ID, ImageTableMap::FILE, ImageTableMap::VISIBLE, ImageTableMap::POSITION, ImageTableMap::CREATED_AT, ImageTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'SOURCE', 'SOURCE_ID', 'FILE', 'VISIBLE', 'POSITION', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'source', 'source_id', 'file', 'visible', 'position', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+    );
+
+    /**
+     * holds an array of keys for quick access to the fieldnames array
+     *
+     * first dimension keys are the type constants
+     * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
+     */
+    protected static $fieldKeys = array (
+        self::TYPE_PHPNAME       => array('Id' => 0, 'Source' => 1, 'SourceId' => 2, 'File' => 3, 'Visible' => 4, 'Position' => 5, 'CreatedAt' => 6, 'UpdatedAt' => 7, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'source' => 1, 'sourceId' => 2, 'file' => 3, 'visible' => 4, 'position' => 5, 'createdAt' => 6, 'updatedAt' => 7, ),
+        self::TYPE_COLNAME       => array(ImageTableMap::ID => 0, ImageTableMap::SOURCE => 1, ImageTableMap::SOURCE_ID => 2, ImageTableMap::FILE => 3, ImageTableMap::VISIBLE => 4, ImageTableMap::POSITION => 5, ImageTableMap::CREATED_AT => 6, ImageTableMap::UPDATED_AT => 7, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'SOURCE' => 1, 'SOURCE_ID' => 2, 'FILE' => 3, 'VISIBLE' => 4, 'POSITION' => 5, 'CREATED_AT' => 6, 'UPDATED_AT' => 7, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'source' => 1, 'source_id' => 2, 'file' => 3, 'visible' => 4, 'position' => 5, 'created_at' => 6, 'updated_at' => 7, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, )
+    );
+
+    /**
+     * Initialize the table attributes and columns
+     * Relations are not initialized by this method since they are lazy loaded
+     *
+     * @return void
+     * @throws PropelException
+     */
+    public function initialize()
+    {
+        // attributes
+        $this->setName('image');
+        $this->setPhpName('Image');
+        $this->setClassName('\\Thelia\\Model\\Image');
+        $this->setPackage('Thelia.Model');
+        $this->setUseIdGenerator(true);
+        // columns
+        $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
+        $this->addColumn('SOURCE', 'Source', 'VARCHAR', true, 50, null);
+        $this->addColumn('SOURCE_ID', 'SourceId', 'INTEGER', true, null, null);
+        $this->addColumn('FILE', 'File', 'VARCHAR', true, 255, null);
+        $this->addColumn('VISIBLE', 'Visible', 'TINYINT', true, null, 1);
+        $this->addColumn('POSITION', 'Position', 'INTEGER', false, null, null);
+        $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
+        $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
+    } // initialize()
+
+    /**
+     * Build the RelationMap objects for this table relationships
+     */
+    public function buildRelations()
+    {
+        $this->addRelation('ImageI18n', '\\Thelia\\Model\\ImageI18n', RelationMap::ONE_TO_MANY, array('id' => 'id', ), 'CASCADE', null, 'ImageI18ns');
+    } // buildRelations()
+
+    /**
+     *
+     * Gets the list of behaviors registered for this table
+     *
+     * @return array Associative array (name => parameters) of behaviors
+     */
+    public function getBehaviors()
+    {
+        return array(
+            'validate' => array('slugRule' => array ('column' => 'source','validator' => 'Regex','options' => array ('pattern' => '/[a-z0-9\\-]{3,50}/',),), ),
+            'timestampable' => array('create_column' => 'created_at', 'update_column' => 'updated_at', ),
+            'i18n' => array('i18n_table' => '%TABLE%_i18n', 'i18n_phpname' => '%PHPNAME%I18n', 'i18n_columns' => 'title, description, chapo, postscriptum', 'locale_column' => 'locale', 'locale_length' => '5', 'default_locale' => '', 'locale_alias' => '', ),
+        );
+    } // getBehaviors()
+    /**
+     * Method to invalidate the instance pool of all tables related to image     * by a foreign key with ON DELETE CASCADE
+     */
+    public static function clearRelatedInstancePool()
+    {
+        // Invalidate objects in ".$this->getClassNameFromBuilder($joinedTableTableMapBuilder)." instance pool,
+        // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.
+                ImageI18nTableMap::clearInstancePool();
+            }
+
+    /**
+     * Retrieves a string version of the primary key from the DB resultset row that can be used to uniquely identify a row in this table.
+     *
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, a serialize()d version of the primary key will be returned.
+     *
+     * @param array  $row       resultset row.
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM
+     */
+    public static function getPrimaryKeyHashFromRow($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+        // If the PK cannot be derived from the row, return NULL.
+        if ($row[TableMap::TYPE_NUM == $indexType ? 0 + $offset : static::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)] === null) {
+            return null;
+        }
+
+        return (string) $row[TableMap::TYPE_NUM == $indexType ? 0 + $offset : static::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
+    }
+
+    /**
+     * Retrieves the primary key from the DB resultset row
+     * For tables with a single-column primary key, that simple pkey value will be returned.  For tables with
+     * a multi-column primary key, an array of the primary key columns will be returned.
+     *
+     * @param array  $row       resultset row.
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM
+     *
+     * @return mixed The primary key of the row
+     */
+    public static function getPrimaryKeyFromRow($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+
+            return (int) $row[
+                            $indexType == TableMap::TYPE_NUM
+                            ? 0 + $offset
+                            : self::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)
+                        ];
+    }
+
+    /**
+     * The class that the tableMap will make instances of.
+     *
+     * If $withPrefix is true, the returned path
+     * uses a dot-path notation which is translated into a path
+     * relative to a location on the PHP include_path.
+     * (e.g. path.to.MyClass -> 'path/to/MyClass.php')
+     *
+     * @param boolean $withPrefix Whether or not to return the path with the class name
+     * @return string path.to.ClassName
+     */
+    public static function getOMClass($withPrefix = true)
+    {
+        return $withPrefix ? ImageTableMap::CLASS_DEFAULT : ImageTableMap::OM_CLASS;
+    }
+
+    /**
+     * Populates an object of the default type or an object that inherit from the default.
+     *
+     * @param array  $row       row returned by DataFetcher->fetch().
+     * @param int    $offset    The 0-based offset for reading from the resultset row.
+     * @param string $indexType The index type of $row. Mostly DataFetcher->getIndexType().
+                                 One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
+     *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
+     *
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     * @return array (Image object, last column rank)
+     */
+    public static function populateObject($row, $offset = 0, $indexType = TableMap::TYPE_NUM)
+    {
+        $key = ImageTableMap::getPrimaryKeyHashFromRow($row, $offset, $indexType);
+        if (null !== ($obj = ImageTableMap::getInstanceFromPool($key))) {
+            // We no longer rehydrate the object, since this can cause data loss.
+            // See http://www.propelorm.org/ticket/509
+            // $obj->hydrate($row, $offset, true); // rehydrate
+            $col = $offset + ImageTableMap::NUM_HYDRATE_COLUMNS;
+        } else {
+            $cls = ImageTableMap::OM_CLASS;
+            $obj = new $cls();
+            $col = $obj->hydrate($row, $offset, false, $indexType);
+            ImageTableMap::addInstanceToPool($obj, $key);
+        }
+
+        return array($obj, $col);
+    }
+
+    /**
+     * The returned array will contain objects of the default type or
+     * objects that inherit from the default.
+     *
+     * @param DataFetcherInterface $dataFetcher
+     * @return array
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function populateObjects(DataFetcherInterface $dataFetcher)
+    {
+        $results = array();
+
+        // set the class once to avoid overhead in the loop
+        $cls = static::getOMClass(false);
+        // populate the object(s)
+        while ($row = $dataFetcher->fetch()) {
+            $key = ImageTableMap::getPrimaryKeyHashFromRow($row, 0, $dataFetcher->getIndexType());
+            if (null !== ($obj = ImageTableMap::getInstanceFromPool($key))) {
+                // We no longer rehydrate the object, since this can cause data loss.
+                // See http://www.propelorm.org/ticket/509
+                // $obj->hydrate($row, 0, true); // rehydrate
+                $results[] = $obj;
+            } else {
+                $obj = new $cls();
+                $obj->hydrate($row);
+                $results[] = $obj;
+                ImageTableMap::addInstanceToPool($obj, $key);
+            } // if key exists
+        }
+
+        return $results;
+    }
+    /**
+     * Add all the columns needed to create a new object.
+     *
+     * Note: any columns that were marked with lazyLoad="true" in the
+     * XML schema will not be added to the select list and only loaded
+     * on demand.
+     *
+     * @param Criteria $criteria object containing the columns to add.
+     * @param string   $alias    optional table alias
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function addSelectColumns(Criteria $criteria, $alias = null)
+    {
+        if (null === $alias) {
+            $criteria->addSelectColumn(ImageTableMap::ID);
+            $criteria->addSelectColumn(ImageTableMap::SOURCE);
+            $criteria->addSelectColumn(ImageTableMap::SOURCE_ID);
+            $criteria->addSelectColumn(ImageTableMap::FILE);
+            $criteria->addSelectColumn(ImageTableMap::VISIBLE);
+            $criteria->addSelectColumn(ImageTableMap::POSITION);
+            $criteria->addSelectColumn(ImageTableMap::CREATED_AT);
+            $criteria->addSelectColumn(ImageTableMap::UPDATED_AT);
+        } else {
+            $criteria->addSelectColumn($alias . '.ID');
+            $criteria->addSelectColumn($alias . '.SOURCE');
+            $criteria->addSelectColumn($alias . '.SOURCE_ID');
+            $criteria->addSelectColumn($alias . '.FILE');
+            $criteria->addSelectColumn($alias . '.VISIBLE');
+            $criteria->addSelectColumn($alias . '.POSITION');
+            $criteria->addSelectColumn($alias . '.CREATED_AT');
+            $criteria->addSelectColumn($alias . '.UPDATED_AT');
+        }
+    }
+
+    /**
+     * Returns the TableMap related to this object.
+     * This method is not needed for general use but a specific application could have a need.
+     * @return TableMap
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function getTableMap()
+    {
+        return Propel::getServiceContainer()->getDatabaseMap(ImageTableMap::DATABASE_NAME)->getTable(ImageTableMap::TABLE_NAME);
+    }
+
+    /**
+     * Add a TableMap instance to the database for this tableMap class.
+     */
+    public static function buildTableMap()
+    {
+      $dbMap = Propel::getServiceContainer()->getDatabaseMap(ImageTableMap::DATABASE_NAME);
+      if (!$dbMap->hasTable(ImageTableMap::TABLE_NAME)) {
+        $dbMap->addTableObject(new ImageTableMap());
+      }
+    }
+
+    /**
+     * Performs a DELETE on the database, given a Image or Criteria object OR a primary key value.
+     *
+     * @param mixed               $values Criteria or Image object or primary key or array of primary keys
+     *              which is used to create the DELETE statement
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
+     *                if supported by native driver or if emulated using Propel.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+     public static function doDelete($values, ConnectionInterface $con = null)
+     {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        if ($values instanceof Criteria) {
+            // rename for clarity
+            $criteria = $values;
+        } elseif ($values instanceof \Thelia\Model\Image) { // it's a model object
+            // create criteria based on pk values
+            $criteria = $values->buildPkeyCriteria();
+        } else { // it's a primary key, or an array of pks
+            $criteria = new Criteria(ImageTableMap::DATABASE_NAME);
+            $criteria->add(ImageTableMap::ID, (array) $values, Criteria::IN);
+        }
+
+        $query = ImageQuery::create()->mergeWith($criteria);
+
+        if ($values instanceof Criteria) { ImageTableMap::clearInstancePool();
+        } elseif (!is_object($values)) { // it's a primary key, or an array of pks
+            foreach ((array) $values as $singleval) { ImageTableMap::removeInstanceFromPool($singleval);
+            }
+        }
+
+        return $query->delete($con);
+    }
+
+    /**
+     * Deletes all rows from the image table.
+     *
+     * @param ConnectionInterface $con the connection to use
+     * @return int The number of affected rows (if supported by underlying database driver).
+     */
+    public static function doDeleteAll(ConnectionInterface $con = null)
+    {
+        return ImageQuery::create()->doDeleteAll($con);
+    }
+
+    /**
+     * Performs an INSERT on the database, given a Image or Criteria object.
+     *
+     * @param mixed               $criteria Criteria or Image object containing data that is used to create the INSERT statement.
+     * @param ConnectionInterface $con the ConnectionInterface connection to use
+     * @return mixed           The new primary key.
+     * @throws PropelException Any exceptions caught during processing will be
+     *         rethrown wrapped into a PropelException.
+     */
+    public static function doInsert($criteria, ConnectionInterface $con = null)
+    {
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getWriteConnection(ImageTableMap::DATABASE_NAME);
+        }
+
+        if ($criteria instanceof Criteria) {
+            $criteria = clone $criteria; // rename for clarity
+        } else {
+            $criteria = $criteria->buildCriteria(); // build Criteria from Image object
+        }
+
+        if ($criteria->containsKey(ImageTableMap::ID) && $criteria->keyContainsValue(ImageTableMap::ID) ) {
+            throw new PropelException('Cannot insert a value for auto-increment primary key ('.ImageTableMap::ID.')');
+        }
+
+
+        // Set the correct dbName
+        $query = ImageQuery::create()->mergeWith($criteria);
+
+        try {
+            // use transaction because $criteria could contain info
+            // for more than one table (I guess, conceivably)
+            $con->beginTransaction();
+            $pk = $query->doInsert($con);
+            $con->commit();
+        } catch (PropelException $e) {
+            $con->rollBack();
+            throw $e;
+        }
+
+        return $pk;
+    }
+
+} // ImageTableMap
+// This is the static code needed to register the TableMap for this table with the main Propel class.
+//
+ImageTableMap::buildTableMap();

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -514,6 +514,34 @@
       <parameter name="log_created_by" value="true" />
     </behavior>
   </table>
+  <table name="image" namespace="Thelia\Model">
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="source" required="true" size="50" type="VARCHAR" />
+    <column name="source_id" required="true" type="INTEGER" />
+    <column name="file" required="true" size="255" type="VARCHAR" />
+    <column defaultValue="1" name="visible" required="true" type="TINYINT" />
+    <column name="position" type="INTEGER" />
+    <column name="title" size="255" type="VARCHAR" />
+    <column name="description" type="CLOB" />
+    <column name="chapo" type="LONGVARCHAR" />
+    <column name="postscriptum" type="LONGVARCHAR" />
+    <index name="idx_image_source_source_id">
+      <index-column name="source" />
+      <index-column name="source_id" />
+    </index>
+    <index name="idx_image_source_source_id_position">
+      <index-column name="source" />
+      <index-column name="source_id" />
+      <index-column name="position" />
+    </index>
+    <behavior name="validate">
+      <parameter name="slugRule" value="{column: source, validator: Regex, options: {pattern: &quot;/[a-z0-9\-]{3,50}/&quot;}}" />
+    </behavior>
+    <behavior name="timestampable" />
+    <behavior name="i18n">
+      <parameter name="i18n_columns" value="title, description, chapo, postscriptum" />
+    </behavior>
+  </table>
   <table name="product_image" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="product_id" required="true" type="INTEGER" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -606,6 +606,27 @@ CREATE TABLE `content`
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------
+-- image
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image`;
+
+CREATE TABLE `image`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `source` VARCHAR(50) NOT NULL,
+    `source_id` INTEGER NOT NULL,
+    `file` VARCHAR(255) NOT NULL,
+    `visible` TINYINT DEFAULT 1 NOT NULL,
+    `position` INTEGER,
+    `created_at` DATETIME,
+    `updated_at` DATETIME,
+    PRIMARY KEY (`id`),
+    INDEX `idx_image_source_source_id` (`source`, `source_id`),
+    INDEX `idx_image_source_source_id_position` (`source`, `source_id`, `position`)
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+-- ---------------------------------------------------------------------
 -- product_image
 -- ---------------------------------------------------------------------
 
@@ -2552,6 +2573,27 @@ CREATE TABLE `content_i18n`
     CONSTRAINT `content_i18n_FK_1`
         FOREIGN KEY (`id`)
         REFERENCES `content` (`id`)
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+-- ---------------------------------------------------------------------
+-- image_i18n
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image_i18n`;
+
+CREATE TABLE `image_i18n`
+(
+    `id` INTEGER NOT NULL,
+    `locale` VARCHAR(5) DEFAULT 'en_US' NOT NULL,
+    `title` VARCHAR(255),
+    `description` LONGTEXT,
+    `chapo` TEXT,
+    `postscriptum` TEXT,
+    PRIMARY KEY (`id`,`locale`),
+    CONSTRAINT `image_i18n_FK_1`
+        FOREIGN KEY (`id`)
+        REFERENCES `image` (`id`)
         ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 

--- a/setup/update/sql/2.2.0-beta2.sql
+++ b/setup/update/sql/2.2.0-beta2.sql
@@ -1,0 +1,45 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------
+-- image
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image`;
+
+CREATE TABLE `image`
+(
+`id` INTEGER NOT NULL AUTO_INCREMENT,
+`source` INTEGER NOT NULL,
+`source_id` INTEGER NOT NULL,
+`file` VARCHAR(255) NOT NULL,
+`visible` TINYINT DEFAULT 1 NOT NULL,
+`position` INTEGER,
+`created_at` DATETIME,
+`updated_at` DATETIME,
+PRIMARY KEY (`id`),
+INDEX `idx_image_source_source_id` (`source`, `source_id`),
+INDEX `idx_image_source_source_id_position` (`source`, `source_id`, `position`)
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+-- ---------------------------------------------------------------------
+-- create table image_i18n
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image_i18n`;
+
+CREATE TABLE `image_i18n`
+(
+`id` INTEGER NOT NULL,
+`locale` VARCHAR(5) DEFAULT 'en_US' NOT NULL,
+`title` VARCHAR(255),
+`description` LONGTEXT,
+`chapo` TEXT,
+`postscriptum` TEXT,
+PRIMARY KEY (`id`,`locale`),
+CONSTRAINT `image_i18n_FK_1`
+FOREIGN KEY (`id`)
+REFERENCES `image` (`id`)
+ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.2.0-beta2.sql.tpl
+++ b/setup/update/tpl/2.2.0-beta2.sql.tpl
@@ -1,0 +1,45 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------
+-- image
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image`;
+
+CREATE TABLE `image`
+(
+`id` INTEGER NOT NULL AUTO_INCREMENT,
+`source` VARCHAR(50) NOT NULL,
+`source_id` INTEGER NOT NULL,
+`file` VARCHAR(255) NOT NULL,
+`visible` TINYINT DEFAULT 1 NOT NULL,
+`position` INTEGER,
+`created_at` DATETIME,
+`updated_at` DATETIME,
+PRIMARY KEY (`id`),
+INDEX `idx_image_source_source_id` (`source`, `source_id`),
+INDEX `idx_image_source_source_id_position` (`source`, `source_id`, `position`)
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+-- ---------------------------------------------------------------------
+-- create table image_i18n
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `image_i18n`;
+
+CREATE TABLE `image_i18n`
+(
+`id` INTEGER NOT NULL,
+`locale` VARCHAR(5) DEFAULT 'en_US' NOT NULL,
+`title` VARCHAR(255),
+`description` LONGTEXT,
+`chapo` TEXT,
+`postscriptum` TEXT,
+PRIMARY KEY (`id`,`locale`),
+CONSTRAINT `image_i18n_FK_1`
+FOREIGN KEY (`id`)
+REFERENCES `image` (`id`)
+ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8';
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Hello,

Add the ability to have other sources for images.

Add table image
```xml
  <table name="image" namespace="Thelia\Model">
    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
    <column name="source" required="true" size="50" type="VARCHAR" />
    <column name="source_id" required="true" type="INTEGER" />
    <column name="file" required="true" size="255" type="VARCHAR" />
    <column defaultValue="1" name="visible" required="true" type="TINYINT" />
    <column name="position" type="INTEGER" />
    <column name="title" size="255" type="VARCHAR" />
    <column name="description" type="CLOB" />
    <column name="chapo" type="LONGVARCHAR" />
    <column name="postscriptum" type="LONGVARCHAR" />
    <index name="idx_image_source_source_id">
      <index-column name="source" />
      <index-column name="source_id" />
    </index>
    <index name="idx_image_source_source_id_position">
      <index-column name="source" />
      <index-column name="source_id" />
      <index-column name="position" />
    </index>
    <behavior name="validate">
      <parameter name="slugRule" value="{column: source, validator: Regex, options: {pattern: &quot;/[a-z0-9\-]{3,50}/&quot;}}" />
    </behavior>
    <behavior name="timestampable" />
    <behavior name="i18n">
      <parameter name="i18n_columns" value="title, description, chapo, postscriptum" />
    </behavior>
  </table>
```
The name of the source is limited to 50 characters, only numbers, letters and dashes.

Loop image example
```smarty
{loop type="image" name="image" source="my-source" source_id=44}
```
The old behaviors of the image loop is not changed.

Cheers,