### PR TITLE
the noAmp method was not apply in generateUrlFunction

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -74,9 +74,7 @@ class UrlGenerator extends AbstractSmartyPlugin
             $mode
         );
 
-        $this->applyNoAmpAndTarget($params, $url);
-
-        return $url;
+        return $this->applyNoAmpAndTarget($params, $url);
     }
 
     /**


### PR DESCRIPTION
This PR is linked to #1552 (but doesn't resolved it!)

the method ```applyNoAmpAndTarget``` was not applied in function ```generateUrlFunction``` this is why we have a different behaviour between branch master and 2.1

The bug is explained in issue #1554 
