### PR TITLE
Update templates to easierly handle order status created by modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add module image edition in backoffice
 - The language change links should now use the locale instead of the language code, e.g. http://www.yourshop/some-page?lang=fr_FR instead if http://www.yourshop/some-page?lang=fr. Backward compatibility is provided.
+- Order status added by modules have their CSS label color handled or have a default color
 
 # 2.2.0-beta1
 
@@ -17,7 +18,7 @@
 - Add order by ```weight``` and ```weight_reverse``` in  product sale elements loop
 - Add the ability to remove arguments in loops.
 - new back-office is enhanced with a group button actions and a new layout
-- Added an optionnal 'ajax-view' parameter to card add form
+- Added an optional 'ajax-view' parameter to card add form
 - Add validation groups in form from parser context
 - Feature value are not translatable
 - Allow multiple authors in module.xml file. Fixed #1459

--- a/templates/backOffice/default/includes/main-menu.html
+++ b/templates/backOffice/default/includes/main-menu.html
@@ -68,11 +68,18 @@
             </li>
 
             {loop name="order-status-list" type="order-status"}
-                {assign "orderStatusLabel" "order_$CODE"}
+                {assign "orderStatusCode" "order_$CODE"}
+                {if #$orderStatusCode# == ''}
+                    {assign "defaultLabel" "label-default"}
+                    {assign "orderStatusLabel" $CODE}
+                {else}
+                    {assign "defaultLabel" ''}
+                    {assign "orderStatusLabel" #$orderStatusCode#}
+                {/if}
                 <li role="menuitem">
                     <a class="clearfix" data-target="{url path="admin/orders/$LABEL"}" href="{url path="admin/orders" status={$ID}}">
                         <span class="pull-left">{$TITLE}</span>
-                        <span class="label label-{#$orderStatusLabel#|default:${"order_$CODE"}} pull-right">{count type="order" customer="*" backend_context="1" status={$ID}}</span>
+                        <span class="label {$defaultLabel} label-{$orderStatusLabel} pull-right">{count type="order" customer="*" backend_context="1" status={$ID}}</span>
                     </a>
                 </li>
             {/loop}

--- a/templates/backOffice/default/order-edit.html
+++ b/templates/backOffice/default/order-edit.html
@@ -53,12 +53,15 @@
                                                 <div class="col-sm-6">
                                                     <select class="js-update-order-status" name="status_id" data-toggle="selectpicker">
                                                     {loop type="order-status" name="all-status"}
-                                                        {assign "orderStatusLabel" "order_$CODE"}
-                                                        {$orderStatusLabel={#$orderStatusLabel#}}
-                                                        {if empty($orderStatusLabel)}
-                                                            {$orderStatusLabel="default"}
+                                                        {assign "orderStatusCode" "order_$CODE"}
+                                                        {if #$orderStatusCode# == ''}
+                                                            {assign "defaultLabel" "label-default"}
+                                                            {assign "orderStatusLabel" $CODE}
+                                                        {else}
+                                                            {assign "defaultLabel" ''}
+                                                            {assign "orderStatusLabel" #$orderStatusCode#}
                                                         {/if}
-                                                        <option {if $ID == $orderStatusId}selected="selected" {/if} value="{$ID}" data-content="<span class='label label-{$orderStatusLabel}'>{$TITLE}</span>">{$TITLE}</option>
+                                                        <option {if $ID == $orderStatusId}selected="selected" {/if} value="{$ID}" data-content="<span class='label {$defaultLabel} label-{$orderStatusLabel}'>{$TITLE}</span>">{$TITLE}</option>
                                                     {/loop}
                                                     </select>
                                                 </div>

--- a/templates/backOffice/default/orders.html
+++ b/templates/backOffice/default/orders.html
@@ -121,20 +121,26 @@
 
                                     {loop type="order-status" name="order-status" id=$STATUS}
                                         {assign "orderStatus" $TITLE}
-                                        {assign "orderStatusLabel" "order_$CODE"}
+                                        {assign "orderStatusCode" "order_$CODE"}
+                                        {if #$orderStatusCode# == ''}
+                                            {assign "defaultLabel" "label-default"}
+                                            {assign "orderStatusLabel" $CODE}
+                                        {else}
+                                            {assign "defaultLabel" ''}
+                                            {assign "orderStatusLabel" #$orderStatusCode#}
+                                        {/if}
                                     {/loop}
 
-		                            <tr>
-
+                                    <tr>
                                         <td><a href="{url path="/admin/order/update/%id" id=$ID}">{$ID}</a></td>
-		                               	<td><a href="{url path="/admin/order/update/%id" id=$ID}">{$REF}</a></td>
-		                               	<td>{format_date date=$CREATE_DATE}</td>
-		                               	<td>{$orderInvoiceCompany}</td>
-		                               	<td><a href="{url path='/admin/customer/update' customer_id=$CUSTOMER}">{$orderInvoiceFirstName|ucwords} {$orderInvoiceLastName|upper}</a></td>
-		                               	<td class="text-right">{format_money number=$TOTAL_TAXED_AMOUNT symbol=$orderCurrency}</td>
-		                               	<td class="text-center"><span class="label label-{#$orderStatusLabel#}">{$orderStatus}</span></td>
+                                       	<td><a href="{url path="/admin/order/update/%id" id=$ID}">{$REF}</a></td>
+                                       	<td>{format_date date=$CREATE_DATE}</td>
+                                       	<td>{$orderInvoiceCompany}</td>
+                                       	<td><a href="{url path='/admin/customer/update' customer_id=$CUSTOMER}">{$orderInvoiceFirstName|ucwords} {$orderInvoiceLastName|upper}</a></td>
+                                       	<td class="text-right">{format_money number=$TOTAL_TAXED_AMOUNT symbol=$orderCurrency}</td>
+                                        <td class="text-center"><span class="label {$defaultLabel} label-{$orderStatusLabel}">{$orderStatus}</span></td>
                                         {* *}
-		                                {hook name="orders.table-row" location="orders_table_row" order_id={$ID} }
+                                        {hook name="orders.table-row" location="orders_table_row" order_id={$ID} }
 
                                         <td>
                                             <div class="btn-toolbar btn toolbar-primary">

--- a/templates/frontOffice/default/account.html
+++ b/templates/frontOffice/default/account.html
@@ -168,7 +168,19 @@
                                     <td>{$REF}</td>
                                     <td>{format_date date=$CREATE_DATE}</td>
                                     <td>{format_number number=$TOTAL_TAXED_AMOUNT} {loop type="currency" name="order.currency" id={$CURRENCY}}{$SYMBOL}{/loop}</td>
-                                    <td>{loop type="order-status" name="order.status" id={$STATUS}}{assign "orderStatusLabel" "order_$CODE"}<span class="label label-{#$orderStatusLabel#}">{$TITLE}</span>{/loop}</td>
+                                    <td>
+                                        {loop type="order-status" name="order.status" id={$STATUS}}
+                                            {assign "orderStatusCode" "order_$CODE"}
+                                            {if #$orderStatusCode# == ''}
+                                                {assign "defaultLabel" "label-default"}
+                                                {assign "orderStatusLabel" $CODE}
+                                            {else}
+                                                {assign "defaultLabel" ''}
+                                                {assign "orderStatusLabel" #$orderStatusCode#}
+                                            {/if}
+                                            <span class="label {$defaultLabel} label-{$orderStatusLabel}">{$TITLE}</span>
+                                        {/loop}
+                                    </td>
                                     <td>
                                         <a href="{url path="/account/order/%id" id=$ID}" class="btn btn-link" data-toggle="tooltip" title="{intl l="View order %ref details" ref={$REF}}">{intl l="Order details"}</a>
                                     </td>


### PR DESCRIPTION
Template files (front and back) showing order status now use the status code for status created by modules, to create the CSS class.