### PR TITLE
Language change fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2.0-beta2
 
 - Add module image edition in backoffice
+- The language change links should now use the locale instead of the language code, e.g. http://www.yourshop/some-page?lang=fr_FR instead if http://www.yourshop/some-page?lang=fr. Backward compatibility is provided.
 
 # 2.2.0-beta1
 

--- a/local/modules/HookLang/templates/frontOffice/default/main-navbar-secondary.html
+++ b/local/modules/HookLang/templates/frontOffice/default/main-navbar-secondary.html
@@ -3,7 +3,7 @@
         <a href="{url path="/login"}" class="language-label dropdown-toggle" data-toggle="dropdown">{lang attr="title"}</a>
         <ul class="dropdown-menu">
             {loop type="lang" name="lang_available" exclude="{lang attr="id"}"}
-            <li><a href="{url path="{navigate to="current"}" lang={$CODE}}">{$TITLE}</a></li>
+            <li><a href="{url path="{navigate to="current"}" lang={$LOCALE}}">{$TITLE}</a></li>
             {/loop}
         </ul>
     </li>

--- a/tests/phpunit/Thelia/Tests/Api/TitleControllerTest.php
+++ b/tests/phpunit/Thelia/Tests/Api/TitleControllerTest.php
@@ -149,7 +149,7 @@ class TitleControllerTest extends ApiTestCase
 
         $client->request(
             'POST',
-            '/api/title?sign='.$this->getSignParameter($requestContent),
+            '/api/title?lang=en_US&sign='.$this->getSignParameter($requestContent),
             [],
             [],
             $servers,
@@ -197,7 +197,7 @@ class TitleControllerTest extends ApiTestCase
 
         $client->request(
             'PUT',
-            '/api/title?no-cache=yes&sign='.$this->getSignParameter($requestContent),
+            '/api/title?lang=en_US&no-cache=yes&sign='.$this->getSignParameter($requestContent),
             [],
             [],
             $servers,

--- a/tests/phpunit/Thelia/Tests/WebTestCase.php
+++ b/tests/phpunit/Thelia/Tests/WebTestCase.php
@@ -13,6 +13,7 @@
 namespace Thelia\Tests;
 
 use Thelia\Core\Thelia;
+use Thelia\Model\ConfigQuery;
 
 /**
  * Class WebTestCase
@@ -21,6 +22,17 @@ use Thelia\Core\Thelia;
  */
 class WebTestCase extends \PHPUnit_Framework_TestCase
 {
+    protected $isMultiDomainActivated;
+
+    public function setUp()
+    {
+        // We have to shut down the "One domain for each lang feature" before tests,
+        // to prevent 302 redirections during the tests.
+        $this->isMultiDomainActivated = ConfigQuery::read('one_domain_foreach_lang');
+
+        ConfigQuery::write('one_domain_foreach_lang', false);
+    }
+
     /**
      * @var \Thelia\Core\Thelia
      */
@@ -51,6 +63,8 @@ class WebTestCase extends \PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+        ConfigQuery::write('one_domain_foreach_lang', $this->isMultiDomainActivated);
+
         if (null !== static::$kernel) {
             static::$kernel->shutdown();
         }

--- a/tests/phpunit/Thelia/Tests/WebTestCase.php
+++ b/tests/phpunit/Thelia/Tests/WebTestCase.php
@@ -24,7 +24,7 @@ class WebTestCase extends \PHPUnit_Framework_TestCase
 {
     protected $isMultiDomainActivated;
 
-    public function setUp()
+    protected function setUp()
     {
         // We have to shut down the "One domain for each lang feature" before tests,
         // to prevent 302 redirections during the tests.


### PR DESCRIPTION
This PR fixes a problem with langage change when the rewriting is enabled (lang is not changed in the 'lang' parameter appears in the URL).

The language change URL should now contain the locale (e.g. fr_FR) instead of the lang code (e.g. fr), to be sure to get the proper language. Until now, we cannot distinguish fa_FR from fr_CA.
A backward compatibility is provided.