### PR TITLE
Remove any UploadedFile object from session form data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - ```address_id``` in template ```address-update.html``` for hooks ```address-update.form-top```, ```address-update.bottom```, ```address-update.after-javascript-include```, ```address-update.javascript-initialization```
 - #1587 Fix redirect url for the folder image and folder document
 - #1590 Fix Thelia request initialization
+- #1593 Fix form serialization in session that contain uploaded files
 
 # 2.2.0-beta2
 

--- a/core/lib/Thelia/Core/Template/ParserContext.php
+++ b/core/lib/Thelia/Core/Template/ParserContext.php
@@ -12,10 +12,11 @@
 
 namespace Thelia\Core\Template;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Thelia\Core\Form\TheliaFormFactoryInterface;
 use Thelia\Core\Form\TheliaFormValidatorInterface;
-use Thelia\Core\Thelia;
 use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Thelia;
 use Thelia\Form\BaseForm;
 use TheliaSmarty\Template\Exception\SmartyPluginException;
 
@@ -111,9 +112,17 @@ class ParserContext implements \IteratorAggregate
 
         $this->set(get_class($form) . ":" . $form->getType(), $form);
 
+        /** Remove unserializable objects \Symfony\Component\HttpFoundation\File\UploadedFile */
+        $formData = $form->getForm()->getData();
+        foreach ($formData as $idx => $value) {
+            if ($value instanceof UploadedFile) {
+                unset($formData[$idx]);
+            }
+        }
+
         // Set form error information
         $formErrorInformation[get_class($form) . ":" . $form->getType()] = [
-            'data'              => $form->getForm()->getData(),
+            'data'              => $formData,
             'hasError'          => $form->hasError(),
             'errorMessage'      => $form->getErrorMessage(),
             'method'            => $this->request->getMethod(),


### PR DESCRIPTION
UploadedFile objects are not serializable and makes php-cgi process to freeze