### PR TITLE
Add set error in TheliaFormValidator when form is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.2.0-beta3
 
+- #1601 Add set error in TheliaFormValidator when form is not valid
 - #1585 Add parameters in frontOffice hooks
     - ```order_id``` in template ```account-order.html``` for hooks ```account-order.after-javascript-include```, ```account-order.javascript-initialization```
     - ```address_id``` in template ```address-update.html``` for hooks ```address-update.form-top```, ```address-update.bottom```, ```address-update.after-javascript-include```, ```address-update.javascript-initialization```

--- a/core/lib/Thelia/Core/Form/TheliaFormValidator.php
+++ b/core/lib/Thelia/Core/Form/TheliaFormValidator.php
@@ -78,7 +78,7 @@ class TheliaFormValidator implements TheliaFormValidatorInterface
                         $this->getErrorMessages($form)
                     );
                 }
-
+                $aBaseForm->setError(true);
                 throw new FormValidationException($errorMessage);
             }
         } else {


### PR DESCRIPTION
Currently [Thelia BaseForm has_error](https://github.com/thelia/thelia/blob/master/core/lib/Thelia/Form/BaseForm.php#L80) must be set manually or with setErrorMessage().
I think this is TheliaFormValidator responsibility to set this value.