### PR TITLE
Prevent obscur "[] this value cannot be null" messages.

### DIFF
--- a/core/lib/Thelia/Core/Form/TheliaFormValidator.php
+++ b/core/lib/Thelia/Core/Form/TheliaFormValidator.php
@@ -110,7 +110,11 @@ class TheliaFormValidator implements TheliaFormValidatorInterface
         /** @var Form $child */
         foreach ($form->all() as $child) {
             if (!$child->isValid()) {
-                $fieldName = $child->getConfig()->getOption('label', $child->getName());
+                $fieldName = $child->getConfig()->getOption('label', null);
+
+                if (empty($fieldName)) {
+                    $fieldName = $child->getName();
+                }
 
                 $errors .= sprintf("[%s] %s, ", $fieldName, $this->getErrorMessages($child));
             }


### PR DESCRIPTION
The field name is always used instead an empty ('') field label.