### PR TITLE
Fix fieldVars param in renderFormCollectionField smarty block

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Form.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Form.php
@@ -878,7 +878,7 @@ class Form extends AbstractSmartyPlugin
             $this->buildFieldName($formField),
             $formField->getViewData(),
             $formFieldConfig->getType(),
-            $formFieldConfig->getOptions()
+            $formField->createView()->vars
         );
 
         return '';


### PR DESCRIPTION
Currently in the [Form::renderFormCollectionField()](https://github.com/thelia/thelia/blob/master/local/modules/TheliaSmarty/Template/Plugins/Form.php#L876) method the assignFieldValues $fieldVars param is the FormConfigBuilder options attribute.

I replace it with the current FormView field vars like in [Form::processFormField()](https://github.com/thelia/thelia/blob/master/local/modules/TheliaSmarty/Template/Plugins/Form.php#L321) because the FormConfigBuilder options doesn't contains the Form error.