### PR TITLE
New TheliaEvents::CART_FINDITEM event to improve cart management flexibility

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -278,13 +278,13 @@ class Cart extends BaseAction implements EventSubscriberInterface
      */
     public function findCartItem(CartEvent $event)
     {
-        $foundItem = CartItemQuery::create()
+        if (null !== $foundItem = CartItemQuery::create()
             ->filterByCartId($event->getCart()->getId())
             ->filterByProductId($event->getProduct())
             ->filterByProductSaleElementsId($event->getProductSaleElementsId())
-            ->findOne();
-
-        $event->setCartItem($foundItem);
+            ->findOne()) {
+            $event->setCartItem($foundItem);
+        }
     }
 
     /**

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -84,7 +84,10 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $productSaleElementsId = $event->getProductSaleElementsId();
         $productId = $event->getProduct();
 
-        $cartItem = $this->findItem($cart->getId(), $productId, $productSaleElementsId);
+        // Search for an identical item in the cart
+        $event->getDispatcher()->dispatch(TheliaEvents::CART_FINDITEM, $event);
+
+        $cartItem = $event->getCartItem();
 
         if ($cartItem === null || $newness) {
             $productSaleElements = ProductSaleElementsQuery::create()->findPk($productSaleElementsId);
@@ -256,6 +259,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
      * @param  int           $productId
      * @param  int           $productSaleElementsId
      * @return CartItem
+     *
+     * @deprecated this method is deprecated. Dispatch a TheliaEvents::CART_FINDITEM instead
      */
     protected function findItem($cartId, $productId, $productSaleElementsId)
     {
@@ -264,6 +269,22 @@ class Cart extends BaseAction implements EventSubscriberInterface
             ->filterByProductId($productId)
             ->filterByProductSaleElementsId($productSaleElementsId)
             ->findOne();
+    }
+
+    /**
+     * Find a specific record in CartItem table using the current CartEvent
+     *
+     * @param CartEvent $event the cart event
+     */
+    public function findCartItem(CartEvent $event)
+    {
+        $foundItem = CartItemQuery::create()
+            ->filterByCartId($event->getCart()->getId())
+            ->filterByProductId($event->getProduct())
+            ->filterByProductSaleElementsId($event->getProductSaleElementsId())
+            ->findOne();
+
+        $event->setCartItem($foundItem);
     }
 
     /**
@@ -462,6 +483,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
             TheliaEvents::CART_RESTORE_CURRENT => array("restoreCurrentCart", 128),
             TheliaEvents::CART_CREATE_NEW => array("createEmptyCart", 128),
             TheliaEvents::CART_ADDITEM => array("addItem", 128),
+            TheliaEvents::CART_FINDITEM => array("findCartItem", 128),
             TheliaEvents::CART_DELETEITEM => array("deleteItem", 128),
             TheliaEvents::CART_UPDATEITEM => array("changeItem", 128),
             TheliaEvents::CART_CLEAR => array("clear", 128),

--- a/core/lib/Thelia/Core/Event/Cart/CartEvent.php
+++ b/core/lib/Thelia/Core/Event/Cart/CartEvent.php
@@ -53,12 +53,24 @@ class CartEvent extends ActionEvent
     }
 
     /**
-     * @param  CartItem  $cartItem
+     * @param  CartItem $cartItem
      * @return CartEvent
      */
     public function setCartItem(CartItem $cartItem)
     {
         $this->cartItem = $cartItem;
+
+        return $this;
+    }
+
+    /**
+     * Clear the current cart item
+     *
+     * @return CartEvent
+     */
+    public function clearCartItem()
+    {
+        $this->cartItem = null;
 
         return $this;
     }

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -361,6 +361,11 @@ final class TheliaEvents
     const AFTER_CARTADDITEM = "cart.after.addItem";
 
     /**
+     * sent for searching an item in the cart
+     */
+    const CART_FINDITEM = "cart.findItem";
+
+    /**
      * sent when a cart item is modify
      */
     const AFTER_CARTUPDATEITEM = "cart.updateItem";

--- a/setup/faker.php
+++ b/setup/faker.php
@@ -16,6 +16,12 @@ if (php_sapi_name() != 'cli') {
     throw new \Exception('this script can only be launched with cli sapi');
 }
 
+// Set this to true to get "real text" instead of random letters in titles, chapo, descriptions, etc.
+// WARNING : relaTextMode is much more slower than false text mode, and may cause problems with Travis
+// such as  "No output has been received in the last 10 minutes, this potentially indicates a stalled
+// build or something wrong with the build itself."
+$realTextMode = false;
+
 $bootstrapToggle = false;
 $bootstraped = false;
 
@@ -955,13 +961,17 @@ function generate_document($document, $typeobj, $id)
 }
 
 function getRealText($length, $locale = 'en_US') {
-    global $localizedFaker;
-    
-    $text = $localizedFaker[$locale]->realText($length);
+    global $localizedFaker, $realTextMode;
 
-    // Below 20 chars, generate a simple text, without ponctuation nor newlines.
-    if ($length <= 20)
-        $text = ucfirst(strtolower(preg_replace("/[^\pL\pM\pN\ ]/", '', $text)));
+    if ($realTextMode) {
+        $text = $localizedFaker[$locale]->realText($length);
+
+        // Below 20 chars, generate a simple text, without ponctuation nor newlines.
+        if ($length <= 20)
+            $text = ucfirst(strtolower(preg_replace("/[^\pL\pM\pN\ ]/", '', $text)));
+    } else {
+        $text = $localizedFaker[$locale]->text($length);
+    }
 
     // echo "Generated $locale text ($length) : $locale:$text\n";
 


### PR DESCRIPTION
This PR introduce a little bit more flexibility in cart management.

Until now, the `Cart::findItem()` method was called to check if a cart item with the same PSE already exists in the current cart.

However, some modules may want to change the way the Cart action is searching for existing items, but they can't, as `Cart::findItem()` is a protected method.

This PR introduces the `TheliaEvents::CART_FINDITEM` event, which is now used in the Cart action instead of a direct call to `Cart::findItem()`, allowing modules to perform some specific actions.

The `Cart::findItem()` method still exists to ensure a backward compatibility, but is deprecated.