### PR TITLE
Remove duplicate admin route

### DIFF
--- a/core/lib/Thelia/Config/Resources/routing/admin.xml
+++ b/core/lib/Thelia/Config/Resources/routing/admin.xml
@@ -686,10 +686,6 @@
         <default key="_controller">Thelia\Controller\Admin\CurrencyController::deleteAction</default>
     </route>
 
-    <route id="admin.configuration.currencies.update-position" path="/admin/configuration/currencies/update-position">
-        <default key="_controller">Thelia\Controller\Admin\CurrencyController::updatePositionAction</default>
-    </route>
-
 
     <!-- Product templates management -->
 


### PR DESCRIPTION
No impact since the two copies are exactly the same, but no reason to leave it.