### PR TITLE
Resolve #1636 : impossibility to edit an API. Fix some CSS stuff.

### DIFF
--- a/templates/backOffice/default/api.html
+++ b/templates/backOffice/default/api.html
@@ -69,7 +69,7 @@
                                         </div>
                                         <div class="toolbar-options hidden">
                                             {loop type="auth" name="can_delete" role="ADMIN" resource="admin.configuration.api" access="UPDATE"}
-                                                <a title="{intl l='Change this api access'}" href="{url path="/admin/configuration/api/update/%id" id={$api.Id}}" data-toggle="modal"><span class="glyphicon glyphicon-edit"></span></a>
+                                                <a title="{intl l='Change this api access'}" href="{url path="/admin/configuration/api/update/%id" id={$api.Id}}"><span class="glyphicon glyphicon-edit"></span></a>
                                             {/loop}
 
                                             {loop type="auth" name="can_delete" role="ADMIN" resource="admin.configuration.api" access="DELETE"}

--- a/templates/backOffice/default/attribute-edit.html
+++ b/templates/backOffice/default/attribute-edit.html
@@ -68,7 +68,7 @@
 
 		     						<div class="col-md-6">
 
-		     						    <p class="title title-without-tabs">
+		     						    <p class="title title-without-tabs clearfix">
 
 		     						         {intl l='Attribute values'}
 

--- a/templates/backOffice/default/feature-edit.html
+++ b/templates/backOffice/default/feature-edit.html
@@ -68,7 +68,7 @@
 
 		     						<div class="col-md-6">
 
-		     						    <p class="title title-without-tabs">
+		     						    <p class="title title-without-tabs clearfix">
 
 		     						         {intl l='Feature values'}
 


### PR DESCRIPTION
API edit button now opens the edition modal when clicked.
"Add" button for attribute and feature values doesn't overflow on the blue info panel.