### PR TITLE
Resolve #1280 : stock problem when updating order status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.2.0-beta3
 
+- #1643 Fix stock errors when changing order status
 - #1637 Fix admin API edit button
 - #1635 Add unit tests for the routing files (admin, api, front)
 - #1634 Remove leftover uncallable routes (admin)

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -24,6 +24,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Security\User\UserInterface;
+use Thelia\Core\Translation\Translator;
 use Thelia\Exception\TheliaProcessException;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\AddressQuery;
@@ -500,28 +501,68 @@ class Order extends BaseAction implements EventSubscriberInterface
     }
 
     /**
-     * @param  ModelOrder                               $order
+     * @param  ModelOrder $order
      * @param $newStatus
-     * @param $canceledStatus
      * @throws \Thelia\Exception\TheliaProcessException
      */
     public function updateQuantity(ModelOrder $order, $newStatus)
     {
-        $canceledStatus = OrderStatusQuery::getCancelledStatus()->getId();
+        $notPaidStatus = OrderStatusQuery::getNotPaidStatus()->getId();
         $paidStatus = OrderStatusQuery::getPaidStatus()->getId();
-        if ($newStatus == $canceledStatus || $order->isCancelled()) {
-            $this->updateQuantityForCanceledOrder($order, $newStatus, $canceledStatus);
-        } elseif ($paidStatus == $newStatus && $order->isNotPaid() && $order->getVersion() == 1) {
-            $this->updateQuantityForPaidOrder($order);
+        $processingStatus = OrderStatusQuery::getProcessingStatus()->getId();
+        $sentStatus = OrderStatusQuery::getSentStatus()->getId();
+        $cancelledStatus = OrderStatusQuery::getCancelledStatus()->getId();
+        $refundedStatus = OrderStatusQuery::getRefundedStatus()->getId();
+
+        switch ($newStatus) {
+            case $notPaidStatus:
+                if (!$order->isCancelled()) {
+                    $this->updateQuantityOnStatusChange($order, true);
+                }
+                break;
+
+            case $cancelledStatus:
+                if (!$order->isNotPaid()) {
+                    $this->updateQuantityOnStatusChange($order, true);
+                }
+                break;
+
+            case $paidStatus:
+                if (!$order->isProcessing() && !$order->isSent() && !$order->isRefunded()) {
+                    $this->updateQuantityOnStatusChange($order, false);
+                }
+                break;
+
+            case $processingStatus:
+                if (!$order->isPaid() && !$order->isSent() && !$order->isRefunded()) {
+                    $this->updateQuantityOnStatusChange($order, false);
+                }
+                break;
+
+            case $sentStatus:
+                if (!$order->isPaid() && !$order->isProcessing() && !$order->isRefunded()) {
+                    $this->updateQuantityOnStatusChange($order, false);
+                }
+                break;
+
+            case $refundedStatus:
+                if ( !$order->isPaid() && !$order->isProcessing() && !$order->isSent()) {
+                    $this->updateQuantityOnStatusChange($order, false);
+                }
+                break;
+
+            default:
+                break;
         }
     }
 
     /**
      * @param ModelOrder $order
+     * @param $increase
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    protected function updateQuantityForPaidOrder(ModelOrder $order)
+    public function updateQuantityOnStatusChange(ModelOrder $order, $increase)
     {
         $paymentModule = ModuleQuery::create()->findPk($order->getPaymentModuleId());
 
@@ -537,50 +578,20 @@ class Order extends BaseAction implements EventSubscriberInterface
 
                 /** @var ProductSaleElements $productSaleElements */
                 if (null !== $productSaleElements = ProductSaleElementsQuery::create()->findPk($productSaleElementsId)) {
-                    /* check still in stock */
-                    if ($orderProduct->getQuantity() > $productSaleElements->getQuantity() && true === ConfigQuery::checkAvailableStock()) {
-                        throw new TheliaProcessException($productSaleElements->getRef() . " : Not enough stock");
+                    if ($increase) {
+                        // Increase stock
+                        $productSaleElements->setQuantity($productSaleElements->getQuantity() + $orderProduct->getQuantity());
+                    } elseif (!$increase) {
+                        /* Check if still in stock */
+                        if ($orderProduct->getQuantity() > $productSaleElements->getQuantity() && true === ConfigQuery::checkAvailableStock()) {
+                            throw new TheliaProcessException(Translator::getInstance()->trans(
+                                "Product ref %ref : not enough stock", ['%ref' => $productSaleElements->getRef()]));
+                        }
+                        // Decrease stock
+                        $productSaleElements->setQuantity($productSaleElements->getQuantity() - $orderProduct->getQuantity());
                     }
-
-                    $productSaleElements->setQuantity($productSaleElements->getQuantity() - $orderProduct->getQuantity());
-
                     $productSaleElements->save();
                 }
-            }
-        }
-    }
-
-    /**
-     * Update product quantity if new status is canceled or if old status is canceled.
-     *
-     * @param ModelOrder $order
-     * @param $newStatus
-     * @param $canceledStatus
-     * @throws \Exception
-     * @throws \Propel\Runtime\Exception\PropelException
-     */
-    protected function updateQuantityForCanceledOrder(ModelOrder $order, $newStatus, $canceledStatus)
-    {
-        $orderProductList = $order->getOrderProducts();
-
-        /** @var OrderProduct  $orderProduct */
-        foreach ($orderProductList as $orderProduct) {
-            $productSaleElementsId = $orderProduct->getProductSaleElementsId();
-
-            /** @var ProductSaleElements $productSaleElements */
-            if (null !== $productSaleElements = ProductSaleElementsQuery::create()->findPk($productSaleElementsId)) {
-                if ($newStatus == $canceledStatus) {
-                    $productSaleElements->setQuantity($productSaleElements->getQuantity() + $orderProduct->getQuantity());
-                } else {
-                    /* check still in stock */
-                    if ($orderProduct->getQuantity() > $productSaleElements->getQuantity() && true === ConfigQuery::checkAvailableStock()) {
-                        throw new TheliaProcessException($productSaleElements->getRef() . " : Not enough stock");
-                    }
-
-                    $productSaleElements->setQuantity($productSaleElements->getQuantity() - $orderProduct->getQuantity());
-                }
-
-                $productSaleElements->save();
             }
         }
     }

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -797,4 +797,5 @@ return array(
     'update form' => 'update form',
     'value table header' => 'value table header',
     'value table row' => 'value table row',
+    'Product ref %ref : not enough stock' => 'Product ref %ref : not enough stock',
 );

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -797,4 +797,5 @@ return array(
     'update form' => 'Formulaire de modification',
     'value table header' => 'colonne tableau valeur',
     'value table row' => 'ligne tableau valeurs',
+    'Product ref %ref : not enough stock' => 'Produit référence %ref : pas assez de stock',
 );


### PR DESCRIPTION
Stocks are now well managed when changing an order status.
Error message if no stock is now translated.
This solves the problem but is not very evolutive, if some status are added they won't be taken in charge.