### PR TITLE
don't store form object in session

### DIFF
--- a/core/lib/Thelia/Core/Template/ParserContext.php
+++ b/core/lib/Thelia/Core/Template/ParserContext.php
@@ -115,7 +115,7 @@ class ParserContext implements \IteratorAggregate
         /** Remove unserializable objects \Symfony\Component\HttpFoundation\File\UploadedFile */
         $formData = $form->getForm()->getData();
         foreach ($formData as $idx => $value) {
-            if ($value instanceof UploadedFile) {
+            if (is_object($value)) {
                 unset($formData[$idx]);
             }
         }


### PR DESCRIPTION
As explained in #1597 storing object in session is not a good practice, we have issues with the serialization of some objects.

I suggest to never store object in session but keep all existing data who are not objects.

What do you think ?