### PR TITLE
Deprecated admin includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.2.0-beta3
 
+- #1653 Remove ```AdminIncludes``` folder in the module generation
 - #1649 Add index in table rewriting_url
 - #1644 Allow relative path use with Tlog
 - #1640 Add docker and docker-compose configuration
@@ -20,6 +21,10 @@
 - #1583 Add German translations
 - #1615 New TheliaEvents::CART_FINDITEM event to improve cart management flexibility
 - #1618 Configurable faker
+
+##DEPRECATED
+
+- Deprecated AdminIncludes, it's better to use the hooks
 
 # 2.2.0-beta2
 

--- a/core/lib/Thelia/Command/BaseModuleGenerate.php
+++ b/core/lib/Thelia/Command/BaseModuleGenerate.php
@@ -12,8 +12,6 @@
 
 namespace Thelia\Command;
 
-use Thelia\Model\Module;
-
 /**
  * base class for module commands
  *
@@ -38,7 +36,6 @@ abstract class BaseModuleGenerate extends ContainerAwareCommand
          'Controller',
          'EventListeners',
          'I18n',
-         Module::ADMIN_INCLUDES_DIRECTORY_NAME,
          'templates',
          'Hook',
      );


### PR DESCRIPTION
Hello,
While it was pretty useful for some time, the AdminInclude functionnality is now deprecated.

The question is, we must remove the admin includes in version 2.3 or 2.4 ?

What do you think ?