### PR TITLE
Product attributes select size is now limited.

### DIFF
--- a/templates/backOffice/default/ajax/product-attributes-tab.html
+++ b/templates/backOffice/default/ajax/product-attributes-tab.html
@@ -1,3 +1,5 @@
+{config_load file='variables.conf'}
+
 {* Set the default translation domain, that will be used by {intl} when the 'd' parameter is not set *}
 {default_translation_domain domain='bo.default'}
 
@@ -178,16 +180,22 @@
 							                               {$selected[] = $FEATURE_AV_ID}
 							                            {/loop}
 
-								                        {capture "select_options"}
+								                        {capture name="select_options"}
 								                        {loop name="product-features-av" type="feature-availability" feature=$ID order="manual" backend_context="1" lang="$edit_language_id"}
 								                            <option value="{$ID}" {if in_array($ID, $selected)}selected="selected"{/if}>{$TITLE}</option>
 
 								                            {$options_count = $LOOP_COUNT} {* LOOP_COUNT is only available inside the loop ! *}
 								                        {/loop}
+
+                                                        {if $options_count > #maximum_product_attribute_select_size#}
+                                                            {$select_size = #maximum_product_attribute_select_size#}
+                                                        {else}
+                                                            {$select_size = $options_count}
+                                                        {/if}
 								                        {/capture}
 
 								                        <div class="input-form">
-								                            <select multiple="multiple" name="feature_value[{$ID}][]" id="feature_value_{$ID}" size="{$options_count}" class="form-control">
+								                            <select multiple="multiple" name="feature_value[{$ID}][]" id="feature_value_{$ID}" size="{$select_size}" class="form-control">
 								                            {$smarty.capture.select_options nofilter}
 								                            </select>
 								                        </div>

--- a/templates/backOffice/default/configs/variables.conf
+++ b/templates/backOffice/default/configs/variables.conf
@@ -4,6 +4,10 @@ max_displayed_orders = 20
 max_displayed_customers = 20
 max_displayed_products = 20
 
+# Maximum select size in the attributes tab of product edit page
+# --------------------------------------------------------------
+maximum_product_attribute_select_size = 10
+
 # order status - used in admin-layout.tpl to build the order menu items
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
In the Attributes & Features tab of the product , the select size for an attribute is set to the number of attributes values (aka attribute availability). This is a problem when an attribute has many values.

This PR limits the number of options to `maximum_product_attribute_select_size`, a value defined in the `variables.conf` file of the default BO template.

The current value is 10.