### PR TITLE
Order loop improvements

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -293,6 +293,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                 ->set('PAYMENT_MODULE', $order->getPaymentModuleId())
                 ->set('DELIVERY_MODULE', $order->getDeliveryModuleId())
                 ->set('STATUS', $order->getStatusId())
+                ->set('STATUS_CODE', $order->getOrderStatus()->getCode())
                 ->set('LANG', $order->getLangId())
                 ->set('DISCOUNT', $order->getDiscount())
                 ->set('TOTAL_TAX', $tax)

--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -172,7 +172,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
         }
 
         if (null !== $excludeStatus = $this->getExcludeStatus()) {
-            $search->filterByStatusId($status, Criteria::NOT_IN);
+            $search->filterByStatusId($excludeStatus, Criteria::NOT_IN);
         }
 
         $statusCode = $this->getStatusCode();
@@ -188,7 +188,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
         if (null !== $excludeStatusCode = $this->getExcludeStatusCode()) {
             $search
                 ->useOrderStatusQuery()
-                ->filterByCode($statusCode, Criteria::NOT_IN)
+                ->filterByCode($excludeStatusCode, Criteria::NOT_IN)
                 ->endUse()
             ;
         }

--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -60,6 +60,15 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                     new Type\EnumType(array('*'))
                 )
             ),
+            Argument::createIntListTypeArgument('exclude_status'),
+            new Argument(
+                'status_code',
+                new TypeCollection(
+                    new Type\AnyListType(),
+                    new Type\EnumType(array('*'))
+                )
+            ),
+            Argument::createAnyListTypeArgument('exclude_status_code'),
             new Argument(
                 'order',
                 new TypeCollection(
@@ -162,6 +171,28 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
             $search->filterByStatusId($status, Criteria::IN);
         }
 
+        if (null !== $excludeStatus = $this->getExcludeStatus()) {
+            $search->filterByStatusId($status, Criteria::NOT_IN);
+        }
+
+        $statusCode = $this->getStatusCode();
+
+        if (null !== $statusCode && $statusCode != '*') {
+            $search
+                ->useOrderStatusQuery()
+                ->filterByCode($statusCode, Criteria::IN)
+                ->endUse()
+            ;
+        }
+
+        if (null !== $excludeStatusCode = $this->getExcludeStatusCode()) {
+            $search
+                ->useOrderStatusQuery()
+                ->filterByCode($statusCode, Criteria::NOT_IN)
+                ->endUse()
+            ;
+        }
+
         $orderers = $this->getOrder();
 
         foreach ($orderers as $orderer) {
@@ -216,7 +247,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                         ->withColumn(CustomerTableMap::LASTNAME, 'lastname')
                         ->orderBy('lastname', Criteria::ASC)
                         ->orderBy('firstname', Criteria::ASC)
-                        ;
+                    ;
                     break;
                 case 'customer-name-reverse':
                     $search


### PR DESCRIPTION
This PR adds three new parameters to the order loop:
- exclude_status, to exclude some status IDs
- status_code, to filter using a status code (paid, not_paid, processing, etc.)
- exclude_status_code, to exclude some status codes.

A new output variable is added, to return the status code (paid, not_paid, etc.) : 
- $STATUS_CODE