### PR TITLE
Fix HTTP sub-requests causing two container request scope exit

### DIFF
--- a/core/lib/Thelia/Core/TheliaHttpKernel.php
+++ b/core/lib/Thelia/Core/TheliaHttpKernel.php
@@ -68,7 +68,10 @@ class TheliaHttpKernel extends HttpKernel
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        if (false === $this->container->isScopeActive('request')) {
+        if (
+            HttpKernelInterface::MASTER_REQUEST === $type
+            && false === $this->container->isScopeActive('request')
+        ) {
             $this->container->enterScope('request');
             $this->container->set('request', $request, 'request');
         }
@@ -81,7 +84,9 @@ class TheliaHttpKernel extends HttpKernel
             throw $e;
         }
 
-        $this->container->leaveScope('request');
+        if (HttpKernelInterface::MASTER_REQUEST === $type) {
+            $this->container->leaveScope('request');
+        }
 
         return $response;
     }


### PR DESCRIPTION
The type of the request (master or sub) is not checked when entering and leaving the container request scope. Thus, sub-requests (such as the one created by `BaseAdminController::forward()`) causes multiple exits from the scope, raising an exception.

Any possible side-effects from this change ?

This fixes https://github.com/thelia/thelia/issues/1689.