### PR TITLE
Order::createOrder() improvement to allow order duplication.

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -382,6 +382,7 @@ class Order extends BaseAction implements EventSubscriberInterface
 
     /**
      * Create an order outside of the front-office context, e.g. manually from the back-office.
+     * @param OrderManualEvent $event
      */
     public function createManual(OrderManualEvent $event)
     {
@@ -524,9 +525,8 @@ class Order extends BaseAction implements EventSubscriberInterface
     }
 
     /**
-     * @param  ModelOrder                               $order
-     * @param $newStatus
-     * @param $canceledStatus
+     * @param ModelOrder $order
+     * @param $newStatus $newStatus the new status ID
      * @throws \Thelia\Exception\TheliaProcessException
      */
     public function updateQuantity(ModelOrder $order, $newStatus)

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -246,7 +246,6 @@ class Order extends BaseAction implements EventSubscriberInterface
 
             $taxCountry = $deliveryAddress->getCountry();
         }
->>>>>>> Improved manual order creation to allow order duplication
 
         $placedOrder->setStatusId(
             OrderStatusQuery::getNotPaidStatus()->getId()

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -26,7 +26,6 @@ use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Security\User\UserInterface;
 use Thelia\Exception\TheliaProcessException;
 use Thelia\Mailer\MailerFactory;
-use Thelia\Model\Address;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\Cart as CartModel;
 use Thelia\Model\ConfigQuery;
@@ -34,8 +33,8 @@ use Thelia\Model\Currency as CurrencyModel;
 use Thelia\Model\Lang as LangModel;
 use Thelia\Model\Map\OrderTableMap;
 use Thelia\Model\ModuleQuery;
-use Thelia\Model\Order as OrderModel;
 use Thelia\Model\Order as ModelOrder;
+use Thelia\Model\Order as OrderModel;
 use Thelia\Model\OrderAddress;
 use Thelia\Model\OrderAddressQuery;
 use Thelia\Model\OrderProduct;
@@ -178,8 +177,14 @@ class Order extends BaseAction implements EventSubscriberInterface
 
         $placedOrder = $sessionOrder->copy();
 
-        // Be sure to create a brand new order
+        // Be sure to create a brand new order, as copy raises the modified flag for all fields
+        // and will also copy order reference and id.
         $placedOrder->setId(null)->setRef(null)->setNew(true);
+
+        // Dates should be marked as not updated so that Propel will update them.
+        $placedOrder->resetModified(OrderTableMap::CREATED_AT);
+        $placedOrder->resetModified(OrderTableMap::UPDATED_AT);
+        $placedOrder->resetModified(OrderTableMap::VERSION_CREATED_AT);
 
         $placedOrder->setDispatcher($dispatcher);
 

--- a/core/lib/Thelia/Core/Event/Order/OrderManualEvent.php
+++ b/core/lib/Thelia/Core/Event/Order/OrderManualEvent.php
@@ -12,11 +12,11 @@
 
 namespace Thelia\Core\Event\Order;
 
-use Thelia\Model\Order;
-use Thelia\Model\Currency;
-use Thelia\Model\Lang;
 use Thelia\Model\Cart;
+use Thelia\Model\Currency;
 use Thelia\Model\Customer;
+use Thelia\Model\Lang;
+use Thelia\Model\Order;
 
 class OrderManualEvent extends OrderEvent
 {
@@ -24,6 +24,7 @@ class OrderManualEvent extends OrderEvent
     protected $lang = null;
     protected $cart = null;
     protected $customer = null;
+    protected $useOrderDefinedAddresses = false;
 
     /**
      * @param \Thelia\Model\Order    $order
@@ -34,8 +35,9 @@ class OrderManualEvent extends OrderEvent
      */
     public function __construct(Order $order, Currency $currency, Lang $lang, Cart $cart, Customer $customer)
     {
+        parent::__construct($order);
+
         $this
-            ->setOrder($order)
             ->setCurrency($currency)
             ->setLang($lang)
             ->setCart($cart)
@@ -43,189 +45,15 @@ class OrderManualEvent extends OrderEvent
         ;
     }
 
-    /**
-     * @param Order $order
-     */
-    public function setOrder(Order $order)
-    {
-        $this->order = $order;
-
-        return $this;
-    }
-
-    /**
-     * @param Order $order
-     */
-    public function setPlacedOrder(Order $order)
-    {
-        $this->placedOrder = $order;
-
-        return $this;
-    }
-
-    /**
-     * @param $address
-     */
-    public function setInvoiceAddress($address)
-    {
-        $this->invoiceAddress = $address;
-
-        return $this;
-    }
-
-    /**
-     * @param $address
-     */
-    public function setDeliveryAddress($address)
-    {
-        $this->deliveryAddress = $address;
-
-        return $this;
-    }
-
-    /**
-     * @param $module
-     */
-    public function setDeliveryModule($module)
-    {
-        $this->deliveryModule = $module;
-
-        return $this;
-    }
-
-    /**
-     * @param $module
-     */
-    public function setPaymentModule($module)
-    {
-        $this->paymentModule = $module;
-
-        return $this;
-    }
-
-    /**
-     * @param $postage
-     */
-    public function setPostage($postage)
-    {
-        $this->postage = $postage;
-
-        return $this;
-    }
-
-    /**
-     * @param $ref
-     */
-    public function setRef($ref)
-    {
-        $this->ref = $ref;
-
-        return $this;
-    }
-
-    /**
-     * @param $status
-     */
-    public function setStatus($status)
-    {
-        $this->status = $status;
-
-        return $this;
-    }
-
-    /**
-     * @param $deliveryRef
-     */
-    public function setDeliveryRef($deliveryRef)
-    {
-        $this->deliveryRef = $deliveryRef;
-    }
-
-    /**
-     * @return null|Order
-     */
-    public function getOrder()
-    {
-        return $this->order;
-    }
-
-    /**
-     * @return null|Order
-     */
-    public function getPlacedOrder()
-    {
-        return $this->placedOrder;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getInvoiceAddress()
-    {
-        return $this->invoiceAddress;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getDeliveryAddress()
-    {
-        return $this->deliveryAddress;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getDeliveryModule()
-    {
-        return $this->deliveryModule;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getPaymentModule()
-    {
-        return $this->paymentModule;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getPostage()
-    {
-        return $this->postage;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getRef()
-    {
-        return $this->ref;
-    }
-
-    /**
-     * @return null|int
-     */
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getDeliveryRef()
-    {
-        return $this->deliveryRef;
-    }
-
     public function getCurrency()
     {
         return $this->currency;
     }
 
+    /**
+     * @param Currency $currency
+     * @return $this
+     */
     public function setCurrency($currency)
     {
         $this->currency = $currency;
@@ -233,11 +61,18 @@ class OrderManualEvent extends OrderEvent
         return $this;
     }
 
+    /**
+     * @return Lang
+     */
     public function getLang()
     {
         return $this->lang;
     }
 
+    /**
+     * @param Lang $lang
+     * @return $this
+     */
     public function setLang($lang)
     {
         $this->lang = $lang;
@@ -245,11 +80,18 @@ class OrderManualEvent extends OrderEvent
         return $this;
     }
 
+    /**
+     * @return Cart
+     */
     public function getCart()
     {
         return $this->cart;
     }
 
+    /**
+     * @param Cart $cart
+     * @return $this
+     */
     public function setCart($cart)
     {
         $this->cart = $cart;
@@ -257,15 +99,43 @@ class OrderManualEvent extends OrderEvent
         return $this;
     }
 
+    /**
+     * @return Customer
+     */
     public function getCustomer()
     {
         return $this->customer;
     }
 
+    /**
+     * @param Customer $customer
+     * @return $this
+     */
     public function setCustomer($customer)
     {
         $this->customer = $customer;
 
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseOrderDefinedAddresses()
+    {
+        return $this->useOrderDefinedAddresses;
+    }
+
+    /**
+     * If true, the order will be created using the delivery and invoice addresses defined in $this->order instead of
+     * creating new OrderAdresses using the Order::getChoosenXXXAddress().
+     *
+     * @param boolean $useOrderDefinedAddresses
+     * @return $this
+     */
+    public function setUseOrderDefinedAddresses($useOrderDefinedAddresses)
+    {
+        $this->useOrderDefinedAddresses = $useOrderDefinedAddresses;
         return $this;
     }
 }

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -15,13 +15,15 @@ class Order extends BaseOrder
 {
     use ModelEventDispatcherTrait;
 
+    /** @var int|null  */
     protected $choosenDeliveryAddress = null;
+    /** @var int|null  */
     protected $choosenInvoiceAddress = null;
 
     protected $disableVersioning = false;
 
     /**
-     * @param Address $choosenDeliveryAddress
+     * @param int $choosenDeliveryAddress the choosen delivery address ID
      * @return $this
      */
     public function setChoosenDeliveryAddress($choosenDeliveryAddress)
@@ -57,7 +59,7 @@ class Order extends BaseOrder
     }
 
     /**
-     * @return Address
+     * @return int|null the choosen delivery address ID
      */
     public function getChoosenDeliveryAddress()
     {
@@ -65,7 +67,7 @@ class Order extends BaseOrder
     }
 
     /**
-     * @param Address $choosenInvoiceAddress
+     * @param int  $choosenInvoiceAddress the choosen invoice address
      * @return $this
      */
     public function setChoosenInvoiceAddress($choosenInvoiceAddress)
@@ -76,7 +78,7 @@ class Order extends BaseOrder
     }
 
     /**
-     * @return Address
+     * @return int|null the choosen invoice address ID
      */
     public function getChoosenInvoiceAddress()
     {


### PR DESCRIPTION
This PR improves the `Order::createOrder()` so that the method could be used to duplicate an order by re-using the delivery and invoice addresses defined in the original order.

The `$useOrderDefinedAddresses` parameter has been  added to select the required behaviour. If `true`, the order addresses are re-used. If `false`, the getChoosen*XXXX*Address() methods are used to get the customer addresses choice, and new `OrderAdress`es are created.





