### PR TITLE
Hook improvements

### DIFF
--- a/core/lib/Thelia/Action/ModuleHook.php
+++ b/core/lib/Thelia/Action/ModuleHook.php
@@ -117,6 +117,7 @@ class ModuleHook extends BaseAction implements EventSubscriberInterface
             ->setModuleActive($this->isModuleActive($event->getModuleId()))
             ->setHookActive($this->isHookActive($event->getHookId()))
             ->setPosition($this->getLastPositionInHook($event->getHookId()))
+            ->setTemplates($event->getTemplates())
             ->save();
 
         // Be sure to delete this module hook from the ignored module hook table
@@ -139,6 +140,7 @@ class ModuleHook extends BaseAction implements EventSubscriberInterface
                 ->setMethod($event->getMethod())
                 ->setActive($event->getActive())
                 ->setHookActive($this->isHookActive($event->getHookId()))
+                ->setTemplates($event->getTemplates())
                 ->save();
 
             $event->setModuleHook($moduleHook);

--- a/core/lib/Thelia/Command/HookCleanCommand.php
+++ b/core/lib/Thelia/Command/HookCleanCommand.php
@@ -1,0 +1,153 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Thelia\Core\Event\Cache\CacheEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\IgnoredModuleHookQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleHookQuery;
+use Thelia\Model\ModuleQuery;
+
+/**
+ * Clean hook
+ *
+ * Class HookCleanCommand
+ * @package Thelia\Command
+ *
+ * @author Julien Chanséaume <julien@thelia.net>
+ *
+ */
+class HookCleanCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName("hook:clean")
+            ->setDescription("Clean hooks. It will delete all hooks, then recreate it.")
+            ->addOption(
+                "assume-yes",
+                'y',
+                InputOption::VALUE_NONE,
+                'Assume to answer yes to all questions'
+            )
+            ->addArgument(
+                "module",
+                InputArgument::OPTIONAL,
+                "The module code to clean up"
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $module = $this->getModule($input);
+
+            if (!$this->askConfirmation($input, $output)) {
+                return;
+            }
+
+            $this->deleteHooks($module);
+
+            $output->writeln("<info>Hooks have been successfully deleted</info>");
+
+            $this->clearCache($output);
+        } catch (\Exception $ex) {
+            $output->writeln(sprintf("<error>%s</error>", $ex->getMessage()));
+        }
+
+    }
+
+    private function getModule(InputInterface $input)
+    {
+        $module = null;
+        $moduleCode = $input->getArgument("module");
+
+        if (!empty($moduleCode)) {
+            if (null === $module = ModuleQuery::create()->findOneByCode($moduleCode)) {
+                throw new \RuntimeException(sprintf("Module %s does not exist.", $moduleCode));
+            }
+        }
+
+        return $module;
+    }
+
+    private function askConfirmation(InputInterface $input, OutputInterface $output)
+    {
+        $assumeYes = $input->getOption("assume-yes");
+
+        if (!$assumeYes) {
+            /** @var DialogHelper $dialog */
+            $dialog = $this->getHelperSet()->get('dialog');
+            $question = "Would you like to delete all hooks ";
+            $question .= (empty($moduleCode))
+                ? "of all modules"
+                : "of module " . $moduleCode;
+            $question .= " ? (yes, or no) ";
+
+            if (!$dialog->askConfirmation($output, $question, false)) {
+                $output->writeln("<info>No hooks deleted</info>");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Delete module hooks
+     *
+     * @param Module|null $module if specified it will only delete hooks related to this module.
+     * @throws \Exception
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    protected function deleteHooks($module)
+    {
+        $query = ModuleHookQuery::create();
+        if (null !== $module) {
+            $query
+                ->filterByModule($module)
+                ->delete();
+        } else {
+            $query->deleteAll();
+        }
+
+        $query = IgnoredModuleHookQuery::create();
+        if (null !== $module) {
+            $query
+                ->filterByModule($module)
+                ->delete();
+        } else {
+            $query->deleteAll();
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    protected function clearCache(OutputInterface $output)
+    {
+        try {
+            $cacheDir = $this->getContainer()->getParameter("kernel.cache_dir");
+            $cacheEvent = new CacheEvent($cacheDir);
+            $this->getDispatcher()->dispatch(TheliaEvents::CACHE_CLEAR, $cacheEvent);
+        } catch (\Exception $ex) {
+            throw new \Exception(sprintf("Error during clearing of cache : %s", $ex->getMessage()));
+        }
+    }
+}

--- a/core/lib/Thelia/Config/Resources/command.xml
+++ b/core/lib/Thelia/Config/Resources/command.xml
@@ -23,6 +23,7 @@
         <command class="Thelia\Command\ConfigCommand"/>
         <command class="Thelia\Command\SaleCheckActivationCommand"/>
         <command class="Thelia\Command\GenerateSQLCommand"/>
+        <command class="Thelia\Command\HookCleanCommand"/>
     </commands>
 
 </config>

--- a/core/lib/Thelia/Controller/Admin/ModuleHookController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleHookController.php
@@ -20,6 +20,7 @@ use Thelia\Core\Event\Hook\ModuleHookToggleActivationEvent;
 use Thelia\Core\Event\Hook\ModuleHookUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Core\Hook\BaseHook;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
@@ -126,10 +127,11 @@ class ModuleHookController extends AbstractCrudController
         $data = [
             'id'        => $object->getId(),
             'hook_id'   => $object->getHookId(),
-            'module_id'   => $object->getModuleId(),
+            'module_id' => $object->getModuleId(),
             'classname' => $object->getClassname(),
             'method'    => $object->getMethod(),
             'active'    => $object->getActive(),
+            'templates' => $object->getTemplates(),
         ];
 
         return $this->createForm(AdminForm::MODULE_HOOK_MODIFICATION, 'form', $data);
@@ -174,7 +176,9 @@ class ModuleHookController extends AbstractCrudController
                 ->setHookId($formData['hook_id'])
                 ->setClassname($formData['classname'])
                 ->setMethod($formData['method'])
-                ->setActive($formData['active']);
+                ->setActive($formData['active'])
+                ->setTemplates($formData['templates'])
+            ;
         }
 
         return $event;
@@ -360,7 +364,7 @@ class ModuleHookController extends AbstractCrudController
             return $response;
         }
 
-        $result = [];
+        $result = [BaseHook::INJECT_TEMPLATE_METHOD_NAME];
 
         $moduleHooks = ModuleHookQuery::create()
             ->filterByModuleId($moduleId)

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -246,16 +246,18 @@ class RegisterHookListenersPass implements CompilerPassInterface
                     )
                 );
 
-                if (!empty($moduleHook->getTemplates())) {
-                    $container
-                        ->getDefinition($moduleHook->getClassname())
-                        ->addMethodCall(
-                            'addTemplate',
-                            array(
-                                'hook.' . $hook->getType() . '.' . $hook->getCode(),
-                                $moduleHook->getTemplates()
-                            )
-                        );
+                if ($moduleHook->getTemplates()) {
+                    if ($container->hasDefinition($moduleHook->getClassname())) {
+                        $container
+                            ->getDefinition($moduleHook->getClassname())
+                            ->addMethodCall(
+                                'addTemplate',
+                                array(
+                                    'hook.' . $hook->getType() . '.' . $hook->getCode(),
+                                    $moduleHook->getTemplates()
+                                )
+                            );
+                    }
                 }
             }
         }

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -18,11 +18,13 @@ use ReflectionMethod;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Thelia\Core\Hook\BaseHook;
 use Thelia\Core\Hook\HookDefinition;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Log\Tlog;
 use Thelia\Model\Base\IgnoredModuleHookQuery;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\Hook;
 use Thelia\Model\HookQuery;
 use Thelia\Model\ModuleHookQuery;
 use Thelia\Model\ModuleHook;
@@ -71,18 +73,16 @@ class RegisterHookListenersPass implements CompilerPassInterface
             $module = null;
             if (array_key_exists('module', $properties)) {
                 $moduleCode = explode(".", $properties['module'])[1];
-                if (null !== $module = ModuleQuery::create()->findOneByCode($moduleCode)) {
-                    $module = $module->getId();
-                }
+                $module = ModuleQuery::create()->findOneByCode($moduleCode);
             }
 
-            foreach ($events as $event) {
-                $this->registerHook($class, $module, $id, $event);
+            foreach ($events as $hookAttributes) {
+                $this->registerHook($class, $module, $id, $hookAttributes);
             }
         }
 
         // now we can add listeners for active hooks and active module
-        $this->addHooksMethodCall($definition);
+        $this->addHooksMethodCall($container, $definition);
     }
 
     /**
@@ -91,60 +91,38 @@ class RegisterHookListenersPass implements CompilerPassInterface
      * @param string               $class  the namespace of the class
      * @param \Thelia\Model\Module $module the module
      * @param string               $id     the service (hook) id
-     * @param array                $event  the event attributes
+     * @param array                $attributes  the hook attributes
      *
      * @throws \InvalidArgumentException
      */
-    protected function registerHook($class, $module, $id, $event)
+    protected function registerHook($class, $module, $id, $attributes)
     {
-        $active = isset($event['active']) ? intval($event['active']) : 1;
-        $active = (1 === $active);
-
-        if (!isset($event['event'])) {
+        if (!isset($attributes['event'])) {
             throw new \InvalidArgumentException(sprintf('Service "%s" must define the "event" attribute on "hook.event_listener" tags.', $id));
         }
 
-        $type = (isset($event['type'])) ? $this->getHookType($event['type']) : TemplateDefinition::FRONT_OFFICE;
+        $active = isset($attributes['active']) ? intval($attributes['active']) : 1;
+        $attributes['active'] = (1 === $active);
+        $attributes['templates'] = isset($attributes['templates']) ? strval($attributes['templates']) : '';
+        $attributes['type'] = (isset($attributes['type'])) ? $this->getHookType($attributes['type']) : TemplateDefinition::FRONT_OFFICE;
 
-        $hook = HookQuery::create()
-            ->filterByCode($event['event'])
-            ->filterByType($type)
-            ->findOne();
-
-        if (null === $hook) {
-            Tlog::getInstance()->addAlert(sprintf("Hook %s is unknown.", $event['event']));
-
+        if (null === $hook = $this->getHook($attributes['event'], $attributes['type'])) {
             return;
         }
 
-        if (! $hook->getActivate()) {
-            Tlog::getInstance()->addAlert(sprintf("Hook %s is not activated.", $event['event']));
-
-            return;
-        }
-
-        if (!isset($event['method'])) {
-            $callback = function ($matches) {
-                return strtoupper($matches[0]);
-            };
-            $event['method'] = 'on'.preg_replace_callback(array(
-                    '/(?<=\b)[a-z]/i',
-                    '/[^a-z0-9]/i',
-                ), $callback, $event['event']);
-            $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
-        }
+        $attributes = $this->getMethodName($attributes);
 
         // test if method exists
         $validMethod = true;
-        if (! $this->isValidHookMethod($class, $event['method'], $hook->getBlock())) {
+        if (! $this->isValidHookMethod($class, $attributes['method'], $hook->getBlock())) {
             $validMethod = false;
         }
 
         // test if hook is already registered in ModuleHook
         $moduleHook = ModuleHookQuery::create()
-            ->filterByModuleId($module)
+            ->filterByModuleId($module->getId())
             ->filterByHook($hook)
-            ->filterByMethod($event['method'])
+            ->filterByMethod($attributes['method'])
             ->findOne();
 
         if (null === $moduleHook) {
@@ -152,9 +130,9 @@ class RegisterHookListenersPass implements CompilerPassInterface
                 Tlog::getInstance()->addAlert(
                     sprintf(
                         "Module [%s] could not be registered hook [%s], method [%s] is not reachable.",
-                        $module,
-                        $event['event'],
-                        $event['method']
+                        $module->getCode(),
+                        $attributes['event'],
+                        $attributes['method']
                     )
                 );
                 return;
@@ -163,43 +141,53 @@ class RegisterHookListenersPass implements CompilerPassInterface
             // Assign the module to the hook only if it has not been "deleted"
             $ignoreCount = IgnoredModuleHookQuery::create()
                 ->filterByHook($hook)
-                ->filterByModuleId($module)
+                ->filterByModuleId($module->getId())
                 ->count();
 
             if (0 === $ignoreCount) {
                 // hook for module doesn't exist, we add it with default registered values
                 $moduleHook = new ModuleHook();
+
                 $moduleHook->setHook($hook)
-                    ->setModuleId($module)
+                    ->setModuleId($module->getId())
                     ->setClassname($id)
-                    ->setMethod($event['method'])
+                    ->setMethod($attributes['method'])
                     ->setActive($active)
                     ->setHookActive(true)
                     ->setModuleActive(true)
-                    ->setPosition(ModuleHook::MAX_POSITION)
-                    ->save();
+                    ->setPosition(ModuleHook::MAX_POSITION);
+
+                if (isset($attributes['templates'])) {
+                    $moduleHook->setTemplates($attributes['templates']);
+                }
+
+                $moduleHook->save();
             }
         } else {
             if (!$validMethod) {
                 Tlog::getInstance()->addAlert(
                     sprintf(
                         "Module [%s] could not use hook [%s], method [%s] is not reachable anymore.",
-                        $module,
-                        $event['event'],
-                        $event['method']
+                        $module->getCode(),
+                        $attributes['event'],
+                        $attributes['method']
                     )
                 );
 
                 $moduleHook
                     ->setHookActive(false)
                     ->save();
+
             } else {
+                //$moduleHook->setTemplates($attributes['templates']);
+
                 // Update hook if id was changed in the definition
                 if ($moduleHook->getClassname() != $id) {
                     $moduleHook
-                        ->setClassname($id)
-                        ->save();
+                        ->setClassname($id);
                 }
+
+                $moduleHook->save();
             }
         }
     }
@@ -212,7 +200,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
      *
      * @param Definition $definition The service definition
      */
-    protected function addHooksMethodCall(Definition $definition)
+    protected function addHooksMethodCall(ContainerBuilder $container, Definition $definition)
     {
         $moduleHooks = ModuleHookQuery::create()
             ->orderByHookId()
@@ -236,7 +224,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
                 // new module hook, we set it at the end of the queue for this event
                 $moduleHook->setPosition($modulePosition)->save();
             } else {
-                $modulePosition = $moduleHook->getPosition($modulePosition);
+                $modulePosition = $moduleHook->getPosition();
             }
 
             // Add the the new listener for active hooks, we have to reverse the priority and the position
@@ -257,6 +245,18 @@ class RegisterHookListenersPass implements CompilerPassInterface
                         ModuleHook::MAX_POSITION - $moduleHook->getPosition()
                     )
                 );
+
+                if (!empty($moduleHook->getTemplates())) {
+                    $container
+                        ->getDefinition($moduleHook->getClassname())
+                        ->addMethodCall(
+                            'addTemplate',
+                            array(
+                                'hook.' . $hook->getType() . '.' . $hook->getCode(),
+                                $moduleHook->getTemplates()
+                            )
+                        );
+                }
             }
         }
     }
@@ -285,6 +285,36 @@ class RegisterHookListenersPass implements CompilerPassInterface
         }
 
         return $type;
+    }
+
+    /**
+     * G<et a hook for a hook name (code) and a hook type. The hook should exists and be activated.
+     *
+     * @param string $hookName
+     * @param int $hookType
+     *
+     * @return Hook|null
+     */
+    protected function getHook($hookName, $hookType)
+    {
+        $hook = HookQuery::create()
+            ->filterByCode($hookName)
+            ->filterByType($hookType)
+            ->findOne();
+
+        if (null === $hook) {
+            Tlog::getInstance()->addAlert(sprintf("Hook %s is unknown.", $hookName));
+
+            return null;
+        }
+
+        if (! $hook->getActivate()) {
+            Tlog::getInstance()->addAlert(sprintf("Hook %s is not activated.", $hookName));
+
+            return null;
+        }
+
+        return $hook;
     }
 
     /**
@@ -324,5 +354,35 @@ class RegisterHookListenersPass implements CompilerPassInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param $event
+     * @return mixed
+     */
+    protected function getMethodName($event)
+    {
+        if (!isset($event['method'])) {
+            if (!empty($event['templates'])) {
+                $event['method'] = BaseHook::INJECT_TEMPLATE_METHOD_NAME;
+                return $event;
+            } else {
+                $callback = function ($matches) {
+                    return strtoupper($matches[0]);
+                };
+                $event['method'] = 'on' . preg_replace_callback(
+                    array(
+                        '/(?<=\b)[a-z]/i',
+                        '/[^a-z0-9]/i',
+                    ),
+                    $callback,
+                    $event['event']
+                );
+                $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);
+                return $event;
+            }
+        }
+
+        return $event;
     }
 }

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
@@ -50,6 +50,7 @@ use Thelia\Model\Map\ImportTableMap;
  */
 class XmlFileLoader extends FileLoader
 {
+    const DEFAULT_HOOK_CLASS = "Thelia\\Core\\Hook\\DefaultHook";
     /**
      * Loads an XML file.
      *
@@ -275,6 +276,10 @@ class XmlFileLoader extends FileLoader
     {
         if (!array_key_exists('scope', $hook)) {
             $hook['scope'] = 'request';
+        }
+
+        if (! isset($hook['class'])) {
+            $hook['class'] = self::DEFAULT_HOOK_CLASS;
         }
 
         $definition = $this->parseService($id, $hook, $file);

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
@@ -273,6 +273,10 @@ class XmlFileLoader extends FileLoader
 
     protected function parseHook($id, $hook, $file, $type)
     {
+        if (!array_key_exists('scope', $hook)) {
+            $hook['scope'] = 'request';
+        }
+
         $definition = $this->parseService($id, $hook, $file);
         if (null !== $definition) {
             if (null !== $type) {

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
@@ -199,6 +199,7 @@
         <xsd:attribute name="method" type="xsd:string" />
         <xsd:attribute name="type" type="hook_type" />
         <xsd:attribute name="active" type="hook_active" />
+        <xsd:attribute name="templates" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:simpleType name="hook_type">

--- a/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
@@ -22,22 +22,23 @@ use Symfony\Component\EventDispatcher\Event;
 class BaseHookRenderEvent extends Event
 {
     /** @var  string $code the code of the hook */
-    protected $code = array();
+    protected $code = null;
 
-    /** @var  array $arguments an array of arguments passed to the template engine function  */
+    /** @var  array $arguments an array of arguments passed to the template engine function */
     protected $arguments = array();
+
 
     public function __construct($code, array $arguments = array())
     {
-        $this->setName($code);
-        $this->setArguments($arguments);
+        $this->code = $code;
+        $this->arguments = $arguments;
     }
 
     /**
      * Set the code of the hook
      *
-     * @param  string          $code
-     * @return BaseRenderEvent $this
+     * @param  string $code
+     * @return $this
      */
     public function setCode($code)
     {
@@ -59,8 +60,8 @@ class BaseHookRenderEvent extends Event
     /**
      * Set all arguments
      *
-     * @param  array           $arguments
-     * @return BaseRenderEvent $this
+     * @param  array $arguments
+     * @return $this
      */
     public function setArguments($arguments)
     {
@@ -82,9 +83,9 @@ class BaseHookRenderEvent extends Event
     /**
      * add or replace an argument
      *
-     * @param  string          $key
-     * @param  string          $value
-     * @return HookRenderEvent $this
+     * @param  string $key
+     * @param  string $value
+     * @return $this
      */
     public function setArgument($key, $value)
     {
@@ -95,7 +96,7 @@ class BaseHookRenderEvent extends Event
 
     /**
      * Get an argument
-     * @param  string      $key
+     * @param  string $key
      * @param  string|null $default
      * @return mixed|null  the value of the argument or `$default` if it not exists
      */

--- a/core/lib/Thelia/Core/Event/Hook/ModuleHookCreateEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/ModuleHookCreateEvent.php
@@ -19,10 +19,20 @@ namespace Thelia\Core\Event\Hook;
  */
 class ModuleHookCreateEvent extends ModuleHookEvent
 {
+    /** @var int */
     protected $module_id;
+
+    /** @var int */
     protected $hook_id;
-    protected $classname;
+
+    /** @var string */
     protected $method;
+
+    /** @var string */
+    protected $classname;
+
+    /** @var string */
+    protected $templates;
 
     /**
      * @param int $hook_id
@@ -99,4 +109,25 @@ class ModuleHookCreateEvent extends ModuleHookEvent
     {
         return $this->method;
     }
+
+    /**
+     * @return string
+     */
+    public function getTemplates()
+    {
+        return $this->templates;
+    }
+
+    /**
+     * @param string $templates
+     * @return $this
+     */
+    public function setTemplates($templates)
+    {
+        $this->templates = $templates;
+
+        return $this;
+    }
+
+
 }

--- a/core/lib/Thelia/Core/Hook/DefaultHook.php
+++ b/core/lib/Thelia/Core/Hook/DefaultHook.php
@@ -1,0 +1,24 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Hook;
+
+/**
+ * Class DefaultHook
+ * @package Thelia\Core\Hook
+ * @author Julien Chanséaume <julien@thelia.net>
+ */
+class DefaultHook extends BaseHook
+{
+
+}

--- a/core/lib/Thelia/Core/Template/Loop/ModuleHook.php
+++ b/core/lib/Thelia/Core/Template/Loop/ModuleHook.php
@@ -162,6 +162,7 @@ class ModuleHook extends BaseI18nLoop implements PropelSearchLoopInterface
                     ->set("HOOK_ACTIVE", $moduleHook->getHookActive())
                     ->set("MODULE_ACTIVE", $moduleHook->getModuleActive())
                     ->set("POSITION", $moduleHook->getPosition())
+                    ->set("TEMPLATES", $moduleHook->getTemplates())
                 ;
 
                 $loopResult->addRow($loopResultRow);

--- a/core/lib/Thelia/Model/Base/ModuleHook.php
+++ b/core/lib/Thelia/Model/Base/ModuleHook.php
@@ -110,6 +110,12 @@ abstract class ModuleHook implements ActiveRecordInterface
     protected $position;
 
     /**
+     * The value for the templates field.
+     * @var        string
+     */
+    protected $templates;
+
+    /**
      * @var        Module
      */
     protected $aModule;
@@ -485,6 +491,17 @@ abstract class ModuleHook implements ActiveRecordInterface
     }
 
     /**
+     * Get the [templates] column value.
+     *
+     * @return   string
+     */
+    public function getTemplates()
+    {
+
+        return $this->templates;
+    }
+
+    /**
      * Set the value of [id] column.
      *
      * @param      int $v new value
@@ -706,6 +723,27 @@ abstract class ModuleHook implements ActiveRecordInterface
     } // setPosition()
 
     /**
+     * Set the value of [templates] column.
+     *
+     * @param      string $v new value
+     * @return   \Thelia\Model\ModuleHook The current object (for fluent API support)
+     */
+    public function setTemplates($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->templates !== $v) {
+            $this->templates = $v;
+            $this->modifiedColumns[ModuleHookTableMap::TEMPLATES] = true;
+        }
+
+
+        return $this;
+    } // setTemplates()
+
+    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -768,6 +806,9 @@ abstract class ModuleHook implements ActiveRecordInterface
 
             $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : ModuleHookTableMap::translateFieldName('Position', TableMap::TYPE_PHPNAME, $indexType)];
             $this->position = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : ModuleHookTableMap::translateFieldName('Templates', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->templates = (null !== $col) ? (string) $col : null;
             $this->resetModified();
 
             $this->setNew(false);
@@ -776,7 +817,7 @@ abstract class ModuleHook implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 9; // 9 = ModuleHookTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 10; // 10 = ModuleHookTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException("Error populating \Thelia\Model\ModuleHook object", 0, $e);
@@ -1039,6 +1080,9 @@ abstract class ModuleHook implements ActiveRecordInterface
         if ($this->isColumnModified(ModuleHookTableMap::POSITION)) {
             $modifiedColumns[':p' . $index++]  = '`POSITION`';
         }
+        if ($this->isColumnModified(ModuleHookTableMap::TEMPLATES)) {
+            $modifiedColumns[':p' . $index++]  = '`TEMPLATES`';
+        }
 
         $sql = sprintf(
             'INSERT INTO `module_hook` (%s) VALUES (%s)',
@@ -1076,6 +1120,9 @@ abstract class ModuleHook implements ActiveRecordInterface
                         break;
                     case '`POSITION`':
                         $stmt->bindValue($identifier, $this->position, PDO::PARAM_INT);
+                        break;
+                    case '`TEMPLATES`':
+                        $stmt->bindValue($identifier, $this->templates, PDO::PARAM_STR);
                         break;
                 }
             }
@@ -1166,6 +1213,9 @@ abstract class ModuleHook implements ActiveRecordInterface
             case 8:
                 return $this->getPosition();
                 break;
+            case 9:
+                return $this->getTemplates();
+                break;
             default:
                 return null;
                 break;
@@ -1204,6 +1254,7 @@ abstract class ModuleHook implements ActiveRecordInterface
             $keys[6] => $this->getHookActive(),
             $keys[7] => $this->getModuleActive(),
             $keys[8] => $this->getPosition(),
+            $keys[9] => $this->getTemplates(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1278,6 +1329,9 @@ abstract class ModuleHook implements ActiveRecordInterface
             case 8:
                 $this->setPosition($value);
                 break;
+            case 9:
+                $this->setTemplates($value);
+                break;
         } // switch()
     }
 
@@ -1311,6 +1365,7 @@ abstract class ModuleHook implements ActiveRecordInterface
         if (array_key_exists($keys[6], $arr)) $this->setHookActive($arr[$keys[6]]);
         if (array_key_exists($keys[7], $arr)) $this->setModuleActive($arr[$keys[7]]);
         if (array_key_exists($keys[8], $arr)) $this->setPosition($arr[$keys[8]]);
+        if (array_key_exists($keys[9], $arr)) $this->setTemplates($arr[$keys[9]]);
     }
 
     /**
@@ -1331,6 +1386,7 @@ abstract class ModuleHook implements ActiveRecordInterface
         if ($this->isColumnModified(ModuleHookTableMap::HOOK_ACTIVE)) $criteria->add(ModuleHookTableMap::HOOK_ACTIVE, $this->hook_active);
         if ($this->isColumnModified(ModuleHookTableMap::MODULE_ACTIVE)) $criteria->add(ModuleHookTableMap::MODULE_ACTIVE, $this->module_active);
         if ($this->isColumnModified(ModuleHookTableMap::POSITION)) $criteria->add(ModuleHookTableMap::POSITION, $this->position);
+        if ($this->isColumnModified(ModuleHookTableMap::TEMPLATES)) $criteria->add(ModuleHookTableMap::TEMPLATES, $this->templates);
 
         return $criteria;
     }
@@ -1402,6 +1458,7 @@ abstract class ModuleHook implements ActiveRecordInterface
         $copyObj->setHookActive($this->getHookActive());
         $copyObj->setModuleActive($this->getModuleActive());
         $copyObj->setPosition($this->getPosition());
+        $copyObj->setTemplates($this->getTemplates());
         if ($makeNew) {
             $copyObj->setNew(true);
             $copyObj->setId(NULL); // this is a auto-increment column, so set to default value
@@ -1546,6 +1603,7 @@ abstract class ModuleHook implements ActiveRecordInterface
         $this->hook_active = null;
         $this->module_active = null;
         $this->position = null;
+        $this->templates = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
         $this->resetModified();

--- a/core/lib/Thelia/Model/Base/ModuleHookQuery.php
+++ b/core/lib/Thelia/Model/Base/ModuleHookQuery.php
@@ -30,6 +30,7 @@ use Thelia\Model\Map\ModuleHookTableMap;
  * @method     ChildModuleHookQuery orderByHookActive($order = Criteria::ASC) Order by the hook_active column
  * @method     ChildModuleHookQuery orderByModuleActive($order = Criteria::ASC) Order by the module_active column
  * @method     ChildModuleHookQuery orderByPosition($order = Criteria::ASC) Order by the position column
+ * @method     ChildModuleHookQuery orderByTemplates($order = Criteria::ASC) Order by the templates column
  *
  * @method     ChildModuleHookQuery groupById() Group by the id column
  * @method     ChildModuleHookQuery groupByModuleId() Group by the module_id column
@@ -40,6 +41,7 @@ use Thelia\Model\Map\ModuleHookTableMap;
  * @method     ChildModuleHookQuery groupByHookActive() Group by the hook_active column
  * @method     ChildModuleHookQuery groupByModuleActive() Group by the module_active column
  * @method     ChildModuleHookQuery groupByPosition() Group by the position column
+ * @method     ChildModuleHookQuery groupByTemplates() Group by the templates column
  *
  * @method     ChildModuleHookQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildModuleHookQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -65,6 +67,7 @@ use Thelia\Model\Map\ModuleHookTableMap;
  * @method     ChildModuleHook findOneByHookActive(boolean $hook_active) Return the first ChildModuleHook filtered by the hook_active column
  * @method     ChildModuleHook findOneByModuleActive(boolean $module_active) Return the first ChildModuleHook filtered by the module_active column
  * @method     ChildModuleHook findOneByPosition(int $position) Return the first ChildModuleHook filtered by the position column
+ * @method     ChildModuleHook findOneByTemplates(string $templates) Return the first ChildModuleHook filtered by the templates column
  *
  * @method     array findById(int $id) Return ChildModuleHook objects filtered by the id column
  * @method     array findByModuleId(int $module_id) Return ChildModuleHook objects filtered by the module_id column
@@ -75,6 +78,7 @@ use Thelia\Model\Map\ModuleHookTableMap;
  * @method     array findByHookActive(boolean $hook_active) Return ChildModuleHook objects filtered by the hook_active column
  * @method     array findByModuleActive(boolean $module_active) Return ChildModuleHook objects filtered by the module_active column
  * @method     array findByPosition(int $position) Return ChildModuleHook objects filtered by the position column
+ * @method     array findByTemplates(string $templates) Return ChildModuleHook objects filtered by the templates column
  *
  */
 abstract class ModuleHookQuery extends ModelCriteria
@@ -163,7 +167,7 @@ abstract class ModuleHookQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT `ID`, `MODULE_ID`, `HOOK_ID`, `CLASSNAME`, `METHOD`, `ACTIVE`, `HOOK_ACTIVE`, `MODULE_ACTIVE`, `POSITION` FROM `module_hook` WHERE `ID` = :p0';
+        $sql = 'SELECT `ID`, `MODULE_ID`, `HOOK_ID`, `CLASSNAME`, `METHOD`, `ACTIVE`, `HOOK_ACTIVE`, `MODULE_ACTIVE`, `POSITION`, `TEMPLATES` FROM `module_hook` WHERE `ID` = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -557,6 +561,35 @@ abstract class ModuleHookQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(ModuleHookTableMap::POSITION, $position, $comparison);
+    }
+
+    /**
+     * Filter the query on the templates column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByTemplates('fooValue');   // WHERE templates = 'fooValue'
+     * $query->filterByTemplates('%fooValue%'); // WHERE templates LIKE '%fooValue%'
+     * </code>
+     *
+     * @param     string $templates The value to use as filter.
+     *              Accepts wildcards (* and % trigger a LIKE)
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildModuleHookQuery The current query, for fluid interface
+     */
+    public function filterByTemplates($templates = null, $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($templates)) {
+                $comparison = Criteria::IN;
+            } elseif (preg_match('/[\%\*]/', $templates)) {
+                $templates = str_replace('*', '%', $templates);
+                $comparison = Criteria::LIKE;
+            }
+        }
+
+        return $this->addUsingAlias(ModuleHookTableMap::TEMPLATES, $templates, $comparison);
     }
 
     /**

--- a/core/lib/Thelia/Model/Map/ModuleHookTableMap.php
+++ b/core/lib/Thelia/Model/Map/ModuleHookTableMap.php
@@ -58,7 +58,7 @@ class ModuleHookTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 9;
+    const NUM_COLUMNS = 10;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class ModuleHookTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 9;
+    const NUM_HYDRATE_COLUMNS = 10;
 
     /**
      * the column name for the ID field
@@ -116,6 +116,11 @@ class ModuleHookTableMap extends TableMap
     const POSITION = 'module_hook.POSITION';
 
     /**
+     * the column name for the TEMPLATES field
+     */
+    const TEMPLATES = 'module_hook.TEMPLATES';
+
+    /**
      * The default string format for model objects of the related table
      */
     const DEFAULT_STRING_FORMAT = 'YAML';
@@ -127,12 +132,12 @@ class ModuleHookTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'ModuleId', 'HookId', 'Classname', 'Method', 'Active', 'HookActive', 'ModuleActive', 'Position', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'moduleId', 'hookId', 'classname', 'method', 'active', 'hookActive', 'moduleActive', 'position', ),
-        self::TYPE_COLNAME       => array(ModuleHookTableMap::ID, ModuleHookTableMap::MODULE_ID, ModuleHookTableMap::HOOK_ID, ModuleHookTableMap::CLASSNAME, ModuleHookTableMap::METHOD, ModuleHookTableMap::ACTIVE, ModuleHookTableMap::HOOK_ACTIVE, ModuleHookTableMap::MODULE_ACTIVE, ModuleHookTableMap::POSITION, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'MODULE_ID', 'HOOK_ID', 'CLASSNAME', 'METHOD', 'ACTIVE', 'HOOK_ACTIVE', 'MODULE_ACTIVE', 'POSITION', ),
-        self::TYPE_FIELDNAME     => array('id', 'module_id', 'hook_id', 'classname', 'method', 'active', 'hook_active', 'module_active', 'position', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, )
+        self::TYPE_PHPNAME       => array('Id', 'ModuleId', 'HookId', 'Classname', 'Method', 'Active', 'HookActive', 'ModuleActive', 'Position', 'Templates', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'moduleId', 'hookId', 'classname', 'method', 'active', 'hookActive', 'moduleActive', 'position', 'templates', ),
+        self::TYPE_COLNAME       => array(ModuleHookTableMap::ID, ModuleHookTableMap::MODULE_ID, ModuleHookTableMap::HOOK_ID, ModuleHookTableMap::CLASSNAME, ModuleHookTableMap::METHOD, ModuleHookTableMap::ACTIVE, ModuleHookTableMap::HOOK_ACTIVE, ModuleHookTableMap::MODULE_ACTIVE, ModuleHookTableMap::POSITION, ModuleHookTableMap::TEMPLATES, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'MODULE_ID', 'HOOK_ID', 'CLASSNAME', 'METHOD', 'ACTIVE', 'HOOK_ACTIVE', 'MODULE_ACTIVE', 'POSITION', 'TEMPLATES', ),
+        self::TYPE_FIELDNAME     => array('id', 'module_id', 'hook_id', 'classname', 'method', 'active', 'hook_active', 'module_active', 'position', 'templates', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, )
     );
 
     /**
@@ -142,12 +147,12 @@ class ModuleHookTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'ModuleId' => 1, 'HookId' => 2, 'Classname' => 3, 'Method' => 4, 'Active' => 5, 'HookActive' => 6, 'ModuleActive' => 7, 'Position' => 8, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'moduleId' => 1, 'hookId' => 2, 'classname' => 3, 'method' => 4, 'active' => 5, 'hookActive' => 6, 'moduleActive' => 7, 'position' => 8, ),
-        self::TYPE_COLNAME       => array(ModuleHookTableMap::ID => 0, ModuleHookTableMap::MODULE_ID => 1, ModuleHookTableMap::HOOK_ID => 2, ModuleHookTableMap::CLASSNAME => 3, ModuleHookTableMap::METHOD => 4, ModuleHookTableMap::ACTIVE => 5, ModuleHookTableMap::HOOK_ACTIVE => 6, ModuleHookTableMap::MODULE_ACTIVE => 7, ModuleHookTableMap::POSITION => 8, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'MODULE_ID' => 1, 'HOOK_ID' => 2, 'CLASSNAME' => 3, 'METHOD' => 4, 'ACTIVE' => 5, 'HOOK_ACTIVE' => 6, 'MODULE_ACTIVE' => 7, 'POSITION' => 8, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'module_id' => 1, 'hook_id' => 2, 'classname' => 3, 'method' => 4, 'active' => 5, 'hook_active' => 6, 'module_active' => 7, 'position' => 8, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'ModuleId' => 1, 'HookId' => 2, 'Classname' => 3, 'Method' => 4, 'Active' => 5, 'HookActive' => 6, 'ModuleActive' => 7, 'Position' => 8, 'Templates' => 9, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'moduleId' => 1, 'hookId' => 2, 'classname' => 3, 'method' => 4, 'active' => 5, 'hookActive' => 6, 'moduleActive' => 7, 'position' => 8, 'templates' => 9, ),
+        self::TYPE_COLNAME       => array(ModuleHookTableMap::ID => 0, ModuleHookTableMap::MODULE_ID => 1, ModuleHookTableMap::HOOK_ID => 2, ModuleHookTableMap::CLASSNAME => 3, ModuleHookTableMap::METHOD => 4, ModuleHookTableMap::ACTIVE => 5, ModuleHookTableMap::HOOK_ACTIVE => 6, ModuleHookTableMap::MODULE_ACTIVE => 7, ModuleHookTableMap::POSITION => 8, ModuleHookTableMap::TEMPLATES => 9, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'MODULE_ID' => 1, 'HOOK_ID' => 2, 'CLASSNAME' => 3, 'METHOD' => 4, 'ACTIVE' => 5, 'HOOK_ACTIVE' => 6, 'MODULE_ACTIVE' => 7, 'POSITION' => 8, 'TEMPLATES' => 9, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'module_id' => 1, 'hook_id' => 2, 'classname' => 3, 'method' => 4, 'active' => 5, 'hook_active' => 6, 'module_active' => 7, 'position' => 8, 'templates' => 9, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, )
     );
 
     /**
@@ -175,6 +180,7 @@ class ModuleHookTableMap extends TableMap
         $this->addColumn('HOOK_ACTIVE', 'HookActive', 'BOOLEAN', true, 1, null);
         $this->addColumn('MODULE_ACTIVE', 'ModuleActive', 'BOOLEAN', true, 1, null);
         $this->addColumn('POSITION', 'Position', 'INTEGER', true, null, null);
+        $this->addColumn('TEMPLATES', 'Templates', 'LONGVARCHAR', false, null, null);
     } // initialize()
 
     /**
@@ -333,6 +339,7 @@ class ModuleHookTableMap extends TableMap
             $criteria->addSelectColumn(ModuleHookTableMap::HOOK_ACTIVE);
             $criteria->addSelectColumn(ModuleHookTableMap::MODULE_ACTIVE);
             $criteria->addSelectColumn(ModuleHookTableMap::POSITION);
+            $criteria->addSelectColumn(ModuleHookTableMap::TEMPLATES);
         } else {
             $criteria->addSelectColumn($alias . '.ID');
             $criteria->addSelectColumn($alias . '.MODULE_ID');
@@ -343,6 +350,7 @@ class ModuleHookTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.HOOK_ACTIVE');
             $criteria->addSelectColumn($alias . '.MODULE_ACTIVE');
             $criteria->addSelectColumn($alias . '.POSITION');
+            $criteria->addSelectColumn($alias . '.TEMPLATES');
         }
     }
 

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1752,6 +1752,7 @@
     <column name="hook_active" required="true" type="BOOLEAN" />
     <column name="module_active" required="true" type="BOOLEAN" />
     <column name="position" required="true" type="INTEGER" />
+    <column name="templates" type="LONGVARCHAR" />
     <foreign-key foreignTable="module" name="fk_module_hook_module_id" onDelete="CASCADE" onUpdate="RESTRICT">
       <reference foreign="id" local="module_id" />
     </foreign-key>

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -2152,6 +2152,7 @@ CREATE TABLE `module_hook`
     `hook_active` TINYINT(1) NOT NULL,
     `module_active` TINYINT(1) NOT NULL,
     `position` INTEGER NOT NULL,
+    `templates` TEXT,
     PRIMARY KEY (`id`),
     INDEX `idx_module_hook_active` (`active`),
     INDEX `fk_module_hook_module_id_idx` (`module_id`),

--- a/setup/update/sql/2.3.0-alpha1.sql
+++ b/setup/update/sql/2.3.0-alpha1.sql
@@ -6,4 +6,6 @@ UPDATE `config` SET `value`='3' WHERE `name`='thelia_minus_version';
 UPDATE `config` SET `value`='0' WHERE `name`='thelia_release_version';
 UPDATE `config` SET `value`='alpha1' WHERE `name`='thelia_extra_version';
 
+ALTER TABLE `module_hook` ADD `templates` TEXT AFTER`position`;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.3.0-alpha1.sql.tpl
+++ b/setup/update/tpl/2.3.0-alpha1.sql.tpl
@@ -6,4 +6,6 @@ UPDATE `config` SET `value`='3' WHERE `name`='thelia_minus_version';
 UPDATE `config` SET `value`='0' WHERE `name`='thelia_release_version';
 UPDATE `config` SET `value`='alpha1' WHERE `name`='thelia_extra_version';
 
+ALTER TABLE `module_hook` ADD `templates` TEXT AFTER`position`;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/templates/backOffice/default/module-hook-edit.html
+++ b/templates/backOffice/default/module-hook-edit.html
@@ -68,6 +68,11 @@
                                             </select>
                                         {/custom_render_form_field}
                                     </div>
+                                    <div class="col-md-12">
+
+                                        {render_form_field field="templates"}
+
+                                    </div>
                                 </div>
                             </form>
                             {/form}
@@ -95,19 +100,19 @@
 {/block}
 
 {block name="javascript-initialization"}
-    <script>
-        (function($) {
-            // Declare current values for classname and method selects
-            {loop name="module_hook_edit" type="module_hook" id="$module_hook_id" backend_context="1" lang="$edit_language_id"}
-                var currentClassname = "{$CLASSNAME}";
-                var currentMethod = "{$METHOD}";
-            {/loop}
+<script>
+(function($) {
+    // Declare current values for classname and method selects
+    {loop name="module_hook_edit" type="module_hook" id="$module_hook_id" backend_context="1" lang="$edit_language_id"}
+        var currentClassname = "{$CLASSNAME}";
+        var currentMethod = "{$METHOD}";
+    {/loop}
 
-            {include file="includes/hook-edition.js.inc"}
+    {include file="includes/hook-edition.js.inc"}
 
-            $('#module_id').change();
-        })(jQuery);
-    </script>
+    $('#module_id').change();
+})(jQuery);
+</script>
 {/block}
 
 {block name="javascript-last-call"}

--- a/templates/backOffice/default/module-hooks.html
+++ b/templates/backOffice/default/module-hooks.html
@@ -185,6 +185,8 @@
         </select>
     {/custom_render_form_field}
 
+    {render_form_field field="templates"}
+
     {hook name="module-hook.create-form" location="module_hook_create_form" }
 
 {/capture}


### PR DESCRIPTION
This PR aims to simplify the use of hooks and fixes some issues.

Now, it's no longer required to implement your own class to handle hooks. If you only want to render a template or add a css or js file you can do it easily. Here is an example : 

```xml
<hooks>
    <hook id="hooknavigation.hook.test">
      <tag name="hook.event_listener" event="main.navbar-primary" templates="render:myTemplate.html" />
      <tag name="hook.event_listener" event="main.stylesheet" type="front" active="1" templates="css:myCss.css;render:theme.css.html" />
    </hook>
</hooks>
```

You can notice that the `class` argument has been omitted as well as the `scope` argument.

The tag syntax is similar and it operates the same way,  except for the new argument `templates`. This argument is used to define what contents are going to be *injected* in the hook. 

The syntax : 

```
templates="<action>:<file>[;<action>:<file>]*"
```

- action (what to do with the file) :
    - **render** : this is the default one (if action is omitted). It will render the file. all parameters affected to the hook will be available in the template.
    - **dump** : will just dump the content of the file.
    - **css** : will create a `link` html tag and add the CSS file.
    - **js** : will create a `script` html tag and add the JavaScript file.
- file : this is the full path of the file related to the root directory of your template directory. For example, if the hook is a front office hook and want to render the file `myTemplate.html`. This template should be located in your module inside the `templates\frontOffice\default\` directory. The overriding system is the same as used with classic hook.

I've also added a command to cleanup hooks of a module or for all modules. They will be recreated (with default configuration) when the cache of the application will be cleared :

```bash
# remove module hooks of the HookNavigation module (without confirmation)
php Thelia hook:clean HookNavigation --assume-yes
# remove hooks of all modules (with confirmation)
php Thelia hook:clean
```

Feel free to comment this PR. It's not finished and all your remarks are welcome. 
