### PR TITLE
Replaced parameter "locale" with "lang" in generated URL

### DIFF
--- a/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
+++ b/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
@@ -134,10 +134,16 @@ class ParamInitMiddleware implements HttpKernelInterface
     protected function detectLang(TheliaRequest $request)
     {
         // first priority => lang parameter present in request (get or post)
-        if ($request->query->has("lang")) {
-            // The lang parameter may contains a lang code (fr, en, ru) for Thelia < 2.2,
-            // or a locale (fr_FR, en_US, etc.) for Thelia > 2.2.beta1
-            $requestedLangCodeOrLocale = $request->query->get("lang");
+        $requestedLangCodeOrLocale = $request->query->get("lang");
+
+        // add a fallback on locale parameter
+        if (null === $requestedLangCodeOrLocale) {
+            $requestedLangCodeOrLocale = $request->query->get("locale");
+        }
+
+        // The lang parameter may contains a lang code (fr, en, ru) for Thelia < 2.2,
+        // or a locale (fr_FR, en_US, etc.) for Thelia > 2.2.beta1
+        if (null !== $requestedLangCodeOrLocale) {
 
             if (strlen($requestedLangCodeOrLocale) > 2) {
                 $lang = LangQuery::create()->findOneByLocale($requestedLangCodeOrLocale);

--- a/core/lib/Thelia/Model/RewritingUrlQuery.php
+++ b/core/lib/Thelia/Model/RewritingUrlQuery.php
@@ -57,7 +57,7 @@ class RewritingUrlQuery extends BaseRewritingUrlQuery
             ->joinRewritingArgument('ra', Criteria::LEFT_JOIN)
             ->where('ISNULL(`ra`.REWRITING_URL_ID)')
             ->filterByView($view)
-            ->filterByViewLocale($viewLocale)
+            ->filterByViewLocale($this->retrieveLocale($viewLocale))
             ->filterByViewId($viewId)
             ->filterByRedirected(null)
             ->orderById(Criteria::DESC)
@@ -78,7 +78,7 @@ class RewritingUrlQuery extends BaseRewritingUrlQuery
             ->joinRewritingArgument('ra', Criteria::LEFT_JOIN)
             ->withColumn('`ra`.REWRITING_URL_ID', 'ra_REWRITING_URL_ID')
             ->filterByView($view)
-            ->filterByViewLocale($viewLocale)
+            ->filterByViewLocale($this->retrieveLocale($viewLocale))
             ->filterByViewId($viewId)
             ->filterByRedirected(null)
             ->orderById(Criteria::DESC);
@@ -109,5 +109,17 @@ class RewritingUrlQuery extends BaseRewritingUrlQuery
 
         return $urlQuery->findOne();
     }
+
+    protected function retrieveLocale($viewLocale)
+    {
+        if (strlen($viewLocale) == 2) {
+            if (null !== $lang = LangQuery::create()->findOneByCode($viewLocale)) {
+                $viewLocale = $lang->getLocale();
+            }
+        }
+
+        return $viewLocale;
+    }
+
 }
 // RewritingUrlQuery

--- a/core/lib/Thelia/Rewriting/RewritingRetriever.php
+++ b/core/lib/Thelia/Rewriting/RewritingRetriever.php
@@ -50,7 +50,7 @@ class RewritingRetriever
 
         $allParametersWithoutView = array();
         if (null !== $viewLocale) {
-            $allParametersWithoutView['locale'] = $viewLocale;
+            $allParametersWithoutView['lang'] = $viewLocale;
         }
         if (null !== $viewId) {
             $allParametersWithoutView[$view . '_id'] = $viewId;
@@ -82,7 +82,7 @@ class RewritingRetriever
         $this->search = $this->rewritingUrlQuery->getSpecificUrlQuery($view, $viewLocale, $viewId, $viewOtherParameters);
 
         $allParametersWithoutView = $viewOtherParameters;
-        $allParametersWithoutView['locale'] = $viewLocale;
+        $allParametersWithoutView['lang'] = $viewLocale;
         if (null !== $viewId) {
             $allParametersWithoutView[$view . '_id'] = $viewId;
         }

--- a/templates/frontOffice/default/sitemap.html
+++ b/templates/frontOffice/default/sitemap.html
@@ -21,7 +21,7 @@ generated on : {$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
         {if $_lang_ == "" || $_lang_ == $CODE }
             {loop type="category" name="category" lang="$ID"}
             <url>
-                <loc>{$URL nofilter}</loc>
+                <loc>{$URL}</loc>
                 <lastmod>{format_date date=$UPDATE_DATE format="c"}</lastmod>
             </url>
             {/loop}
@@ -33,7 +33,7 @@ generated on : {$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
         {if $_lang_ == "" || $_lang_ == $CODE }
             {loop type="product" name="product" lang="$ID"}
                 <url>
-                    <loc>{$URL nofilter}</loc>
+                    <loc>{$URL}</loc>
                     <lastmod>{format_date date=$UPDATE_DATE format="c"}</lastmod>
                 </url>
             {/loop}
@@ -48,7 +48,7 @@ generated on : {$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
         {if $_lang_ == "" || $_lang_ == $CODE }
             {loop type="folder" name="folder" lang="$ID"}
                 <url>
-                    <loc>{$URL nofilter}</loc>
+                    <loc>{$URL}</loc>
                     <lastmod>{format_date date=$UPDATE_DATE format="c"}</lastmod>
                 </url>
             {/loop}
@@ -60,7 +60,7 @@ generated on : {$smarty.now|date_format:'%Y-%m-%d %H:%M:%S'}
         {if $_lang_ == "" || $_lang_ == $CODE }
             {loop type="content" name="content" lang="$ID"}
             <url>
-                <loc>{$URL nofilter}</loc>
+                <loc>{$URL}</loc>
                 <lastmod>{format_date date=$UPDATE_DATE format="c"}</lastmod>
             </url>
             {/loop}

--- a/tests/phpunit/Thelia/Tests/Rewriting/RewritingRetrieverTest.php
+++ b/tests/phpunit/Thelia/Tests/Rewriting/RewritingRetrieverTest.php
@@ -91,7 +91,7 @@ class RewritingRetrieverTest extends \PHPUnit_Framework_TestCase
         $retriever->loadViewUrl('view', 'fr_FR', 1);
 
         $this->assertEquals(URL::getInstance()->absoluteUrl('foo.html'), $retriever->rewrittenUrl);
-        $this->assertEquals(URL::getInstance()->viewUrl('view', array('locale' => 'fr_FR', 'view_id' => 1)), $retriever->url);
+        $this->assertEquals(URL::getInstance()->viewUrl('view', array('lang' => 'fr_FR', 'view_id' => 1)), $retriever->url);
     }
 
     public function testLoadSpecificUrl()
@@ -113,6 +113,6 @@ class RewritingRetrieverTest extends \PHPUnit_Framework_TestCase
         $retriever->loadSpecificUrl('view', 'fr_FR', 1, array('foo0' => 'bar0', 'foo1' => 'bar1'));
 
         $this->assertEquals('foo.html', $retriever->rewrittenUrl);
-        $this->assertEquals(URL::getInstance()->viewUrl('view', array('foo0' => 'bar0', 'foo1' => 'bar1', 'locale' => 'fr_FR', 'view_id' => 1)), $retriever->url);
+        $this->assertEquals(URL::getInstance()->viewUrl('view', array('foo0' => 'bar0', 'foo1' => 'bar1', 'lang' => 'fr_FR', 'view_id' => 1)), $retriever->url);
     }
 }


### PR DESCRIPTION
The `locale` parameter in generated URLs of products, categories, ... is ambiguous with the `lang` parameter. And changing the locale in URL does not change the lang of the displayed content.

As the pages are indexed with the parameter 'locale' and not 'lang' by search engines there is potentialy a problem. In fact, it only happens when the rewriting is disabled on your website, which is rather uncommon.

I 'm not sure that there won't be side effects with this PR. Will you please look it over ?
