### PR TITLE
Added new attributes and some aliases to the {cart} substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - #1668 Add height limit for the select fields in the Attributes and Features tab of the admin product edit page
 - #1669 Add options ```exclude_status, status_code, exclude_status_code``` and output value ```STATUS_CODE``` in Order loop
 - #1674 Add options ```free_text, exclude_free_text``` in FeatureValue loop
+- #1725 Add `weight` and `total_price_without_discount` attributes to the `{cart}` substitution, and some aliases to provide a better english syntax, or a more accurate name to existing attributes : `product_count`, alias of `count_product`, `item_count`, alias of `count_item`, `total_price_with_discount` alias of `total_price`, `total_taxed_price_with_discount` alias of `total_taxed_price`, `contains_virtual_product` alias of `is_virtual`, `total_tax_amount` alias of `total_vat`
 
 # 2.2.0
 

--- a/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
@@ -20,9 +20,11 @@ use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Template\ParserContext;
 use Thelia\Log\Tlog;
 use Thelia\Model\Base\BrandQuery;
+use Thelia\Model\Cart;
 use Thelia\Model\CategoryQuery;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\ContentQuery;
+use Thelia\Model\Country;
 use Thelia\Model\CountryQuery;
 use Thelia\Model\CurrencyQuery;
 use Thelia\Model\FolderQuery;
@@ -285,6 +287,7 @@ class DataAccessFunctions extends AbstractSmartyPlugin
      */
     public function cartDataAccess($params, $smarty)
     {
+        /** @var Country $taxCountry */
         if (array_key_exists('currentCountry', self::$dataAccessCache)) {
             $taxCountry = self::$dataAccessCache['currentCountry'];
         } else {
@@ -292,14 +295,17 @@ class DataAccessFunctions extends AbstractSmartyPlugin
             self::$dataAccessCache['currentCountry'] = $taxCountry;
         }
 
+        /** @var Cart $cart */
         $cart = $this->request->getSession()->getSessionCart($this->dispatcher);
 
         $result = "";
         switch ($params["attr"]) {
             case "count_product":
+            case "product_count":
                 $result = $cart->getCartItems()->count();
                 break;
             case "count_item":
+            case "item_count":
                 $count_allitem = 0;
                 foreach ($cart->getCartItems() as $cartItem) {
                     $count_allitem += $cartItem->getQuantity();
@@ -307,19 +313,29 @@ class DataAccessFunctions extends AbstractSmartyPlugin
                 $result = $count_allitem;
                 break;
             case "total_price":
+            case "total_price_with_discount":
                 $result = $cart->getTotalAmount();
                 break;
+            case "total_price_without_discount":
+                $result = $cart->getTotalAmount(false);
+                break;
             case "total_taxed_price":
+            case "total_taxed_price_with_discount":
                 $result = $cart->getTaxedAmount($taxCountry);
                 break;
             case "total_taxed_price_without_discount":
                 $result = $cart->getTaxedAmount($taxCountry, false);
                 break;
             case "is_virtual":
+            case "contains_virtual_product":
                 $result = $cart->isVirtual();
                 break;
             case "total_vat":
+            case 'total_tax_amount':
                 $result = $cart->getTotalVAT($taxCountry);
+                break;
+            case "weight":
+                $result = $cart->getWeight();
                 break;
         }
 


### PR DESCRIPTION
This PR is add attributes to the `{cart}` substitution 

1. A new `weight` attribute is added, to get the cart total weight.
2. A new `total_price_without_discount` attribute is added, to get the cart total amount without taxes, excluding discount.
3. The following aliases of existing attributes are added, to provide a better english syntax, or a more accurate name : 
  - `product_count`, alias of `count_product`
  - `item_count`, alias of `count_item`
  - `total_price_with_discount` alias of `total_price`
  - `total_taxed_price_with_discount` alias of `total_taxed_price`
  - `contains_virtual_product` alias of `is_virtual`
  - `total_tax_amount` alias of `total_vat`