### PR TITLE
fix export date range

### DIFF
--- a/core/lib/Thelia/ImportExport/Export/ExportHandler.php
+++ b/core/lib/Thelia/ImportExport/Export/ExportHandler.php
@@ -41,6 +41,8 @@ abstract class ExportHandler extends AbstractHandler
 
     protected $isDocumentExport = false;
 
+    protected $rangeExport = false;
+
     protected $rangeDate = null;
 
     /**
@@ -225,6 +227,25 @@ abstract class ExportHandler extends AbstractHandler
     public function isImageExport()
     {
         return $this->isImageExport;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRangeExport()
+    {
+        return $this->rangeExport;
+    }
+
+    /**
+     * @param bool $rangeExport
+     * @return $this
+     */
+    public function setRangeExport($rangeExport)
+    {
+        $this->rangeExport = (bool) $rangeExport;
+
+        return $this;
     }
 
     /**

--- a/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
@@ -38,6 +38,8 @@ use Thelia\Tools\I18n;
  */
 class OrderExport extends ExportHandler
 {
+    protected $rangeExport = true;
+
     /**
      * @return string|array
      *

--- a/templates/backOffice/default/ajax/export-modal.html
+++ b/templates/backOffice/default/ajax/export-modal.html
@@ -27,73 +27,66 @@
                             </div>
                         {/if}
 
-                        {$showRange  = false}
-                        {loop name="export-category" type="export-category" id=$CATEGORY_ID limit=1}
-                            {if $TITLE == {intl l="Orders"} }
-                                {$showRange  = true}
-                            {/if}
-                        {/loop}
-
-                        {if $showRange}
-                        <div class="row">
-                            <div class="col-md-4">
-                                {form_field field="range_date_start"}
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <label for="{$label_attr.for}">
-                                                {$label}
-                                            </label>
+                        {if $IS_RANGE_EXPORT}
+                            <div class="row">
+                                <div class="col-md-4">
+                                    {form_field field="range_date_start"}
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <label for="{$label_attr.for}">
+                                                    {$label}
+                                                </label>
+                                            </div>
+                                            <div class="col-md-12">
+                                                <select name="{$name}[year]" id="{$label_attr.for}_year">
+                                                    {foreach from=$years item=m}
+                                                        <option value="{$m}" {if {$smarty.now|date_format:'%Y'} == $m} selected {/if}>{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                                <select name="{$name}[month]" id="{$label_attr.for}_month">
+                                                    {foreach from=$months item=m}
+                                                        <option value="{$m}" {if {$smarty.now|date_format:'%m'} == $m} selected {/if}>{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                                <select name="{$name}[day]" class="hidden" id="{$label_attr.for}_day">
+                                                    {foreach from=$days item=m}
+                                                        <option value="{$m}">{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                            </div>
                                         </div>
-                                        <div class="col-md-12">
-                                            <select name="{$name}[year]" id="{$label_attr.for}_year">
-                                                {foreach from=$years item=m}
-                                                    <option value="{$m}" {if {$smarty.now|date_format:'%Y'} == $m} selected {/if}>{$m}</option>
-                                                {/foreach}
-                                            </select>
-                                            <select name="{$name}[month]" id="{$label_attr.for}_month">
-                                                {foreach from=$months item=m}
-                                                    <option value="{$m}" {if {$smarty.now|date_format:'%m'} == $m} selected {/if}>{$m}</option>
-                                                {/foreach}
-                                            </select>
-                                            <select name="{$name}[day]" class="hidden" id="{$label_attr.for}_day">
-                                                {foreach from=$days item=m}
-                                                    <option value="{$m}">{$m}</option>
-                                                {/foreach}
-                                            </select>
+                                    {/form_field}
+                                </div>
+                                <div class="col-md-4">
+                                    {form_field field="range_date_end"}
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <label for="{$label_attr.for}">
+                                                    {$label}
+                                                </label>
+                                            </div>
+                                            <div class="col-md-12">
+                                                <select name="{$name}[year]" id="{$label_attr.for}_year">
+                                                    {foreach from=$years item=m}
+                                                        <option value="{$m}" {if {$smarty.now|date_format:'%Y'} == $m} selected {/if}>{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                                <select name="{$name}[month]" id="{$label_attr.for}_month">
+                                                    {foreach from=$months item=m}
+                                                        <option value="{$m}" {if {$smarty.now|date_format:'%m'}+1 == $m} selected {/if}>{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                                <select name="{$name}[day]" class="hidden" id="{$label_attr.for}_day">
+                                                    {foreach from=$days item=m}
+                                                        <option value="{$m}">{$m}</option>
+                                                    {/foreach}
+                                                </select>
+                                            </div>
                                         </div>
-                                    </div>
-                                {/form_field}
+                                    {/form_field}
+                                </div>
                             </div>
-                            <div class="col-md-4">
-                                {form_field field="range_date_end"}
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <label for="{$label_attr.for}">
-                                                {$label}
-                                            </label>
-                                        </div>
-                                        <div class="col-md-12">
-                                            <select name="{$name}[year]" id="{$label_attr.for}_year">
-                                                {foreach from=$years item=m}
-                                                    <option value="{$m}" {if {$smarty.now|date_format:'%Y'} == $m} selected {/if}>{$m}</option>
-                                                {/foreach}
-                                            </select>
-                                            <select name="{$name}[month]" id="{$label_attr.for}_month">
-                                                {foreach from=$months item=m}
-                                                    <option value="{$m}" {if {$smarty.now|date_format:'%m'}+1 == $m} selected {/if}>{$m}</option>
-                                                {/foreach}
-                                            </select>
-                                            <select name="{$name}[day]" class="hidden" id="{$label_attr.for}_day">
-                                                {foreach from=$days item=m}
-                                                    <option value="{$m}">{$m}</option>
-                                                {/foreach}
-                                            </select>
-                                        </div>
-                                    </div>
-                                {/form_field}
-                            </div>
-                        </div>
-                        <br>
+                            <br>
                         {/if}
                         <div class="row">
                             <div class="col-md-12">


### PR DESCRIPTION
Currently, The order export range is a hard coded value in the [export-modal.html](https://github.com/Alban-io/thelia/commit/06e31020167bec70679e6e2ced9361d830e805d4#diff-96a64801063438570e597deaa43e952cL33) template.
This PR adds a [new ExportHandler property](https://github.com/Alban-io/thelia/commit/06e31020167bec70679e6e2ced9361d830e805d4#diff-1ecbc36bc80f92908003ab7ed8882012R44) which determine if an export is a "range export".