### PR TITLE
Add save session on terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - #1669 Add options ```exclude_status, status_code, exclude_status_code``` and output value ```STATUS_CODE``` in Order loop
 - #1674 Add options ```free_text, exclude_free_text``` in FeatureValue loop
 
+# 2.2.1
+
+- Add save session on terminate event for other handler's that native file storage.
+
 # 2.2.0
 
 - #1692 Fix amounts displayed on the PDF invoice when a postage with tax is used (fixes #1693 and #1694)

--- a/core/lib/Thelia/Core/EventListener/SessionListener.php
+++ b/core/lib/Thelia/Core/EventListener/SessionListener.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHa
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Core\Event\SessionEvent;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\TheliaKernelEvents;
@@ -55,6 +57,12 @@ class SessionListener implements EventSubscriberInterface
     {
         return new Session($storage);
     }
+
+    public function saveSession(PostResponseEvent $event)
+    {
+        $event->getRequest()->getSession()->save();
+    }
+
     /**
      * Returns an array of event names this subscriber wants to listen to.
      *
@@ -81,6 +89,9 @@ class SessionListener implements EventSubscriberInterface
             TheliaKernelEvents::SESSION =>[
                 ['prodSession', 0],
                 ['testSession', 128]
+            ],
+            KernelEvents::TERMINATE => [
+                ['saveSession', 0]
             ]
         ];
     }


### PR DESCRIPTION
Other handler's than native file storage doesn't trigger their save action automatically, so this is needed for example for a Redis handler.