### PR TITLE
Fix output value IS_DEFAULT in the product_sale_elements loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 2.3.0-alpha1
 
+- #1746 Removes deprecated classes and methods for the version 2.3
+- #1745 Fix output value IS_DEFAULT in the product_sale_elements loop
+- #1754 Add homepage redirection on /admin/login if the admin is already authenticate. Before this change, there was a render
+- #1765 Fix for prev/next queries in Category and Content loops, and add prev/next in Product and Folder loop
+- #1759 Fix for parent attribute and new exclude_parent attribute of Category loop
 - #1750 Add EQUAL to product loop filter by min or max
 - #1727 Add template & stock inputs on product creation
 - #1722 Replaced parameter "locale" with "lang" in generated URL

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -242,7 +242,7 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
                 ->set("QUANTITY", $PSEValue->getQuantity())
                 ->set("IS_PROMO", $PSEValue->getPromo() === 1 ? 1 : 0)
                 ->set("IS_NEW", $PSEValue->getNewness() === 1 ? 1 : 0)
-                ->set("IS_DEFAULT", $PSEValue->getIsDefault() === 1 ? 1 : 0)
+                ->set("IS_DEFAULT", $PSEValue->getIsDefault() ? 1 : 0)
                 ->set("WEIGHT", $PSEValue->getWeight())
                 ->set("REF", $PSEValue->getRef())
                 ->set("EAN_CODE", $PSEValue->getEanCode())


### PR DESCRIPTION
In the propel schema, the is_default column for the product_sale_elements table, is boolean type.

```xml
<table name="product_sale_elements" namespace="Thelia\Model">
    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
    <column name="product_id" required="true" type="INTEGER" />
    <column name="ref" required="true" size="255" type="VARCHAR" />
    <column name="quantity" required="true" type="FLOAT" />
    <column defaultValue="0" name="promo" type="TINYINT" />
    <column defaultValue="0" name="newness" type="TINYINT" />
    <column defaultValue="0" name="weight" type="FLOAT" />
    <column defaultValue="0" name="is_default" type="BOOLEAN" />
...
```