### PR TITLE
Fix for parent attribute of Category loop, and new exclude_parent attribute

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -47,6 +47,7 @@ use Thelia\Model\Category as CategoryModel;
  * {@inheritdoc}
  * @method int[] getId()
  * @method int getParent()
+ * @method int getExcludeParent()
  * @method int getProduct()
  * @method int getExcludeProduct()
  * @method bool getCurrent()
@@ -70,7 +71,8 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
     {
         return new ArgumentCollection(
             Argument::createIntListTypeArgument('id'),
-            Argument::createIntTypeArgument('parent'),
+            Argument::createIntListTypeArgument('parent'),
+            Argument::createIntListTypeArgument('exclude_parent'),
             Argument::createIntTypeArgument('product'),
             Argument::createIntTypeArgument('exclude_product'),
             Argument::createBooleanTypeArgument('current'),
@@ -129,7 +131,13 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
         $parent = $this->getParent();
 
         if (!is_null($parent)) {
-            $search->filterByParent($parent);
+            $search->filterByParent($parent, Criteria::IN);
+        }
+
+        $excludeParent = $this->getExcludeParent();
+
+        if (!is_null($excludeParent)) {
+            $search->filterByParent($excludeParent, Criteria::NOT_IN);
         }
 
         $current = $this->getCurrent();


### PR DESCRIPTION
This PR fixes the 'parent' attribute of the Category loop, which is described as a list in the Thelia doc.

A new exclude_parent attribute is added.