### PR TITLE
Fix for prev/next queries in Category, Content and Folder loops

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -258,18 +258,34 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
                 $loopResultRow->set("PRODUCT_COUNT", $category->countAllProducts());
             }
 
-            if ($this->getBackendContext() || $this->getWithPrevNextInfo()) {
+            $isBackendContext = $this->getBackendContext();
+
+            if ($isBackendContext || $this->getWithPrevNextInfo()) {
                 // Find previous and next category
-                $previous = CategoryQuery::create()
+                $previousQuery = CategoryQuery::create()
                     ->filterByParent($category->getParent())
                     ->filterByPosition($category->getPosition(), Criteria::LESS_THAN)
+                ;
+
+                if (! $isBackendContext) {
+                    $previousQuery->filterByVisible(true);
+                }
+
+                $previous = $previousQuery
                     ->orderByPosition(Criteria::DESC)
                     ->findOne()
                 ;
 
-                $next = CategoryQuery::create()
+                $nextQuery = CategoryQuery::create()
                     ->filterByParent($category->getParent())
                     ->filterByPosition($category->getPosition(), Criteria::GREATER_THAN)
+                ;
+
+                if (! $isBackendContext) {
+                    $nextQuery->filterByVisible(true);
+                }
+
+                $next = $nextQuery
                     ->orderByPosition(Criteria::ASC)
                     ->findOne()
                 ;

--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -307,20 +307,36 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
      */
     private function findNextPrev(LoopResultRow $loopResultRow, \Thelia\Model\Content $content, $defaultFolderId)
     {
-        if ($this->getBackendContext() || $this->getWithPrevNextInfo()) {
+        $isBackendContext = $this->getBackendContext();
+
+        if ($isBackendContext || $this->getWithPrevNextInfo()) {
             // Find previous and next category
-            $previous = ContentQuery::create()
+            $previousQuery = ContentQuery::create()
                 ->joinContentFolder()
                 ->where('ContentFolder.folder_id = ?', $defaultFolderId)
                 ->filterByPosition($content->getPosition(), Criteria::LESS_THAN)
+            ;
+
+            if (! $isBackendContext) {
+                $previousQuery->filterByVisible(true);
+            }
+
+            $previous = $previousQuery
                 ->orderByPosition(Criteria::DESC)
                 ->findOne()
             ;
 
-            $next = ContentQuery::create()
+            $nextQuery = ContentQuery::create()
                 ->joinContentFolder()
                 ->where('ContentFolder.folder_id = ?', $defaultFolderId)
                 ->filterByPosition($content->getPosition(), Criteria::GREATER_THAN)
+            ;
+
+            if (! $isBackendContext) {
+                $nextQuery->filterByVisible(true);
+            }
+
+            $next = $nextQuery
                 ->orderByPosition(Criteria::ASC)
                 ->findOne()
             ;

--- a/templates/backOffice/default/brand-edit.html
+++ b/templates/backOffice/default/brand-edit.html
@@ -35,6 +35,24 @@
                         <div class="col-md-7 title">
                             {intl l='Edit brand %title' title={$TITLE}}
                         </div>
+
+                        <div class="col-md-5 actions">
+
+                            {if $HAS_PREVIOUS != 0}
+                                <a href="{url path="/admin/brand/update/%previous" previous=$PREVIOUS}" class="btn btn-default" title="{intl l='Edit previous brand'}"><span class="glyphicon glyphicon-arrow-left"></span></a>
+                            {else}
+                                <a href="#" disabled="disabled" class="btn btn-default"><span class="glyphicon glyphicon-arrow-left"></span></a>
+                            {/if}
+
+                            <a href="{$URL nofilter}" target="_blank" class="btn btn-default" title="{intl l='Preview brand page'}"><span class="glyphicon glyphicon-eye-open"></span></a>
+
+                            {if $HAS_NEXT != 0}
+                                <a href="{url path="/admin/brand/update/%next" next=$NEXT}" class="btn btn-default" title="{intl l='Edit next brand'}"><span class="glyphicon glyphicon-arrow-right"></span></a>
+                            {else}
+                                <a href="#" disabled="disabled" class="btn btn-default"><span class="glyphicon glyphicon-arrow-right"></span></a>
+                            {/if}
+                        </div>
+
                     </div>
 
                     <div class="row">

--- a/templates/backOffice/default/content-edit.html
+++ b/templates/backOffice/default/content-edit.html
@@ -33,7 +33,7 @@
                                     <a href="#" disabled="disabled" class="btn btn-default"><span class="glyphicon glyphicon-arrow-left"></span></a>
                                 {/if}
 
-                                <a href="{$URL nofilter}" target="_blank" class="btn btn-default" title="{intl l='Preview folder page'}"><span class="glyphicon glyphicon-eye-open"></span></a>
+                                <a href="{$URL nofilter}" target="_blank" class="btn btn-default" title="{intl l='Preview content page'}"><span class="glyphicon glyphicon-eye-open"></span></a>
 
                                 {if $HAS_NEXT != 0}
                                     <a href="{url path="/admin/content/update/%next" next=$NEXT}" class="btn btn-default" title="{intl l='Edit next content'}"><span class="glyphicon glyphicon-arrow-right"></span></a>


### PR DESCRIPTION
This PR fixes the Prev/Next queries in the Category and Content loops, and add these queries in the Folder loop, where they were missing !

The off-line items are now ignored in these loops, except in the back-end context, where all items are returned, whatever the visibility status is.