### PR TITLE
Increase API key size to 48

### DIFF
--- a/core/lib/Thelia/Model/Api.php
+++ b/core/lib/Thelia/Model/Api.php
@@ -46,7 +46,7 @@ class Api extends BaseApi implements UserInterface
 
         $file = $dir . DS . $this->getApiKey().".key";
         $fs->touch($file);
-        file_put_contents($file, Password::generateHexaRandom(45));
+        file_put_contents($file, Password::generateHexaRandom(48));
         $fs->chmod($file, 0600);
     }
 


### PR DESCRIPTION
An even length for hexadecimal strings increases compatibility with other languages (like python) that systematically refuse to convert odd hexadecimal strings to binary data. This could be blocking if someone tries to consume thelia's API.