### PR TITLE
[WIP] Thelia loop Overriding

### DIFF
--- a/core/lib/Thelia/Core/Event/LoopOverridesEvent.php
+++ b/core/lib/Thelia/Core/Event/LoopOverridesEvent.php
@@ -1,0 +1,145 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Event;
+
+use Thelia\Core\Template\Element\ArraySearchLoopInterface;
+use Thelia\Core\Template\Element\BaseLoop;
+use Thelia\Core\Template\Element\Overrides\ArgDefinitionOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\ArrayBuilderOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\ParseOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\PropelBuilderOverrideInterface;
+use Thelia\Core\Template\Element\PropelSearchLoopInterface;
+
+/**
+ * Class LoopOverridesEvent
+ * @package Thelia\Core\Event
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+class LoopOverridesEvent extends ActionEvent
+{
+    /** @var BaseLoop|null  */
+    protected $loop = null;
+
+    protected $argDefinition = [];
+
+    protected $argInitialization = [];
+
+    protected $builder = [];
+
+    protected $parser = [];
+
+    public function __construct(BaseLoop $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /**
+     * @return null|BaseLoop
+     */
+    public function getLoop()
+    {
+        return $this->loop;
+    }
+
+    /**
+     * @param null|BaseLoop $loop
+     */
+    public function setLoop($loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /**
+     * @return array
+     */
+    public function getBuilder()
+    {
+        return $this->builder;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgDefinition()
+    {
+        return $this->argDefinition;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArgInitialization()
+    {
+        return $this->argInitialization;
+    }
+
+    /**
+     * @return $this
+     */
+    public function getParser()
+    {
+        return $this->parser;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addBuilder($builder)
+    {
+        if ($this->loop instanceof PropelSearchLoopInterface) {
+            if ($builder instanceof PropelBuilderOverrideInterface) {
+                $this->builder[] = $builder;
+            } else {
+                throw new \InvalidArgumentException('builder should implements PropelBuilderOverrideInterface');
+            }
+        } elseif ($this->loop instanceof ArraySearchLoopInterface) {
+            if ($builder instanceof ArrayBuilderOverrideInterface) {
+                $this->builder[] = $builder;
+            } else {
+                throw new \InvalidArgumentException('builder should implements PropelBuilderOverrideInterface');
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addArgDefinition(ArgDefinitionOverrideInterface $argDefinition)
+    {
+        $this->argDefinition[] = $argDefinition;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addArgInitialization(ArgInitializationOverrideInterface $argInitialization)
+    {
+        $this->argInitialization[] = $argInitialization;
+
+        return $this;
+    }
+    /**
+     * @return $this
+     */
+    public function addParser(ParseOverrideInterface $parser)
+    {
+        $this->argParser[] = $parser;
+
+        return $this;
+    }
+}

--- a/core/lib/Thelia/Core/Event/LoopOverridesEvent.php
+++ b/core/lib/Thelia/Core/Event/LoopOverridesEvent.php
@@ -16,8 +16,11 @@ namespace Thelia\Core\Event;
 use Thelia\Core\Template\Element\ArraySearchLoopInterface;
 use Thelia\Core\Template\Element\BaseLoop;
 use Thelia\Core\Template\Element\Overrides\ArgDefinitionOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\ArgDefinitionsOverrideInterface;
 use Thelia\Core\Template\Element\Overrides\ArrayBuilderOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\InitializeArgsOverrideInterface;
 use Thelia\Core\Template\Element\Overrides\ParseOverrideInterface;
+use Thelia\Core\Template\Element\Overrides\ParseResultsOverrideInterface;
 use Thelia\Core\Template\Element\Overrides\PropelBuilderOverrideInterface;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 
@@ -31,13 +34,13 @@ class LoopOverridesEvent extends ActionEvent
     /** @var BaseLoop|null  */
     protected $loop = null;
 
-    protected $argDefinition = [];
+    protected $argDefinitions = [];
 
-    protected $argInitialization = [];
+    protected $initializeArgs = [];
 
     protected $builder = [];
 
-    protected $parser = [];
+    protected $parserResults = [];
 
     public function __construct(BaseLoop $loop)
     {
@@ -61,6 +64,15 @@ class LoopOverridesEvent extends ActionEvent
     }
 
     /**
+     * @return null|string
+     */
+    public function getLoopName()
+    {
+        return $this->loop->getLoopName();
+    }
+
+
+    /**
      * @return array
      */
     public function getBuilder()
@@ -71,25 +83,41 @@ class LoopOverridesEvent extends ActionEvent
     /**
      * @return array
      */
-    public function getArgDefinition()
+    public function getArgDefinitions()
     {
-        return $this->argDefinition;
+        return $this->argDefinitions;
     }
 
     /**
      * @return array
      */
-    public function getArgInitialization()
+    public function getInitializeArgs()
     {
-        return $this->argInitialization;
+        return $this->initializeArgs;
     }
 
     /**
      * @return $this
      */
-    public function getParser()
+    public function getParserResults()
     {
-        return $this->parser;
+        return $this->parserResults;
+    }
+
+    public function addClass($class)
+    {
+        if ($class instanceof ArgDefinitionsOverrideInterface) {
+            $this->addArgDefinitions($class);
+        }
+        if ($class instanceof InitializeArgsOverrideInterface) {
+            $this->addInitializeArgs($class);
+        }
+        if ($class instanceof PropelSearchLoopInterface || $class instanceof ArrayBuilderOverrideInterface) {
+            $this->addBuilder($class);
+        }
+        if ($class instanceof ParseResultsOverrideInterface) {
+            $this->addParserResults($class);
+        }
     }
 
     /**
@@ -107,7 +135,7 @@ class LoopOverridesEvent extends ActionEvent
             if ($builder instanceof ArrayBuilderOverrideInterface) {
                 $this->builder[] = $builder;
             } else {
-                throw new \InvalidArgumentException('builder should implements PropelBuilderOverrideInterface');
+                throw new \InvalidArgumentException('builder should implements ArraySearchLoopInterface');
             }
         }
 
@@ -117,9 +145,9 @@ class LoopOverridesEvent extends ActionEvent
     /**
      * @return $this
      */
-    public function addArgDefinition(ArgDefinitionOverrideInterface $argDefinition)
+    public function addArgDefinitions(ArgDefinitionsOverrideInterface $argDefinitions)
     {
-        $this->argDefinition[] = $argDefinition;
+        $this->argDefinitions[] = $argDefinitions;
 
         return $this;
     }
@@ -127,18 +155,19 @@ class LoopOverridesEvent extends ActionEvent
     /**
      * @return $this
      */
-    public function addArgInitialization(ArgInitializationOverrideInterface $argInitialization)
+    public function addInitializeArgs(InitializeArgsOverrideInterface $initializeArgs)
     {
-        $this->argInitialization[] = $argInitialization;
+        $this->initializeArgs[] = $initializeArgs;
 
         return $this;
     }
+
     /**
      * @return $this
      */
-    public function addParser(ParseOverrideInterface $parser)
+    public function addParserResults(ParseResultsOverrideInterface $parserResults)
     {
-        $this->argParser[] = $parser;
+        $this->parserResults[] = $parserResults;
 
         return $this;
     }

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -759,8 +759,24 @@ final class TheliaEvents
     const MODULE_INSTALL = 'thelia.module.install';
 
     /* Invoke payment module */
-
     const MODULE_PAY = 'thelia.module.pay';
+
+    /* Loop */
+    const LOOP_OVERRIDES_LOOPS = 'thelia.loop.overrides';
+    const LOOP_OVERRIDES_LOOP = 'thelia.loop.overrides.%s';
+
+    /**
+     * Generate the name of the event for a specific loop
+     *
+     * @param string $loopName the loop name
+     * @return string the event name
+     */
+    public static function getLoopOverridesEvent($loopName)
+    {
+        $loopName = preg_replace("[^A-Za-z0-9]", "-", $loopName);
+
+        return sprintf(self::LOOP_OVERRIDES_LOOP, $loopName);
+    }
 
     /**
      * Hook

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ArgDefinitionOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ArgDefinitionOverrideInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+namespace Thelia\Core\Template\Element\Overrides;
+
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Template\Element\BaseLoop;
+use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+
+
+/**
+ * Class ArgDefinitionOverride
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+interface ArgDefinitionOverrideInterface
+{
+    /**
+     *
+     *
+     * @param BaseLoop  $loop      the current loop
+     *
+     * @return ArgumentCollection|null      new argument collection that will be added to the loop argument collection
+     */
+    public function getDefinitions(BaseLoop $loop);
+}

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ArgDefinitionsOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ArgDefinitionsOverrideInterface.php
@@ -9,29 +9,33 @@
 /*      For the full copyright and license information, please view the LICENSE.txt  */
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
-
-
 namespace Thelia\Core\Template\Element\Overrides;
 
+use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Template\Element\BaseLoop;
-use Thelia\Core\Template\Element\LoopResult;
-use Thelia\Core\Template\Element\LoopResultRow;
+use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+
 
 /**
- * Class ParseOverrideInterface
- * @package Thelia\Core\Template\Element\Overrides
+ * Class ArgDefinitionsOverride
  * @author Julien Chanséaume <jchanseaume@openstudio.fr>
  */
-interface ParseOverrideInterface
+interface ArgDefinitionsOverrideInterface
 {
     /**
+     * Manipulate argument definitions
      *
+     * For instance:
      *
-     * @param BaseLoop        $loop    the current loop
-     * @param LoopResultRow   $result  the current loop result row of the loop
-     * @param object|array    $item
+     * $loop->getArgs()->addArgument(
+     *     Argument::createEnumListTypeArgument(
+     *         'export',
+     *         ['JSON', 'json', 'csv', 'xml'],
+     *     )
+     * );
      *
-     * @return LoopResult             the modified LoopResult
+     * @param BaseLoop  $loop      the current loop
+     *
      */
-    public function parse(BaseLoop $loop, LoopResultRow $result, $item);
+    public function getArgDefinitions(BaseLoop $loop);
 }

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ArgInitializationOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ArgInitializationOverrideInterface.php
@@ -1,0 +1,31 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Template\Element\Overrides;
+
+use Thelia\Core\Template\Element\BaseLoop;
+
+/**
+ * Class ArgInitializationOverrideInterface
+ * @package Thelia\Core\Template\Element\Overrides
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+interface ArgInitializationOverrideInterface
+{
+    /**
+     * @param BaseLoop $loop
+     * @param array $nameValuePairs
+     * @return array
+     */
+    public function initialize(BaseLoop $loop, array $nameValuePairs);
+}

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ArrayBuilderOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ArrayBuilderOverrideInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Template\Element\Overrides;
+
+use Thelia\Core\Template\Element\BaseLoop;
+
+/**
+ * Class ArrayBuilderOverrideInterface
+ * @package Thelia\Core\Template\Element\Overrides
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+interface ArrayBuilderOverrideInterface
+{
+    public function build(BaseLoop $loop, array $search);
+}

--- a/core/lib/Thelia/Core/Template/Element/Overrides/InitializeArgsOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/InitializeArgsOverrideInterface.php
@@ -16,16 +16,21 @@ namespace Thelia\Core\Template\Element\Overrides;
 use Thelia\Core\Template\Element\BaseLoop;
 
 /**
- * Class ArgInitializationOverrideInterface
+ * Class InitializeArgsOverrideInterface
  * @package Thelia\Core\Template\Element\Overrides
  * @author Julien Chanséaume <jchanseaume@openstudio.fr>
  */
-interface ArgInitializationOverrideInterface
+interface InitializeArgsOverrideInterface
 {
     /**
+     * Manipulate arguments of a loop
+     *
+     * For instance:
+     *
+     * $nameValuePairs['export'] = 'json';
+     *
      * @param BaseLoop $loop
      * @param array $nameValuePairs
-     * @return array
      */
-    public function initialize(BaseLoop $loop, array $nameValuePairs);
+    public function initializeArgs(BaseLoop $loop, array $nameValuePairs);
 }

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ParseOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ParseOverrideInterface.php
@@ -1,0 +1,37 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Template\Element\Overrides;
+
+use Thelia\Core\Template\Element\BaseLoop;
+use Thelia\Core\Template\Element\LoopResult;
+use Thelia\Core\Template\Element\LoopResultRow;
+
+/**
+ * Class ParseOverrideInterface
+ * @package Thelia\Core\Template\Element\Overrides
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+interface ParseOverrideInterface
+{
+    /**
+     *
+     *
+     * @param BaseLoop        $loop    the current loop
+     * @param LoopResultRow   $result  the current loop result row of the loop
+     * @param object|array    $item
+     *
+     * @return LoopResult             the modified LoopResult
+     */
+    public function parse(BaseLoop $loop, LoopResultRow $result, $item);
+}

--- a/core/lib/Thelia/Core/Template/Element/Overrides/ParseResultsOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/ParseResultsOverrideInterface.php
@@ -9,25 +9,35 @@
 /*      For the full copyright and license information, please view the LICENSE.txt  */
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
+
+
 namespace Thelia\Core\Template\Element\Overrides;
 
-use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Template\Element\BaseLoop;
-use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
-
+use Thelia\Core\Template\Element\LoopResult;
+use Thelia\Core\Template\Element\LoopResultRow;
 
 /**
- * Class ArgDefinitionOverride
+ * Class ParseResultsOverrideInterface
+ * @package Thelia\Core\Template\Element\Overrides
  * @author Julien Chanséaume <jchanseaume@openstudio.fr>
  */
-interface ArgDefinitionOverrideInterface
+interface ParseResultsOverrideInterface
 {
     /**
+     * Manipulate the parse results
+     *
+     * For instance:
+     *
+     * $characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+     * $result->set('TEST', str_shuffle($characters));
      *
      *
-     * @param BaseLoop  $loop      the current loop
+     * @param BaseLoop        $loop    the current loop
+     * @param LoopResultRow   $result  the current loop result row of the loop
+     * @param object|array    $item
      *
-     * @return ArgumentCollection|null      new argument collection that will be added to the loop argument collection
+     * @return LoopResult             the modified LoopResult
      */
-    public function getDefinitions(BaseLoop $loop);
+    public function parseResults(BaseLoop $loop, LoopResultRow $result, $item);
 }

--- a/core/lib/Thelia/Core/Template/Element/Overrides/PropelBuilderOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/PropelBuilderOverrideInterface.php
@@ -1,0 +1,37 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Core\Template\Element\Overrides;
+
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Template\Element\BaseLoop;
+use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+
+/**
+ * Class PropelBuilderOverrideInterface
+ * @package Thelia\Core\Template\Element\Overrides
+ * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ */
+interface PropelBuilderOverrideInterface
+{
+    /**
+     *
+     *
+     * @param BaseLoop        $loop      the current loop
+     * @param ModelCriteria   $search    the search ModelCriteria of the loop
+     *
+     * @return ModelCriteria             the modified ModelCriteria
+     */
+    public function build(BaseLoop $loop, ModelCriteria $search);
+}

--- a/core/lib/Thelia/Core/Template/Element/Overrides/PropelBuilderOverrideInterface.php
+++ b/core/lib/Thelia/Core/Template/Element/Overrides/PropelBuilderOverrideInterface.php
@@ -26,12 +26,15 @@ use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 interface PropelBuilderOverrideInterface
 {
     /**
+     * Manipulate the ModelCriteria
      *
+     * For instance:
+     *
+     * $search->orderBy('id', Criteria::DESC);
      *
      * @param BaseLoop        $loop      the current loop
      * @param ModelCriteria   $search    the search ModelCriteria of the loop
      *
-     * @return ModelCriteria             the modified ModelCriteria
      */
     public function build(BaseLoop $loop, ModelCriteria $search);
 }

--- a/core/lib/Thelia/Core/Template/Loop/Accessory.php
+++ b/core/lib/Thelia/Core/Template/Loop/Accessory.php
@@ -35,6 +35,8 @@ use Thelia\Model\AccessoryQuery;
  */
 class Accessory extends Product
 {
+    protected $loopName = 'accessory';
+
     protected $accessoryId;
     protected $accessoryPosition;
 

--- a/core/lib/Thelia/Core/Template/Loop/Address.php
+++ b/core/lib/Thelia/Core/Template/Loop/Address.php
@@ -41,6 +41,8 @@ use Thelia\Type;
  */
 class Address extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'address';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Admin.php
+++ b/core/lib/Thelia/Core/Template/Loop/Admin.php
@@ -37,6 +37,8 @@ use Thelia\Model\Admin as AdminModel;
  */
 class Admin extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'admin';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/ArchiveBuilder.php
+++ b/core/lib/Thelia/Core/Template/Loop/ArchiveBuilder.php
@@ -32,6 +32,8 @@ use Thelia\Type\TypeCollection;
  */
 class ArchiveBuilder extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'archive-builder';
+
     /**
      * this method returns an array
      *

--- a/core/lib/Thelia/Core/Template/Loop/Area.php
+++ b/core/lib/Thelia/Core/Template/Loop/Area.php
@@ -40,6 +40,8 @@ use Thelia\Type\TypeCollection;
  */
 class Area extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'area';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/AssociatedContent.php
+++ b/core/lib/Thelia/Core/Template/Loop/AssociatedContent.php
@@ -36,6 +36,8 @@ use Thelia\Model\CategoryAssociatedContentQuery;
  */
 class AssociatedContent extends Content
 {
+    protected $loopName = 'associated-content';
+
     protected $contentId;
     protected $contentPosition;
 

--- a/core/lib/Thelia/Core/Template/Loop/Attribute.php
+++ b/core/lib/Thelia/Core/Template/Loop/Attribute.php
@@ -48,6 +48,8 @@ use Thelia\Model\Map\AttributeTemplateTableMap;
  */
 class Attribute extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'attribute';
+
     protected $useAttributePosistion;
 
     protected $timestampable = true;

--- a/core/lib/Thelia/Core/Template/Loop/AttributeAvailability.php
+++ b/core/lib/Thelia/Core/Template/Loop/AttributeAvailability.php
@@ -44,6 +44,8 @@ use Thelia\Type;
  */
 class AttributeAvailability extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'attribute-availability';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/AttributeCombination.php
+++ b/core/lib/Thelia/Core/Template/Loop/AttributeCombination.php
@@ -39,6 +39,8 @@ use Thelia\Type\TypeCollection;
  */
 class AttributeCombination extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'attribute-combination';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Auth.php
+++ b/core/lib/Thelia/Core/Template/Loop/Auth.php
@@ -37,6 +37,8 @@ use Thelia\Type\TypeCollection;
  */
 class Auth extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'auth';
+
     public function getArgDefinitions()
     {
         return new ArgumentCollection(

--- a/core/lib/Thelia/Core/Template/Loop/Brand.php
+++ b/core/lib/Thelia/Core/Template/Loop/Brand.php
@@ -45,6 +45,8 @@ use Thelia\Type\TypeCollection;
  */
 class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'brand';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Cart.php
+++ b/core/lib/Thelia/Core/Template/Loop/Cart.php
@@ -36,6 +36,8 @@ use Thelia\Type;
  */
 class Cart extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'cart';
+
     /**
      *
      * @return \Thelia\Core\Template\Loop\Argument\ArgumentCollection

--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -61,6 +61,8 @@ use Thelia\Model\Category as CategoryModel;
  */
 class Category extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'category';
+
     protected $timestampable = true;
     protected $versionable = true;
 

--- a/core/lib/Thelia/Core/Template/Loop/CategoryPath.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryPath.php
@@ -42,6 +42,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class CategoryPath extends BaseI18nLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'category-path';
+
     /**
      * @return ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
@@ -45,6 +45,8 @@ use Thelia\Core\Template\Element\BaseI18nLoop;
  */
 class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'category-tree';
+
     /**
      * @return ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/Config.php
+++ b/core/lib/Thelia/Core/Template/Loop/Config.php
@@ -47,6 +47,8 @@ use Thelia\Model\Config as ConfigModel;
  */
 class Config extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'config';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -53,6 +53,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'content';
+
     protected $timestampable = true;
     protected $versionable = true;
 

--- a/core/lib/Thelia/Core/Template/Loop/Country.php
+++ b/core/lib/Thelia/Core/Template/Loop/Country.php
@@ -40,6 +40,8 @@ use Thelia\Model\CountryQuery;
  */
 class Country extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'country';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Coupon.php
+++ b/core/lib/Thelia/Core/Template/Loop/Coupon.php
@@ -44,6 +44,8 @@ use Thelia\Type\TypeCollection;
  */
 class Coupon extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'coupon';
+
     /**
      * Define all args used in your loop
      *

--- a/core/lib/Thelia/Core/Template/Loop/Currency.php
+++ b/core/lib/Thelia/Core/Template/Loop/Currency.php
@@ -41,6 +41,8 @@ use Thelia\Model\Currency as CurrencyModel;
  */
 class Currency extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'currency';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Customer.php
+++ b/core/lib/Thelia/Core/Template/Loop/Customer.php
@@ -47,6 +47,8 @@ use Thelia\Type;
  */
 class Customer extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInterface
 {
+    protected $loopName = 'customer';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Delivery.php
+++ b/core/lib/Thelia/Core/Template/Loop/Delivery.php
@@ -34,6 +34,8 @@ use Thelia\Module\Exception\DeliveryException;
  */
 class Delivery extends BaseSpecificModule
 {
+    protected $loopName = 'delivery';
+
     public function getArgDefinitions()
     {
         $collection = parent::getArgDefinitions();

--- a/core/lib/Thelia/Core/Template/Loop/Document.php
+++ b/core/lib/Thelia/Core/Template/Loop/Document.php
@@ -52,6 +52,8 @@ use Thelia\Log\Tlog;
  */
 class Document extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'document';
+
     protected $objectType;
     protected $objectId;
 

--- a/core/lib/Thelia/Core/Template/Loop/Export.php
+++ b/core/lib/Thelia/Core/Template/Loop/Export.php
@@ -21,6 +21,8 @@ use Thelia\Model\ExportQuery;
  */
 class Export extends ImportExportType
 {
+    protected $loopName = 'export';
+
     protected function getBaseUrl()
     {
         return $this->container->getParameter("export.base_url");

--- a/core/lib/Thelia/Core/Template/Loop/ExportCategory.php
+++ b/core/lib/Thelia/Core/Template/Loop/ExportCategory.php
@@ -21,6 +21,8 @@ use Thelia\Model\ExportCategoryQuery;
  */
 class ExportCategory extends ImportExportCategory
 {
+    protected $loopName = 'export-category';
+
     protected function getQueryModel()
     {
         return ExportCategoryQuery::create();

--- a/core/lib/Thelia/Core/Template/Loop/Feature.php
+++ b/core/lib/Thelia/Core/Template/Loop/Feature.php
@@ -52,6 +52,8 @@ use Thelia\Model\Feature as FeatureModel;
  */
 class Feature extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'feature';
+
     protected $useFeaturePosition;
 
     protected $timestampable = true;

--- a/core/lib/Thelia/Core/Template/Loop/FeatureAvailability.php
+++ b/core/lib/Thelia/Core/Template/Loop/FeatureAvailability.php
@@ -41,6 +41,8 @@ use Thelia\Type;
  */
 class FeatureAvailability extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'feature-availability';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/FeatureValue.php
+++ b/core/lib/Thelia/Core/Template/Loop/FeatureValue.php
@@ -44,6 +44,8 @@ use Thelia\Type;
  */
 class FeatureValue extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'feature-value';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Feed.php
+++ b/core/lib/Thelia/Core/Template/Loop/Feed.php
@@ -31,6 +31,8 @@ use Thelia\Core\Template\Loop\Argument\Argument;
  */
 class Feed extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'feed';
+
     public function getArgDefinitions()
     {
         return new ArgumentCollection(

--- a/core/lib/Thelia/Core/Template/Loop/Folder.php
+++ b/core/lib/Thelia/Core/Template/Loop/Folder.php
@@ -44,6 +44,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'folder';
+
     protected $timestampable = true;
     protected $versionable = true;
 

--- a/core/lib/Thelia/Core/Template/Loop/FolderPath.php
+++ b/core/lib/Thelia/Core/Template/Loop/FolderPath.php
@@ -33,6 +33,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class FolderPath extends BaseI18nLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'folder-path';
+
     /**
      * @return \Thelia\Core\Template\Loop\Argument\ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/FolderTree.php
+++ b/core/lib/Thelia/Core/Template/Loop/FolderTree.php
@@ -42,6 +42,8 @@ use Thelia\Core\Template\Element\BaseI18nLoop;
  */
 class FolderTree extends BaseI18nLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'folder-tree';
+
     /**
      * @return ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/Formatter.php
+++ b/core/lib/Thelia/Core/Template/Loop/Formatter.php
@@ -33,6 +33,8 @@ use Thelia\Type\TypeCollection;
  */
 class Formatter extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'formatter';
+
     /**
      * this method returns an array
      *

--- a/core/lib/Thelia/Core/Template/Loop/Hook.php
+++ b/core/lib/Thelia/Core/Template/Loop/Hook.php
@@ -39,6 +39,8 @@ use Thelia\Type\TypeCollection;
  */
 class Hook extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'hook';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Image.php
+++ b/core/lib/Thelia/Core/Template/Loop/Image.php
@@ -60,6 +60,8 @@ use Thelia\Log\Tlog;
  */
 class Image extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'image';
+
     protected $objectType;
     protected $objectId;
 

--- a/core/lib/Thelia/Core/Template/Loop/Import.php
+++ b/core/lib/Thelia/Core/Template/Loop/Import.php
@@ -21,6 +21,8 @@ use Thelia\Model\ImportQuery;
  */
 class Import extends ImportExportType
 {
+    protected $loopName = 'import';
+
     protected function getBaseUrl()
     {
         return $this->container->getParameter("import.base_url");

--- a/core/lib/Thelia/Core/Template/Loop/ImportCategory.php
+++ b/core/lib/Thelia/Core/Template/Loop/ImportCategory.php
@@ -21,6 +21,8 @@ use Thelia\Model\ImportCategoryQuery;
  */
 class ImportCategory extends ImportExportCategory
 {
+    protected $loopName = 'import-category';
+
     protected function getQueryModel()
     {
         return ImportCategoryQuery::create();

--- a/core/lib/Thelia/Core/Template/Loop/Lang.php
+++ b/core/lib/Thelia/Core/Template/Loop/Lang.php
@@ -44,6 +44,8 @@ use Thelia\Type;
  */
 class Lang extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'lang';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Message.php
+++ b/core/lib/Thelia/Core/Template/Loop/Message.php
@@ -44,6 +44,8 @@ use Thelia\Model\Message as MessageModel;
  */
 class Message extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'message';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -50,6 +50,8 @@ use Thelia\Type\TypeCollection;
  */
 class Module extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'module';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/ModuleConfig.php
+++ b/core/lib/Thelia/Core/Template/Loop/ModuleConfig.php
@@ -38,6 +38,8 @@ use Thelia\Model\ModuleQuery;
  */
 class ModuleConfig extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'module-config';
+
     /**
      * @return ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/ModuleHook.php
+++ b/core/lib/Thelia/Core/Template/Loop/ModuleHook.php
@@ -43,6 +43,8 @@ use Thelia\Type\TypeCollection;
  */
 class ModuleHook extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'module-hook';
+
     protected $timestampable = false;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -46,6 +46,8 @@ use Thelia\Type\TypeCollection;
  */
 class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInterface
 {
+    protected $loopName = 'order';
+
     protected $countable = true;
     protected $timestampable = true;
     protected $versionable = false;

--- a/core/lib/Thelia/Core/Template/Loop/OrderAddress.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderAddress.php
@@ -36,6 +36,8 @@ use Thelia\Model\OrderAddress as OrderAddressModel;
  */
 class OrderAddress extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-address';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/OrderCoupon.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderCoupon.php
@@ -38,6 +38,8 @@ use Thelia\Model\OrderQuery;
  */
 class OrderCoupon extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-coupon';
+
     /**
      * Define all args used in your loop
      *

--- a/core/lib/Thelia/Core/Template/Loop/OrderProduct.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderProduct.php
@@ -40,6 +40,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class OrderProduct extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-product';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/OrderProductAttributeCombination.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderProductAttributeCombination.php
@@ -39,6 +39,8 @@ use Thelia\Model\OrderProductAttributeCombination as OrderProductAttributeCombin
  */
 class OrderProductAttributeCombination extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-product-attribute-combination';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/OrderProductTax.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderProductTax.php
@@ -36,6 +36,8 @@ use Thelia\Model\OrderProductTax as OrderProductTaxModel;
  */
 class OrderProductTax extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-product-tax';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/OrderStatus.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderStatus.php
@@ -36,6 +36,8 @@ use Thelia\Model\OrderStatus as OrderStatusModel;
  */
 class OrderStatus extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'order-status';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Payment.php
+++ b/core/lib/Thelia/Core/Template/Loop/Payment.php
@@ -25,6 +25,8 @@ use Thelia\Module\PaymentModuleInterface;
  */
 class Payment extends BaseSpecificModule implements PropelSearchLoopInterface
 {
+    protected $loopName = 'payment';
+
     public function getArgDefinitions()
     {
         $collection = parent::getArgDefinitions();

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -76,6 +76,8 @@ use Thelia\Type\TypeCollection;
  */
 class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'product';
+
     protected $timestampable = true;
     protected $versionable = true;
 

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -50,6 +50,8 @@ use Thelia\Type\TypeCollection;
  */
 class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'product-sale-elements';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElementsDocument.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElementsDocument.php
@@ -34,6 +34,8 @@ use Propel\Runtime\ActiveQuery\Criteria;
  */
 class ProductSaleElementsDocument extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'product-sale-elements-document';
+
     /**
      * @param LoopResult $loopResult
      *

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElementsImage.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElementsImage.php
@@ -34,6 +34,8 @@ use Propel\Runtime\ActiveQuery\Criteria;
  */
 class ProductSaleElementsImage extends BaseLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'product-sale-elements-image';
+
     /**
      * @param LoopResult $loopResult
      *

--- a/core/lib/Thelia/Core/Template/Loop/ProductTemplate.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductTemplate.php
@@ -37,6 +37,8 @@ use Thelia\Model\Template as TemplateModel;
  */
 class ProductTemplate extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'product-template';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Profile.php
+++ b/core/lib/Thelia/Core/Template/Loop/Profile.php
@@ -36,6 +36,8 @@ use Thelia\Model\Profile as ProfileModel;
  */
 class Profile extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'profile';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Resource.php
+++ b/core/lib/Thelia/Core/Template/Loop/Resource.php
@@ -39,6 +39,8 @@ use Thelia\Model\Resource as ResourceModel;
  */
 class Resource extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'resource';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Sale.php
+++ b/core/lib/Thelia/Core/Template/Loop/Sale.php
@@ -42,6 +42,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    protected $loopName = 'sale';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Tax.php
+++ b/core/lib/Thelia/Core/Template/Loop/Tax.php
@@ -44,6 +44,8 @@ use Thelia\Model\Tax as TaxModel;
  */
 class Tax extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'tax';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/TaxRule.php
+++ b/core/lib/Thelia/Core/Template/Loop/TaxRule.php
@@ -40,6 +40,8 @@ use Thelia\Model\TaxRule as TaxRuleModel;
  */
 class TaxRule extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'tax-rule';
+
     protected $timestampable = true;
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/TaxRuleCountry.php
+++ b/core/lib/Thelia/Core/Template/Loop/TaxRuleCountry.php
@@ -45,6 +45,8 @@ use Thelia\Model\TaxRuleCountry as TaxRuleCountryModel;
  */
 class TaxRuleCountry extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'tax-rule-country';
+
     protected $taxCountForOriginCountry;
 
     protected $timestampable = true;

--- a/core/lib/Thelia/Core/Template/Loop/Template.php
+++ b/core/lib/Thelia/Core/Template/Loop/Template.php
@@ -33,6 +33,8 @@ use Thelia\Type;
  */
 class Template extends BaseLoop implements ArraySearchLoopInterface
 {
+    protected $loopName = 'template';
+
     /**
      * @return ArgumentCollection
      */

--- a/core/lib/Thelia/Core/Template/Loop/Title.php
+++ b/core/lib/Thelia/Core/Template/Loop/Title.php
@@ -36,6 +36,8 @@ use Thelia\Model\CustomerTitle as CustomerTitleModel;
  */
 class Title extends BaseI18nLoop implements PropelSearchLoopInterface
 {
+    protected $loopName = 'title';
+
     protected $timestampable = true;
 
     /**


### PR DESCRIPTION
This PR tries to offer a way to *override* Thelia Loops.

For now, you could extends loops in PHP but it's problematic if several module do it on same loops.

So I use the event dispatcher at the initialization of a loop to collect classes that will be use to manipulate some functions of the loop.

For instance : 

config.xml

```xml
<services>
    <service id="loopevent.loop.overrides" class="LoopEvent\EventListeners\Loop">
        <tag name="kernel.event_subscriber" />
    </service>
</services>
```

The service : 

```php
class Loop implements EventSubscriberInterface
{
    public function overrides(LoopOverridesEvent $event)
    {
        if ($event->getLoop() instanceof PropelSearchLoopInterface) {
            $overrideClass = new LoopOverrides();
            // Register the class for each function separately, the class should implements the right interface
            // or the all class with `$event->addClass($overrideClass);`
            $event->addArgDefinitions($overrideClass);
            $event->addInitializeArgs($overrideClass);
            $event->addBuilder($overrideClass);
            $event->addParserResults($overrideClass);
        }
    }

    public function overridesCountry(LoopOverridesEvent $event)
    {
        $overrideClass = new LoopCountryOverrides();
        $event->addClass($overrideClass);
    }

    public static function getSubscribedEvents()
    {
        return [
            // Called for every loops
            TheliaEvents::LOOP_OVERRIDES_LOOPS => 'overrides',
            // Called only for the country loop
            TheliaEvents::getLoopOverridesEvent('country') => 'overridesCountry',
        ];
    }
}
```

The class `LoopOverrides` that will manipulate the loop :

```php
class LoopOverrides implements
    ArgDefinitionsOverrideInterface,
    InitializeArgsOverrideInterface,
    PropelBuilderOverrideInterface,
    ParseResultsOverrideInterface
{
    /**
     * Add a new argument export to all loops
     */
    public function getArgDefinitions(BaseLoop $loop)
    {
        $loop->getArgs()->addArgument(
            Argument::createEnumListTypeArgument(
                'export',
                ['json', 'csv', 'xml']
            )
        );
    }

    /**
     * Manipulate the argument of loops
     */
    public function initializeArgs(BaseLoop $loop, array $nameValuePairs)
    {
        if (!array_key_exists('export', $nameValuePairs)) {
            $nameValuePairs['export'] = 'json';
        }
    }

    /**
     * Manipulate the ModelCriteria
     */
    public function build(BaseLoop $loop, ModelCriteria $search)
    {
        $search->orderBy('id', Criteria::DESC);
    }

    /**
     * Add new output variables
     */
    public function parseResults(BaseLoop $loop, LoopResultRow $result, $item)
    {
        $characters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
        $result->set('TEST', str_shuffle($characters));
        
        $data = $result->getVarVal();
        $result->set('JSON', json_encode($data));
    }
}
```

What do you thing about this PR ?  do you have suggestions ?