### PR TITLE
Add: hide/show textarea of email template when read only

### DIFF
--- a/templates/backOffice/default/message-edit.html
+++ b/templates/backOffice/default/message-edit.html
@@ -281,8 +281,10 @@
             var aceEditor = editor[$(this).data('toggle-textarea')];
             if ($(this).val() != '') {
                 aceEditor.setReadOnly(true);
+                $(this).parents(".row").next().slideUp()
             } else {
                 aceEditor.setReadOnly(false);
+                $(this).parents(".row").next().slideDown()
             }
         });
 


### PR DESCRIPTION
Une petite amélioration ergonomique: le grand textarea pour éditer un template de mél est maintenant caché en lecture seule.