### PR TITLE
Fixed cart duplication conditions at user login/logout

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -348,7 +348,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    private function manageNonPersistentCookie(CartRestoreEvent $cartRestoreEvent)
+    protected function manageNonPersistentCookie(CartRestoreEvent $cartRestoreEvent)
     {
         $cart = $cartRestoreEvent->getCart();
 
@@ -371,7 +371,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    private function managePersistentCart(CartRestoreEvent $cartRestoreEvent, $cookieName)
+    protected function managePersistentCart(CartRestoreEvent $cartRestoreEvent, $cookieName)
     {
         // The cart cookie exists -> get the cart token
         $token = $this->request->cookies->get($cookieName);
@@ -384,7 +384,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         return $cart;
     }
 
-    private function manageCartDuplicationAtCustomerLogin(CartModel $cart, EventDispatcherInterface $dispatcher)
+    protected function manageCartDuplicationAtCustomerLogin(CartModel $cart, EventDispatcherInterface $dispatcher)
     {
         /** @var CustomerModel $customer */
         if (null !== $customer = $this->session->getCustomerUser()) {

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -353,7 +353,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $cart = $cartRestoreEvent->getCart();
 
         if (null === $cart) {
-            $cart = $cart = $this->dispatchNewCart($cartRestoreEvent->getDispatcher());
+            $cart = $this->dispatchNewCart($cartRestoreEvent->getDispatcher());
         } else {
             $cart = $this->manageCartDuplicationAtCustomerLogin($cart, $cartRestoreEvent->getDispatcher());
         }


### PR DESCRIPTION
This PR is a fix for #1798 : the cart should be duplicated when a user with a permanent discount is logging in.

The code for deciding if the current cart should be duplicated has been factorized and improved.