### PR TITLE
The image file name is no longer the default image title

### DIFF
--- a/core/lib/Thelia/Controller/Admin/FileController.php
+++ b/core/lib/Thelia/Controller/Admin/FileController.php
@@ -190,16 +190,10 @@ class FileController extends BaseAdminController
             throw new ProcessFileException('', 404);
         }
 
-        $defaultTitle = $parentModel->getTitle();
-
-        if (empty($defaultTitle)) {
-            $defaultTitle = $fileBeingUploaded->getClientOriginalName();
-        }
-
         $fileModel
             ->setParentId($parentId)
             ->setLocale(Lang::getDefaultLanguage()->getLocale())
-            ->setTitle($defaultTitle)
+            ->setTitle($parentModel->getTitle())
         ;
 
         $fileCreateOrUpdateEvent = new FileCreateOrUpdateEvent($parentId);


### PR DESCRIPTION
This is a fix for  #1774. An image did not require a default title (documents do).