### PR TITLE
Fix: TheliaFormValidator parsable translation

### DIFF
--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -215,6 +215,7 @@ return array(
     'Free product when buying one or more selected products' => 'Un produit offert pour l\'achat d\'un ou plusieurs produits',
     'Front Office' => 'Front Office',
     'Full Name' => 'Nom complet',
+    'Further submissions will be ignored during %time' => 'Les prochains envois seront ignorés pendant %time',
     'Greater than' => 'Supérieur à',
     'Greater than or equals' => 'Supérieur ou égal à',
     'HTML Message' => 'Message au format HTML',

--- a/core/lib/Thelia/Core/Form/TheliaFormValidator.php
+++ b/core/lib/Thelia/Core/Form/TheliaFormValidator.php
@@ -55,9 +55,8 @@ class TheliaFormValidator implements TheliaFormValidatorInterface
             if ($form->isValid()) {
                 if ($aBaseForm instanceof FirewallForm && !$aBaseForm->isFirewallOk($this->environment)) {
                     throw new FormValidationException(
-                        $this->translator->trans(
-                            "You've submitted this form too many times. ".
-                            "Further submissions will be ignored during %time",
+                      $this->translator->trans("You've submitted this form too many times. ")
+                      .$this->translator->trans("Further submissions will be ignored during %time",
                             [
                                 "%time" => $aBaseForm->getWaitingTime(),
                             ]


### PR DESCRIPTION
The first param inside translation->trans() was splited in 2 string
    making the parser not working for that particular case.
I could have modified the regex expression in core/lib/Thelia/Action/Translation.php
but the result was incertain.