### PR TITLE
fix the render for module hooks

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -248,15 +248,20 @@ class RegisterHookListenersPass implements CompilerPassInterface
 
                 if ($moduleHook->getTemplates()) {
                     if ($container->hasDefinition($moduleHook->getClassname())) {
+                        $moduleHookEventName = 'hook.' . $hook->getType() . '.' . $hook->getCode();
+                        if (true === $moduleHook->getHook()->getByModule()) {
+                            $moduleHookEventName .= '.' . $moduleHook->getModuleId();
+                        }
                         $container
                             ->getDefinition($moduleHook->getClassname())
                             ->addMethodCall(
                                 'addTemplate',
                                 array(
-                                    'hook.' . $hook->getType() . '.' . $hook->getCode(),
+                                    $moduleHookEventName,
                                     $moduleHook->getTemplates()
                                 )
-                            );
+                            )
+                        ;
                     }
                 }
             }


### PR DESCRIPTION
For the module hooks, the id of the module needs to be present after the event name.