### PR TITLE
CategoryTree loop speed improve

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
@@ -39,6 +39,7 @@ use Thelia\Core\Template\Element\BaseI18nLoop;
  * @method int getCategory()
  * @method int getDepth()
  * @method bool getNeedCountChild()
+ * @method bool getNeedUrl()
  * @method bool|string getVisible()
  * @method int[] getExclude()
  * @method string[] getOrder()
@@ -56,6 +57,7 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
             Argument::createIntTypeArgument('category', null, true),
             Argument::createIntTypeArgument('depth', PHP_INT_MAX),
             Argument::createBooleanTypeArgument('need_count_child', false),
+            Argument::createBooleanTypeArgument('need_url', false),
             Argument::createBooleanOrBothTypeArgument('visible', true, false),
             Argument::createIntListTypeArgument('exclude', array()),
             new Argument(
@@ -80,8 +82,6 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
 
             $search = CategoryQuery::create();
             $this->configureI18nProcessing($search, array('TITLE'));
-
-            //$search->filterByParent($parent);
 
             if ($visible !== BooleanOrBothType::ANY) {
                 $search->filterByVisible($visible);
@@ -119,6 +119,7 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
             $results = $search->find();
 
             $needCountChild = $this->getNeedCountChild();
+            $needUrl = $this->getNeedUrl();
 
             foreach ($results as $result) {
                 if (!isset($this->categories[$result->getParent()])) {
@@ -128,10 +129,11 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
                     "ID" => $result->getId(),
                     "TITLE" => $result->getVirtualColumn('i18n_TITLE'),
                     "PARENT" => $result->getParent(),
-                    //URL never used but getUrl is very slow
-                    //"URL" => $result->getUrl($this->locale),
                     "VISIBLE" => $result->getVisible() ? "1" : "0",
                 ];
+                if ($needUrl) {
+                    $row['URL'] = $result->getUrl($this->locale);
+                }
                 if ($needCountChild) {
                     $row['CHILD_COUNT'] = $result->countChild();
                 }

--- a/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryTree.php
@@ -45,6 +45,8 @@ use Thelia\Core\Template\Element\BaseI18nLoop;
  */
 class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
 {
+    private $categories;
+
     /**
      * @return ArgumentCollection
      */
@@ -73,66 +75,79 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
             return;
         }
 
-        $search = CategoryQuery::create();
-        $this->configureI18nProcessing($search, array('TITLE'));
+        if ($this->categories === null) {
+            $this->categories = [];
 
-        $search->filterByParent($parent);
+            $search = CategoryQuery::create();
+            $this->configureI18nProcessing($search, array('TITLE'));
 
-        if ($visible !== BooleanOrBothType::ANY) {
-            $search->filterByVisible($visible);
-        }
+            //$search->filterByParent($parent);
 
-        if ($exclude != null) {
-            $search->filterById($exclude, Criteria::NOT_IN);
-        }
-
-        $orders  = $this->getOrder();
-
-        foreach ($orders as $order) {
-            switch ($order) {
-                case "position":
-                    $search->orderByPosition(Criteria::ASC);
-                    break;
-                case "position_reverse":
-                    $search->orderByPosition(Criteria::DESC);
-                    break;
-                case "id":
-                    $search->orderById(Criteria::ASC);
-                    break;
-                case "id_reverse":
-                    $search->orderById(Criteria::DESC);
-                    break;
-                case "alpha":
-                    $search->addAscendingOrderByColumn('i18n_TITLE');
-                    break;
-                case "alpha_reverse":
-                    $search->addDescendingOrderByColumn('i18n_TITLE');
-                    break;
-            }
-        }
-
-        $results = $search->find();
-
-        $needCountChild = $this->getNeedCountChild();
-
-        foreach ($results as $result) {
-            $row = array(
-                "ID" => $result->getId(),
-                "TITLE" => $result->getVirtualColumn('i18n_TITLE'),
-                "PARENT" => $result->getParent(),
-                "URL" => $result->getUrl($this->locale),
-                "VISIBLE" => $result->getVisible() ? "1" : "0",
-                "LEVEL" => $level,
-                'PREV_LEVEL' => $previousLevel,
-            );
-
-            if ($needCountChild) {
-                $row['CHILD_COUNT'] = $result->countChild();
+            if ($visible !== BooleanOrBothType::ANY) {
+                $search->filterByVisible($visible);
             }
 
-            $resultsList[] = $row;
+            if ($exclude != null) {
+                $search->filterById($exclude, Criteria::NOT_IN);
+            }
 
-            $this->buildCategoryTree($result->getId(), $visible, 1 + $level, $level, $maxLevel, $exclude, $resultsList);
+            $orders  = $this->getOrder();
+
+            foreach ($orders as $order) {
+                switch ($order) {
+                    case "position":
+                        $search->orderByPosition(Criteria::ASC);
+                        break;
+                    case "position_reverse":
+                        $search->orderByPosition(Criteria::DESC);
+                        break;
+                    case "id":
+                        $search->orderById(Criteria::ASC);
+                        break;
+                    case "id_reverse":
+                        $search->orderById(Criteria::DESC);
+                        break;
+                    case "alpha":
+                        $search->addAscendingOrderByColumn('i18n_TITLE');
+                        break;
+                    case "alpha_reverse":
+                        $search->addDescendingOrderByColumn('i18n_TITLE');
+                        break;
+                }
+            }
+
+            $results = $search->find();
+
+            $needCountChild = $this->getNeedCountChild();
+
+            foreach ($results as $result) {
+                if (!isset($this->categories[$result->getParent()])) {
+                    $this->categories[$result->getParent()] = [];
+                }
+                $row = [
+                    "ID" => $result->getId(),
+                    "TITLE" => $result->getVirtualColumn('i18n_TITLE'),
+                    "PARENT" => $result->getParent(),
+                    //URL never used but getUrl is very slow
+                    //"URL" => $result->getUrl($this->locale),
+                    "VISIBLE" => $result->getVisible() ? "1" : "0",
+                ];
+                if ($needCountChild) {
+                    $row['CHILD_COUNT'] = $result->countChild();
+                }
+                $this->categories[$result->getParent()][] = $row;
+            }
+        }
+        if (isset($this->categories[$parent])) {
+            foreach ($this->categories[$parent] as $category) {
+                $row = $category;
+                $row['LEVEL'] = $level;
+                $row['PREV_LEVEL'] = $previousLevel;
+
+                $resultsList[] = $row;
+
+                $this->buildCategoryTree($row['ID'], $visible, 1 + $level, $level, $maxLevel, $exclude, $resultsList);
+            }
         }
     }
 
@@ -158,6 +173,7 @@ class CategoryTree extends BaseI18nLoop implements ArraySearchLoopInterface
 
         $resultsList = array();
 
+        $this->categories = null;
         $this->buildCategoryTree($id, $visible, 0, 0, $depth, $exclude, $resultsList);
 
         return $resultsList;


### PR DESCRIPTION
This loop is very slow when categories count more than 1000.
For example, when you try to edit product in backOffice it loading about minute because of this loop versus max 3 sec with this improvement (with buit-in php server)
