### PR TITLE
[WIP] Fix smarty form_collection_field

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Form.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Form.php
@@ -884,10 +884,38 @@ class Form extends AbstractSmartyPlugin
             $this->buildFieldName($formField),
             $formField->getViewData(),
             $formFieldConfig->getType(),
-            $formField->createView()->vars
+            $this->findCollectionFieldFormView($form->getView(), $formField)
         );
 
         return '';
+    }
+
+    /**
+     * @param FormView $formView
+     * @param SymfonyForm $formField
+     * @return array
+     */
+    protected function findCollectionFieldFormView(FormView $formView, SymfonyForm $formField)
+    {
+        $formFieldParentList = [];
+
+        do {
+            // don't need to set first form name child
+            if (null === $formField->getParent()) {
+                break;
+            }
+
+            $formFieldParentList[] = $formField->getConfig()->getName();
+
+        } while (null !== $formField = $formField->getParent());
+
+        $formFieldParentList = array_reverse($formFieldParentList);
+
+        foreach ($formFieldParentList as $val) {
+            $formView = $formView->children[$val];
+        }
+
+        return $formView->vars;
     }
 
     /**


### PR DESCRIPTION
A performance problem was introduced after this PR: #1613 because ​the Form::createView() method create all form view on each call.

This problem comes from ​the fact that TheliaSmarty/Template/Plugins/Form::renderFormCollectionField() doesn't have the current form view field.

My fixed method scan ​the current form field and retrieve this form field view from the parser context current form view.

I'm not convinced this is the right way, I tried with PropertyPath to retrieve the​ form field view but the performance ​was lower.

If anyone has ​another idea ..?