### PR TITLE
correction of hookblack : order.tab

### DIFF
--- a/templates/backOffice/default/order-edit.html
+++ b/templates/backOffice/default/order-edit.html
@@ -103,7 +103,7 @@
                                 <ul class="nav nav-tabs clearfix">
                                     <li {if $order_tab == 'cart'}class="active"{/if}><a href="#cart" data-tab-name="cart" data-toggle="tab"><span class="glyphicon glyphicon-shopping-cart"></span> {intl l="Ordered products"}</a></li>
                                     <li {if $order_tab == 'bill'}class="active"{/if}><a href="#bill" data-tab-name="bill" data-toggle="tab"><span class="glyphicon glyphicon-list-alt"></span> {intl l="Invoice and Delivery"}</a></li>
-                                    {$smarty.capture.folder_tab_tab nofilter}
+                                    {$smarty.capture.order_tab_tab nofilter}
                                     <li {if $order_tab == 'modules'}class="active"{/if}><a href="#modules" data-tab-name="modules" data-toggle="tab"><span class="glyphicon glyphicon-paperclip"></span> {intl l="Modules"}</a></li>
                                 </ul>
 


### PR DESCRIPTION
There is a wrong use of capture order_tab_tab in order-edit.html (probably do to a copy/paste from folder-edit.html)