### PR TITLE
Update RemoveXAmount - exec

### DIFF
--- a/core/lib/Thelia/Coupon/Type/RemoveXAmount.php
+++ b/core/lib/Thelia/Coupon/Type/RemoveXAmount.php
@@ -61,7 +61,16 @@ class RemoveXAmount extends AbstractRemove
      */
     public function exec()
     {
-        return $this->amount;
+        $discount = 0;
+        $cartItems = $this->facade->getCart()->getCartItems();
+        /** @var CartItem $cartItem */
+        foreach ($cartItems as $cartItem) {
+			if (! $cartItem->getPromo() || $this->isAvailableOnSpecialOffers()) {
+				$discount = $this->amount;
+            }
+        }
+
+        return $discount;
     }
 
     /**


### PR DESCRIPTION
ne pas faire de remise si il y a que des produits en promo et que isAvailableOnSpecialOffers n'est pas coché.
