### PR TITLE
Update form.html

### DIFF
--- a/templates/backOffice/default/coupon/form.html
+++ b/templates/backOffice/default/coupon/form.html
@@ -6,7 +6,7 @@
 
         <div class="row">
             <div class="col-md-12 title title-without-tabs">
-                {$title}
+                {$title nofilter}
             </div>
         </div>
 


### PR DESCRIPTION
If a user includes HTML mark-up ("<",">") then the display of the coupon name in the page title is double escaped.

I added nofilter, and the title is escaped once, I haven't security tested other inclusions of the "form.html" template with this change.

I'm not experienced SMARTY user, other fixes to this issue may be preferable.
