### PR TITLE
Fix Carousel update

### DIFF
--- a/local/modules/Carousel/Carousel.php
+++ b/local/modules/Carousel/Carousel.php
@@ -73,7 +73,7 @@ class Carousel extends BaseModule
         $uploadDir = $this->getUploadDir();
         $fileSystem = new Filesystem();
 
-        if (!file_exists($uploadDir)) {
+        if (!$fileSystem->exists($uploadDir) && $fileSystem->exists(__DIR__ . DS . 'media' . DS . 'carousel')) {
             $finder = new Finder();
             $finder->files()->in(__DIR__ . DS . 'media' . DS . 'carousel');
 


### PR DESCRIPTION
The finder returns an exception if the origin path does not exist