### PR TITLE
A fix for "terms & conditions" bootbox height.

### DIFF
--- a/templates/frontOffice/default/order-invoice.html
+++ b/templates/frontOffice/default/order-invoice.html
@@ -389,7 +389,7 @@ jQuery(function($) {
             bootbox.hideAll();
             // Show dialog
             bootbox.dialog({
-                message : $("#content-main",data),
+                message : '<div class="clearfix">'+$("#content-main",data).html()+'</div>',
                 onEscape: function() {
                     bootbox.hideAll();
                 }


### PR DESCRIPTION
A fix for this : 

![img-2016-01-10 10 41 26](https://cloud.githubusercontent.com/assets/2197734/12220950/cb359daa-b786-11e5-916b-e3c74008f3af.png)
