### PR TITLE
The module list in the translation page is now ordered by module code instead of module title

### DIFF
--- a/templates/backOffice/default/translations.html
+++ b/templates/backOffice/default/translations.html
@@ -65,7 +65,7 @@
 
 		                                            <select id="item_name" required="required" name="item_name" class="submit-on-change form-control">
 		                                                <option value="">{intl l='Please select the module to translate'}</option>
-					                                    {loop type="module" name="translate-module" backend_context=1 order="title"}
+					                                    {loop type="module" name="translate-module" backend_context=1 order="code"}
 					                                        <option value="{$ID}" {if $item_name == $ID}selected="selected"{/if}>{$CODE} - {$TITLE}</option>
 					                                    {/loop}
 					                                </select>


### PR DESCRIPTION
As each item starts with the module code, it's easier to find a module if the list is ordered by module code.