### PR TITLE
Fixed translations bug in user mode with view only missing translations activated

### DIFF
--- a/templates/backOffice/default/translations.html
+++ b/templates/backOffice/default/translations.html
@@ -237,7 +237,6 @@
                                                     <input class="submit-on-change" type="checkbox" name="view_missing_traductions_only" value="1" {if $view_missing_traductions_only}checked="checked"{/if}> {intl l='View only missing translations.'}
                                                     (<a class="copy-all" href="#" title="{intl l='Copy all missing translations.'}">{intl l='Copy all translations.'}</a>)
                                                 </label>
-
                                             </div>
                                         </div>
                                     </div>
@@ -349,10 +348,14 @@
 	                                    </tr>
 
 	                                {else}
-
-	                                   {* Text is not displayed, put it in a hidden field *}
-	                                   <input type="hidden" id="translation_{$idx}" name="translation[]" value="{$info.translation}" />
-
+                                        <tr class="hidden">
+                                            <td colspan="2">
+                                                {* Text is not displayed, put it in a hidden field *}
+                                                <input type="hidden" id="translation_{$idx}" name="translation[]" value="{$info.translation}" />
+                                                <input type="hidden" id="translation_custom{$idx}" name="translation_custom[]" value="{$info.custom_fallback}" />
+                                                <input type="hidden" id="translation_global_{$idx}" name="translation_global[]" value="{$info.global_fallback}" />
+                                            </td>
+                                        </tr>
                                     {/if}
 
                                     {$idx = $idx + 1}


### PR DESCRIPTION
For instance, when you translate something in **user mode** with **view only missing translations activated**, if a line was hidden (i.e.: translated) then the translations are shifted and everything is broken. 