### PR TITLE
fix redirection after coupon consume

### DIFF
--- a/templates/frontOffice/default/order-invoice.html
+++ b/templates/frontOffice/default/order-invoice.html
@@ -35,6 +35,14 @@
 
                 {form_hidden_fields}
 
+                {form_field field='success_url'}
+                    <input type="hidden" name="{$name}" value="{url path="/order/invoice"}" />
+                {/form_field}
+
+                {form_field field='error_url'}
+                    <input type="hidden" name="{$name}" value="{url path="/order/invoice"}" />
+                {/form_field}
+
                 {if $form_error}<div class="alert alert-danger">{$form_error_message}</div>{/if}
 
                 <table class="table table-cart table-bordered">


### PR DESCRIPTION
In #1903 a new redirection was added on [CouponController::consume](https://github.com/thelia/thelia/blob/master/local/modules/Front/Controller/CouponController.php#L148)
Currently on a form error, user is redirect on [base_url](https://github.com/thelia/thelia/blob/master/core/lib/Thelia/Form/BaseForm.php#L342) because error_url is not defined in template.

After an update on Thelia 2.3.0 if user template doesn't contain error_url it will be affected by base_url redirection.