### PR TITLE
Fix: TaxType class only if extension == php

### DIFF
--- a/core/lib/Thelia/TaxEngine/TaxEngine.php
+++ b/core/lib/Thelia/TaxEngine/TaxEngine.php
@@ -81,8 +81,10 @@ class TaxEngine
 
                     foreach ($directoryIterator as $fileinfo) {
                         if ($fileinfo->isFile()) {
-                            $fileName  = $fileinfo->getFilename();
-                            $className = substr($fileName, 0, (1+strlen($fileinfo->getExtension())) * -1);
+                            $extension = $fileinfo->getExtension();
+                            if (strtolower($extension) !== 'php')
+                                continue;
+                            $className  = $fileinfo->getBaseName('.php');
 
                             try {
                                 $fullyQualifiedClassName = "$namespace\\$className";


### PR DESCRIPTION
This fix a problem when php.ini files (or any non php file) are present
in core/lib/Thelia/TaxEngine/TaxType/
see http://thelia.net/forum/viewtopic.php?id=11849