### PR TITLE
Added a way to get category/product from related content ID

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -46,10 +46,11 @@ use Thelia\Model\Category as CategoryModel;
  *
  * {@inheritdoc}
  * @method int[] getId()
- * @method int getParent()
- * @method int getExcludeParent()
- * @method int getProduct()
- * @method int getExcludeProduct()
+ * @method int[] getParent()
+ * @method int[] getExcludeParent()
+ * @method int[] getProduct()
+ * @method int[] getExcludeProduct()
+ * @method int[] getContent()
  * @method bool getCurrent()
  * @method bool getNotEmpty()
  * @method bool getWithPrevNextInfo()
@@ -73,8 +74,9 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
             Argument::createIntListTypeArgument('id'),
             Argument::createIntListTypeArgument('parent'),
             Argument::createIntListTypeArgument('exclude_parent'),
-            Argument::createIntTypeArgument('product'),
-            Argument::createIntTypeArgument('exclude_product'),
+            Argument::createIntListTypeArgument('product'),
+            Argument::createIntListTypeArgument('exclude_product'),
+            Argument::createIntListTypeArgument('content'),
             Argument::createBooleanTypeArgument('current'),
             Argument::createBooleanTypeArgument('not_empty', 0),
             Argument::createBooleanTypeArgument('with_prev_next_info', false),
@@ -160,27 +162,36 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
             $search->filterByVisible($visible ? 1 : 0);
         }
 
-        $product = $this->getProduct();
+        $products = $this->getProduct();
 
-        if ($product != null) {
-            $obj = ProductQuery::create()->findPk($product);
+        if ($products != null) {
+            $obj = ProductQuery::create()->findPks($products);
 
             if ($obj != null) {
                 $search->filterByProduct($obj, Criteria::IN);
             }
         }
 
-        $excludeProduct = $this->getExcludeProduct();
+        $excludeProducts = $this->getExcludeProduct();
 
-        if ($excludeProduct != null) {
-            $obj = ProductQuery::create()->findPk($excludeProduct);
+        if ($excludeProducts != null) {
+            $obj = ProductQuery::create()->findPks($excludeProducts);
 
             if ($obj != null) {
                 $search->filterByProduct($obj, Criteria::NOT_IN);
             }
         }
 
-        $orders  = $this->getOrder();
+        $contentId = $this->getContent();
+
+        if ($contentId != null) {
+            $search->useCategoryAssociatedContentQuery()
+                ->filterByContentId($contentId, Criteria::IN)
+                ->endUse()
+            ;
+        }
+
+        $orders = $this->getOrder();
 
         foreach ($orders as $order) {
             switch ($order) {

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -51,6 +51,7 @@ use Thelia\Type\TypeCollection;
  * @method int[] getBrand()
  * @method int[] getSale()
  * @method int[] getCategoryDefault()
+ * @method int[] getContent()
  * @method bool getNew()
  * @method bool getPromo()
  * @method float getMinPrice()
@@ -92,6 +93,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             Argument::createIntListTypeArgument('brand'),
             Argument::createIntListTypeArgument('sale'),
             Argument::createIntListTypeArgument('category_default'),
+            Argument::createIntListTypeArgument('content'),
             Argument::createBooleanTypeArgument('new'),
             Argument::createBooleanTypeArgument('promo'),
             Argument::createFloatTypeArgument('min_price'),
@@ -591,6 +593,15 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
         if ($brand_id !== null) {
             $search->filterByBrandId($brand_id, Criteria::IN);
+        }
+
+        $contentId = $this->getContent();
+
+        if ($contentId != null) {
+            $search->useProductAssociatedContentQuery()
+                ->filterByContentId($contentId, Criteria::IN)
+                ->endUse()
+            ;
         }
 
         $sale_id = $this->getSale();


### PR DESCRIPTION
This PR add a "content" parameter to Category and Product loop, so that these loop could return categories / products given a related (= "associated") content ID.

Before this PR, it was not possible to get a product / category form a related content.