### PR TITLE
Add missing join condition operator in customer loop

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Customer.php
+++ b/core/lib/Thelia/Core/Template/Loop/Customer.php
@@ -151,7 +151,7 @@ class Customer extends BaseLoop implements SearchLoopInterface, PropelSearchLoop
 
         $search
             ->addJoinObject($join, 'newsletter_join')
-            ->addJoinCondition('newsletter_join', NewsletterTableMap::UNSUBSCRIBED, false, null, \PDO::PARAM_BOOL)
+            ->addJoinCondition('newsletter_join', NewsletterTableMap::UNSUBSCRIBED . ' = ?', false, null, \PDO::PARAM_BOOL)
             ->withColumn("IF(ISNULL(".NewsletterTableMap::EMAIL."), 0, 1)", "is_registered_to_newsletter");
 
         // If "*" === $newsletter, no filter will be applied, so it won't change anything


### PR DESCRIPTION
The previous form happens to work (because the value is a boolean), but reverse the intended condition since the value argument will never be used.

The `ModelCriteria::addJoinCondition` is meant to be used with an explicit `?` value placeholder as far as I can tell : this call does not work on the current Propel master version.