### PR TITLE
Address format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "michelf/php-markdown": "1.5.0",
         "smarty/smarty": "3.1.19",
         "ramsey/array_column": "~1.1",
-        "propel/propel": "dev-thelia-2.3"
+        "propel/propel": "dev-thelia-2.3",
+        "commerceguys/addressing": "0.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cdd0b808ef352895c85e5d5e7d2c2c60",
-    "content-hash": "5df2e490534893de8ff85076170e550e",
+    "hash": "33522623a5d8474183268206a017aac8",
+    "content-hash": "854c2a014bd9b06b7203d3f9f6f41090",
     "packages": [
         {
             "name": "commerceguys/addressing",

--- a/composer.lock
+++ b/composer.lock
@@ -8,6 +8,107 @@
     "content-hash": "5df2e490534893de8ff85076170e550e",
     "packages": [
         {
+            "name": "commerceguys/addressing",
+            "version": "v0.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/addressing.git",
+                "reference": "93ddf176d7dd851edb0bb05694ed1614c5c67ef8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/addressing/zipball/93ddf176d7dd851edb0bb05694ed1614c5c67ef8",
+                "reference": "93ddf176d7dd851edb0bb05694ed1614c5c67ef8",
+                "shasum": ""
+            },
+            "require": {
+                "commerceguys/enum": "~1.0",
+                "doctrine/collections": "~1.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "1.*",
+                "phpunit/phpunit": "~4.0",
+                "symfony/intl": ">=2.3",
+                "symfony/validator": ">=2.3"
+            },
+            "suggest": {
+                "commerceguys/intl": "to use it as the source of country data",
+                "symfony/form": "to generate Symfony address forms",
+                "symfony/intl": "to use it as the source of country data",
+                "symfony/validator": "to validate addresses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Addressing\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                },
+                {
+                    "name": "Damien Tournoud"
+                }
+            ],
+            "description": "Addressing library powered by Google's address data.",
+            "keywords": [
+                "address",
+                "internationalization",
+                "localization",
+                "postal"
+            ],
+            "time": "2015-12-24 23:07:20"
+        },
+        {
+            "name": "commerceguys/enum",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/commerceguys/enum.git",
+                "reference": "1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/commerceguys/enum/zipball/1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95",
+                "reference": "1d9db2dbeb1a02500e7a14589ae2f9cb402c5c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CommerceGuys\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bojan Zivanovic"
+                }
+            ],
+            "description": "A PHP 5.4+ enumeration library.",
+            "time": "2015-02-27 21:36:56"
+        },
+        {
             "name": "doctrine/cache",
             "version": "v1.3.0",
             "source": {
@@ -80,6 +181,72 @@
                 "caching"
             ],
             "time": "2013-10-25 19:04:14"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2015-04-14 22:21:58"
         },
         {
             "name": "ensepar/html2pdf",

--- a/core/composer.json
+++ b/core/composer.json
@@ -49,7 +49,8 @@
         "michelf/php-markdown": "1.5.0",
         "smarty/smarty": "3.1.19",
         "ramsey/array_column": "~1.1",
-        "propel/propel": "dev-thelia-2.3"
+        "propel/propel": "dev-thelia-2.3",
+        "commerceguys/addressing": "0.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -133,6 +133,15 @@ class ConfigQuery extends BaseConfigQuery
     }
 
     /**
+     * @since 2.3.0-alpha2
+     * @return int|null the store country id
+     */
+    public static function getStoreCountry()
+    {
+        return self::read('store_country', null);
+    }
+
+    /**
      * @return array a list of email addresses to send the shop's notifications
      */
     public static function getNotificationEmailsList()

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -2,6 +2,7 @@
 
 namespace Thelia\Model;
 
+use LogicException;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
@@ -168,12 +169,18 @@ class Country extends BaseCountry
      */
     public static function getShopLocation()
     {
-        $dc = CountryQuery::create()->findOneByShopCountry(true);
+        $countryId = ConfigQuery::getStoreCountry();
 
-        if ($dc == null) {
+        // return the default country if no shop country defined
+        if ($countryId === null) {
+            return self::getDefaultCountry();
+        }
+
+        $shopCountry = CountryQuery::create()->findPk($countryId);
+        if ($shopCountry === null) {
             throw new \LogicException(Translator::getInstance()->trans("Cannot find the shop country. Please select a shop country."));
         }
 
-        return $dc;
+        return $shopCountry;
     }
 }

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -172,7 +172,7 @@ class Country extends BaseCountry
         $countryId = ConfigQuery::getStoreCountry();
 
         // return the default country if no shop country defined
-        if ($countryId === null) {
+        if (empty($countryId)) {
             return self::getDefaultCountry();
         }
 

--- a/core/lib/Thelia/Tools/AddressFormat.php
+++ b/core/lib/Thelia/Tools/AddressFormat.php
@@ -1,0 +1,231 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+
+namespace Thelia\Tools;
+
+use CommerceGuys\Addressing\Formatter\DefaultFormatter;
+use CommerceGuys\Addressing\Formatter\PostalLabelFormatter;
+use CommerceGuys\Addressing\Model\Address;
+use CommerceGuys\Addressing\Model\AddressInterface;
+use CommerceGuys\Addressing\Repository\AddressFormatRepository;
+use CommerceGuys\Addressing\Repository\CountryRepository;
+use CommerceGuys\Addressing\Repository\SubdivisionRepository;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\OrderAddress;
+
+/**
+ * Class AddressFormat
+ * @package Thelia\Tools
+ * @author Julien Chanséaume <julien@thelia.net>
+ */
+class AddressFormat
+{
+    private static $instance;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public static function getInstance()
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new AddressFormat();
+        }
+
+        return self::$instance;
+    }
+
+
+    /**
+     * Format an address
+     *
+     * @param AddressInterface $address
+     * @param null $locale
+     * @param bool $html
+     * @param string $htmlTag
+     * @param array $htmlAttributes
+     * @return string
+     */
+    public function format(
+        AddressInterface $address,
+        $locale = null,
+        $html = true,
+        $htmlTag = "p",
+        $htmlAttributes = []
+    ) {
+        $locale = $this->normalizeLocale($locale);
+
+        $addressFormatRepository = new AddressFormatRepository();
+        $countryRepository = new CountryRepository();
+        $subdivisionRepository = new SubdivisionRepository();
+
+        $formatter = new DefaultFormatter(
+            $addressFormatRepository,
+            $countryRepository,
+            $subdivisionRepository,
+            $locale
+        );
+
+        $formatter->setOption('html', $html);
+        $formatter->setOption('html_tag', $htmlTag);
+        $formatter->setOption('html_attributes', $htmlAttributes);
+
+
+        $addressFormatted = $formatter->format($address);
+
+        return $addressFormatted;
+    }
+
+    /**
+     * Format a Thelia address (Address or OrderAddress)
+     *
+     * @param \Thelia\Model\OrderAddress|OrderAddress $address
+     * @param null $locale
+     * @param bool $html
+     * @param string $htmlTag
+     * @param array $htmlAttributes
+     * @return string
+     */
+    public function formatTheliaAddress($address, $locale = null, $html = true, $htmlTag = "p", $htmlAttributes = [])
+    {
+        $address = $this->mapTheliaAddress($address, $locale);
+        return $this->format($address, $locale, $html, $htmlTag, $htmlAttributes);
+    }
+
+    /**
+     * Format an address to a postal label
+     *
+     * @param AddressInterface $address
+     * @param null $locale
+     * @param null $originCountry
+     * @param array $options
+     * @return string
+     */
+    public function postalLabelFormat(AddressInterface $address, $locale = null, $originCountry = null, $options = [])
+    {
+        $locale = $this->normalizeLocale($locale);
+
+        $addressFormatRepository = new AddressFormatRepository();
+        $countryRepository = new CountryRepository();
+        $subdivisionRepository = new SubdivisionRepository();
+
+        if (null === $originCountry) {
+            $countryId = Country::getShopLocation();
+            if (null === $country = CountryQuery::create()->findPk($countryId)) {
+                $country = Country::getDefaultCountry();
+            }
+
+            $originCountry = $country->getIsoalpha2();
+        }
+
+        $formatter = new PostalLabelFormatter(
+            $addressFormatRepository,
+            $countryRepository,
+            $subdivisionRepository,
+            $originCountry,
+            $locale,
+            $options
+        );
+
+        $addressFormatted = $formatter->format($address);
+
+        return $addressFormatted;
+    }
+
+    /**
+     * Format a Thelia address (Address or OrderAddress) to a postal label
+     *
+     * @param \Thelia\Model\OrderAddress|OrderAddress $address
+     * @param null $locale
+     * @param null $originCountry
+     * @param array $options
+     * @return string
+     */
+    public function postalLabelFormatTheliaAddress($address, $locale = null, $originCountry = null, $options = [])
+    {
+        $address = $this->mapTheliaAddress($address, $locale);
+        return $this->postalLabelFormat($address, $locale, $originCountry, $options);
+    }
+
+    /**
+     * Convert a Thelia address (Address or OrderAddress) to ImmutableAddressInterface
+     *
+     * @param \Thelia\Model\OrderAddress|OrderAddress $address
+     * @return Address|\CommerceGuys\Addressing\Model\ImmutableAddressInterface
+     */
+    protected function mapTheliaAddress($address, $locale = null)
+    {
+        $country = $address->getCountry();
+        if (null === $locale) {
+            $locale = Lang::getDefaultLanguage()->getLocale();
+        }
+        $customerTitle = $address->getCustomerTitle()
+            ->setLocale($this->denormalizeLocale($locale))
+            ->getShort()
+        ;
+
+        $addressModel = new Address();
+        $addressModel = $addressModel
+            ->withCountryCode($country->getIsoalpha2())
+            ->withAddressLine1($address->getAddress1())
+            ->withAddressLine2($address->getAddress2())
+            ->withPostalCode($address->getZipcode())
+            ->withLocality($address->getCity())
+            ->withOrganization($address->getCompany())
+            ->withRecipient(
+                sprintf(
+                    '%s %s %s',
+                    $customerTitle,
+                    $address->getLastname(),
+                    $address->getFirstname()
+                )
+            )
+        ;
+
+
+        if ($country->getHasStates() && intval($address->getStateId()) !== 0) {
+            $addressModel = $addressModel->withAdministrativeArea(
+                sprintf(
+                    '%s-%s',
+                    $country->getIsoalpha2(),
+                    $address->getState()->getIsocode()
+                )
+            );
+        }
+
+        return $addressModel;
+    }
+
+    private function normalizeLocale($locale)
+    {
+        if (null !== $locale) {
+            $locale = str_replace('_', '-', $locale);
+        }
+
+        return $locale;
+    }
+
+    private function denormalizeLocale($locale)
+    {
+        if (null !== $locale) {
+            $locale = str_replace('-', '_', $locale);
+        }
+
+        return $locale;
+    }
+}

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/FormatTest.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/FormatTest.php
@@ -14,7 +14,10 @@ namespace TheliaSmarty\Tests\Template\Plugin;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Thelia\Core\HttpFoundation\Request;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\CountryQuery;
 use Thelia\Model\CurrencyQuery;
+use Thelia\Model\StateQuery;
 use TheliaSmarty\Template\Plugins\Format;
 
 /**
@@ -120,6 +123,99 @@ class FormatTest extends SmartyPluginTestCase
 
         $this->assertEquals($currency->getSymbol() . "10.00", $data);
     }
+
+    public function testFormatAddress()
+    {
+        // Test for address in France
+        $countryFR = CountryQuery::create()->filterByIsoalpha2('FR')->findOne();
+        $address = AddressQuery::create()->findOne();
+        $address
+            ->setCountryId($countryFR->getId())
+            ->save();
+
+        $data = $this->renderString(
+            '{format_address address=$address locale="fr_FR"}',
+            [
+            'address' => $address->getId()
+            ]
+        );
+
+        $title = $address->getCustomerTitle()
+            ->setLocale('fr_FR')
+            ->getShort();
+
+        $expected = [
+            '<p >',
+            sprintf('<span class="recipient">%s %s %s</span><br>', $title, $address->getLastname(), $address->getFirstname()),
+            sprintf('<span class="address-line1">%s</span><br>', $address->getAddress1()),
+            sprintf('<span class="postal-code">%s</span> <span class="locality">%s</span><br>', $address->getZipcode(), $address->getCity()),
+            '<span class="country">France</span>',
+            '</p>'
+        ];
+
+        $this->assertEquals($data, implode("\n", $expected));
+
+        // Test for address in USA
+        $stateDC = StateQuery::create()->filterByIsocode('DC')->findOne();
+        $countryUS = $stateDC->getCountry();
+        $address
+            ->setCountryId($countryUS->getId())
+            ->setStateId($stateDC->getId())
+            ->save();
+
+        $data = $this->renderString(
+            '{format_address address=$address locale="en_US"}',
+            [
+                'address' => $address->getId()
+            ]
+        );
+
+        $title = $address->getCustomerTitle()
+            ->setLocale('en_US')
+            ->getShort();
+
+        $expected = [
+            '<p >',
+            sprintf('<span class="recipient">%s %s %s</span><br>', $title, $address->getLastname(), $address->getFirstname()),
+            sprintf('<span class="address-line1">%s</span><br>', $address->getAddress1()),
+            sprintf(
+                '<span class="locality">%s</span>, <span class="administrative-area">%s</span> <span class="postal-code">%s</span><br>',
+                $address->getCity(),
+                $stateDC->getIsocode(),
+                $address->getZipcode()
+            ),
+            '<span class="country">United States</span>',
+            '</p>'
+        ];
+
+        $this->assertEquals($data, implode("\n", $expected));
+
+        // Test html tag
+        $data = $this->renderString(
+            '{format_address html_tag="address" html_class="a_class" html_id="an_id" address=$address}',
+            ['address' => $address->getId()]
+        );
+
+        $this->assertTrue(strpos($data, '<address class="a_class" id="an_id">') !== false);
+
+        // Test plain text
+        $data = $this->renderString(
+            '{format_address html="0" address=$address locale="en_US"}',
+            [
+                'address' => $address->getId()
+            ]
+        );
+
+        $expected = [
+            sprintf('%s %s %s', $title, $address->getLastname(), $address->getFirstname()),
+            sprintf('%s', $address->getAddress1()),
+            sprintf('%s, %s %s', $address->getCity(), $stateDC->getIsocode(), $address->getZipcode()),
+            'United States',
+        ];
+        $this->assertEquals($data, implode("\n", $expected));
+
+    }
+
 
     /**
      * @return \TheliaSmarty\Template\AbstractSmartyPlugin

--- a/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
+++ b/local/modules/TheliaSmarty/Tests/Template/Plugin/SmartyPluginTestCase.php
@@ -82,11 +82,21 @@ abstract class SmartyPluginTestCase extends ContainerAwareTestCase
 
     protected function render($template, $data = [])
     {
+        return $this->internalRender('file', __DIR__.DS."fixtures".DS.$template, $data);
+    }
+
+    protected function renderString($template, $data = [])
+    {
+        return $this->internalRender('string', $template, $data);
+    }
+
+    protected function internalRender($resourceType, $resourceContent, array $data)
+    {
         foreach ($data as $key => $value) {
             $this->smarty->assign($key, $value);
         }
 
-        return $this->smarty->fetch(__DIR__.DS."fixtures".DS.$template);
+        return $this->smarty->fetch(sprintf("%s:%s", $resourceType, $resourceContent));
     }
 
     /**

--- a/setup/faker.php
+++ b/setup/faker.php
@@ -156,9 +156,20 @@ try {
 
     $stmt->execute();
 
-    echo "Creating customers\n";
+    // default country (France)
+    $defaultCountry = [64, null];
 
-    //API
+    // Store info
+
+    echo "Creating Store information \n";
+
+    Model\ConfigQuery::write('store_name', 'Thelia V2');
+    Model\ConfigQuery::write('store_email', 'test@thelia.net');
+    Model\ConfigQuery::write('store_notification_emails', 'test@thelia.net');
+    Model\ConfigQuery::write('store_address1', "5 rue Rochon");
+    Model\ConfigQuery::write('store_zipcode', "63000");
+    Model\ConfigQuery::write('store_city', "Clermont-Ferrand");
+    Model\ConfigQuery::write('store_country', $defaultCountry[0]);
 
     $api = new Thelia\Model\Api();
 
@@ -168,9 +179,20 @@ try {
         ->setLabel("test")
         ->save();
 
-    //customer
+    // API
+    echo "Creating API key\n";
+
+    $api = new Thelia\Model\Api();
+
+    $api
+        ->setProfileId(null)
+        ->setApiKey('79E95BD784CADA0C9A578282E')
+        ->setLabel("test")
+        ->save();
+
+    // Customer
+    echo "Creating customers\n";
     $customer = new Thelia\Model\Customer();
-    $country = getRandomCountry();
 
     $customer->createOrUpdate(
         1,
@@ -183,7 +205,7 @@ try {
         "0601020304",
         "63000",
         "clermont-ferrand",
-        $country[0],
+        $defaultCountry[0],
         "test@thelia.net",
         "azerty",
         null,
@@ -193,11 +215,11 @@ try {
         null,
         null,
         false,
-        $country[1]
+        $defaultCountry[1]
     );
     for ($j = 0; $j <= 3; $j++) {
         $address = new Thelia\Model\Address();
-
+        $country = getRandomCountry();
         $address->setLabel(getRealText(20))
             ->setTitleId(rand(1, 3))
             ->setFirstname($faker->firstname)

--- a/templates/email/default/order_confirmation.html
+++ b/templates/email/default/order_confirmation.html
@@ -35,32 +35,12 @@
                         {hook name="email-html.order-confirmation.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
                     {/ifhook}
                     {elsehook rel="email-html.order-confirmation.delivery-address"}
-                        {loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-                        {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                        {$FIRSTNAME} {$LASTNAME}<br />
-                        {$ADDRESS1}<br>
-                        {if $ADDRESS2 != ""}{$ADDRESS2}<br />{/if}
-                        {if $ADDRESS3 != ""}{$ADDRESS3}<br />{/if}
-                        {$CITY}<br />
-                        {$ZIPCODE},
-                        {loop type="country" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
-                        {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}<br />
-                        {/loop}
+                        {format_address order_address=$DELIVERY_ADDRESS locale=$locale}
                     {/elsehook}
                 </td>
                 <td valign="top">
                     <strong>{intl l="Billing address:"}</strong><br />
-                    {loop type="order_address" name="invoice_address" id=$INVOICE_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1}<br>
-                    {if $ADDRESS2 != ""}{$ADDRESS2}<br />{/if}
-                    {if $ADDRESS3 != ""}{$ADDRESS3}<br />{/if}
-                    {$CITY}<br />
-                    {$ZIPCODE},
-                    {loop type="country" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}<br />
-                    {/loop}
+                    {format_address order_address=$INVOICE_ADDRESS locale=$locale}
                 </td>
             </tr>
         </table>

--- a/templates/email/default/order_confirmation.txt
+++ b/templates/email/default/order_confirmation.txt
@@ -10,23 +10,12 @@
 {hook name="email-txt.order-confirmation.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
 {/ifhook}
 {elsehook rel="email-txt.order-confirmation.delivery-address"}
-{loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-{if $COMPANY != ""}{$COMPANY}
-{/if}{loop type="title" name="order-delivery-address-title" id=$TITLE}{$LONG}{/loop} {$FIRSTNAME} {$LASTNAME}
-{$ADDRESS1} {$ADDRESS2} {$ADDRESS3}
-{$ZIPCODE} {$CITY}
-{loop type="country" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop} {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}
-{/loop}
+{format_address order_address=$DELIVERY_ADDRESS locale=$locale html="0"}
 {/elsehook}
 
 {intl l="Your billing address"}
-{loop type="order_address" name="billing_address" id=$INVOICE_ADDRESS}
-{if $COMPANY != ""}{$COMPANY}
-{/if}{loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG}{/loop} {$FIRSTNAME} {$LASTNAME}
-{$ADDRESS1} {$ADDRESS2} {$ADDRESS3}
-{$ZIPCODE} {$CITY}
-{loop type="country" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop} {if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}
-{/loop}
+{format_address order_address=$INVOICE_ADDRESS locale=$locale html="0"}
+
 {hook name="email-txt.order-confirmation.after-address" order=$order_id}
 
 {intl l="Items ordered:"}

--- a/templates/email/default/order_notification.html
+++ b/templates/email/default/order_notification.html
@@ -39,30 +39,12 @@
                         {hook name="email-html.order-notification.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
                     {/ifhook}
                     {elsehook rel="email-html.order-notification.delivery-address"}
-                    {loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1}<br>
-                    {if $ADDRESS2 != ""}{$ADDRESS2}<br />{/if}
-                    {if $ADDRESS3 != ""}{$ADDRESS3}<br />{/if}
-                    {$CITY}<br />
-                    {$ZIPCODE}, {loop type="country" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}<br />
-                    {/loop}
+                    {format_address order_address=$DELIVERY_ADDRESS locale=$locale}
                     {/elsehook}
                 </td>
                 <td valign="top">
                     <strong>{intl l="Customer billing address:"}</strong><br />
-                    {loop type="order_address" name="invoice_address" id=$INVOICE_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1}<br>
-                    {if $ADDRESS2 != ""}{$ADDRESS2}<br />{/if}
-                    {if $ADDRESS3 != ""}{$ADDRESS3}<br />{/if}
-                    {$CITY}<br />
-                    {$ZIPCODE}, {loop type="country" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}<br />
-                    {/loop}
+                    {format_address order_address=$INVOICE_ADDRESS locale=$locale}
                 </td>
             </tr>
         </table>

--- a/templates/email/default/order_notification.txt
+++ b/templates/email/default/order_notification.txt
@@ -10,23 +10,11 @@
 {hook name="email-txt.order-notification.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
 {/ifhook}
 {elsehook rel="email-txt.order-notification.delivery-address"}
-{loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-{if $COMPANY != ""}{$COMPANY}
-{/if}{loop type="title" name="order-delivery-address-title" id=$TITLE}{$LONG}{/loop} {$FIRSTNAME} {$LASTNAME}
-{$ADDRESS1} {$ADDRESS2} {$ADDRESS3}
-{$ZIPCODE} {$CITY}
-{loop type="country" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop} {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}
-{/loop}
+{format_address order_address=$DELIVERY_ADDRESS locale=$locale html="0"}
 {/elsehook}
 
 {intl l="* Billing address"}
-{loop type="order_address" name="invoice_address" id=$INVOICE_ADDRESS}
-{if $COMPANY != ""}{$COMPANY}
-{/if}{loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG}{/loop} {$FIRSTNAME} {$LASTNAME}
-{$ADDRESS1} {$ADDRESS2} {$ADDRESS3}
-{$ZIPCODE} {$CITY}
-{loop type="country" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop} {if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}
-{/loop}
+{format_address order_address=$INVOICE_ADDRESS locale=$locale html="0"}
 
 {hook name="email-txt.order-notification.after-address" order=$order_id}
 

--- a/templates/frontOffice/default/account-order.html
+++ b/templates/frontOffice/default/account-order.html
@@ -91,14 +91,8 @@
                             {hook name="account-order.delivery-address" module="{$delivery_id}" order="{$order_id}"}
                         {/ifhook}
                         {elsehook rel="account-order.delivery-address"}
-                            {loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-                                {loop type="title" name="order-delivery-address-title" id=$TITLE}{$LONG} {/loop}{$FIRSTNAME} {$LASTNAME}<br />
-                                {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                                {$ZIPCODE} {$CITY}<br/>
-                                {loop type="country" visible="*" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
-                            {/loop}
+                            {format_address order_address=$DELIVERY_ADDRESS}
                         {/elsehook}
-
 
                     </div>
                 </div>
@@ -125,12 +119,7 @@
                             {hook name="account-order.invoice-address" module="{$payment_id}" order="{$order_id}"}
                         {/ifhook}
                         {elsehook rel="account-order.invoice-address"}
-                            {loop type="order_address" name="invoice_address" id=$INVOICE_ADDRESS}
-                                {loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG} {/loop}{$FIRSTNAME} {$LASTNAME}<br />
-                                {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                                {$ZIPCODE} {$CITY}<br/>
-                                {loop type="country" visible="*" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop}
-                            {/loop}
+                            {format_address order_address=$DELIVERY_ADDRESS}
                         {/elsehook}
 
                         {hook name="account-order.invoice-address-bottom" module="{$delivery_id}" order="{$order_id}"}

--- a/templates/frontOffice/default/account.html
+++ b/templates/frontOffice/default/account.html
@@ -38,22 +38,7 @@
                             {loop type="address" name="address.default" default="true"}
                             <ul class="list-info list-unstyled row">
                                 <li class="col-sm-4">
-                                    <address class="adr">
-                                        {if $COMPANY}
-                                          <span class="org">{$COMPANY}</span><br>
-                                        {/if}
-                                        <span class="street-address">{$ADDRESS1}</span><br>
-                                        {if $ADDRESS2 != ""}
-                                            <span class="extended-address">{$ADDRESS2}</span><br>
-                                        {/if}
-                                        {if $ADDRESS3 != ""}
-                                            <span class="extended-address">{$ADDRESS3}</span><br>
-                                        {/if}
-                                        <span class="postal-code">{$ZIPCODE}</span>
-                                        <span class="locality">{$CITY}<br>
-                                        <span class="country-name">{loop type="country" name="customer.country.info" id=$COUNTRY}{$TITLE}{/loop}</span></span>
-                                        {if $STATE}, <span class="state-name">{loop type="state" name="customer.state.info" id=$STATE}{$TITLE}{/loop}</span></span>{/if}
-                                    </address>
+                                    {format_address address=$ID html_tag='address' html_class='adr'}
                                 </li>
                                 <li class="col-sm-4">
                                     {if $PHONE != ""}

--- a/templates/pdf/default/delivery.html
+++ b/templates/pdf/default/delivery.html
@@ -207,30 +207,12 @@
                 {hook name="delivery.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
                 {/ifhook}
                 {elsehook rel="delivery.delivery-address"}                
-				<p>
-                    {loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG} {/loop}{$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                    {$ZIPCODE} {$CITY}<br/>
-                    {loop type="country" visible="*" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}
-                    {/loop}
-                </p>
+				    {format_address order_address=$DELIVERY_ADDRESS locale=$locale}
                 {/elsehook}
             </td>
             <td style="border-left: solid 1mm #f6993c;">
                 <h3>{intl l="Invoice address"}</h3>
-                <p>
-                    {loop type="order_address" name="delivery_address" id=$INVOICE_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG} {/loop}{$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                    {$ZIPCODE} {$CITY}<br/>
-                    {loop type="country" visible="*" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop}
-                    -{if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}
-                    {/loop}
-                </p>
+                {format_address order_address=$INVOICE_ADDRESS locale=$locale}
             </td>
         </tr>
     </table>

--- a/templates/pdf/default/invoice.html
+++ b/templates/pdf/default/invoice.html
@@ -209,30 +209,12 @@
                     {hook name="invoice.delivery-address" module={$DELIVERY_MODULE} order=$order_id}
                 {/ifhook}
                 {elsehook rel="invoice.delivery-address"}                
-				<p>
-                    {loop type="order_address" name="delivery_address" id=$DELIVERY_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG} {/loop} {$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                    {$ZIPCODE} {$CITY}<br/>
-                    {loop type="country" visible="*" name="country_delivery" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_delivery" id=$STATE}{$TITLE}{/loop}{/if}
-                    {/loop}
-                </p>
+				    {format_address order_address=$DELIVERY_ADDRESS locale=$locale}
                	{/elsehook}
             </td>
             <td style="border-left: solid 1mm #f6993c;">
                 <h3>{intl l="Invoice address"}</h3>
-                <p>
-                    {loop type="order_address" name="delivery_address" id=$INVOICE_ADDRESS}
-                    {if $COMPANY != ""}{$COMPANY}<br />{/if}
-                    {loop type="title" name="order-invoice-address-title" id=$TITLE}{$LONG} {/loop}{$FIRSTNAME} {$LASTNAME}<br />
-                    {$ADDRESS1} {$ADDRESS2} {$ADDRESS3}<br />
-                    {$ZIPCODE} {$CITY}<br/>
-                    {loop type="country" visible="*" name="country_invoice" id=$COUNTRY}{$TITLE}{/loop}
-                    {if $STATE}{loop type="state" name="state_invoice" id=$STATE}{$TITLE}{/loop}{/if}
-                    {/loop}
-                </p>
+                {format_address order_address=$INVOICE_ADDRESS locale=$locale}
             </td>
         </tr>
     </table>


### PR DESCRIPTION
This pull request aims to provide a way to display an address according to a country. 

A new smarty function `format_address` is available. This function formats the address according to the address country :

```smarty
{* format Address 1 in html *}
{format_address address="1"}

{* format Address 1 in html and in french (default is the session lang) *}
{format_address address="1" locale="fr_FR"}

{* format Address 1 in html with custom tag and attributes *}
{format_address address="1" html_tag="address" html_class="customer-address" html_id="address1" }

{* format Address 1 in plain text *}
{format_address address="1" html="0"}

{* format Address 1 as a postal label *}
{format_address postal="1" address="1"}

{* format Address 1 as a postal label and set the origin country (default is the shop country, then the default country) *}
{format_address postal="1" address="1" origin_country='FR'}

{* format order address 1 *}
{format_address order_address="1"}

{* format a custom address *}
{format_address 
    recipient="M. Barack Obama" 
    organization="The White House" 
    address_line1="1600 Pennsylvania Avenue NW" 
    postal_code="20500"
    locality="Washington"
    country_code="US"
    administrative_area="US-DC"
}
```