### PR TITLE
Add create and update cart item event

### DIFF
--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -405,6 +405,12 @@ final class TheliaEvents
     const CART_DELETEITEM = "action.deleteArticle";
     const CART_CLEAR = "action.clear";
 
+    /** before inserting a cart item in database */
+    const CART_ITEM_CREATE_BEFORE = "action.cart.item.create.before";
+
+    /** before updating a cart item in database */
+    const CART_ITEM_UPDATE_BEFORE = "action.cart.item.update.before";
+
     /**
      * Order linked event
      */

--- a/core/lib/Thelia/Model/CartItem.php
+++ b/core/lib/Thelia/Model/CartItem.php
@@ -4,6 +4,7 @@ namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Cart\CartItemEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\Base\CartItem as BaseCartItem;
 use Thelia\Core\Event\Cart\CartEvent;
@@ -11,11 +12,33 @@ use Thelia\TaxEngine\Calculator;
 
 class CartItem extends BaseCartItem
 {
+    /** @var EventDispatcherInterface */
     protected $dispatcher;
 
+    /**
+     * @param EventDispatcherInterface $dispatcher
+     */
     public function setDisptacher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    public function preInsert(ConnectionInterface $con = null)
+    {
+        if ($this->dispatcher) {
+            $cartItemEvent = new CartItemEvent($this);
+            $this->dispatcher->dispatch(TheliaEvents::CART_ITEM_CREATE_BEFORE, $cartItemEvent);
+        }
+        return true;
+    }
+
+    public function preUpdate(ConnectionInterface $con = null)
+    {
+        if ($this->dispatcher) {
+            $cartItemEvent = new CartItemEvent($this);
+            $this->dispatcher->dispatch(TheliaEvents::CART_ITEM_UPDATE_BEFORE, $cartItemEvent);
+        }
+        return true;
     }
 
     public function postInsert(ConnectionInterface $con = null)


### PR DESCRIPTION
This PR introduce two "missing" cart item events : 

- CART_ITEM_CREATE_BEFORE => [Thelia\Model\CartItem::preInsert](https://github.com/thelia/thelia/compare/master...Alban-io:add-cart-item-event?expand=1#diff-276c6eeb36a7ad3118acbfc8fe027361R26) 

- CART_ITEM_UPDATE_BEFORE => [Thelia\Model\CartItem::preUpdate](https://github.com/thelia/thelia/compare/master...Alban-io:add-cart-item-event?expand=1#diff-276c6eeb36a7ad3118acbfc8fe027361R35)