### PR TITLE
CartDuplicationEvent to provide both original and duplicated cart to listeners

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -484,7 +484,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $cartEvent = new CartDuplicationEvent($newCart, $cart);
         $dispatcher->dispatch(TheliaEvents::CART_DUPLICATE, $cartEvent);
 
-        return $cartEvent->getCart();
+        return $cartEvent->getDuplicatedCart();
     }
 
     /**

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -15,6 +15,7 @@ namespace Thelia\Action;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Thelia\Core\Event\Cart\CartCreateEvent;
+use Thelia\Core\Event\Cart\CartDuplicationEvent;
 use Thelia\Core\Event\Cart\CartPersistEvent;
 use Thelia\Core\Event\Cart\CartRestoreEvent;
 use Thelia\Core\Event\Cart\CartEvent;
@@ -480,8 +481,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
             $dispatcher
         );
 
-        $cartEvent = new CartEvent($newCart);
-
+        $cartEvent = new CartDuplicationEvent($newCart, $cart);
         $dispatcher->dispatch(TheliaEvents::CART_DUPLICATE, $cartEvent);
 
         return $cartEvent->getCart();

--- a/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
+++ b/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
@@ -30,7 +30,7 @@ class CartDuplicationEvent extends CartEvent
      */
     public function getDuplicatedCart()
     {
-        return $this->cart;
+        return parent::getCart();
     }
 
     /**

--- a/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
+++ b/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
@@ -1,0 +1,43 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Event\Cart;
+
+use Thelia\Model\Cart;
+
+class CartDuplicationEvent extends CartEvent
+{
+    protected $oldCart;
+
+    public function __construct(Cart $newCart, Cart $oldCart)
+    {
+        parent::__construct($newCart);
+
+        $this->oldCart = $oldCart;
+    }
+
+    /**
+     * @return Cart
+     */
+    public function getNewCart()
+    {
+        return $this->cart;
+    }
+
+    /**
+     * @return Cart
+     */
+    public function getOldCart()
+    {
+        return $this->oldCart;
+    }
+}

--- a/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
+++ b/core/lib/Thelia/Core/Event/Cart/CartDuplicationEvent.php
@@ -16,19 +16,19 @@ use Thelia\Model\Cart;
 
 class CartDuplicationEvent extends CartEvent
 {
-    protected $oldCart;
+    protected $originalCart;
 
-    public function __construct(Cart $newCart, Cart $oldCart)
+    public function __construct(Cart $duplicatedCart, Cart $originalCart)
     {
-        parent::__construct($newCart);
+        parent::__construct($duplicatedCart);
 
-        $this->oldCart = $oldCart;
+        $this->originalCart = $originalCart;
     }
 
     /**
      * @return Cart
      */
-    public function getNewCart()
+    public function getDuplicatedCart()
     {
         return $this->cart;
     }
@@ -36,8 +36,8 @@ class CartDuplicationEvent extends CartEvent
     /**
      * @return Cart
      */
-    public function getOldCart()
+    public function getOriginalCart()
     {
-        return $this->oldCart;
+        return $this->originalCart;
     }
 }


### PR DESCRIPTION
This PR introduces the CartDuplicationEvent, which stores the original cart so that listeners will get both duplicated and original carts.

Currently, only the duplicated cart is passed, and the listeners have no simple way to get the original one.

CartDuplicationEvent extends CartEvent, thus preserving BC.