### PR TITLE
Fix module version field length

### DIFF
--- a/core/lib/Thelia/Model/Map/ModuleTableMap.php
+++ b/core/lib/Thelia/Model/Map/ModuleTableMap.php
@@ -182,7 +182,7 @@ class ModuleTableMap extends TableMap
         // columns
         $this->addPrimaryKey('ID', 'Id', 'INTEGER', true, null, null);
         $this->addColumn('CODE', 'Code', 'VARCHAR', true, 55, null);
-        $this->addColumn('VERSION', 'Version', 'VARCHAR', true, 10, '');
+        $this->addColumn('VERSION', 'Version', 'VARCHAR', true, 25, '');
         $this->addColumn('TYPE', 'Type', 'TINYINT', true, null, null);
         $this->addColumn('CATEGORY', 'Category', 'VARCHAR', true, 50, 'classic');
         $this->addColumn('ACTIVATE', 'Activate', 'TINYINT', false, null, null);

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <database defaultIdMethod="native" name="thelia">
   <vendor type="mysql">
     <parameter name="Engine" value="InnoDB"/>
@@ -784,7 +784,7 @@
   <table name="module" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="code" required="true" size="55" type="VARCHAR" />
-    <column defaultValue="" name="version" required="true" size="10" type="VARCHAR" />
+    <column defaultValue="" name="version" required="true" size="25" type="VARCHAR" />
     <column name="type" required="true" type="TINYINT" />
     <column defaultValue="classic" name="category" required="true" size="50" type="VARCHAR" />
     <column name="activate" type="TINYINT" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -924,7 +924,7 @@ CREATE TABLE `module`
 (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `code` VARCHAR(55) NOT NULL,
-    `version` VARCHAR(10) DEFAULT '' NOT NULL,
+    `version` VARCHAR(25) DEFAULT '' NOT NULL,
     `type` TINYINT NOT NULL,
     `category` VARCHAR(50) DEFAULT 'classic' NOT NULL,
     `activate` TINYINT,

--- a/setup/update/sql/2.3.0-alpha2.sql
+++ b/setup/update/sql/2.3.0-alpha2.sql
@@ -47,4 +47,9 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
     (@max_id + 2, 'es_ES', NULL, NULL, NULL, NULL),    (@max_id + 1, 'fr_FR', 'The minimum length required for an administrator password', NULL, NULL, NULL),
     (@max_id + 2, 'fr_FR', 'Autoriser les administrateurs à recréer leur mot de passe', NULL, NULL, NULL);
 
+
+-- Update module version column
+
+ALTER TABLE `module` MODIFY `version` varchar(25) NOT NULL DEFAULT '';
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.3.0-alpha2.sql.tpl
+++ b/setup/update/tpl/2.3.0-alpha2.sql.tpl
@@ -50,4 +50,9 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `description`, `chapo`, `pos
 {/foreach}
 ;
 
+
+-- Update module version column
+
+ALTER TABLE `module` MODIFY `version` varchar(25) NOT NULL DEFAULT '';
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Update schema to increase module version field to 25 chars.
With only 10 chars update function may be call on each `module:refresh`, `cache:clear` commands.

Image your module is at version `1.0.0.beta.2`, only `1.0.0.beta` was stored.
Image your module is at version `1.0.0.alpha`, only `1.0.0.alph` was stored.

In both case update function was call for these modules with truncated version as `$currentVersion` and current (real) version as `$newVersion`.

For information `BaseModule::update` signature is
```php
public function update($currentVersion, $newVersion, ConnectionInterface $con = null)
```