### PR TITLE
WIP Address form placeholders

### DIFF
--- a/core/lib/Thelia/Form/AddressCreateForm.php
+++ b/core/lib/Thelia/Form/AddressCreateForm.php
@@ -98,12 +98,14 @@ class AddressCreateForm extends FirewallForm
                     "label" => Translator::getInstance()->trans("Street Address"),
                     "label_attr" => array(
                         "for" => "address1",
+                        "placeholder" => Translator::getInstance()->trans("Street address information")
                     ),
                 ))
             ->add("address2", "text", array(
                     "label" => Translator::getInstance()->trans("Address Line 2"),
                     "label_attr" => array(
                         "for" => "address2",
+                        "placeholder" => Translator::getInstance()->trans("Address line 2 information")
                     ),
                     "required" => false,
                 ))
@@ -111,6 +113,7 @@ class AddressCreateForm extends FirewallForm
                     "label" => Translator::getInstance()->trans("Address Line 3"),
                     "label_attr" => array(
                         "for" => "address3",
+                        "placeholder" => Translator::getInstance()->trans("Address line 3 information")
                     ),
                     "required" => false,
                 ))

--- a/templates/frontOffice/default/address.html
+++ b/templates/frontOffice/default/address.html
@@ -149,7 +149,7 @@
                             <label class="control-label col-sm-3" for="{$label_attr.for}">{$label}:{if $required} <span class="required">*</span>{/if} </label>
 
                             <div class="control-input col-sm-5">
-                                <input type="text" name="{$name}" value="{$value}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{intl l="Placeholder address2"}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
+                                <input type="text" name="{$name}" value="{$value}" id="{$label_attr.for}" class="form-control" maxlength="255" placeholder="{$label_attr.placeholder}"{if $required} aria-required="true" required{/if}{if !isset($error_focus) && $error} autofocus{/if}>
                                 {if $error }
                                     <span class="help-block">{$message}</span>
                                     {assign var="error_focus" value="true"}


### PR DESCRIPTION
It's often asked to have Address 2 label different from Address 2 placeholder, a good way to do that (and the actual one) is to put an intl tag to fill placeholder, but in this case translations are not on the same element (core files for label, template for intl).
Adding a label_attr.placeholder could be a good way to gather translations together.

Dunno if it should be added on all inputs of all forms and in all templates or just for addresses 2 & 3 ?