### PR TITLE
Use a wider version requirement on thelia/installer for setup/

### DIFF
--- a/setup/composer.json
+++ b/setup/composer.json
@@ -2,7 +2,7 @@
     "name": "thelia/setup",
     "type": "thelia-local",
     "require": {
-        "thelia/installer": "1.1",
+        "thelia/installer": "~1.1",
         "fzaninotto/faker": "1.5.*"
     },
     "extra": {


### PR DESCRIPTION
The exact version requirement can cause compatibility issues.

Fixes #1979.