### PR TITLE
navbar title allready hidden on "SM size" while navbar-toggle is visible

### DIFF
--- a/local/modules/HookNavigation/templates/frontOffice/default/main-navbar-primary.html
+++ b/local/modules/HookNavigation/templates/frontOffice/default/main-navbar-primary.html
@@ -7,7 +7,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand visible-xs" href="{navigate to="index"}">{intl l="Categories" d="hooknavigation.fo.default"}</a>
+            <a class="navbar-brand visible-xs-block visible-sm-block" href="{navigate to="index"}">{intl l="Categories" d="hooknavigation.fo.default"}</a>
         </div>
         <div class="collapse navbar-collapse" id="navbar-primary">
             <ul class="nav navbar-nav navbar-categories">
@@ -41,7 +41,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand visible-xs" href="{navigate to="index"}">{intl l="Categories" d="hooknavigation.fo.default"}</a>
+            <a class="navbar-brand visible-xs-block visible-sm-block" href="{navigate to="index"}">{intl l="Categories" d="hooknavigation.fo.default"}</a>
         </div>
         <div class="collapse navbar-collapse" id="navbar-primary">
             <ul class="nav navbar-nav navbar-categories">


### PR DESCRIPTION
![capture](https://cloud.githubusercontent.com/assets/7933327/13346997/c5dbe1f8-dc6a-11e5-9f80-6c202f421da7.PNG)
PS: `visible-xs` is depreced as of bootstrap v3.2.0
http://getbootstrap.com/css/#responsive-utilities-classes