### PR TITLE
Fixed translation regexp prefix for templates

### DIFF
--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -78,7 +78,7 @@ class Translation extends BaseAction implements EventSubscriberInterface
 
             $allowedExts = array('php');
         } elseif ($walkMode == TranslationEvent::WALK_MODE_TEMPLATE) {
-            $prefix = '\{intl(?:.*?)l=[\s]*';
+            $prefix = '\{intl(?:.*?)[\s]l=[\s]*';
 
             $allowedExts = array('html', 'tpl', 'xml', 'txt');
         } else {


### PR DESCRIPTION
The current regexp catches `l="invoice.imprint"` in `{elsehook rel="invoice.imprint"}`. The new one don't.