### PR TITLE
Fix possible circular reference for category tree and folder tree

### DIFF
--- a/templates/backOffice/default/category-edit.html
+++ b/templates/backOffice/default/category-edit.html
@@ -119,8 +119,12 @@
                                                     {custom_render_form_field field='parent'}
                                                          <select {form_field_attributes field='parent' extra_class="form_control"}>
                                                               <option value="0">{intl l="Top level"}</option>
+                                                              {$excludeCategories = []}
+                                                              {loop name="exclude-categories" type="category" parent=$category_id}
+                                                                {$excludeCategories[] = $ID}
+                                                              {/loop}
                                                               {$myparent=$PARENT}
-                                                              {loop name="cat-parent" type="category-tree" visible="*" category="0"}
+                                                              {loop name="cat-parent" type="category-tree" visible="*" category="0" exclude={','|implode:$excludeCategories}}
                                                                    <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $myparent == $ID}selected="selected"{/if} {if $category_id == $ID}disabled="disabled"{/if}>{$TITLE}</option>
                                                               {/loop}
                                                         </select>

--- a/templates/backOffice/default/folder-edit.html
+++ b/templates/backOffice/default/folder-edit.html
@@ -121,12 +121,14 @@
 
 		                                                <select id="{$label_attr.for}" required="required" name="{$name}" class="form-control">
 		                                                      <option value="0">{intl l="Top level"}</option>
-
+                                                              {$excludeFolders = []}
+                                                              {loop name="exclude-folders" type="folder" parent=$folder_id}
+                                                                {$excludeFolders[] = $ID}
+                                                              {/loop}
                                                               {$myparent=$PARENT}
-		                                                      {loop name="fold-parent" type="folder-tree" visible="*" folder="0"}
+		                                                      {loop name="fold-parent" type="folder-tree" visible="*" folder="0" exclude={','|implode:$excludeFolders}}
 		                                                           <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $myparent == $ID}selected="selected"{/if} {if $folder_id == $ID}disabled="disabled"{/if}>{$TITLE}</option>
 		                                                      {/loop}
-
 		                                                </select>
 		                                             </div>
 		                                        {/form_field}


### PR DESCRIPTION
Currently, it's possible to create an circular reference for category tree and folder tree.
This pull request prevents this problem and avoids this error
![editer la rubrique panel d administration de thelia](https://cloud.githubusercontent.com/assets/7335734/13752168/c44404be-ea0d-11e5-9301-61a1f1bfe2f3.jpeg)