### PR TITLE
Template variables are now available in hook methods

### DIFF
--- a/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
@@ -18,6 +18,7 @@ use Symfony\Component\EventDispatcher\Event;
  * Class BaseHookRenderEvent
  * @package Thelia\Core\Event\Hook
  * @author Julien Chanséaume <jchanseaume@openstudio.fr>
+ * @author  Franck Allimant <franck@cqfdev.fr>
  */
 class BaseHookRenderEvent extends Event
 {
@@ -84,6 +85,16 @@ class BaseHookRenderEvent extends Event
     }
 
     /**
+     * Get all template vars
+     *
+     * @return array all template vars
+     */
+    public function getTemplateVars()
+    {
+        return $this->templateVars;
+    }
+
+    /**
      * add or replace an argument
      *
      * @param  string $key
@@ -118,6 +129,7 @@ class BaseHookRenderEvent extends Event
     {
         return array_key_exists($key, $this->arguments);
     }
+
 
     /**
      * Return a template variable value. An exception is thorwn if the variable is not defined.

--- a/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/BaseHookRenderEvent.php
@@ -25,13 +25,16 @@ class BaseHookRenderEvent extends Event
     protected $code = null;
 
     /** @var  array $arguments an array of arguments passed to the template engine function */
-    protected $arguments = array();
+    protected $arguments = [];
 
+    /** @var array $templateVars the variable currently defined in the template */
+    protected $templateVars = [];
 
-    public function __construct($code, array $arguments = array())
+    public function __construct($code, array $arguments = [], array $templateVars = [])
     {
         $this->code = $code;
         $this->arguments = $arguments;
+        $this->templateVars = $templateVars;
     }
 
     /**
@@ -114,5 +117,34 @@ class BaseHookRenderEvent extends Event
     public function hasArgument($key)
     {
         return array_key_exists($key, $this->arguments);
+    }
+
+    /**
+     * Return a template variable value. An exception is thorwn if the variable is not defined.
+     *
+     * @param string $templateVariableName the variable name
+     *
+     * @return mixed the variable value
+     * @throws \InvalidArgumentException if the variable is not defined
+     */
+    public function getTemplateVar($templateVariableName)
+    {
+        if (! isset($this->templateVars[$templateVariableName])) {
+            throw new \InvalidArgumentException(sprintf("Template variable '%s' is not defined.", $templateVariableName));
+        }
+
+        return $this->templateVars[$templateVariableName];
+    }
+
+    /**
+     * Check if a template variable is defined.
+     *
+     * @param $templateVariableName
+     *
+     * @return bool true if the template variable is defined, false otherwise
+     */
+    public function hasTemplateVar($templateVariableName)
+    {
+        return isset($this->templateVars[$templateVariableName]);
     }
 }

--- a/core/lib/Thelia/Core/Event/Hook/HookRenderBlockEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/HookRenderBlockEvent.php
@@ -28,9 +28,9 @@ class HookRenderBlockEvent extends BaseHookRenderEvent
     /** @var array fields that can be added, if empty array any fields can be added */
     protected $fields = [];
 
-    public function __construct($code, array $arguments = [], array $fields = [])
+    public function __construct($code, array $arguments = [], array $fields = [], array $templateVariables = [])
     {
-        parent::__construct($code, $arguments);
+        parent::__construct($code, $arguments, $templateVariables);
         $this->fragmentBag = new FragmentBag();
         $this->fields = $fields;
     }

--- a/core/lib/Thelia/Core/Event/Hook/HookRenderEvent.php
+++ b/core/lib/Thelia/Core/Event/Hook/HookRenderEvent.php
@@ -24,9 +24,9 @@ class HookRenderEvent extends BaseHookRenderEvent
     /** @var  array $fragments an array of fragments collected during the event dispatch */
     protected $fragments;
 
-    public function __construct($code, array $arguments = array())
+    public function __construct($code, array $arguments = [], array $templateVariables = [])
     {
-        parent::__construct($code, $arguments);
+        parent::__construct($code, $arguments, $templateVariables);
         $this->fragments = array();
     }
 

--- a/core/lib/Thelia/Core/Hook/BaseHook.php
+++ b/core/lib/Thelia/Core/Hook/BaseHook.php
@@ -93,11 +93,15 @@ abstract class BaseHook
         if (array_key_exists($code, $this->templates)) {
             $templates = explode(';', $this->templates[$code]);
 
+            // Concatenate arguments and template variables,
+            // giving the precedence to arguments.
+            $allArguments = $event->getTemplateVars() + $event->getArguments();
+
             foreach ($templates as $template) {
                 list($type, $filepath) = $this->getTemplateParams($template);
 
                 if ("render" === $type) {
-                    $event->add($this->render($filepath, $event->getArguments()));
+                    $event->add($this->render($filepath, $allArguments));
                     continue;
                 }
 
@@ -117,7 +121,7 @@ abstract class BaseHook
                 }
 
                 if (method_exists($this, $type)) {
-                    $this->{$type}($filepath, $event->getArguments());
+                    $this->{$type}($filepath, $allArguments);
                 }
             }
         }

--- a/local/modules/TheliaSmarty/Template/Plugins/Hook.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Hook.php
@@ -87,7 +87,7 @@ class Hook extends AbstractSmartyPlugin
 
         $type = $smarty->getTemplateDefinition()->getType();
 
-        $event = new HookRenderEvent($hookName, $params);
+        $event = new HookRenderEvent($hookName, $params, $smarty->getTemplateVars());
 
         $event->setArguments($this->getArgumentsFromParams($params));
 
@@ -233,7 +233,7 @@ class Hook extends AbstractSmartyPlugin
 
         $type = $smarty->getTemplateDefinition()->getType();
 
-        $event = new HookRenderBlockEvent($hookName, $params, $fields);
+        $event = new HookRenderBlockEvent($hookName, $params, $fields, $smarty->getTemplateVars());
 
         $event->setArguments($this->getArgumentsFromParams($params));
 


### PR DESCRIPTION
This PR makes the variables of the template from which the hook is called available to Hook methods, using two new methods of `BaseHookRenderEvent` : 
- `getTemplateVariable()` to get the value of a template variable,
- `hasTemplateVariable()` to check if a variable is defined in the template from which the hook is called
