### PR TITLE
Version::parse() Allow -dev version + allow 2 digit only test (for module version)

### DIFF
--- a/core/lib/Thelia/Tools/Version/Version.php
+++ b/core/lib/Thelia/Tools/Version/Version.php
@@ -111,8 +111,11 @@ class Version
             (?<major>[0-9]+)\.
             (?<minus>[0-9]+)\.
             (?<release>[0-9]+)
-            -?(?<extra>[a-zA-Z0-9]*) # extra_version will also match empty string
-        )$`x";
+            -?(?<extra>
+                [a-zA-Z0-9]*    # extra_version can match alphanumeric or empty string
+                (?:(?<!-)-dev)? # -dev suffix optional (but not --dev), and will be included it in the extra string
+            )
+            )$`x";
 
         if (!preg_match($pattern, $version, $match)) {
             throw new \InvalidArgumentException(

--- a/tests/phpunit/Thelia/Tests/Tools/Version/Version.php
+++ b/tests/phpunit/Thelia/Tests/Tools/Version/Version.php
@@ -82,40 +82,61 @@ class Version extends \PHPUnit_Framework_TestCase
     public function parseProvider()
     {
         return [
-            [ '2.1.0', [
+            [ '2.1.0', true, [
                 'version'         => '2.1.0',
                 'major'           => '2',
                 'minus'           => '1',
                 'release'         => '0',
                 'extra'           => '',
             ] ],
-            [ '2.5.0', [
+            [ '2.5.0', true, [
                 'version' => '2.5.0',
                 'major'   => '2',
                 'minus'   => '5',
                 'release' => '0',
                 'extra'   => '',
             ], ],
-            [ '2.3.0-alpha2', [
+            [ '2.3.0-alpha2', true, [
                 'version' => '2.3.0-alpha2',
                 'major'   => '2',
                 'minus'   => '3',
                 'release' => '0',
                 'extra'   => 'alpha2',
             ], ],
-            [ '2.3.0-alpha3-dev', [
+            [ '2.3.0-alpha3-dev', true, [
                 'version' => '2.3.0-alpha3-dev',
                 'major'   => '2',
                 'minus'   => '3',
                 'release' => '0',
                 'extra'   => 'alpha3-dev',
             ], ],
-            [ '2.3.0-dev', [
+            [ '2.3.0-dev', true, [
                 'version' => '2.3.0-dev',
                 'major'   => '2',
                 'minus'   => '3',
                 'release' => '0',
                 'extra'   => 'dev',
+            ], ],
+            [ '2.3.0', true, [
+                'version' => '2.3.0',
+                'major'   => '2',
+                'minus'   => '3',
+                'release' => '0',
+                'extra'   => '',
+            ], ],
+            [ '2.3.0', false, [
+                'version' => '2.3.0',
+                'major'   => '2',
+                'minus'   => '3',
+                'release' => '0',
+                'extra'   => '',
+            ], ],
+            [ '2.3', false, [
+                'version' => '2.3',
+                'major'   => '2',
+                'minus'   => '3',
+                'release' => '',
+                'extra'   => '',
             ], ],
         ];
     }
@@ -123,18 +144,20 @@ class Version extends \PHPUnit_Framework_TestCase
     public function exceptionParseProvider()
     {
         return [
-            ['x.3.1',         ],
-            ['2.x.1',         ],
-            ['2.3.x',         ],
-            ['2.3.1-alpha.2', ],
-            ['2.1',           ],
-            ['a.4',           ],
-            ['2.1.2.4',       ],
-            ['2.1.2.4.5',     ],
-            ['1.alpha.8',     ],
-            ['.1.2',          ],
-            [ '2.3.-dev',     ],
-            [ '2.3.2--dev',   ],
+            ['x.3.1',         true,],
+            ['2.x.1',         true,],
+            ['2.3.x',         true,],
+            ['2.3.1-alpha.2', true,],
+            ['2.1',           true,],
+            ['a.4',           true,],
+            ['2.1.2.4',       true,],
+            ['2.1.2.4.5',     true,],
+            ['1.alpha.8',     true,],
+            ['.1.2',          true,],
+            [ '2.3.-dev',     true,],
+            [ '2.3.2--dev',   true,],
+            [ '2.3',          true,],
+            [ '2.3',          true,],
         ];
     }
 
@@ -158,22 +181,22 @@ class Version extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider ParseProvider
      */
-    public function testParse($version, $expected)
+    public function testParse($version, $releaseMandatory, $expected)
     {
         $message = sprintf(
             "=====\n\tVersion: %s\n\t expected: %s\n======\n",
             var_export($version, true),
             var_export($expected, true)
         );
-        $this->assertEquals($expected, Tester::parse($version), $message);
+        $this->assertEquals($expected, Tester::parse($version, $releaseMandatory), $message);
     }
 
     /**
      * @dataProvider exceptionParseProvider
      * @expectedException InvalidArgumentException
      */
-    public function testExceptionParse($version)
+    public function testExceptionParse($version, $releaseMandatory)
     {
-        Tester::parse($version);
+        Tester::parse($version, $releaseMandatory);
     }
 }

--- a/tests/phpunit/Thelia/Tests/Tools/Version/Version.php
+++ b/tests/phpunit/Thelia/Tests/Tools/Version/Version.php
@@ -103,6 +103,20 @@ class Version extends \PHPUnit_Framework_TestCase
                 'release' => '0',
                 'extra'   => 'alpha2',
             ], ],
+            [ '2.3.0-alpha3-dev', [
+                'version' => '2.3.0-alpha3-dev',
+                'major'   => '2',
+                'minus'   => '3',
+                'release' => '0',
+                'extra'   => 'alpha3-dev',
+            ], ],
+            [ '2.3.0-dev', [
+                'version' => '2.3.0-dev',
+                'major'   => '2',
+                'minus'   => '3',
+                'release' => '0',
+                'extra'   => 'dev',
+            ], ],
         ];
     }
 
@@ -119,6 +133,8 @@ class Version extends \PHPUnit_Framework_TestCase
             ['2.1.2.4.5',     ],
             ['1.alpha.8',     ],
             ['.1.2',          ],
+            [ '2.3.-dev',     ],
+            [ '2.3.2--dev',   ],
         ];
     }
 


### PR DESCRIPTION
This commit makes the method `Version::parse()` working if Thelia version has a `-dev` suffix.

This way, install and update process can be tested more easily if you set version number like `2.3.0-alpha2-dev`. For example:

1) I install Thelia from the repository:master branch (which will install version `2.3.0-alpha2`.
2) I add or remove some fields/column, propel rebuild
3) I can test the update process from `2.3.0-alpha2` to `2.3.0-alpha2-dev`

This PR also add a 2nd parameter `releaseMandatory` (default to true). If set to false, it allows version number with only 2 digits, if this method is used for module version or other things.
