### PR TITLE
Front template minor syntax fixes

### DIFF
--- a/templates/frontOffice/default/account-order.html
+++ b/templates/frontOffice/default/account-order.html
@@ -26,9 +26,9 @@
 
     <article class="col-main" role="main" aria-labelledby="main-label">
 
-        <h1 id="main-label" class="page-header">{intl l="Order details %ref" ref="{$REF}"}</h1>
+        <h1 id="main-label" class="page-header">{intl l="Order details %ref" ref={$REF}}</h1>
 
-        {hook name="account-order.top" order="{$order_id}"}
+        {hook name="account-order.top" order={$order_id}}
 
         {* Infos *}
         <dl class="order-information dl-horizontal">
@@ -60,7 +60,7 @@
             <dt>{intl l="Customer Number"}</dt>
             <dd>{loop type="customer" name="customer.invoice" id=$CUSTOMER current="0"}{$REF}{/loop}</dd>
 
-            {hookblock name="account-order.information" order="{$order_id}" fields="title,value"}
+            {hookblock name="account-order.information" order={$order_id} fields="title,value"}
             {forhook rel="account-order.information"}
                 <dt>{$title}</dt>
                 <dd>{$value}</dd>
@@ -68,7 +68,7 @@
             {/hookblock}
         </dl>
 
-        {hook name="account-order.after-information" order="{$order_id}"}
+        {hook name="account-order.after-information" order={$order_id}}
 
         {* Addresses *}
         <div id="order-addresses" class="row">
@@ -78,7 +78,7 @@
                     <div class="panel-body">
                         <h4>{intl l="Delivery Mode"}</h4>
                         {ifhook rel="account-order.delivery-information"}
-                            {hook name="account-order.delivery-information" module="{$delivery_id}" order="{$order_id}"}
+                            {hook name="account-order.delivery-information" module={$delivery_id} order={$order_id}}
                         {/ifhook}
                         {elsehook rel="account-order.delivery-information"}
                             <p>{loop name="delivery-module" type="module" id=$DELIVERY_MODULE}{$TITLE}{/loop}</p>
@@ -88,13 +88,13 @@
 
                         {ifhook rel="account-order.delivery-address"}
                             {* delivery module can customize the delivery address *}
-                            {hook name="account-order.delivery-address" module="{$delivery_id}" order="{$order_id}"}
+                            {hook name="account-order.delivery-address" module={$delivery_id} order={$order_id}}
                         {/ifhook}
                         {elsehook rel="account-order.delivery-address"}
                             {format_address order_address=$DELIVERY_ADDRESS}
                         {/elsehook}
 
-                        {hook name="account-order.delivery-address-bottom" module="{$delivery_id}" order="{$order_id}"}
+                        {hook name="account-order.delivery-address-bottom" module={$delivery_id} order={$order_id}}
                     </div>
                 </div>
             </div>
@@ -104,7 +104,7 @@
                     <div class="panel-body">
                         <h4>{intl l="Billing Mode"}</h4>
                         {ifhook rel="account-order.invoice-information"}
-                            {hook name="account-order.invoice-information" module="{$payment_id}" order="{$order_id}"}
+                            {hook name="account-order.invoice-information" module={$payment_id} order={$order_id}}
                         {/ifhook}
                         {elsehook rel="account-order.invoice-information"}
                             <p>{loop name="payment-module" type="module" id=$PAYMENT_MODULE}{$TITLE}{/loop}</p>
@@ -117,19 +117,19 @@
 
                         {ifhook rel="account-order.invoice-address"}
                             {* payment module can customize the delivery address *}
-                            {hook name="account-order.invoice-address" module="{$payment_id}" order="{$order_id}"}
+                            {hook name="account-order.invoice-address" module={$payment_id} order={$order_id}}
                         {/ifhook}
                         {elsehook rel="account-order.invoice-address"}
                             {format_address order_address=$DELIVERY_ADDRESS}
                         {/elsehook}
 
-                        {hook name="account-order.invoice-address-bottom" module="{$payment_id}" order="{$order_id}"}
+                        {hook name="account-order.invoice-address-bottom" module={$payment_id} order={$order_id}}
                     </div>
                 </div>
             </div>
         </div>
 
-        {hook name="account-order.after-addresses" order="{$order_id}"}
+        {hook name="account-order.after-addresses" order={$order_id}}
 
         {* products *}
         <table class="table table-order table-bordered order-products">
@@ -162,7 +162,7 @@
             {ifhook rel="account-order.products-top"}
             <tr>
                 <td class="products-top" colspan="5">
-                    {hook name="account-order.products-top" order="{$order_id}"}
+                    {hook name="account-order.products-top" order={$order_id}}
                 </td>
             </tr>
             {/ifhook}
@@ -182,7 +182,7 @@
 
                 {$taxes[{$TAX_RULE_TITLE}][] = $realTax * $QUANTITY}
 
-                <tr data-id="{$ID}"  data-product-id="{$PRODUCT_ID}" data-pse-id="{$PRODUCT_SALE_ELEMENTS_ID}">
+                <tr data-id={$ID}  data-product-id={$PRODUCT_ID} data-pse-id={$PRODUCT_SALE_ELEMENTS_ID}>
                     <td class="product" >
                         <p>{$TITLE}</p>
                         {ifloop rel="combinations"}
@@ -201,7 +201,7 @@
                 {ifhook rel="account-order.product-extra"}
                 <tr>
                     <td class="product-extra" colspan="5">
-                        {hook name="account-order.product-extra" order="{$order_id}" order_product="{$ID}" product="{$PRODUCT_ID}"}
+                        {hook name="account-order.product-extra" order={$order_id} order_product={$ID} product={$PRODUCT_ID}}
                     </td>
                 </tr>
                 {/ifhook}
@@ -210,7 +210,7 @@
             {ifhook rel="account-order.products-bottom"}
             <tr>
                 <td class="products-bottom" colspan="5">
-                    {hook name="account-order.products-bottom" order="{$order_id}"}
+                    {hook name="account-order.products-bottom" order={$order_id}}
                 </td>
             </tr>
             {/ifhook}
@@ -218,7 +218,7 @@
             </tbody>
         </table>
 
-        {hook name="account-order.after-products" order="{$order_id}"}
+        {hook name="account-order.after-products" order={$order_id}}
 
         <div class="row">
             <div class="col-md-6 col-md-offset-6 col-sm-9 col-sm-offset-3 col-xs-12">
@@ -270,7 +270,7 @@
             </div>
         </div>
 
-        {hook name="account-order.bottom" order="{$order_id}"}
+        {hook name="account-order.bottom" order={$order_id}}
 
     </article>
 

--- a/templates/frontOffice/default/ajax/order-delivery-module-list.html
+++ b/templates/frontOffice/default/ajax/order-delivery-module-list.html
@@ -45,7 +45,7 @@
             <td>
                 <div class="price">
                     {if $POSTAGE}
-                        {format_money number=$POSTAGE}
+                        {format_money number=$POSTAGE symbol={currency attr='symbol'}}
                     {else}
                         &nbsp;
                     {/if}

--- a/templates/frontOffice/default/brand.html
+++ b/templates/frontOffice/default/brand.html
@@ -88,10 +88,11 @@
 
                 {ifloop rel="product_list"}
                     <hr/>
+
                     {assign var="amount" value={count type="product" brand=$ID}}
                     <div class="toolbar toolbar-top" role="toolbar">
                         <div class="sorter-container clearfix">
-                            <span class="amount">{if ($amount > 1)}{intl l="%nb Items" nb={$amount}}{else}{intl l="%nb Item" nb={$amount}}{/if}</span>
+                            <span class="amount">{if ($amount > 1)}{intl l="%nb Items" nb=$amount}{else}{intl l="%nb Item" nb=$amount}{/if}</span>
 
                             <span class="limiter">
                                 <label for="limit-top">{intl l="Show"}</label>

--- a/templates/frontOffice/default/content.html
+++ b/templates/frontOffice/default/content.html
@@ -30,7 +30,7 @@
     {if $content_id}
         {$breadcrumbs = []}
         {loop type="content" name="content-breadcrumb" id=$content_id limit="1"}
-            {loop name="folder_path" type="folder-path" folder="{$DEFAULT_FOLDER}"}
+            {loop name="folder_path" type="folder-path" folder={$DEFAULT_FOLDER}}
                 {$breadcrumbs[] = ['title' => {$TITLE}, 'url'=> {$URL nofilter}]}
             {/loop}
             {$breadcrumbs[] = ['title' => {$TITLE}, 'url'=> {$URL nofilter}]}
@@ -63,7 +63,7 @@
                 {ifloop rel="blog.document"}
                 <div class="documents">
                     <ul>
-                    {loop name="blog.document"  type="document" content="{$ID}"}
+                    {loop name="blog.document"  type="document" content={$ID}}
                     <li><a href="{$DOCUMENT_URL nofilter}" target="_blank">{$TITLE}</a></li>
                     {/loop}  
                     </ul>

--- a/templates/frontOffice/default/currency.html
+++ b/templates/frontOffice/default/currency.html
@@ -18,7 +18,7 @@
             {hook name="currency.top"}
             <ul class="nav nav-tabs nav-justified" style="margin-bottom:60px;">
             {loop type="currency" name="currency_available"}
-              <li{if $ID eq "{currency attr="id"}"} class="active"{/if}><a href="{url current="1" currency={$ISOCODE}}">{$SYMBOL} - {$NAME}</a></li>
+              <li{if $ID eq {currency attr="id"}} class="active"{/if}><a href="{url current="1" currency={$ISOCODE}}">{$SYMBOL} - {$NAME}</a></li>
             {/loop}
             </ul>
             {hook name="currency.bottom"}

--- a/templates/frontOffice/default/folder.html
+++ b/templates/frontOffice/default/folder.html
@@ -41,7 +41,7 @@
 
 {* Content *}
 {block name="main-content"}
-{assign var="$folder_id" value="{folder attr="id"}"}
+{assign var="$folder_id" value={folder attr="id"}}
     {hook name="folder.top" folder="$folder_id"}
     <div class="main">
         {hook name="folder.main-top" folder="$folder_id"}
@@ -103,7 +103,7 @@
                 {ifloop rel="blog.document"}
                 <div class="documents">
                     <ul>
-                    {loop name="blog.document"  type="document" folder="{$ID}"}
+                    {loop name="blog.document"  type="document" folder={$ID}}
                     <li><a href="{$DOCUMENT_URL nofilter}" target="_blank">{$TITLE}</a></li>
                     {/loop}  
                     </ul>

--- a/templates/frontOffice/default/includes/addedToCart.html
+++ b/templates/frontOffice/default/includes/addedToCart.html
@@ -18,12 +18,12 @@
             </td>
             <td class="col-md-4">
                 <h2>{$TITLE}</h2>
-                {loop type="attribute_combination" name="product_options" product_sale_elements="{$smarty.get.pse_id}" order="manual"}
+                {loop type="attribute_combination" name="product_options" product_sale_elements={$smarty.get.pse_id} order="manual"}
                     <p>{$ATTRIBUTE_TITLE} : {$ATTRIBUTE_AVAILABILITY_TITLE}</p>
                 {/loop}
             </td>
             <td class="col-md-4">
-                {loop type="product_sale_elements" name="product_price" id="{$smarty.get.pse_id}"}
+                {loop type="product_sale_elements" name="product_price" id={$smarty.get.pse_id}}
                     {if $IS_PROMO == 1}
                         {assign "real_price" $TAXED_PROMO_PRICE}
                         <div class="special-price"><span class="price">{format_money number=$TAXED_PROMO_PRICE}</span></div>

--- a/templates/frontOffice/default/includes/single-product.html
+++ b/templates/frontOffice/default/includes/single-product.html
@@ -116,7 +116,7 @@
             {/if}
         </div>
 
-        {hook name="singleproduct.bottom" product="{$product_id}"}
+        {hook name="singleproduct.bottom" product={$product_id}}
 
     </article><!-- /product -->
 </li>

--- a/templates/frontOffice/default/language.html
+++ b/templates/frontOffice/default/language.html
@@ -18,7 +18,7 @@
             {hook name="language.top"}
             <ul class="nav nav-tabs nav-justified" style="margin-bottom:60px;">
             {loop type="lang" name="lang_available"}
-              <li{if $ID eq "{lang attr="id"}"} class="active"{/if}><a href="{url current="1" lang={$CODE}}">{$TITLE}</a></li>
+              <li{if $ID eq {lang attr="id"}} class="active"{/if}><a href="{url current="1" lang={$CODE}}">{$TITLE}</a></li>
             {/loop}
             </ul>
             {hook name="language.bottom"}

--- a/templates/frontOffice/default/order-delivery.html
+++ b/templates/frontOffice/default/order-delivery.html
@@ -157,8 +157,6 @@
 
     <script type="text/javascript">
         jQuery(function($) {
-            $('#delivery-module-list-block').load('{url path="/order/deliveryModuleList"}');
-
             $('.js-change-delivery-address').change(function(e) {
                 if (this.checked) {
                     $('#delivery-module-list-block').load(
@@ -172,6 +170,8 @@
                     );
                 }
             });
+
+            $('.js-change-delivery-address:checked').change();
         });
     </script>
     {hook name="order-delivery.javascript-initialization"}

--- a/templates/frontOffice/default/product.html
+++ b/templates/frontOffice/default/product.html
@@ -28,7 +28,7 @@
 {block name='no-return-functions' append}
     {$breadcrumbs = []}
     {loop type="product" name="product_breadcrumb" id=$product_id limit="1" with_prev_next_info="1"}
-        {loop name="category_path" type="category-path" category="{$DEFAULT_CATEGORY}"}
+        {loop name="category_path" type="category-path" category={$DEFAULT_CATEGORY}}
             {$breadcrumbs[] = ['title' => {$TITLE}, 'url'=> {$URL nofilter}]}
         {/loop}
         {$breadcrumbs[] = ['title' => {$TITLE}, 'url'=> {$URL nofilter}]}
@@ -45,28 +45,28 @@
             {$pse_count=$PSE_COUNT}
 
             {* Use the meta tag to specify content that is not visible on the page in any way *}
-            {loop name="brand.feature" type="brand" product="{$ID}"}
+            {loop name="brand.feature" type="brand" product={$ID}}
                 <meta itemprop="brand" content="{$TITLE}">
             {/loop}
 
             {* Add custom feature if needed
-            {loop name="isbn.feature" type="feature" product="{$ID}" title="isbn"}
-                {loop name="isbn.value" type="feature_value" feature="{$ID}" product="{product attr="id"}"}
+            {loop name="isbn.feature" type="feature" product={$ID} title="isbn"}
+                {loop name="isbn.value" type="feature_value" feature={$ID} product=$product_id}
                     <meta itemprop="productID" content="isbn:{$TITLE}">
                 {/loop}
             {/loop}
             *}
 
-            {hook name="product.top" product="{$ID}"}
+            {hook name="product.top" product={$ID}}
 
             {ifhook rel="product.gallery"}
-               {hook name="product.gallery" product="{$ID}"}
+               {hook name="product.gallery" product={$ID}}
             {/ifhook}
             {elsehook rel="product.gallery"}
             <section id="product-gallery" class="col-sm-6">
                 {ifloop rel="image.main"}
                 <figure class="product-image">
-                    {loop type="image" name="image.main" product="{$ID}" width="560" height="445" resize_mode="borders" limit="1"}
+                    {loop type="image" name="image.main" product={$ID} width="560" height="445" resize_mode="borders" limit="1"}
                         <img src="{$IMAGE_URL nofilter}" alt="{$TITLE}" class="img-responsive" itemprop="image" data-toggle="magnify">
                     {/loop}
                 </figure>
@@ -77,10 +77,10 @@
                     <div class="carousel-inner">
                         <div class="item active">
                             <ul class="list-inline">
-                                {loop name="image.carousel" type="image" product="{$ID}"  width="560" height="445" resize_mode="borders" limit="5"}
+                                {loop name="image.carousel" type="image" product={$ID}  width="560" height="445" resize_mode="borders" limit="5"}
                                 <li>
                                     <a href="{$IMAGE_URL nofilter}" class="thumbnail {if $LOOP_COUNT == 1}active{/if}">
-                                        {loop type="image" name="image.thumbs" id="{$ID}" product="$OBJECT_ID" width="118" height="85" resize_mode="borders"}
+                                        {loop type="image" name="image.thumbs" id={$ID} product="$OBJECT_ID" width="118" height="85" resize_mode="borders"}
                                             <img src="{$IMAGE_URL nofilter}" alt="{$TITLE}">
                                         {/loop}
                                     </a>
@@ -91,10 +91,10 @@
                         {ifloop rel="image.carouselsup"}
                         <div class="item">
                             <ul class="list-inline">
-                                {loop name="image.carouselsup" type="image" product="{$ID}"  width="560" height="445" resize_mode="borders" offset="5"}
+                                {loop name="image.carouselsup" type="image" product={$ID}  width="560" height="445" resize_mode="borders" offset="5"}
                                     <li>
                                         <a href="{$IMAGE_URL nofilter}" class="thumbnail">
-                                            {loop type="image" name="image.thumbssup" id="{$ID}" product="$OBJECT_ID" width="118" height="85" resize_mode="borders"}
+                                            {loop type="image" name="image.thumbssup" id={$ID} product="$OBJECT_ID" width="118" height="85" resize_mode="borders"}
                                                 <img src="{$IMAGE_URL nofilter}" alt="{$TITLE}">
                                             {/loop}
                                         </a>
@@ -114,13 +114,13 @@
             {/elsehook}
 
             <section id="product-details" class="col-sm-6">
-                {hook name="product.details-top" product="{$ID}"}
+                {hook name="product.details-top" product={$ID}}
 
                 <div class="product-info">
                     <h1 class="name"><span itemprop="name">{$TITLE}</span><span id="pse-name" class="pse-name"></span></h1>
                     {if $REF}<span itemprop="sku" class="sku">{intl l='Ref.'}: <span id="pse-ref">{$REF}</span></span>{/if}
 
-                    {loop name="brand_info" type="brand" product="{$ID}" limit="1"}
+                    {loop name="brand_info" type="brand" product={$ID} limit="1"}
                         <p><a href="{$URL nofilter}" title="{intl l="More information about this brand"}"><span itemprop="brand">{$TITLE}</span></a></p>
                     {/loop}
 
@@ -129,7 +129,7 @@
                     </div>{/if}
                 </div>
 
-                {loop type="sale" name="product-sale-info" product="{$ID}" active="1"}
+                {loop type="sale" name="product-sale-info" product={$ID} active="1"}
                     <div class="product-promo">
                         <p class="sale-label">{$SALE_LABEL}</p>
                         <p class="sale-saving"> {intl l="Save %amount%sign on this product" amount={$PRICE_OFFSET_VALUE} sign={$PRICE_OFFSET_SYMBOL}}</p>
@@ -233,18 +233,18 @@
 
                 </form>
                 {/form}
-                {hook name="product.details-bottom" product="{$ID}"}
+                {hook name="product.details-bottom" product={$ID}}
             </section>
 
             {strip}
                 {capture "additional"}
                     {ifloop rel="feature_info"}
                         <ul>
-                            {loop name="feature_info" type="feature" product="{$ID}"}
+                            {loop name="feature_info" type="feature" product={$ID}}
                             {ifloop rel="feature_value_info"}
                                 <li>
                                     <strong>{$TITLE}</strong> :
-                                    {loop name="feature_value_info" type="feature_value" feature="{$ID}" product="{product attr="id"}"}
+                                    {loop name="feature_value_info" type="feature_value" feature={$ID} product=$product_id}
                                         {if $LOOP_COUNT > 1}, {else} {/if}
                                         <span>{if $IS_FREE_TEXT == 1}{$FREE_TEXT_VALUE}{else}{$TITLE}{/if}</span>
                                     {/loop}
@@ -258,7 +258,7 @@
 
             {strip}
                 {capture "brand_info"}
-                    {loop name="brand_info" type="brand" product="{$ID}" limit="1"}
+                    {loop name="brand_info" type="brand" product={$ID} limit="1"}
                         <p><strong><a href="{$URL nofilter}">{$TITLE}</a></strong></p>
 
                         {loop name="brand.image" type="image" source="brand" id={$LOGO_IMAGE_ID} width=218 height=146 resize_mode="borders"}
@@ -299,7 +299,7 @@
             {/strip}
 
             <section id="product-tabs" class="col-sm-12">
-                {hookblock name="product.additional" product="{product attr="id"}" fields="id,class,title,content"}
+                {hookblock name="product.additional" product=$product_id fields="id,class,title,content"}
                 <ul class="nav nav-tabs" role="tablist">
                     <li class="active" role="presentation"><a id="tab1" href="#description" data-toggle="tab" role="tab">{intl l="Description"}</a></li>
                     {if $smarty.capture.additional ne ""}<li role="presentation"><a id="tab2" href="#additional" data-toggle="tab" role="tab">{intl l="Additional Info"}</a></li>{/if}
@@ -336,22 +336,22 @@
                 </div>
                 {/hookblock}
             </section>
-            {hook name="product.bottom" product="{$ID}"}
+            {hook name="product.bottom" product={$ID}}
 
 {* javascript confiuguration to display pse *}
 {$pse=[]}
 {$combination_label=[]}
 {$combination_values=[]}
-{loop name="pse" type="product_sale_elements" product="{product attr="id"}"}
-    {$pse[$ID]=["id" => $ID, "isDefault" => $IS_DEFAULT, "isPromo" => $IS_PROMO, "isNew" => $IS_NEW, "ref" => "{$REF}", "ean" => "{$EAN}", "quantity" => {$QUANTITY}, "price" => "{format_money number=$TAXED_PRICE}", "promo" => "{format_money number=$TAXED_PROMO_PRICE}" ]}
+{loop name="pse" type="product_sale_elements" product=$product_id}
+    {$pse[$ID]=["id" => $ID, "isDefault" => $IS_DEFAULT, "isPromo" => $IS_PROMO, "isNew" => $IS_NEW, "ref" => {$REF}, "ean" => {$EAN}, "quantity" => {$QUANTITY}, "price" => {format_money number=$TAXED_PRICE}, "promo" => {format_money number=$TAXED_PROMO_PRICE} ]}
     {$pse_combination=[]}
     {loop name="combi" type="attribute_combination" product_sale_elements="$ID" order="manual"}
         {if ! $combination_label[$ATTRIBUTE_ID]}
-            {$combination_label[$ATTRIBUTE_ID]=["name" => "{$ATTRIBUTE_TITLE}", "values" => []]}
+            {$combination_label[$ATTRIBUTE_ID]=["name" => {$ATTRIBUTE_TITLE}, "values" => []]}
         {/if}
         {if ! $combination_values[$ATTRIBUTE_AVAILABILITY_ID]}
             {$combination_label[$ATTRIBUTE_ID]["values"][]=$ATTRIBUTE_AVAILABILITY_ID}
-            {$combination_values[$ATTRIBUTE_AVAILABILITY_ID]=["{$ATTRIBUTE_AVAILABILITY_TITLE}", $ATTRIBUTE_ID]}
+            {$combination_values[$ATTRIBUTE_AVAILABILITY_ID]=[{$ATTRIBUTE_AVAILABILITY_TITLE}, $ATTRIBUTE_ID]}
         {/if}
         {$pse_combination[]=$ATTRIBUTE_AVAILABILITY_ID}
     {/loop}
@@ -377,12 +377,12 @@
 
         <ul class="pager">
             {if $HAS_PREVIOUS == 1}
-                {loop type="product" name="prev_product" id="{$PREVIOUS}"}
+                {loop type="product" name="prev_product" id={$PREVIOUS}}
                     <li class="previous"><a href="{$URL nofilter}"><i class="fa fa-chevron-left"></i> {intl l="Previous product"}</a></li>
                 {/loop}
             {/if}
             {if $HAS_NEXT == 1}
-                {loop type="product" name="next_product" id="{$NEXT}"}
+                {loop type="product" name="next_product" id={$NEXT}}
                     <li class="next"><a href="{$URL nofilter}"><i class="fa fa-chevron-right"></i> {intl l="Next product"}</a></li>
                 {/loop}
             {/if}

--- a/templates/frontOffice/default/sale.html
+++ b/templates/frontOffice/default/sale.html
@@ -6,7 +6,7 @@
 {block name='no-return-functions' append}
     {loop name="sale-details" type="sale" id={$product_sale}}
         {$breadcrumbs = [
-            ['title' => "{$SALE_LABEL}", 'url'=>{url path="/sale" sale="{$ID}"}]
+            ['title' => "{$SALE_LABEL}", 'url'=>{url path="/sale" sale={$ID}}]
         ]}
     {/loop}
 {/block}
@@ -49,7 +49,7 @@
                 {/if}
             </div>
 
-            {assign var="amount" value="{count type="product" sale=$ID}"}
+            {assign var="amount" value={count type="product" sale=$ID}}
 
 
 
@@ -59,7 +59,7 @@
                 <div class="products-content">
                     {ifloop rel="product_list"}
                         <ul class="list-unstyled row">
-                        {loop type="product" sale="{$ID}" name="product_list" limit=$limit page=$product_page order=$product_order}
+                        {loop type="product" sale={$ID} name="product_list" limit=$limit page=$product_page order=$product_order}
                             {include file="includes/single-product.html" product_id=$ID hasBtn=true hasDescription=true width="700" height="320"}
                         {/loop}
                         </ul>

--- a/templates/frontOffice/default/search.html
+++ b/templates/frontOffice/default/search.html
@@ -20,13 +20,13 @@
     <article class="col-main  {$smarty.get.mode|default:"grid"}"  role="main" aria-labelledby="main-label">
 
         <h1 id="main-label" class="page-header">{intl l="Search Result for"} <small>{$smarty.get.q}</small></h1>
-        {assign var="amount" value="{count type="product" title="{$smarty.get.q}"}"}
+        {assign var="amount" value={count type="product" title={$smarty.get.q}}}
         {include file="includes/toolbar.html" toolbar="top" limit=$limit order=$product_order amount={$amount}}
         <div id="category-products">
             <div class="products-content">
                 {ifloop rel="product_list"}
                     <ul class="list-unstyled row">
-                        {loop type="product" name="product_list" title="{$smarty.get.q}"  limit=$limit page=$product_page order=$product_order}
+                        {loop type="product" name="product_list" title={$smarty.get.q}  limit=$limit page=$product_page order=$product_order}
                             {include file="includes/single-product.html" product_id=$ID hasBtn=true hasDescription=true width="369" height="247"}
                         {/loop}
                     </ul>

--- a/templates/frontOffice/default/view_all.html
+++ b/templates/frontOffice/default/view_all.html
@@ -22,7 +22,7 @@
     <article class="col-main  {$smarty.get.mode|default:"grid"}"  role="main" aria-labelledby="main-label">
 
         <h1 id="main-label" class="page-header">{if $product_type == "new"}{intl l="Latest products"}{elseif $product_type == "offers"}{intl l="Product Offers"}{/if}</h1>
-        {assign var="amount" value="{count type="product" promo="{$product_type == "offers"}" new="{$product_type == "new"}"}"}
+        {assign var="amount" value={count type="product" promo="{$product_type == "offers"}" new="{$product_type == "new"}"}}
 
         {hook name="viewall.top"}
 
@@ -31,7 +31,7 @@
             <div class="products-content">
                 {ifloop rel="product_list"}
                     <ul class="list-unstyled row">
-                        {loop type="product" promo="{$product_type == "offers"}" new="{$product_type == "new"}" name="product_list" limit=$limit page=$product_page order=$product_order}
+                        {loop type="product" promo={$product_type == "offers"} new={$product_type == "new"} name="product_list" limit=$limit page=$product_page order=$product_order}
                             {include file="includes/single-product.html" colClass="col-sm-4" product_id=$ID hasBtn=true hasDescription=true width="700" height="320"}
                         {/loop}
                     </ul>


### PR DESCRIPTION
This PR fixes the front template syntax which confuses the PHPStorm parser. This is mostly due to useless quotes, such as `{loop ... param="{$somevar}" ... }`, which could be expressed as `{loop ... param={$somevar} ... }`

We're keeping the `{$somevar}` form instead of using `$somevar`, to be sure the `somevar` variable content is escaped