### PR TITLE
WIP fix issue #2003 : product and pse ref in invoice template

### DIFF
--- a/templates/email/default/order_confirmation.html
+++ b/templates/email/default/order_confirmation.html
@@ -76,7 +76,7 @@
             {/if}
                 <tr>
                     <td style="border-bottom:1px solid #000">
-                        <b>{$TITLE}</b> <i>({$REF})</i>
+                        <b>{$TITLE}</b> <i>({$REF}{if $REF != $PRODUCT_SALE_ELEMENTS_REF}, {$PRODUCT_SALE_ELEMENTS_REF}{/if})</i>
                         {ifloop rel="combinations"}<br />
                         {loop type="order_product_attribute_combination" name="combinations" order_product=$ID}
                             <span style="color:#999;display:block;font-size:11px;line-height:1.2">* {$ATTRIBUTE_TITLE}: {$ATTRIBUTE_AVAILABILITY_TITLE}</span>

--- a/templates/email/default/order_notification.html
+++ b/templates/email/default/order_notification.html
@@ -78,7 +78,7 @@
             {/if}
                 <tr>
                     <td style="border-bottom:1px solid #000">
-                        <b>{$TITLE}</b> <i>({$REF})</i>
+                        <b>{$TITLE}</b> <i>({$REF}{if $REF != $PRODUCT_SALE_ELEMENTS_REF}, {$PRODUCT_SALE_ELEMENTS_REF}{/if})</i>
                         {ifloop rel="combinations"}<br />
                         {loop type="order_product_attribute_combination" name="combinations" order_product=$ID}
                             <span style="color:#999;display:block;font-size:11px;line-height:1.2">* {$ATTRIBUTE_TITLE}: {$ATTRIBUTE_AVAILABILITY_TITLE}</span>

--- a/templates/pdf/default/delivery.html
+++ b/templates/pdf/default/delivery.html
@@ -238,6 +238,7 @@
         <tr>
             <td style="border:solid 1px #dddddd;">
                 <p>{$REF}</p>
+                {if $REF != $PRODUCT_SALE_ELEMENTS_REF}<p>{$PRODUCT_SALE_ELEMENTS_REF}</p>{/if}
             </td>
             <td style="border:solid 1px #dddddd;">
                 <p>{$TITLE}</p>

--- a/templates/pdf/default/invoice.html
+++ b/templates/pdf/default/invoice.html
@@ -255,6 +255,10 @@
             <tr class="table-2">
                 <td>
                     <p>{$TITLE}</p>
+                    <p>
+                        {intl l="Product ref : "}{$REF}<br>
+                        {intl l="Combination ref : "}{$PRODUCT_SALE_ELEMENTS_REF}
+                    </p>
                     {ifloop rel="combinations"}
                     {loop type="order_product_attribute_combination" name="combinations" order_product=$ID}
                         {$ATTRIBUTE_TITLE} - {$ATTRIBUTE_AVAILABILITY_TITLE}<br>


### PR DESCRIPTION
Product ref and pse ref added to invoice and delivery template and to emails.


![tmp1](https://cloud.githubusercontent.com/assets/16164512/14250330/383ea916-fa7e-11e5-87e3-a14ecafdb15d.png)

![tmp2](https://cloud.githubusercontent.com/assets/16164512/14250331/3842733e-fa7e-11e5-8035-88f952964b14.png)

![tmp3](https://cloud.githubusercontent.com/assets/16164512/14250332/3842b54c-fa7e-11e5-9512-68814d6a48ed.png)

Resolve #2003
To do : update.php in 2.4