### PR TITLE
Added missing "calendar" PHP extension to docker config

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
  git \
  zip \
  libzip-dev \
-    && docker-php-ext-install intl pdo_mysql mcrypt mbstring zip \
+    && docker-php-ext-install intl pdo_mysql mcrypt mbstring zip calendar \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-pecl-install xdebug-2.3.3


### PR DESCRIPTION
The calendar extension is required to display the B.O. home graph.