### PR TITLE
Fix search in i18n fields when backend_context=1, and search improvements

### DIFF
--- a/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
+++ b/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
@@ -26,7 +26,7 @@ trait StandardI18nFieldsSearchTrait
         "postscriptum"
     ];
 
-    public function getStandardI18nSearchFields()
+    protected function getStandardI18nSearchFields()
     {
         return self::$standardI18nSearchFields;
     }
@@ -36,7 +36,7 @@ trait StandardI18nFieldsSearchTrait
      * @param $searchTerm
      * @param $searchCriteria
      */
-    public function addStandardI18nSearch(&$search, $searchTerm, $searchCriteria)
+    protected function addStandardI18nSearch(&$search, $searchTerm, $searchCriteria)
     {
         foreach (self::$standardI18nSearchFields as $index => $searchInElement) {
             if ($index > 0) {

--- a/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
+++ b/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
@@ -16,25 +16,34 @@ use Propel\Runtime\ActiveQuery\ModelCriteria;
 
 /**
  *
- * @author Etienne Roudeix <eroudeix@openstudio.fr>
- *
  */
-interface SearchLoopInterface
+trait StandardI18nFieldsSearchTrait
 {
-    const MODE_ANY_WORD = 'any_word';
-    const MODE_SENTENCE = 'sentence';
-    const MODE_STRICT_SENTENCE = 'strict_sentence';
+    protected static $standardI18nSearchFields = [
+        "title",
+        "chapo",
+        "description",
+        "postscriptum"
+    ];
+
+    public function getStandardI18nSearchFields()
+    {
+        return self::$standardI18nSearchFields;
+    }
 
     /**
-     * @return array of available field to search in
+     * @param ModelCriteria $search
+     * @param $searchTerm
+     * @param $searchCriteria
      */
-    public function getSearchIn();
+    public function addStandardI18nSearch(&$search, $searchTerm, $searchCriteria)
+    {
+        foreach (self::$standardI18nSearchFields as $index => $searchInElement) {
+            if ($index > 0) {
+                $search->_or();
+            }
 
-    /**
-     * @param ModelCriteria $search a query
-     * @param string $searchTerm the searched term
-     * @param array $searchIn available field to search in
-     * @param string $searchCriteria the search criteria, such as Criterial::LIKE, Criteria::EQUAL, etc.
-     */
-    public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria);
+            $this->addSearchInI18nColumn($search, strtoupper($searchInElement), $searchCriteria, $searchTerm);
+        }
+    }
 }

--- a/core/lib/Thelia/Core/Template/Loop/Brand.php
+++ b/core/lib/Thelia/Core/Template/Loop/Brand.php
@@ -105,13 +105,7 @@ class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoo
     {
         $search->_and();
 
-        $search->where(
-            "CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID)
-            THEN `requested_locale_i18n`.`TITLE`ELSE `default_locale_i18n`.`TITLE`
-            END ".$searchCriteria." ?",
-            $searchTerm,
-            \PDO::PARAM_STR
-        );
+        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
     }
 
     public function buildModelCriteria()
@@ -153,14 +147,7 @@ class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoo
         $title = $this->getTitle();
 
         if (!is_null($title)) {
-            $search->where(
-                "CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID)
-                THEN `requested_locale_i18n`.`TITLE`
-                ELSE `default_locale_i18n`.`TITLE`
-                END ".Criteria::LIKE." ?",
-                "%".$title."%",
-                \PDO::PARAM_STR
-            );
+            $this->addSearchInI18nColumn($search, 'TITLE', Criteria::LIKE, "%".$title."%");
         }
 
         $current = $this->getCurrent();

--- a/core/lib/Thelia/Core/Template/Loop/Brand.php
+++ b/core/lib/Thelia/Core/Template/Loop/Brand.php
@@ -18,6 +18,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Model\BrandQuery;
@@ -46,6 +47,8 @@ use Thelia\Type\TypeCollection;
  */
 class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    use StandardI18nFieldsSearchTrait;
+
     protected $timestampable = true;
 
     /**
@@ -90,22 +93,20 @@ class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoo
      */
     public function getSearchIn()
     {
-        return [
-            "title"
-        ];
+        return $this->getStandardI18nSearchFields();
     }
 
     /**
      * @param BrandQuery $search
      * @param string $searchTerm
-     * @param string $searchIn
+     * @param array $searchIn
      * @param string $searchCriteria
      */
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
 
-        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -113,8 +113,8 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
-
-        $search->where("CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".$searchCriteria." ?", $searchTerm, \PDO::PARAM_STR);
+    
+        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -18,6 +18,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Model\CategoryQuery;
@@ -62,6 +63,8 @@ use Thelia\Model\Category as CategoryModel;
  */
 class Category extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    use StandardI18nFieldsSearchTrait;
+
     protected $timestampable = true;
     protected $versionable = true;
 
@@ -99,22 +102,20 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
      */
     public function getSearchIn()
     {
-        return [
-            "title"
-        ];
+        return $this->getStandardI18nSearchFields();
     }
 
     /**
      * @param CategoryQuery $search
      * @param string $searchTerm
-     * @param string $searchIn
+     * @param array $searchIn
      * @param string $searchCriteria
      */
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
     
-        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -18,6 +18,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Model\ContentFolderQuery;
@@ -54,6 +55,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    use StandardI18nFieldsSearchTrait;
+
     protected $timestampable = true;
     protected $versionable = true;
 
@@ -104,22 +107,20 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
      */
     public function getSearchIn()
     {
-        return [
-            "title"
-        ];
+        return $this->getStandardI18nSearchFields();
     }
 
     /**
      * @param ContentQuery $search
      * @param string $searchTerm
-     * @param string $searchIn
+     * @param array $searchIn
      * @param string $searchCriteria
      */
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
-    
-        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
+
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -118,8 +118,8 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
-
-        $search->where("CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".$searchCriteria." ?", $searchTerm, \PDO::PARAM_STR);
+    
+        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
     }
 
     public function buildModelCriteria()
@@ -198,7 +198,7 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $title = $this->getTitle();
 
         if (!is_null($title)) {
-            $search->where("CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".Criteria::LIKE." ?", "%".$title."%", \PDO::PARAM_STR);
+            $this->addSearchInI18nColumn($search, 'TITLE', Criteria::LIKE, "%".$title."%");
         }
 
         $search->withColumn('`FolderSelect`.POSITION', 'position_delegate');

--- a/core/lib/Thelia/Core/Template/Loop/Folder.php
+++ b/core/lib/Thelia/Core/Template/Loop/Folder.php
@@ -105,21 +105,7 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
     {
         $search->_and();
 
-        $this->addTitleSearchWhereClause($search, $searchCriteria, $searchTerm);
-    }
-
-    /**
-     * @param FolderQuery $search
-     * @param string $criteria
-     * @param string $value
-     */
-    protected function addTitleSearchWhereClause($search, $criteria, $value)
-    {
-        $search->where(
-            "CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".$criteria." ?",
-            $value,
-            \PDO::PARAM_STR
-        );
+        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
     }
 
     public function buildModelCriteria()
@@ -171,7 +157,7 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
         $title = $this->getTitle();
 
         if (!is_null($title)) {
-            $this->addTitleSearchWhereClause($search, Criteria::LIKE, '%'.$title.'%');
+            $this->addSearchInI18nColumn($search, 'TITLE', Criteria::LIKE, "%".$title."%");
         }
 
         $visible = $this->getVisible();

--- a/core/lib/Thelia/Core/Template/Loop/Folder.php
+++ b/core/lib/Thelia/Core/Template/Loop/Folder.php
@@ -18,6 +18,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Model\ContentQuery;
@@ -45,6 +46,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    use StandardI18nFieldsSearchTrait;
+
     protected $timestampable = true;
     protected $versionable = true;
 
@@ -90,22 +93,20 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
      */
     public function getSearchIn()
     {
-        return [
-            "title"
-        ];
+        return $this->getStandardI18nSearchFields();
     }
 
     /**
      * @param FolderQuery $search
      * @param string $searchTerm
-     * @param string $searchIn
+     * @param array $searchIn
      * @param string $searchCriteria
      */
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
-
-        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
+        
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -19,6 +19,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Exception\TaxEngineException;
@@ -81,6 +82,8 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     protected $timestampable = true;
     protected $versionable = true;
 
+    use StandardI18nFieldsSearchTrait;
+    
     /**
      * @return ArgumentCollection
      */
@@ -172,10 +175,10 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
     public function getSearchIn()
     {
-        return [
-            "ref",
-            "title",
-        ];
+        return array_merge(
+            [ 'ref' ],
+            $this->getStandardI18nSearchFields()
+        );
     }
 
     /**
@@ -187,6 +190,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
         $search->_and();
+
         foreach ($searchIn as $index => $searchInElement) {
             if ($index > 0) {
                 $search->_or();
@@ -195,11 +199,10 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 case "ref":
                     $search->filterByRef($searchTerm, $searchCriteria);
                     break;
-                case "title":
-                    $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
-                    break;
             }
         }
+
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function parseResults(LoopResult $loopResult)

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -196,14 +196,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     $search->filterByRef($searchTerm, $searchCriteria);
                     break;
                 case "title":
-                    $search->where(
-                        "CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID)
-                        THEN `requested_locale_i18n`.`TITLE`
-                        ELSE `default_locale_i18n`.`TITLE`
-                        END ".$searchCriteria." ?",
-                        $searchTerm,
-                        \PDO::PARAM_STR
-                    );
+                    $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
                     break;
             }
         }
@@ -571,7 +564,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $title = $this->getTitle();
 
         if (!is_null($title)) {
-            $search->where("CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".Criteria::LIKE." ?", "%".$title."%", \PDO::PARAM_STR);
+            $this->addSearchInI18nColumn($search, 'TITLE', Criteria::LIKE, "%".$title."%");
         }
 
         $manualOrderAllowed = false;

--- a/core/lib/Thelia/Core/Template/Loop/Sale.php
+++ b/core/lib/Thelia/Core/Template/Loop/Sale.php
@@ -18,6 +18,7 @@ use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Element\LoopResultRow;
 use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
+use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Model\SaleQuery;
@@ -42,6 +43,8 @@ use Thelia\Type\BooleanOrBothType;
  */
 class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
+    use StandardI18nFieldsSearchTrait;
+    
     protected $timestampable = true;
 
     /**
@@ -89,17 +92,34 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
      */
     public function getSearchIn()
     {
-        return [
-            "title"
-        ];
+        return array_merge(
+            [ "sale_label" ],
+            $this->getStandardI18nSearchFields()
+        );
     }
 
+    /**
+     * @param SaleQuery $search
+     * @param string $searchTerm
+     * @param array $searchIn
+     * @param string $searchCriteria
+     */
     public function doSearch(&$search, $searchTerm, $searchIn, $searchCriteria)
     {
-        /** @var SaleQuery $search */
         $search->_and();
+        
+        foreach ($searchIn as $index => $searchInElement) {
+            if ($index > 0) {
+                $search->_or();
+            }
+            switch ($searchInElement) {
+                case "sale_label":
+                    $this->addSearchInI18nColumn($search, 'SALE_LABEL', $searchCriteria, $searchTerm);
+                    break;
+            }
+        }
     
-        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
+        $this->addStandardI18nSearch($search, $searchTerm, $searchCriteria);
     }
 
     public function buildModelCriteria()

--- a/core/lib/Thelia/Core/Template/Loop/Sale.php
+++ b/core/lib/Thelia/Core/Template/Loop/Sale.php
@@ -98,8 +98,8 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
     {
         /** @var SaleQuery $search */
         $search->_and();
-
-        $search->where("CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID) THEN `requested_locale_i18n`.`TITLE` ELSE `default_locale_i18n`.`TITLE` END ".$searchCriteria." ?", $searchTerm, \PDO::PARAM_STR);
+    
+        $this->addSearchInI18nColumn($search, 'TITLE', $searchCriteria, $searchTerm);
     }
 
     public function buildModelCriteria()

--- a/templates/backOffice/default/search.html
+++ b/templates/backOffice/default/search.html
@@ -252,7 +252,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="category" name="category-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="category" name="category-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title,chapo,description,postscriptum" return_url=false  limit=26}
 
                             {if $LOOP_COUNT < 26}
                             <tr>
@@ -331,7 +331,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="product" name="product-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="ref,title" return_url=false  limit=26}
+                            {loop type="product" name="product-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="ref,title,chapo,description,postscriptum" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 {$id_product=$ID}
                                  <tr>
@@ -423,7 +423,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="folder" name="folder-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="folder" name="folder-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title,chapo,description,postscriptum" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 <tr>
                                     <td>{$ID}</td>
@@ -499,7 +499,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="content" name="content-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="content" name="content-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title,chapo,description,postscriptum" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 <tr>
                                     <td>{$ID}</td>

--- a/templates/backOffice/default/search.html
+++ b/templates/backOffice/default/search.html
@@ -73,7 +73,7 @@
                             </thead>
 
                             <tbody>
-                            {loop name="customer_list" type="customer" current="false" visible="*" backend_context="1" search_term=$searchTerm search_in="ref,firstname,lastname,email" limit=26}
+                            {loop name="customer_list" type="customer" current="false" visible="*" backend_context="1" search_mode="sentence" search_term=$searchTerm search_in="ref,firstname,lastname,email" limit=26}
                                 {assign "lastOrderDate" ''}
                                 {assign "lastOrderAmount" ''}
                                 {assign "lastOrderCurrency" ''}

--- a/templates/backOffice/default/search.html
+++ b/templates/backOffice/default/search.html
@@ -252,7 +252,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="category" name="category-search" visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="category" name="category-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
 
                             {if $LOOP_COUNT < 26}
                             <tr>
@@ -331,7 +331,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="product" name="product-search" visible="*" search_mode="sentence" search_term=$searchTerm search_in="ref,title" return_url=false  limit=26}
+                            {loop type="product" name="product-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="ref,title" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 {$id_product=$ID}
                                  <tr>
@@ -423,7 +423,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="folder" name="folder-search" visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="folder" name="folder-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 <tr>
                                     <td>{$ID}</td>
@@ -499,7 +499,7 @@
                             </thead>
 
                             <tbody>
-                            {loop type="content" name="content-search" visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
+                            {loop type="content" name="content-search" backend_context=1 visible="*" search_mode="sentence" search_term=$searchTerm search_in="title" return_url=false  limit=26}
                             {if $LOOP_COUNT < 26}
                                 <tr>
                                     <td>{$ID}</td>


### PR DESCRIPTION
When `backend_context` loop parameter is 1, the `default_locale_i18n` pseudo-column is not defined. However, hard-coded search requests appear is some loops (product, category, etc.), causing an SQL error if `backend_context`=1 and `search_in` is not empty.

Additionally, this PR improves the loop search system, by providing the `StandardI18nFieldsSearchTrait`, which manages searches in the standard internationalized fields (title, chapo, description and postscriptum).

In the back-office, customer search is now in `sentence` (%term%) mode, to allow incomplete word matches, such as part of an email address.