### PR TITLE
Fixed status_id parameter access

### DIFF
--- a/core/lib/Thelia/Controller/Admin/OrderController.php
+++ b/core/lib/Thelia/Controller/Admin/OrderController.php
@@ -63,7 +63,7 @@ class OrderController extends BaseAdminController
 
             $order = OrderQuery::create()->findPk($order_id);
 
-            $statusId = $this->getRequest()->request->get("status_id");
+            $statusId = $this->getRequest()->get("status_id");
             $status = OrderStatusQuery::create()->findPk($statusId);
 
             if (null === $order) {


### PR DESCRIPTION
As \Thelia\Controller\Admin\OrderController::updateStatus() could be by a GET request, the status_id request parameter should not be read from request body, which is set by POST requests only