### PR TITLE
Fixed the update process when thelia.net is out of order

### DIFF
--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -596,7 +596,11 @@ class Update
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($curl, CURLOPT_TIMEOUT, 5);
         $res = curl_exec($curl);
-        if (Version::parse($res))
-            return $res;
+
+        try {
+            return Version::parse($res);
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/core/lib/Thelia/Tools/Version/Version.php
+++ b/core/lib/Thelia/Tools/Version/Version.php
@@ -103,8 +103,9 @@ class Version
      */
     public static function parse($version = null)
     {
-        if (is_null($version))
+        if (is_null($version)) {
             $version = \Thelia\Core\Thelia::THELIA_VERSION;
+        }
 
         $pattern = "`^(?<version>
             (?<major>[0-9]+)\.
@@ -112,6 +113,7 @@ class Version
             (?<release>[0-9]+)
             -?(?<extra>[a-zA-Z0-9]*) # extra_version will also match empty string
         )$`x";
+
         if (!preg_match($pattern, $version, $match)) {
             throw new \InvalidArgumentException(
                 sprintf(

--- a/setup/update.php
+++ b/setup/update.php
@@ -89,8 +89,7 @@ $files   = $update->getLatestVersion();
 $web     = $update->getWebVersion();
 
 while (1) {
-
-    if ($files != $web) {
+    if ($web !== null && $files != $web) {
         cliOutput(sprintf(
             "Thelia server is reporting the current stable release version is %s ",
             $web
@@ -103,8 +102,7 @@ while (1) {
         $files
     ), 'info');
 
-    if ($files < $web) {
-
+    if ($web !== null && $files < $web) {
         cliOutput(sprintf(
             "Your files belongs to version %s, which is not the latest stable release.",
             $web


### PR DESCRIPTION
When thelia.net is out of order, it's not possible to launch the update process.

```
$ php setup/update.php 
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'Invalid version number provided : 
' in /srv/www/thelia/core/lib/Thelia/Tools/Version/Version.php:116
Stack trace:
#0 /srv/www/thelia/core/lib/Thelia/Install/Update.php(599): Thelia\Tools\Version\Version::parse(false)
#1 /srv/www/thelia/setup/update.php(89): Thelia\Install\Update->getWebVersion()
#2 {main}
  thrown in /srv/www/thelia/core/lib/Thelia/Tools/Version/Version.php on line 116
```

This pull request fixes this problem.