### PR TITLE
Add global variable `app` to Smarty

### DIFF
--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -366,8 +366,6 @@ class BaseAdminController extends BaseController
         // Add the template standard extension
         $templateName .= '.html';
 
-        $session = $this->getSession();
-
         // Find the current edit language ID
         $edition_language = $this->getCurrentEditionLang();
 
@@ -376,16 +374,9 @@ class BaseAdminController extends BaseController
 
         // Prepare common template variables
         $args = array_merge($args, array(
-            'locale'               => $session->getLang()->getLocale(),
-            'lang_code'            => $session->getLang()->getCode(),
-            'lang_id'              => $session->getLang()->getId(),
-
             'edit_language_id'     => $edition_language->getId(),
             'edit_language_locale' => $edition_language->getLocale(),
-
             'edit_currency_id'     => $edition_currency->getId(),
-
-            'current_url'          => $this->getRequest()->getUri()
         ));
 
         // Update the current edition language & currency in session

--- a/core/lib/Thelia/Controller/Front/BaseFrontController.php
+++ b/core/lib/Thelia/Controller/Front/BaseFrontController.php
@@ -126,18 +126,7 @@ class BaseFrontController extends BaseController
         // Add the template standard extension
         $templateName .= '.html';
 
-        $session = $this->getSession();
-
-        // Prepare common template variables
-        $args = array_merge($args, array(
-                'locale'               => $session->getLang()->getLocale(),
-                'lang_code'            => $session->getLang()->getCode(),
-                'lang_id'              => $session->getLang()->getId(),
-                'current_url'          => $this->getRequest()->getUri()
-            ));
-
         // Render the template.
-
         $data = $this->getParser($templateDir)->render($templateName, $args);
 
         return $data;


### PR DESCRIPTION
This pull request adds the `app` global variable to Smarty for have a consistency with Twig

```smarty
{$app->environment} {* string	The current environment string (e.g 'dev') *}
{$app->request} {* Request|null	The HTTP request object *}
{$app->session} {* Session|null	The session *}
{$app->debug} {* bool	The current debug mode *}
```

Resolve #2124