### PR TITLE
Fix: #2166 array to string conversion when php setup/update.php

### DIFF
--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -598,7 +598,9 @@ class Update
         $res = curl_exec($curl);
 
         try {
-            return Version::parse($res);
+            if (Version::parse($res)) {
+                return $res;
+            }
         } catch (\Exception $e) {
             return null;
         }


### PR DESCRIPTION
This fixes `PHP Notice:  Array to string conversion in /home/michael/git/github/thelia/setup/update.php on line 96` when trying to update from command line with `php setup/update.php`
