### PR TITLE
Fix customer discount apply on backoffice

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -228,7 +228,9 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
             $price = $product->getVirtualColumn('price');
 
-            if ($securityContext->hasCustomerUser() && $securityContext->getCustomerUser()->getDiscount() > 0) {
+            if (!$this->getBackendContext()
+                && $securityContext->hasCustomerUser()
+                && $securityContext->getCustomerUser()->getDiscount() > 0) {
                 $price = $price * (1-($securityContext->getCustomerUser()->getDiscount()/100));
             }
 
@@ -242,7 +244,9 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             }
             $promoPrice = $product->getVirtualColumn('promo_price');
 
-            if ($securityContext->hasCustomerUser() && $securityContext->getCustomerUser()->getDiscount() > 0) {
+            if (!$this->getBackendContext()
+                && $securityContext->hasCustomerUser()
+                && $securityContext->getCustomerUser()->getDiscount() > 0) {
                 $promoPrice = $promoPrice * (1-($securityContext->getCustomerUser()->getDiscount()/100));
             }
             try {


### PR DESCRIPTION
The custome permanentr discount is also applied on the back office if the user is logged in front office
This pull request adds a test on the product loop to avoid this behavior.
Resovle #2172