### PR TITLE
Fix CSV export cached file size

### DIFF
--- a/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
+++ b/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
@@ -131,6 +131,8 @@ class CSVSerializer extends AbstractSerializer
 
         // Remove last line feed
         $fileObject->ftruncate($fileObject->getSize() - 1);
+
+        clearstatcache(true, $fileObject->getPathname());
     }
 
     public function unserialize(\SplFileObject $fileObject)


### PR DESCRIPTION
Depending platform, generated export file real size and cached size may differ