### PR TITLE
A more effective way to solve issue #2061

### DIFF
--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -386,23 +386,7 @@ class Product extends BaseAction implements EventSubscriberInterface
                 $fileList['documentList']['list'] = ProductDocumentQuery::create()
                     ->findByProductId($event->getProductId());
                 $fileList['documentList']['type'] = TheliaEvents::DOCUMENT_DELETE;
-
-                // Delete free_text_feature AV (see issue #2061)
-                $featureAvs = FeatureAvQuery::create()
-                    ->useFeatureProductQuery()
-                    ->filterByFreeTextValue(true)
-                    ->filterByProductId($event->getProductId())
-                    ->endUse()
-                    ->find($con)
-                ;
-
-                foreach ($featureAvs as $featureAv) {
-                    $featureAv
-                        ->setDispatcher($this->eventDispatcher)
-                        ->delete($con)
-                    ;
-                }
-
+                
                 // Delete product
                 $product
                     ->setDispatcher($this->eventDispatcher)


### PR DESCRIPTION
Deleting free text feature av. of a product is done in  Model\Product::postDelete(), so that features av. are deleted even if Model\Product::delete() is directly called.

This is a better solution than #2063 for solving issue #2061