### PR TITLE
Cancel coupon usage on order cancel

### DIFF
--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -38,6 +38,8 @@ use Thelia\Model\Map\OrderCouponTableMap;
 use Thelia\Model\OrderCoupon;
 use Thelia\Model\OrderCouponCountry;
 use Thelia\Model\OrderCouponModule;
+use Thelia\Model\OrderCouponQuery;
+use Thelia\Model\OrderStatusQuery;
 
 /**
  * Process Coupon Events
@@ -379,6 +381,39 @@ class Coupon extends BaseAction implements EventSubscriberInterface
     }
 
     /**
+     * Cancels order coupons usage when order is canceled.
+     *
+     * @param OrderEvent $event
+     * @param string $eventName
+     * @param EventDispatcherInterface $dispatcher
+     * @throws \Exception
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    public function orderStatusChange(OrderEvent $event, $eventName, EventDispatcherInterface $dispatcher)
+    {
+        // The order has been canceled or refunded ?
+        if ($event->getOrder()->isCancelled() || $event->getOrder()->isRefunded()) {
+            // Cancel usage of all coupons for this order
+            $usedCoupons = OrderCouponQuery::create()
+                ->filterByUsageCanceled(false)
+                ->findByOrderId($event->getOrder()->getId());
+
+            $customerId = $event->getOrder()->getCustomerId();
+
+            /** @var OrderCoupon $usedCoupon */
+            foreach ($usedCoupons as $usedCoupon) {
+                if (null !== $couponModel = CouponQuery::create()->findOneByCode($usedCoupon->getCode())) {
+                    // If the coupon still exists, restore one usage to the usage count.
+                    $this->couponManager->incrementQuantity($couponModel, $customerId);
+
+                    // Mark coupon usage as canceled in the OrderCoupin table
+                    $usedCoupon->setUsageCanceled(true)->save();
+                }
+            }
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
@@ -392,6 +427,7 @@ class Coupon extends BaseAction implements EventSubscriberInterface
             TheliaEvents::COUPON_CONDITION_UPDATE => array("updateCondition", 128),
             TheliaEvents::ORDER_SET_POSTAGE => array("testFreePostage", 132),
             TheliaEvents::ORDER_BEFORE_PAYMENT => array("afterOrder", 128),
+            TheliaEvents::ORDER_UPDATE_STATUS => array("orderStatusChange", 10),
             TheliaEvents::CART_ADDITEM => array("updateOrderDiscount", 10),
             TheliaEvents::CART_UPDATEITEM => array("updateOrderDiscount", 10),
             TheliaEvents::CART_DELETEITEM => array("updateOrderDiscount", 10),

--- a/core/lib/Thelia/Core/Template/Loop/OrderCoupon.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderCoupon.php
@@ -104,6 +104,7 @@ class OrderCoupon extends BaseLoop implements PropelSearchLoopInterface
                     ->set("FREE_SHIPPING_FOR_COUNTRIES_LIST", implode(',', $freeShippingForCountriesIds))
                     ->set("FREE_SHIPPING_FOR_MODULES_LIST", implode(',', $freeShippingForModulesIds))
                     ->set("PER_CUSTOMER_USAGE_COUNT", $orderCoupon->getPerCustomerUsageCount())
+                    ->set("IS_USAGE_CANCELED", $orderCoupon->getUsageCanceled())
                 ;
                 $this->addOutputFields($loopResultRow, $orderCoupon);
 

--- a/core/lib/Thelia/Coupon/Type/AbstractRemove.php
+++ b/core/lib/Thelia/Coupon/Type/AbstractRemove.php
@@ -14,7 +14,6 @@ namespace Thelia\Coupon\Type;
 
 use Thelia\Coupon\FacadeInterface;
 use Thelia\Model\CartItem;
-use Thelia\Model\Category;
 
 /**
  * Allow to remove an amount from the checkout total
@@ -27,7 +26,7 @@ abstract class AbstractRemove extends CouponAbstract implements AmountAndPercent
     /**
      * Set the value of specific coupon fields.
      *
-     * @param Array $effects the Coupon effects params
+     * @param array $effects the Coupon effects params
      */
     abstract public function setFieldsValue($effects);
 
@@ -80,35 +79,6 @@ abstract class AbstractRemove extends CouponAbstract implements AmountAndPercent
         $this->setFieldsValue($effects);
 
         return $this;
-    }
-    /**
-     * @inheritdoc
-     */
-    public function exec()
-    {
-        // This coupon subtracts the specified amount from the order total
-        // for each product of the selected categories.
-        $discount = 0;
-
-        $cartItems = $this->facade->getCart()->getCartItems();
-
-        /** @var CartItem $cartItem */
-        foreach ($cartItems as $cartItem) {
-            if (! $cartItem->getPromo() || $this->isAvailableOnSpecialOffers()) {
-                $categories = $cartItem->getProduct()->getCategories();
-
-                /** @var Category $category */
-                foreach ($categories as $category) {
-                    if (in_array($category->getId(), $this->category_list)) {
-                        $discount += $this->getCartItemDiscount($cartItem);
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        return $discount;
     }
 
     /**

--- a/core/lib/Thelia/Coupon/Type/AbstractRemoveOnAttributeValues.php
+++ b/core/lib/Thelia/Coupon/Type/AbstractRemoveOnAttributeValues.php
@@ -33,7 +33,7 @@ abstract class AbstractRemoveOnAttributeValues extends CouponAbstract implements
 
     /**
      * Set the value of specific coupon fields.
-     * @param Array $effects the Coupon effects params
+     * @param array $effects the Coupon effects params
      */
     abstract public function setFieldsValue($effects);
 

--- a/core/lib/Thelia/Coupon/Type/AbstractRemoveOnCategories.php
+++ b/core/lib/Thelia/Coupon/Type/AbstractRemoveOnCategories.php
@@ -15,6 +15,7 @@ namespace Thelia\Coupon\Type;
 use Thelia\Core\Translation\Translator;
 use Thelia\Coupon\FacadeInterface;
 use Thelia\Model\CartItem;
+use Thelia\Model\Category;
 
 /**
  * Allow to remove an amount from the checkout total
@@ -31,7 +32,7 @@ abstract class AbstractRemoveOnCategories extends CouponAbstract implements Amou
     /**
      * Set the value of specific coupon fields.
      *
-     * @param Array $effects the Coupon effects params
+     * @param array $effects the Coupon effects params
      */
     abstract public function setFieldsValue($effects);
 

--- a/core/lib/Thelia/Coupon/Type/AbstractRemoveOnProducts.php
+++ b/core/lib/Thelia/Coupon/Type/AbstractRemoveOnProducts.php
@@ -33,7 +33,7 @@ abstract class AbstractRemoveOnProducts extends CouponAbstract implements Amount
     /**
      * Set the value of specific coupon fields.
      *
-     * @param Array $effects the Coupon effects params
+     * @param array $effects the Coupon effects params
      */
     abstract public function setFieldsValue($effects);
 

--- a/core/lib/Thelia/Coupon/Type/AmountAndPercentageCouponInterface.php
+++ b/core/lib/Thelia/Coupon/Type/AmountAndPercentageCouponInterface.php
@@ -25,7 +25,7 @@ interface AmountAndPercentageCouponInterface
 {
     /**
      * Set the value of specific coupon fields.
-     * @param Array $effects the Coupon effects params
+     * @param array $effects the Coupon effects params
      */
     public function setFieldsValue($effects);
 
@@ -54,7 +54,13 @@ interface AmountAndPercentageCouponInterface
     public function getBaseFieldList($otherFields);
 
     /**
+     * Check the value of a coupon configuration field
      *
+     * @param string $fieldName
+     * @param string $fieldValue
+     * @return string the field value
+     *
+     * @throws \InvalidArgumentException is field value is not valid.
      */
     public function checkBaseCouponFieldValue($fieldName, $fieldValue);
 }

--- a/core/lib/Thelia/Model/Base/OrderCouponQuery.php
+++ b/core/lib/Thelia/Model/Base/OrderCouponQuery.php
@@ -36,6 +36,7 @@ use Thelia\Model\Map\OrderCouponTableMap;
  * @method     ChildOrderCouponQuery orderByIsAvailableOnSpecialOffers($order = Criteria::ASC) Order by the is_available_on_special_offers column
  * @method     ChildOrderCouponQuery orderBySerializedConditions($order = Criteria::ASC) Order by the serialized_conditions column
  * @method     ChildOrderCouponQuery orderByPerCustomerUsageCount($order = Criteria::ASC) Order by the per_customer_usage_count column
+ * @method     ChildOrderCouponQuery orderByUsageCanceled($order = Criteria::ASC) Order by the usage_canceled column
  * @method     ChildOrderCouponQuery orderByCreatedAt($order = Criteria::ASC) Order by the created_at column
  * @method     ChildOrderCouponQuery orderByUpdatedAt($order = Criteria::ASC) Order by the updated_at column
  *
@@ -54,6 +55,7 @@ use Thelia\Model\Map\OrderCouponTableMap;
  * @method     ChildOrderCouponQuery groupByIsAvailableOnSpecialOffers() Group by the is_available_on_special_offers column
  * @method     ChildOrderCouponQuery groupBySerializedConditions() Group by the serialized_conditions column
  * @method     ChildOrderCouponQuery groupByPerCustomerUsageCount() Group by the per_customer_usage_count column
+ * @method     ChildOrderCouponQuery groupByUsageCanceled() Group by the usage_canceled column
  * @method     ChildOrderCouponQuery groupByCreatedAt() Group by the created_at column
  * @method     ChildOrderCouponQuery groupByUpdatedAt() Group by the updated_at column
  *
@@ -91,6 +93,7 @@ use Thelia\Model\Map\OrderCouponTableMap;
  * @method     ChildOrderCoupon findOneByIsAvailableOnSpecialOffers(boolean $is_available_on_special_offers) Return the first ChildOrderCoupon filtered by the is_available_on_special_offers column
  * @method     ChildOrderCoupon findOneBySerializedConditions(string $serialized_conditions) Return the first ChildOrderCoupon filtered by the serialized_conditions column
  * @method     ChildOrderCoupon findOneByPerCustomerUsageCount(boolean $per_customer_usage_count) Return the first ChildOrderCoupon filtered by the per_customer_usage_count column
+ * @method     ChildOrderCoupon findOneByUsageCanceled(boolean $usage_canceled) Return the first ChildOrderCoupon filtered by the usage_canceled column
  * @method     ChildOrderCoupon findOneByCreatedAt(string $created_at) Return the first ChildOrderCoupon filtered by the created_at column
  * @method     ChildOrderCoupon findOneByUpdatedAt(string $updated_at) Return the first ChildOrderCoupon filtered by the updated_at column
  *
@@ -109,6 +112,7 @@ use Thelia\Model\Map\OrderCouponTableMap;
  * @method     array findByIsAvailableOnSpecialOffers(boolean $is_available_on_special_offers) Return ChildOrderCoupon objects filtered by the is_available_on_special_offers column
  * @method     array findBySerializedConditions(string $serialized_conditions) Return ChildOrderCoupon objects filtered by the serialized_conditions column
  * @method     array findByPerCustomerUsageCount(boolean $per_customer_usage_count) Return ChildOrderCoupon objects filtered by the per_customer_usage_count column
+ * @method     array findByUsageCanceled(boolean $usage_canceled) Return ChildOrderCoupon objects filtered by the usage_canceled column
  * @method     array findByCreatedAt(string $created_at) Return ChildOrderCoupon objects filtered by the created_at column
  * @method     array findByUpdatedAt(string $updated_at) Return ChildOrderCoupon objects filtered by the updated_at column
  *
@@ -199,7 +203,7 @@ abstract class OrderCouponQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT `ID`, `ORDER_ID`, `CODE`, `TYPE`, `AMOUNT`, `TITLE`, `SHORT_DESCRIPTION`, `DESCRIPTION`, `START_DATE`, `EXPIRATION_DATE`, `IS_CUMULATIVE`, `IS_REMOVING_POSTAGE`, `IS_AVAILABLE_ON_SPECIAL_OFFERS`, `SERIALIZED_CONDITIONS`, `PER_CUSTOMER_USAGE_COUNT`, `CREATED_AT`, `UPDATED_AT` FROM `order_coupon` WHERE `ID` = :p0';
+        $sql = 'SELECT `ID`, `ORDER_ID`, `CODE`, `TYPE`, `AMOUNT`, `TITLE`, `SHORT_DESCRIPTION`, `DESCRIPTION`, `START_DATE`, `EXPIRATION_DATE`, `IS_CUMULATIVE`, `IS_REMOVING_POSTAGE`, `IS_AVAILABLE_ON_SPECIAL_OFFERS`, `SERIALIZED_CONDITIONS`, `PER_CUSTOMER_USAGE_COUNT`, `USAGE_CANCELED`, `CREATED_AT`, `UPDATED_AT` FROM `order_coupon` WHERE `ID` = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -779,6 +783,33 @@ abstract class OrderCouponQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT, $perCustomerUsageCount, $comparison);
+    }
+
+    /**
+     * Filter the query on the usage_canceled column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByUsageCanceled(true); // WHERE usage_canceled = true
+     * $query->filterByUsageCanceled('yes'); // WHERE usage_canceled = true
+     * </code>
+     *
+     * @param     boolean|string $usageCanceled The value to use as filter.
+     *              Non-boolean arguments are converted using the following rules:
+     *                * 1, '1', 'true',  'on',  and 'yes' are converted to boolean true
+     *                * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
+     *              Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildOrderCouponQuery The current query, for fluid interface
+     */
+    public function filterByUsageCanceled($usageCanceled = null, $comparison = null)
+    {
+        if (is_string($usageCanceled)) {
+            $usage_canceled = in_array(strtolower($usageCanceled), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+        }
+
+        return $this->addUsingAlias(OrderCouponTableMap::USAGE_CANCELED, $usageCanceled, $comparison);
     }
 
     /**

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -14,6 +14,7 @@ use Thelia\Model\Map\CustomerTableMap;
 use Thelia\Core\Security\Role\Role;
 use Thelia\Core\Event\Customer\CustomerEvent;
 use Thelia\Core\Translation\Translator;
+use Thelia\Model\Tools\ModelEventDispatcherTrait;
 
 /**
  * Skeleton subclass for representing a row from the 'customer' table.
@@ -28,7 +29,7 @@ use Thelia\Core\Translation\Translator;
  */
 class Customer extends BaseCustomer implements UserInterface
 {
-    use \Thelia\Model\Tools\ModelEventDispatcherTrait;
+    use ModelEventDispatcherTrait;
 
     /**
      * @param  int                                       $titleId          customer title id (from customer_title table)
@@ -147,7 +148,7 @@ class Customer extends BaseCustomer implements UserInterface
 
             $con->commit();
         } catch (PropelException $e) {
-            $con->rollback();
+            $con->rollBack();
             throw $e;
         }
     }
@@ -286,7 +287,7 @@ class Customer extends BaseCustomer implements UserInterface
         return parent::setEmail($email);
     }
 
-   /**
+    /**
      * {@inheritDoc}
      */
     public function getUsername()

--- a/core/lib/Thelia/Model/Map/OrderCouponTableMap.php
+++ b/core/lib/Thelia/Model/Map/OrderCouponTableMap.php
@@ -58,7 +58,7 @@ class OrderCouponTableMap extends TableMap
     /**
      * The total number of columns
      */
-    const NUM_COLUMNS = 17;
+    const NUM_COLUMNS = 18;
 
     /**
      * The number of lazy-loaded columns
@@ -68,7 +68,7 @@ class OrderCouponTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    const NUM_HYDRATE_COLUMNS = 17;
+    const NUM_HYDRATE_COLUMNS = 18;
 
     /**
      * the column name for the ID field
@@ -146,6 +146,11 @@ class OrderCouponTableMap extends TableMap
     const PER_CUSTOMER_USAGE_COUNT = 'order_coupon.PER_CUSTOMER_USAGE_COUNT';
 
     /**
+     * the column name for the USAGE_CANCELED field
+     */
+    const USAGE_CANCELED = 'order_coupon.USAGE_CANCELED';
+
+    /**
      * the column name for the CREATED_AT field
      */
     const CREATED_AT = 'order_coupon.CREATED_AT';
@@ -167,12 +172,12 @@ class OrderCouponTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'OrderId', 'Code', 'Type', 'Amount', 'Title', 'ShortDescription', 'Description', 'StartDate', 'ExpirationDate', 'IsCumulative', 'IsRemovingPostage', 'IsAvailableOnSpecialOffers', 'SerializedConditions', 'PerCustomerUsageCount', 'CreatedAt', 'UpdatedAt', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'orderId', 'code', 'type', 'amount', 'title', 'shortDescription', 'description', 'startDate', 'expirationDate', 'isCumulative', 'isRemovingPostage', 'isAvailableOnSpecialOffers', 'serializedConditions', 'perCustomerUsageCount', 'createdAt', 'updatedAt', ),
-        self::TYPE_COLNAME       => array(OrderCouponTableMap::ID, OrderCouponTableMap::ORDER_ID, OrderCouponTableMap::CODE, OrderCouponTableMap::TYPE, OrderCouponTableMap::AMOUNT, OrderCouponTableMap::TITLE, OrderCouponTableMap::SHORT_DESCRIPTION, OrderCouponTableMap::DESCRIPTION, OrderCouponTableMap::START_DATE, OrderCouponTableMap::EXPIRATION_DATE, OrderCouponTableMap::IS_CUMULATIVE, OrderCouponTableMap::IS_REMOVING_POSTAGE, OrderCouponTableMap::IS_AVAILABLE_ON_SPECIAL_OFFERS, OrderCouponTableMap::SERIALIZED_CONDITIONS, OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT, OrderCouponTableMap::CREATED_AT, OrderCouponTableMap::UPDATED_AT, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'ORDER_ID', 'CODE', 'TYPE', 'AMOUNT', 'TITLE', 'SHORT_DESCRIPTION', 'DESCRIPTION', 'START_DATE', 'EXPIRATION_DATE', 'IS_CUMULATIVE', 'IS_REMOVING_POSTAGE', 'IS_AVAILABLE_ON_SPECIAL_OFFERS', 'SERIALIZED_CONDITIONS', 'PER_CUSTOMER_USAGE_COUNT', 'CREATED_AT', 'UPDATED_AT', ),
-        self::TYPE_FIELDNAME     => array('id', 'order_id', 'code', 'type', 'amount', 'title', 'short_description', 'description', 'start_date', 'expiration_date', 'is_cumulative', 'is_removing_postage', 'is_available_on_special_offers', 'serialized_conditions', 'per_customer_usage_count', 'created_at', 'updated_at', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, )
+        self::TYPE_PHPNAME       => array('Id', 'OrderId', 'Code', 'Type', 'Amount', 'Title', 'ShortDescription', 'Description', 'StartDate', 'ExpirationDate', 'IsCumulative', 'IsRemovingPostage', 'IsAvailableOnSpecialOffers', 'SerializedConditions', 'PerCustomerUsageCount', 'UsageCanceled', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'orderId', 'code', 'type', 'amount', 'title', 'shortDescription', 'description', 'startDate', 'expirationDate', 'isCumulative', 'isRemovingPostage', 'isAvailableOnSpecialOffers', 'serializedConditions', 'perCustomerUsageCount', 'usageCanceled', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(OrderCouponTableMap::ID, OrderCouponTableMap::ORDER_ID, OrderCouponTableMap::CODE, OrderCouponTableMap::TYPE, OrderCouponTableMap::AMOUNT, OrderCouponTableMap::TITLE, OrderCouponTableMap::SHORT_DESCRIPTION, OrderCouponTableMap::DESCRIPTION, OrderCouponTableMap::START_DATE, OrderCouponTableMap::EXPIRATION_DATE, OrderCouponTableMap::IS_CUMULATIVE, OrderCouponTableMap::IS_REMOVING_POSTAGE, OrderCouponTableMap::IS_AVAILABLE_ON_SPECIAL_OFFERS, OrderCouponTableMap::SERIALIZED_CONDITIONS, OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT, OrderCouponTableMap::USAGE_CANCELED, OrderCouponTableMap::CREATED_AT, OrderCouponTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'ORDER_ID', 'CODE', 'TYPE', 'AMOUNT', 'TITLE', 'SHORT_DESCRIPTION', 'DESCRIPTION', 'START_DATE', 'EXPIRATION_DATE', 'IS_CUMULATIVE', 'IS_REMOVING_POSTAGE', 'IS_AVAILABLE_ON_SPECIAL_OFFERS', 'SERIALIZED_CONDITIONS', 'PER_CUSTOMER_USAGE_COUNT', 'USAGE_CANCELED', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'order_id', 'code', 'type', 'amount', 'title', 'short_description', 'description', 'start_date', 'expiration_date', 'is_cumulative', 'is_removing_postage', 'is_available_on_special_offers', 'serialized_conditions', 'per_customer_usage_count', 'usage_canceled', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, )
     );
 
     /**
@@ -182,12 +187,12 @@ class OrderCouponTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'OrderId' => 1, 'Code' => 2, 'Type' => 3, 'Amount' => 4, 'Title' => 5, 'ShortDescription' => 6, 'Description' => 7, 'StartDate' => 8, 'ExpirationDate' => 9, 'IsCumulative' => 10, 'IsRemovingPostage' => 11, 'IsAvailableOnSpecialOffers' => 12, 'SerializedConditions' => 13, 'PerCustomerUsageCount' => 14, 'CreatedAt' => 15, 'UpdatedAt' => 16, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'orderId' => 1, 'code' => 2, 'type' => 3, 'amount' => 4, 'title' => 5, 'shortDescription' => 6, 'description' => 7, 'startDate' => 8, 'expirationDate' => 9, 'isCumulative' => 10, 'isRemovingPostage' => 11, 'isAvailableOnSpecialOffers' => 12, 'serializedConditions' => 13, 'perCustomerUsageCount' => 14, 'createdAt' => 15, 'updatedAt' => 16, ),
-        self::TYPE_COLNAME       => array(OrderCouponTableMap::ID => 0, OrderCouponTableMap::ORDER_ID => 1, OrderCouponTableMap::CODE => 2, OrderCouponTableMap::TYPE => 3, OrderCouponTableMap::AMOUNT => 4, OrderCouponTableMap::TITLE => 5, OrderCouponTableMap::SHORT_DESCRIPTION => 6, OrderCouponTableMap::DESCRIPTION => 7, OrderCouponTableMap::START_DATE => 8, OrderCouponTableMap::EXPIRATION_DATE => 9, OrderCouponTableMap::IS_CUMULATIVE => 10, OrderCouponTableMap::IS_REMOVING_POSTAGE => 11, OrderCouponTableMap::IS_AVAILABLE_ON_SPECIAL_OFFERS => 12, OrderCouponTableMap::SERIALIZED_CONDITIONS => 13, OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT => 14, OrderCouponTableMap::CREATED_AT => 15, OrderCouponTableMap::UPDATED_AT => 16, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'ORDER_ID' => 1, 'CODE' => 2, 'TYPE' => 3, 'AMOUNT' => 4, 'TITLE' => 5, 'SHORT_DESCRIPTION' => 6, 'DESCRIPTION' => 7, 'START_DATE' => 8, 'EXPIRATION_DATE' => 9, 'IS_CUMULATIVE' => 10, 'IS_REMOVING_POSTAGE' => 11, 'IS_AVAILABLE_ON_SPECIAL_OFFERS' => 12, 'SERIALIZED_CONDITIONS' => 13, 'PER_CUSTOMER_USAGE_COUNT' => 14, 'CREATED_AT' => 15, 'UPDATED_AT' => 16, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'order_id' => 1, 'code' => 2, 'type' => 3, 'amount' => 4, 'title' => 5, 'short_description' => 6, 'description' => 7, 'start_date' => 8, 'expiration_date' => 9, 'is_cumulative' => 10, 'is_removing_postage' => 11, 'is_available_on_special_offers' => 12, 'serialized_conditions' => 13, 'per_customer_usage_count' => 14, 'created_at' => 15, 'updated_at' => 16, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'OrderId' => 1, 'Code' => 2, 'Type' => 3, 'Amount' => 4, 'Title' => 5, 'ShortDescription' => 6, 'Description' => 7, 'StartDate' => 8, 'ExpirationDate' => 9, 'IsCumulative' => 10, 'IsRemovingPostage' => 11, 'IsAvailableOnSpecialOffers' => 12, 'SerializedConditions' => 13, 'PerCustomerUsageCount' => 14, 'UsageCanceled' => 15, 'CreatedAt' => 16, 'UpdatedAt' => 17, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'orderId' => 1, 'code' => 2, 'type' => 3, 'amount' => 4, 'title' => 5, 'shortDescription' => 6, 'description' => 7, 'startDate' => 8, 'expirationDate' => 9, 'isCumulative' => 10, 'isRemovingPostage' => 11, 'isAvailableOnSpecialOffers' => 12, 'serializedConditions' => 13, 'perCustomerUsageCount' => 14, 'usageCanceled' => 15, 'createdAt' => 16, 'updatedAt' => 17, ),
+        self::TYPE_COLNAME       => array(OrderCouponTableMap::ID => 0, OrderCouponTableMap::ORDER_ID => 1, OrderCouponTableMap::CODE => 2, OrderCouponTableMap::TYPE => 3, OrderCouponTableMap::AMOUNT => 4, OrderCouponTableMap::TITLE => 5, OrderCouponTableMap::SHORT_DESCRIPTION => 6, OrderCouponTableMap::DESCRIPTION => 7, OrderCouponTableMap::START_DATE => 8, OrderCouponTableMap::EXPIRATION_DATE => 9, OrderCouponTableMap::IS_CUMULATIVE => 10, OrderCouponTableMap::IS_REMOVING_POSTAGE => 11, OrderCouponTableMap::IS_AVAILABLE_ON_SPECIAL_OFFERS => 12, OrderCouponTableMap::SERIALIZED_CONDITIONS => 13, OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT => 14, OrderCouponTableMap::USAGE_CANCELED => 15, OrderCouponTableMap::CREATED_AT => 16, OrderCouponTableMap::UPDATED_AT => 17, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'ORDER_ID' => 1, 'CODE' => 2, 'TYPE' => 3, 'AMOUNT' => 4, 'TITLE' => 5, 'SHORT_DESCRIPTION' => 6, 'DESCRIPTION' => 7, 'START_DATE' => 8, 'EXPIRATION_DATE' => 9, 'IS_CUMULATIVE' => 10, 'IS_REMOVING_POSTAGE' => 11, 'IS_AVAILABLE_ON_SPECIAL_OFFERS' => 12, 'SERIALIZED_CONDITIONS' => 13, 'PER_CUSTOMER_USAGE_COUNT' => 14, 'USAGE_CANCELED' => 15, 'CREATED_AT' => 16, 'UPDATED_AT' => 17, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'order_id' => 1, 'code' => 2, 'type' => 3, 'amount' => 4, 'title' => 5, 'short_description' => 6, 'description' => 7, 'start_date' => 8, 'expiration_date' => 9, 'is_cumulative' => 10, 'is_removing_postage' => 11, 'is_available_on_special_offers' => 12, 'serialized_conditions' => 13, 'per_customer_usage_count' => 14, 'usage_canceled' => 15, 'created_at' => 16, 'updated_at' => 17, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, )
     );
 
     /**
@@ -221,6 +226,7 @@ class OrderCouponTableMap extends TableMap
         $this->addColumn('IS_AVAILABLE_ON_SPECIAL_OFFERS', 'IsAvailableOnSpecialOffers', 'BOOLEAN', true, 1, null);
         $this->addColumn('SERIALIZED_CONDITIONS', 'SerializedConditions', 'LONGVARCHAR', true, null, null);
         $this->addColumn('PER_CUSTOMER_USAGE_COUNT', 'PerCustomerUsageCount', 'BOOLEAN', true, 1, null);
+        $this->addColumn('USAGE_CANCELED', 'UsageCanceled', 'BOOLEAN', false, 1, false);
         $this->addColumn('CREATED_AT', 'CreatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('UPDATED_AT', 'UpdatedAt', 'TIMESTAMP', false, null, null);
     } // initialize()
@@ -412,6 +418,7 @@ class OrderCouponTableMap extends TableMap
             $criteria->addSelectColumn(OrderCouponTableMap::IS_AVAILABLE_ON_SPECIAL_OFFERS);
             $criteria->addSelectColumn(OrderCouponTableMap::SERIALIZED_CONDITIONS);
             $criteria->addSelectColumn(OrderCouponTableMap::PER_CUSTOMER_USAGE_COUNT);
+            $criteria->addSelectColumn(OrderCouponTableMap::USAGE_CANCELED);
             $criteria->addSelectColumn(OrderCouponTableMap::CREATED_AT);
             $criteria->addSelectColumn(OrderCouponTableMap::UPDATED_AT);
         } else {
@@ -430,6 +437,7 @@ class OrderCouponTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.IS_AVAILABLE_ON_SPECIAL_OFFERS');
             $criteria->addSelectColumn($alias . '.SERIALIZED_CONDITIONS');
             $criteria->addSelectColumn($alias . '.PER_CUSTOMER_USAGE_COUNT');
+            $criteria->addSelectColumn($alias . '.USAGE_CANCELED');
             $criteria->addSelectColumn($alias . '.CREATED_AT');
             $criteria->addSelectColumn($alias . '.UPDATED_AT');
         }

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -333,7 +333,7 @@ class Order extends BaseOrder
     /**
      * Check if the current status of this order is REFUNDED
      *
-     * @return bool true if this order is CANCELED, false otherwise.
+     * @return bool true if this order is REFUNDED, false otherwise.
      */
     public function isRefunded()
     {

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1,9 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <database defaultIdMethod="native" name="thelia">
-  <vendor type="mysql">
-    <parameter name="Engine" value="InnoDB"/>
-    <parameter name="Charset" value="utf8"/>
-  </vendor>
   <table name="category" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column defaultValue="0" name="parent" required="true" type="INTEGER" />
@@ -390,51 +386,41 @@
     </behavior>
   </table>
   <table name="customer" namespace="Thelia\Model">
-    <column name="id" type="INTEGER" required="true" primaryKey="true" autoIncrement="true" />
-
-    <column name="title_id" type="INTEGER" required="true" />
-    <column name="lang_id" type="INTEGER" required="false" />
-
-    <column name="ref" type="VARCHAR" size="50" />
-    <column name="firstname" type="VARCHAR" size="255" required="true" />
-    <column name="lastname" type="VARCHAR" size="255" required="true" />
-    <column name="email" type="VARCHAR" size="255" />
-    <column name="password" type="VARCHAR" size="255" />
-    <column name="algo" type="VARCHAR" size="128" />
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="title_id" required="true" type="INTEGER" />
+    <column name="lang_id" type="INTEGER" />
+    <column name="ref" size="50" type="VARCHAR" />
+    <column name="firstname" required="true" size="255" type="VARCHAR" />
+    <column name="lastname" required="true" size="255" type="VARCHAR" />
+    <column name="email" size="255" type="VARCHAR" />
+    <column name="password" size="255" type="VARCHAR" />
+    <column name="algo" size="128" type="VARCHAR" />
     <column name="reseller" type="TINYINT" />
-    <column name="sponsor" type="VARCHAR" size="50" />
-    <column name="discount" type="DECIMAL" scale="6" size="16" defaultValue="0.000000" />
-    <column name="remember_me_token" type="VARCHAR" size="255" />
-    <column name="remember_me_serial" type="VARCHAR" size="255" />
+    <column name="sponsor" size="50" type="VARCHAR" />
+    <column defaultValue="0.000000" name="discount" scale="6" size="16" type="DECIMAL" />
+    <column name="remember_me_token" size="255" type="VARCHAR" />
+    <column name="remember_me_serial" size="255" type="VARCHAR" />
     <column defaultValue="0" name="enable" type="TINYINT" />
     <column name="confirmation_token" size="255" type="VARCHAR" />
-
-    <unique name="ref_UNIQUE">
-      <unique-column name="ref" />
-    </unique>
-
-    <index name="idx_customer_customer_title_id">
-      <index-column name="title_id" />
-    </index>
-
-    <index name="idx_customer_lang_id">
-      <index-column name="lang_id" />
-    </index>
-
-    <index name="idx_email">
-      <index-column name="email" />
-    </index>
-
     <foreign-key foreignTable="customer_title" name="fk_customer_customer_title_id" onDelete="RESTRICT" onUpdate="RESTRICT">
       <reference foreign="id" local="title_id" />
     </foreign-key>
-
-    <foreign-key foreignTable="lang" phpName="LangModel" name="fk_customer_lang_id" onDelete="SET NULL" onUpdate="RESTRICT">
+    <foreign-key foreignTable="lang" name="fk_customer_lang_id" onDelete="SET NULL" onUpdate="RESTRICT" phpName="LangModel">
       <reference foreign="id" local="lang_id" />
     </foreign-key>
-
+    <unique name="ref_UNIQUE">
+      <unique-column name="ref" />
+    </unique>
+    <index name="idx_customer_customer_title_id">
+      <index-column name="title_id" />
+    </index>
+    <index name="idx_customer_lang_id">
+      <index-column name="lang_id" />
+    </index>
+    <index name="idx_email">
+      <index-column name="email" />
+    </index>
     <behavior name="timestampable" />
-
     <behavior name="versionable">
       <parameter name="log_created_at" value="true" />
       <parameter name="log_created_by" value="true" />
@@ -773,9 +759,9 @@
   <table name="order_status" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="code" required="true" size="45" type="VARCHAR" />
-    <column name="color" type="CHAR" size="7" />
+    <column name="color" size="7" type="CHAR" />
     <column name="position" type="INTEGER" />
-    <column name="protected_status" type="BOOLEAN" defaultValue="0" />
+    <column defaultValue="0" name="protected_status" type="BOOLEAN" />
     <column name="title" size="255" type="VARCHAR" />
     <column name="description" type="CLOB" />
     <column name="chapo" type="LONGVARCHAR" />
@@ -1005,7 +991,7 @@
     <column name="is_enabled" required="true" type="BOOLEAN" />
     <column name="short_description" required="true" type="LONGVARCHAR" />
     <column name="description" required="true" type="CLOB" />
-    <column name="start_date" defaultValue="NULL" type="TIMESTAMP" />
+    <column defaultValue="NULL" name="start_date" type="TIMESTAMP" />
     <column name="expiration_date" type="TIMESTAMP" />
     <column name="max_usage" required="true" type="INTEGER" />
     <column name="is_cumulative" required="true" type="BOOLEAN" />
@@ -1026,9 +1012,6 @@
     <index name="idx_type">
       <index-column name="type" />
     </index>
-    <index name="idx_start_date">
-      <index-column name="start_date" />
-    </index>
     <index name="idx_expiration_date">
       <index-column name="expiration_date" />
     </index>
@@ -1043,6 +1026,9 @@
     </index>
     <index name="idx_is_available_on_special_offers">
       <index-column name="is_available_on_special_offers" />
+    </index>
+    <index name="idx_start_date">
+      <index-column name="start_date" />
     </index>
     <behavior name="timestampable" />
     <behavior name="i18n">
@@ -1435,22 +1421,18 @@
     <behavior name="timestampable" />
   </table>
   <table name="newsletter" namespace="Thelia\Model">
-    <column name="id" type="INTEGER" required="true" primaryKey="true" autoIncrement="true" />
-
-    <column name="email" type="VARCHAR" size="255" required="true" />
-    <column name="firstname" type="VARCHAR" size="255" />
-    <column name="lastname" type="VARCHAR" size="255" />
-    <column name="locale" type="VARCHAR" size="5" />
-    <column name="unsubscribed" type="BOOLEAN" required="true" defaultValue="false"/>
-
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="email" required="true" size="255" type="VARCHAR" />
+    <column name="firstname" size="255" type="VARCHAR" />
+    <column name="lastname" size="255" type="VARCHAR" />
+    <column name="locale" size="5" type="VARCHAR" />
+    <column defaultValue="0" name="unsubscribed" required="true" type="BOOLEAN" />
     <unique name="email_UNIQUE">
       <unique-column name="email" />
     </unique>
-
     <index name="idx_unsubscribed">
       <index-column name="unsubscribed" />
     </index>
-
     <behavior name="timestampable" />
   </table>
   <table name="order_coupon" namespace="Thelia\Model">
@@ -1462,13 +1444,14 @@
     <column name="title" required="true" size="255" type="VARCHAR" />
     <column name="short_description" required="true" type="LONGVARCHAR" />
     <column name="description" required="true" type="CLOB" />
-    <column name="start_date" defaultValue="NULL" type="TIMESTAMP" />
+    <column defaultValue="NULL" name="start_date" type="TIMESTAMP" />
     <column name="expiration_date" required="true" type="TIMESTAMP" />
     <column name="is_cumulative" required="true" type="BOOLEAN" />
     <column name="is_removing_postage" required="true" type="BOOLEAN" />
     <column name="is_available_on_special_offers" required="true" type="BOOLEAN" />
     <column name="serialized_conditions" required="true" type="LONGVARCHAR" />
     <column name="per_customer_usage_count" required="true" type="BOOLEAN" />
+    <column defaultValue="0" name="usage_canceled" type="BOOLEAN" />
     <foreign-key foreignTable="order" name="fk_order_coupon_order_id" onDelete="CASCADE" onUpdate="RESTRICT">
       <reference foreign="id" local="order_id" />
     </foreign-key>

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<database defaultIdMethod="native" name="thelia">
+<database defaultIdMethod="native" name="thelia">  <vendor type="mysql">    <parameter name="Engine" value="InnoDB"/>    <parameter name="Charset" value="utf8"/>  </vendor>
   <table name="category" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column defaultValue="0" name="parent" required="true" type="INTEGER" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -1203,12 +1203,12 @@ CREATE TABLE `coupon`
     INDEX `idx_is_enabled` (`is_enabled`),
     INDEX `idx_is_used` (`is_used`),
     INDEX `idx_type` (`type`),
-    INDEX `idx_start_date` (`start_date`),
     INDEX `idx_expiration_date` (`expiration_date`),
     INDEX `idx_is_cumulative` (`is_cumulative`),
     INDEX `idx_is_removing_postage` (`is_removing_postage`),
     INDEX `idx_max_usage` (`max_usage`),
-    INDEX `idx_is_available_on_special_offers` (`is_available_on_special_offers`)
+    INDEX `idx_is_available_on_special_offers` (`is_available_on_special_offers`),
+    INDEX `idx_start_date` (`start_date`)
 ) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------
@@ -1738,6 +1738,7 @@ CREATE TABLE `order_coupon`
     `is_available_on_special_offers` TINYINT(1) NOT NULL,
     `serialized_conditions` TEXT NOT NULL,
     `per_customer_usage_count` TINYINT(1) NOT NULL,
+    `usage_canceled` TINYINT(1) DEFAULT 0,
     `created_at` DATETIME,
     `updated_at` DATETIME,
     PRIMARY KEY (`id`),

--- a/setup/update/sql/2.4.0-alpha1.sql
+++ b/setup/update/sql/2.4.0-alpha1.sql
@@ -159,4 +159,8 @@ INSERT INTO  `hook_i18n` (`id`, `locale`, `title`, `description`, `chapo`) VALUE
 (@max_id+9,  'fr_FR', NULL, NULL, NULL)
 ;
 
+-- Additional usage_canceled column in order_coupon table
+
+ALTER TABLE `order_coupon` ADD `usage_canceled` TINYINT(1) DEFAULT '0' AFTER `per_customer_usage_count`;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.4.0-alpha1.sql.tpl
+++ b/setup/update/tpl/2.4.0-alpha1.sql.tpl
@@ -117,4 +117,8 @@ INSERT INTO  `hook_i18n` (`id`, `locale`, `title`, `description`, `chapo`) VALUE
 {/foreach}
 ;
 
+-- Additional usage_canceled column in order_coupon table
+
+ALTER TABLE `order_coupon` ADD `usage_canceled` TINYINT(1) DEFAULT '0' AFTER `per_customer_usage_count`;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/phpunit/Thelia/Tests/Files/FileManagerTest.php
+++ b/tests/phpunit/Thelia/Tests/Files/FileManagerTest.php
@@ -176,6 +176,9 @@ class FileManagerTest extends \PHPUnit_Framework_TestCase
 
         $file = $this->fileManager->copyUploadedFile($model, $uploadedFile);
 
+        // Normalize path
+        $file = str_replace('/', DS, $file);
+
         $this->assertEquals("".$file, $targetFile);
 
         $this->assertEquals(basename($targetFile), $model->getFile());
@@ -212,6 +215,9 @@ class FileManagerTest extends \PHPUnit_Framework_TestCase
         );
 
         $file = $this->fileManager->copyUploadedFile($model, $uploadedFile);
+
+        // Normalize path
+        $file = str_replace('/', DS, $file);
 
         $this->assertEquals("".$file, $targetFile);
 

--- a/unit-tests.bat
+++ b/unit-tests.bat
@@ -13,7 +13,7 @@ php Thelia module:refresh
 echo [INFO] Activating Hook Test Module
 php Thelia module:activate HookTest
 
-call phpunit %*
+call bin\phpunit %*
 
 echo [INFO] Desactivating Hook Test Module
 php Thelia module:deactivate HookTest


### PR DESCRIPTION
When an order is canceled, the use of coupons attached to this order is also canceled. For short, coupon usage count is incremented by 1, and the related OrderStatus coupon is marked as canceled.

This PR syncs the schema.xml file with the WorkBench model, and adds minor CS and unit test improvements