### PR TITLE
Check if $error exist, specific for submit type

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Form.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Form.php
@@ -185,11 +185,11 @@ class Form extends AbstractSmartyPlugin
 
         /** @var FormErrorIterator $errors */
         $errors = $fieldVars["errors"];
-
-        $template->assign("error", $errors->count() ? true : false);
-
-        $this->assignFieldErrorVars($template, $errors);
-
+        if ($errors) {
+            $template->assign("error", $errors->count() ? true : false);
+            $this->assignFieldErrorVars($template, $errors);
+        }
+        
         $attr = array();
 
         foreach ($fieldVars["attr"] as $key => $value) {


### PR DESCRIPTION
SubmitType doesn't contain $fieldVars['errors'].
Check if this var exist to add in template.