### PR TITLE
add reset array pointer if $data is an array.

### DIFF
--- a/core/lib/Thelia/ImportExport/Export/AbstractExport.php
+++ b/core/lib/Thelia/ImportExport/Export/AbstractExport.php
@@ -152,6 +152,7 @@ abstract class AbstractExport implements \Iterator
             if (is_array($data)) {
                 $this->data = $data;
                 $this->dataIsArray = true;
+                reset($this->getData());
 
                 return;
             }


### PR DESCRIPTION
Because, if getData() include foreach on $data, key($data) return false and export is empty.