### PR TITLE
évite les doublons dans la loop country avec l'argument "with_area"

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Country.php
+++ b/core/lib/Thelia/Core/Template/Loop/Country.php
@@ -118,6 +118,7 @@ class Country extends BaseI18nLoop implements PropelSearchLoopInterface
 
         if (true === $withArea) {
             $search
+                ->distinct()
                 ->joinCountryArea('with_area', Criteria::LEFT_JOIN)
                 ->where('`with_area`.country_id ' . Criteria::ISNOTNULL);
         } elseif (false === $withArea) {


### PR DESCRIPTION
Correction du problème exposé dans l'issue https://github.com/thelia/thelia/issues/2216