### PR TITLE
Added simple message processing to MailerFactory

### DIFF
--- a/core/lib/Thelia/Controller/Admin/MailingSystemController.php
+++ b/core/lib/Thelia/Controller/Admin/MailingSystemController.php
@@ -23,13 +23,13 @@ use Thelia\Model\ConfigQuery;
 class MailingSystemController extends BaseAdminController
 {
     const RESOURCE_CODE = "admin.mailing-system";
-
+    
     public function defaultAction()
     {
         if (null !== $response = $this->checkAuth(self::RESOURCE_CODE, array(), AccessManager::VIEW)) {
             return $response;
         }
-
+        
         // Hydrate the form abd pass it to the parser
         $data = array(
             'enabled'       => ConfigQuery::isSmtpEnable() ? 1 : 0,
@@ -42,33 +42,33 @@ class MailingSystemController extends BaseAdminController
             'timeout'       => ConfigQuery::getSmtpTimeout(),
             'sourceip'      => ConfigQuery::getSmtpSourceIp(),
         );
-
+        
         // Setup the object form
         $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION, "form", $data);
-
+        
         // Pass it to the parser
         $this->getParserContext()->addForm($form);
-
+        
         // Render the edition template.
         return $this->render('mailing-system');
     }
-
+    
     public function updateAction()
     {
         // Check current user authorization
         if (null !== $response = $this->checkAuth(self::RESOURCE_CODE, array(), AccessManager::UPDATE)) {
             return $response;
         }
-
+        
         $error_msg = false;
-
+        
         // Create the form from the request
         $form = $this->createForm(AdminForm::MAILING_SYSTEM_MODIFICATION);
-
+        
         try {
             // Check the form against constraints violations
             $formData = $this->validateForm($form, "POST");
-
+            
             // Get the form field values
             $event = new MailingSystemEvent();
             $event->setEnabled($formData->get('enabled')->getData());
@@ -80,9 +80,9 @@ class MailingSystemController extends BaseAdminController
             $event->setAuthMode($formData->get('authmode')->getData());
             $event->setTimeout($formData->get('timeout')->getData());
             $event->setSourceIp($formData->get('sourceip')->getData());
-
+            
             $this->dispatch(TheliaEvents::MAILING_SYSTEM_UPDATE, $event);
-
+            
             // Redirect to the success URL
             $response = $this->generateRedirectFromRoute("admin.configuration.mailing-system.view");
         } catch (FormValidationException $ex) {
@@ -92,7 +92,7 @@ class MailingSystemController extends BaseAdminController
             // Any other error
             $error_msg = $ex->getMessage();
         }
-
+        
         if (false !== $error_msg) {
             $this->setupFormErrorContext(
                 $this->getTranslator()->trans("mailing system modification", array()),
@@ -100,44 +100,44 @@ class MailingSystemController extends BaseAdminController
                 $form,
                 $ex
             );
-
+            
             // At this point, the form has errors, and should be redisplayed.
             $response = $this->render('mailing-system');
         }
-
+        
         return $response;
     }
-
+    
     public function testAction()
     {
         // Check current user authorization
         if (null !== $response = $this->checkAuth(self::RESOURCE_CODE, array(), AccessManager::UPDATE)) {
             return $response;
         }
-
+        
         $contactEmail = ConfigQuery::read('store_email');
         $storeName = ConfigQuery::read('store_name', 'Thelia');
-
+        
         $json_data = array(
             "success" => false,
             "message" => "",
         );
-
+        
         if ($contactEmail) {
             $emailTest = $this->getRequest()->get("email", $contactEmail);
-
+            
             $message = $this->getTranslator()->trans("Email test from : %store%", array("%store%" => $storeName));
-
+            
             $htmlMessage = "<p>$message</p>";
-
-            $instance = \Swift_Message::newInstance()
+            
+            $instance = $this->getMailer()->getMessageInstance()
                 ->addTo($emailTest, $storeName)
                 ->addFrom($contactEmail, $storeName)
                 ->setSubject($message)
                 ->setBody($message, 'text/plain')
                 ->setBody($htmlMessage, 'text/html')
             ;
-
+            
             try {
                 $this->getMailer()->send($instance);
                 $json_data["success"] = true;
@@ -148,9 +148,9 @@ class MailingSystemController extends BaseAdminController
         } else {
             $json_data["message"] = $this->getTranslator()->trans("You have to configure your store email first !");
         }
-
+        
         $response = JsonResponse::create($json_data);
-
+        
         return $response;
     }
 }

--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -27,6 +27,7 @@ use Thelia\Model\MessageQuery;
  * Class MailerFactory
  * @package Thelia\Mailer
  * @author Manuel Raynaud <manu@raynaud.io>
+ * @author Franck Allimant <franck@cqfdev.fr>
  */
 class MailerFactory
 {
@@ -34,18 +35,18 @@ class MailerFactory
      * @var \Swift_Mailer
      */
     protected $swiftMailer;
-
+    
     protected $dispatcher;
     protected $parser;
-
+    
     public function __construct(EventDispatcherInterface $dispatcher, ParserInterface $parser)
     {
         $this->dispatcher = $dispatcher;
         $this->parser    = $parser;
-
+        
         $transporterEvent = new MailTransporterEvent();
         $this->dispatcher->dispatch(TheliaEvents::MAILTRANSPORTER_CONFIG, $transporterEvent);
-
+        
         if ($transporterEvent->hasTransporter()) {
             $transporter = $transporterEvent->getTransporter();
         } else {
@@ -55,14 +56,14 @@ class MailerFactory
                 $transporter = \Swift_MailTransport::newInstance();
             }
         }
-
+        
         $this->swiftMailer = new \Swift_Mailer($transporter);
     }
-
+    
     private function configureSmtp()
     {
         $smtpTransporter = \Swift_SmtpTransport::newInstance(ConfigQuery::getSmtpHost(), ConfigQuery::getSmtpPort());
-
+        
         if (ConfigQuery::getSmtpEncryption()) {
             $smtpTransporter->setEncryption(ConfigQuery::getSmtpEncryption());
         }
@@ -81,20 +82,38 @@ class MailerFactory
         if (ConfigQuery::getSmtpSourceIp()) {
             $smtpTransporter->setSourceIp(ConfigQuery::getSmtpSourceIp());
         }
-
+        
         return $smtpTransporter;
     }
-
+    
+    /**
+     * @param \Swift_Mime_Message $message
+     * @param null $failedRecipients
+     * @return int number of recipients who were accepted for delivery.
+     */
     public function send(\Swift_Mime_Message $message, &$failedRecipients = null)
     {
         return $this->swiftMailer->send($message, $failedRecipients);
     }
-
+    
+    /**
+     * @return \Swift_Mailer
+     */
     public function getSwiftMailer()
     {
         return $this->swiftMailer;
     }
-
+    
+    /**
+     * Return a new message instance
+     *
+     * @return \Swift_Message
+     */
+    public function getMessageInstance()
+    {
+        return \Swift_Message::newInstance();
+    }
+    
     /**
      * Send a message to the customer.
      *
@@ -106,7 +125,7 @@ class MailerFactory
     {
         // Always add the customer ID to the parameters
         $messageParameters['customer_id'] = $customer->getId();
-
+        
         $this->sendEmailMessage(
             $messageCode,
             [ ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName() ],
@@ -115,7 +134,7 @@ class MailerFactory
             $customer->getCustomerLang()->getLocale()
         );
     }
-
+    
     /**
      * Send a message to the shop managers.
      *
@@ -126,26 +145,28 @@ class MailerFactory
     public function sendEmailToShopManagers($messageCode, $messageParameters = [], $replyTo = [])
     {
         $storeName = ConfigQuery::getStoreName();
-
+        
         // Build the list of email recipients
         $recipients = ConfigQuery::getNotificationEmailsList();
-
+        
         $to = [];
-
+        
         foreach ($recipients as $recipient) {
             $to[$recipient] = $storeName;
         }
-
+        
         $this->sendEmailMessage(
             $messageCode,
             [ConfigQuery::getStoreEmail() => $storeName],
             $to,
             $messageParameters,
-            null,[],[],
+            null,
+            [],
+            [],
             $replyTo
         );
     }
-
+    
     /**
      * Send a message to the customer.
      *
@@ -161,13 +182,13 @@ class MailerFactory
     public function sendEmailMessage($messageCode, $from, $to, $messageParameters = [], $locale = null, $cc = [], $bcc = [], $replyTo = [])
     {
         $store_email = ConfigQuery::getStoreEmail();
-
+        
         if (! empty($store_email)) {
             if (! empty($to)) {
                 $instance = $this->createEmailMessage($messageCode, $from, $to, $messageParameters, $locale, $cc, $bcc, $replyTo);
-
+                
                 $sentCount = $this->send($instance, $failedRecipients);
-
+                
                 if ($sentCount == 0) {
                     Tlog::getInstance()->addError(
                         Translator::getInstance()->trans(
@@ -189,7 +210,7 @@ class MailerFactory
             Tlog::getInstance()->addError("Can't send email message $messageCode: store email address is not defined.");
         }
     }
-
+    
     /**
      * Create a SwiftMessage instance from a given message code.
      *
@@ -210,53 +231,124 @@ class MailerFactory
             if ($locale === null) {
                 $locale = Lang::getDefaultLanguage()->getLocale();
             }
-
+            
             $message->setLocale($locale);
-
+            
             // Assign parameters
             foreach ($messageParameters as $name => $value) {
                 $this->parser->assign($name, $value);
             }
-
-            $this->parser->assign('locale', $locale);
-
-            $instance = \Swift_Message::newInstance();
-
-            // Add from addresses
-            foreach ($from as $address => $name) {
-                $instance->addFrom($address, $name);
-            }
-
-            // Add to addresses
-            foreach ($to as $address => $name) {
-                $instance->addTo($address, $name);
-            }
-
-            // Add cc addresses
-            foreach ($cc as $address => $name) {
-                $instance->addCc($address, $name);
-            }
             
-            // Add bcc addresses
-            foreach ($bcc as $address => $name) {
-                $instance->addBcc($address, $name);
-            }
-
-            // Add reply to addresses
-            foreach ($replyTo as $address => $name) {
-                $instance->addReplyTo($address, $name);
-            }
+            $this->parser->assign('locale', $locale);
+            
+            $instance = $this->getMessageInstance();
+            
+            $this->setupMessageHeaders($instance, $from, $to, $cc, $bcc, $replyTo);
             
             $message->buildMessage($this->parser, $instance);
-
+            
             return $instance;
         }
-
+        
         throw new \RuntimeException(
             Translator::getInstance()->trans(
                 "Failed to load message with code '%code%', propably because it does'nt exists.",
                 [ '%code%' => $messageCode ]
             )
         );
+    }
+    
+    /**
+     * Create a SwiftMessage instance from text
+     *
+     * @param  array  $from              From addresses. An array of (email-address => name)
+     * @param  array  $to                To addresses. An array of (email-address => name)
+     * @param  string $subject           the message subject
+     * @param  string $htmlBody          the HTML message body, or null
+     * @param  string $textBody          the text message body, or null
+     * @param  array  $cc                Cc addresses. An array of (email-address => name) [optional]
+     * @param  array  $bcc               Bcc addresses. An array of (email-address => name) [optional]
+     * @param  array  $replyTo           Reply to addresses. An array of (email-address => name) [optional]
+     *
+     * @return \Swift_Message the generated and built message.
+     */
+    public function createSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc = [], $bcc = [], $replyTo = [])
+    {
+        $instance = $this->getMessageInstance();
+        
+        $this->setupMessageHeaders($instance, $from, $to, $cc, $bcc, $replyTo);
+        
+        $instance->setSubject($subject);
+        
+        // If we do not have an HTML message
+        if (empty($htmlMessage)) {
+            // Message body is the text message
+            $instance->setBody($textBody, 'text/plain');
+        } else {
+            // The main body is the HTML messahe
+            $instance->setBody($htmlBody, 'text/html');
+            
+            // Use the text as a message part, if we have one.
+            if (! empty($textMessage)) {
+                $instance->addPart($textBody, 'text/plain');
+            }
+        }
+        
+        return $instance;
+    }
+    
+    /**
+     * @param  array  $from              From addresses. An array of (email-address => name)
+     * @param  array  $to                To addresses. An array of (email-address => name)
+     * @param  string $subject           the message subject
+     * @param  string $htmlBody          the HTML message body, or null
+     * @param  string $textBody          the text message body, or null
+     * @param  array  $cc                Cc addresses. An array of (email-address => name) [optional]
+     * @param  array  $bcc               Bcc addresses. An array of (email-address => name) [optional]
+     * @param  array  $replyTo           Reply to addresses. An array of (email-address => name) [optional]
+     * @param  null   $failedRecipients  The failed recipients list
+     * @return int    number of recipients who were accepted for delivery
+     */
+    public function sendSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc = [], $bcc = [], $replyTo = [], &$failedRecipients = null)
+    {
+        $instance = $this->createSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc, $bcc, $replyTo);
+        
+        return $this->send($instance, $failedRecipients);
+    }
+    
+    /**
+     * @param \Swift_Message $instance
+     * @param  array  $from              From addresses. An array of (email-address => name)
+     * @param  array  $to                To addresses. An array of (email-address => name)
+     * @param  array  $cc                Cc addresses. An array of (email-address => name) [optional]
+     * @param  array  $bcc               Bcc addresses. An array of (email-address => name) [optional]
+     * @param  array  $replyTo           Reply to addresses. An array of (email-address => name) [optional]
+     */
+    protected function setupMessageHeaders($instance, $from, $to, $cc = [], $bcc = [], $replyTo = [])
+    {
+        // Add from addresses
+        foreach ($from as $address => $name) {
+            $instance->addFrom($address, $name);
+        }
+        
+        // Add to addresses
+        foreach ($to as $address => $name) {
+            $instance->addTo($address, $name);
+        }
+        
+        // Add cc addresses
+        foreach ($cc as $address => $name) {
+            $instance->addCc($address, $name);
+        }
+        
+        // Add bcc addresses
+        foreach ($bcc as $address => $name) {
+            $instance->addBcc($address, $name);
+        }
+        
+        // Add reply to addresses
+        foreach ($replyTo as $address => $name) {
+            $instance->addReplyTo($address, $name);
+        }
     }
 }

--- a/local/modules/Front/Controller/ContactController.php
+++ b/local/modules/Front/Controller/ContactController.php
@@ -46,16 +46,16 @@ class ContactController extends BaseFrontController
         try {
             $form = $this->validateForm($contactForm);
             
-            $message = $this->getMailer()->getMessageInstance()
-                ->setSubject($form->get('subject')->getData())
-                ->addFrom(ConfigQuery::getStoreEmail(), $form->get('name')->getData())
-                ->addReplyTo($form->get('email')->getData(), $form->get('name')->getData())
-                ->addTo(ConfigQuery::getStoreEmail(), ConfigQuery::getStoreName())
-            ;
-            
-            $message->setBody($form->get('message')->getData());
-            
-            $this->getMailer()->send($message);
+            $this->getMailer()->sendSimpleEmailMessage(
+                [ ConfigQuery::getStoreEmail() => $form->get('name')->getData() ],
+                [ ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName() ],
+                $form->get('subject')->getData(),
+                '',
+                $form->get('message')->getData(),
+                [],
+                [],
+                [ $form->get('email')->getData() => $form->get('name')->getData() ]
+            );
             
             if ($contactForm->hasSuccessUrl()) {
                 return $this->generateSuccessRedirect($contactForm);

--- a/local/modules/Front/Controller/ContactController.php
+++ b/local/modules/Front/Controller/ContactController.php
@@ -24,7 +24,6 @@
 namespace Front\Controller;
 
 use Thelia\Controller\Front\BaseFrontController;
-use Thelia\Form\ContactForm;
 use Thelia\Form\Definition\FrontForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
@@ -43,38 +42,40 @@ class ContactController extends BaseFrontController
     public function sendAction()
     {
         $contactForm = $this->createForm(FrontForm::CONTACT);
-
+        
         try {
             $form = $this->validateForm($contactForm);
-
-            $message = \Swift_Message::newInstance($form->get('subject')->getData())
+            
+            $message = $this->getMailer()->getMessageInstance()
+                ->setSubject($form->get('subject')->getData())
                 ->addFrom(ConfigQuery::getStoreEmail(), $form->get('name')->getData())
                 ->addReplyTo($form->get('email')->getData(), $form->get('name')->getData())
                 ->addTo(ConfigQuery::getStoreEmail(), ConfigQuery::getStoreName())
-                ->setBody($form->get('message')->getData())
             ;
-
+            
+            $message->setBody($form->get('message')->getData());
+            
             $this->getMailer()->send($message);
-
+            
             if ($contactForm->hasSuccessUrl()) {
                 return $this->generateSuccessRedirect($contactForm);
             }
-
+            
             return $this->generateRedirectFromRoute('contact.success');
-
+            
         } catch (FormValidationException $e) {
             $error_message = $e->getMessage();
         }
-
+        
         Tlog::getInstance()->error(sprintf('Error during sending contact mail : %s', $error_message));
-
+        
         $contactForm->setErrorMessage($error_message);
-
+        
         $this->getParserContext()
             ->addForm($contactForm)
             ->setGeneralError($error_message)
         ;
-
+        
         // Redirect to error URL if defined
         if ($contactForm->hasErrorUrl()) {
             return $this->generateErrorRedirect($contactForm);


### PR DESCRIPTION
This PR adds simple messages (no Message object required) processing to the MailerFactory, throug the `sendSimpleEmailMessage()` and `createSimpleEmailMessage()` methods.

A new `getMessageInstance()` method has been added, to prevent direct usage of `\Swift_Message::newInstance()`