### PR TITLE
Fix for two problems with CART_FINDITEM event processing

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -301,7 +301,9 @@ class Cart extends BaseAction implements EventSubscriberInterface
      */
     public function findCartItem(CartEvent $event)
     {
-        if (null !== $foundItem = CartItemQuery::create()
+        // Do not try to find a cartItem if one exists in the event, as previous event handlers
+        // mays have put it in th event.
+        if (null === $event->getCartItem() && null !== $foundItem = CartItemQuery::create()
             ->filterByCartId($event->getCart()->getId())
             ->filterByProductId($event->getProduct())
             ->filterByProductSaleElementsId($event->getProductSaleElementsId())

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -100,7 +100,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $productId = $event->getProduct();
 
         // Search for an identical item in the cart
-        $dispatcher->dispatch(TheliaEvents::CART_FINDITEM, $event);
+        $dispatcher->dispatch(TheliaEvents::CART_FINDITEM, clone $event);
 
         $cartItem = $event->getCartItem();
 

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -98,11 +98,13 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
         $productSaleElementsId = $event->getProductSaleElementsId();
         $productId = $event->getProduct();
-
+    
         // Search for an identical item in the cart
-        $dispatcher->dispatch(TheliaEvents::CART_FINDITEM, clone $event);
-
-        $cartItem = $event->getCartItem();
+        $findItemEvent = clone $event;
+    
+        $dispatcher->dispatch(TheliaEvents::CART_FINDITEM, $findItemEvent);
+    
+        $cartItem = $findItemEvent->getCartItem();
 
         if ($cartItem === null || $newness) {
             $productSaleElements = ProductSaleElementsQuery::create()->findPk($productSaleElementsId);


### PR DESCRIPTION
1) The CartEvent dispatched with CART_FINDITEM was the one received by Thelia\Action\Cart::addItem(), thus stopping event propagation will stop the whole cart add process.

2) Thelia\Action\Cart::findCartItem() was not aware of a cart item set in the event by event listeners with a higher priority, thus this cart item is always overwritten.