### PR TITLE
Hook fixes 

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -61,11 +61,11 @@ class RegisterHookListenersPass implements CompilerPassInterface
         }
     }
 
-    protected function logAlertMessage($message)
+    protected function logAlertMessage($message, $failSafe = false)
     {
         Tlog::getInstance()->addAlert($message);
 
-        if ($this->debugEnabled) {
+        if (!$failSafe && $this->debugEnabled) {
             throw new \InvalidArgumentException($message);
         }
     }
@@ -346,9 +346,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
         }
 
         if (! $hook->getActivate()) {
-            $this->logAlertMessage(sprintf("Hook %s is not activated.", $hookName));
-
-            return null;
+            $this->logAlertMessage(sprintf("Hook %s is not activated.", $hookName), true);
         }
 
         return $hook;

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -13,7 +13,6 @@
 namespace Thelia\Module;
 
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use SplFileInfo;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -48,7 +47,8 @@ class ModuleManagement
 
         $finder
             ->name('module.xml')
-            ->in($this->baseModuleDir . '*'.DS.'Config');
+            ->in($this->baseModuleDir . '*' . DS . 'Config')
+        ;
 
         $errors = [];
 
@@ -84,12 +84,12 @@ class ModuleManagement
     {
         $descriptorValidator = $this->getDescriptorValidator();
 
-        $content   = $descriptorValidator->getDescriptor($file->getRealPath());
+        $content = $descriptorValidator->getDescriptor($file->getRealPath());
         $reflected = new \ReflectionClass((string)$content->fullnamespace);
-        $code      = basename(dirname($reflected->getFileName()));
-        $version   = (string)$content->version;
+        $code = basename(dirname($reflected->getFileName()));
+        $version = (string)$content->version;
         $mandatory = intval($content->mandatory);
-        $hidden    = intval($content->hidden);
+        $hidden = intval($content->hidden);
 
         $module = ModuleQuery::create()->filterByCode($code)->findOne();
 
@@ -117,7 +117,8 @@ class ModuleManagement
                 ->setCategory((string)$content->type)
                 ->setMandatory($mandatory)
                 ->setHidden($hidden)
-                ->save($con);
+                ->save($con)
+            ;
 
             // Update the module images, title and description when the module is installed, but not after
             // as these data may have been modified byt the administrator
@@ -127,7 +128,7 @@ class ModuleManagement
                 if (isset($content->{"images-folder"}) && !$module->isModuleImageDeployed($con)) {
                     /** @var \Thelia\Module\BaseModule $moduleInstance */
                     $moduleInstance = $reflected->newInstance();
-                    $imagesFolder = THELIA_MODULE_DIR . $code . DS . (string) $content->{"images-folder"};
+                    $imagesFolder = THELIA_MODULE_DIR . $code . DS . (string)$content->{"images-folder"};
                     $moduleInstance->deployImageFolder($module, $imagesFolder, $con);
                 }
             }
@@ -143,9 +144,13 @@ class ModuleManagement
                 $instance->update($currentVersion, $version, $con);
             }
 
+            if ($action !== 'none') {
+                $instance->registerHooks();
+            }
+
             $con->commit();
         } catch (\Exception $ex) {
-            Tlog::getInstance()->addError("Failed to update module ".$module->getCode(), $ex);
+            Tlog::getInstance()->addError("Failed to update module " . $module->getCode(), $ex);
 
             $con->rollBack();
             throw $ex;
@@ -188,7 +193,8 @@ class ModuleManagement
                 ->setDescription(isset($description->description) ? $description->description : null)
                 ->setPostscriptum(isset($description->postscriptum) ? $description->postscriptum : null)
                 ->setChapo(isset($description->subtitle) ? $description->subtitle : null)
-                ->save($con);
+                ->save($con)
+            ;
         }
     }
 }


### PR DESCRIPTION
- Fixes the fact that a module can't be installed if it uses a deactivated hook.
- Try to reload module hooks in module:refresh command to prevent error when container is built. (This is not a solution to issue #2211 that need a complete rework of the hook system or hook declaration)