### PR TITLE
Fixed and optimized content and product loops

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -141,8 +141,8 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             // Select the contents which have $folderDefault as the default folder.
             $search
                 ->useContentFolderQuery('FolderSelect')
-                ->filterByDefaultFolder(true)
-                ->filterByFolderId($folderDefault, Criteria::IN)
+                    ->filterByDefaultFolder(true)
+                    ->filterByFolderId($folderDefault, Criteria::IN)
                 ->endUse()
             ;
 
@@ -156,7 +156,7 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
             $search
                 ->useContentFolderQuery('FolderSelect')
-                ->filterByFolderId($allFolderIDs, Criteria::IN)
+                    ->filterByFolderId($allFolderIDs, Criteria::IN)
                 ->endUse()
             ;
 
@@ -164,11 +164,17 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $manualOrderAllowed = (1 == $depth && 1 == count($folderIdList));
         } else {
             $search
-                ->useContentFolderQuery('FolderSelect')
-                ->filterByDefaultFolder(true)
-                ->endUse()
+                ->leftJoinContentFolder('FolderSelect')
+                ->addJoinCondition('FolderSelect', '`FolderSelect`.DEFAULT_FOLDER = 1')
             ;
         }
+
+        $search->withColumn(
+            'CASE WHEN ISNULL(`FolderSelect`.POSITION) THEN \'' . PHP_INT_MAX . '\' ELSE `FolderSelect`.POSITION END',
+            'position_delegate'
+        );
+        $search->withColumn('`FolderSelect`.FOLDER_ID', 'default_folder_id');
+        $search->withColumn('`FolderSelect`.DEFAULT_FOLDER', 'is_default_folder');
 
         $current = $this->getCurrent();
 
@@ -202,7 +208,20 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $this->addSearchInI18nColumn($search, 'TITLE', Criteria::LIKE, "%".$title."%");
         }
 
-        $search->withColumn('`FolderSelect`.POSITION', 'position_delegate');
+        $exclude = $this->getExclude();
+
+        if (!is_null($exclude)) {
+            $search->filterById($exclude, Criteria::NOT_IN);
+        }
+
+        $exclude_folder = $this->getExcludeFolder();
+
+        if (!is_null($exclude_folder)) {
+            $search->filterByFolder(
+                FolderQuery::create()->filterById($exclude_folder, Criteria::IN)->find(),
+                Criteria::NOT_IN
+            );
+        }
 
         $orders  = $this->getOrder();
 
@@ -261,30 +280,29 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             }
         }
 
-        $exclude = $this->getExclude();
-
-        if (!is_null($exclude)) {
-            $search->filterById($exclude, Criteria::NOT_IN);
-        }
-
-        $exclude_folder = $this->getExcludeFolder();
-
-        if (!is_null($exclude_folder)) {
-            $search->filterByFolder(
-                FolderQuery::create()->filterById($exclude_folder, Criteria::IN)->find(),
-                Criteria::NOT_IN
-            );
-        }
+        $search->groupById();
 
         return $search;
     }
 
     public function parseResults(LoopResult $loopResult)
     {
+        echo(
+            \Propel\Runtime\Propel::getWriteConnection(
+                \Thelia\Model\Map\OrderTableMap::DATABASE_NAME
+            )->getLastExecutedQuery()
+        );
+
         /** @var ContentModel $content */
         foreach ($loopResult->getResultDataCollection() as $content) {
             $loopResultRow = new LoopResultRow($content);
-            $defaultFolderId = $content->getDefaultFolderId();
+
+            if ((bool) $content->getVirtualColumn('is_default_folder')) {
+                $defaultFolderId = $content->getVirtualColumn('default_folder_id');
+            } else {
+                $defaultFolderId = $content->getDefaultFolderId();
+            }
+
             $loopResultRow->set("ID", $content->getId())
                 ->set("IS_TRANSLATED", $content->getVirtualColumn('IS_TRANSLATED'))
                 ->set("LOCALE", $this->locale)

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -258,7 +258,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 $taxedPromoPrice = null;
             }
 
-            $default_category_id = $product->getDefaultCategoryId();
+            $defaultCategoryId = $this->getDefaultCategoryId($product);
 
             $loopResultRow
                 ->set("WEIGHT", $product->getVirtualColumn('weight'))
@@ -279,7 +279,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 ->set("PSE_COUNT", $product->getVirtualColumn('pse_count'));
             $this->addOutputFields($loopResultRow, $product);
 
-            $loopResult->addRow($this->associateValues($loopResultRow, $product, $default_category_id));
+            $loopResult->addRow($this->associateValues($loopResultRow, $product, $defaultCategoryId));
         }
 
         return $loopResult;
@@ -311,8 +311,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 $taxedPrice = null;
             }
 
-            // Find previous and next product, in the default category.
-            $default_category_id = $product->getDefaultCategoryId();
+            $defaultCategoryId = $this->getDefaultCategoryId($product);
 
             $loopResultRow
                 ->set("BEST_PRICE", $price)
@@ -321,7 +320,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 ->set("IS_PROMO", $product->getVirtualColumn('main_product_is_promo'))
                 ->set("IS_NEW", $product->getVirtualColumn('main_product_is_new'));
 
-            $loopResult->addRow($this->associateValues($loopResultRow, $product, $default_category_id));
+            $loopResult->addRow($this->associateValues($loopResultRow, $product, $defaultCategoryId));
         }
 
         return $loopResult;
@@ -330,10 +329,10 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     /**
      * @param  LoopResultRow         $loopResultRow the current result row
      * @param  \Thelia\Model\Product $product
-     * @param $default_category_id
+     * @param $defaultCategoryId
      * @return mixed
      */
-    private function associateValues($loopResultRow, $product, $default_category_id)
+    private function associateValues($loopResultRow, $product, $defaultCategoryId)
     {
         $display_initial_price = $product->getVirtualColumn('display_initial_price');
 
@@ -358,12 +357,12 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             ->set("VIRTUAL", $product->getVirtual() ? "1" : "0")
             ->set("VISIBLE", $product->getVisible() ? "1" : "0")
             ->set("TEMPLATE", $product->getTemplateId())
-            ->set("DEFAULT_CATEGORY", $default_category_id)
+            ->set("DEFAULT_CATEGORY", $defaultCategoryId)
             ->set("TAX_RULE_ID", $product->getTaxRuleId())
             ->set("BRAND_ID", $product->getBrandId() ?: 0)
             ->set("SHOW_ORIGINAL_PRICE", $display_initial_price);
 
-        $this->findNextPrev($loopResultRow, $product, $default_category_id);
+        $this->findNextPrev($loopResultRow, $product, $defaultCategoryId);
 
         return $loopResultRow;
     }
@@ -371,23 +370,23 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     /**
      * @param LoopResultRow $loopResultRow
      * @param ProductModel $product
-     * @param int $defaultFolderId
+     * @param int $defaultCategoryId
      */
-    private function findNextPrev(LoopResultRow $loopResultRow, ProductModel $product, $defaultFolderId)
+    private function findNextPrev(LoopResultRow $loopResultRow, ProductModel $product, $defaultCategoryId)
     {
         if ($this->getWithPrevNextInfo()) {
             $currentPosition = ProductCategoryQuery::create()
-                ->filterByCategoryId($defaultFolderId)
+                ->filterByCategoryId($defaultCategoryId)
                 ->filterByProductId($product->getId())
                 ->findOne()->getPosition();
 
             // Find previous and next product
             $previousQuery = ProductCategoryQuery::create()
-                ->filterByCategoryId($defaultFolderId)
+                ->filterByCategoryId($defaultCategoryId)
                 ->filterByPosition($currentPosition, Criteria::LESS_THAN);
 
             $nextQuery = ProductCategoryQuery::create()
-                ->filterByCategoryId($defaultFolderId)
+                ->filterByCategoryId($defaultCategoryId)
                 ->filterByPosition($currentPosition, Criteria::GREATER_THAN);
 
             if (!$this->getBackendContext()) {
@@ -603,13 +602,17 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $manualOrderAllowed = (1 == $depth && 1 == count($categoryIdList));
         } else {
             $search
-                ->useProductCategoryQuery('CategorySelect')
-                ->filterByDefaultCategory(true)
-                ->endUse()
+                ->leftJoinProductCategory('CategorySelect')
+                ->addJoinCondition('CategorySelect', '`CategorySelect`.DEFAULT_CATEGORY = 1')
             ;
         }
 
-        $search->withColumn('`CategorySelect`.POSITION', 'position_delegate');
+        $search->withColumn(
+            'CASE WHEN ISNULL(`CategorySelect`.POSITION) THEN \'' . PHP_INT_MAX . '\' ELSE `CategorySelect`.POSITION END',
+            'position_delegate'
+        );
+        $search->withColumn('`CategorySelect`.CATEGORY_ID', 'default_category_id');
+        $search->withColumn('`CategorySelect`.DEFAULT_CATEGORY', 'is_default_category');
 
         $current = $this->getCurrent();
 
@@ -1098,5 +1101,22 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         }
 
         return $search;
+    }
+
+    /**
+     * Get the default category id for a product
+     *
+     * @param \Thelia\Model\Product $product
+     * @return null|int
+     */
+    protected function getDefaultCategoryId($product)
+    {
+        $defaultCategoryId = null;
+        if ((bool) $product->getVirtualColumn('is_default_category')) {
+            $defaultCategoryId = $product->getVirtualColumn('default_category_id');
+        } else {
+            $defaultCategoryId = $product->getDefaultCategoryId();
+        }
+        return $defaultCategoryId;
     }
 }


### PR DESCRIPTION
- fixed loops for products and contents that do not have category or folder
- fixed duplicated content results
- optimized loops to get the default folder/category id. don't need to rely on extra query when data is available.  