### PR TITLE
Use the success_url when deleting a cart_item

### DIFF
--- a/local/modules/Front/Controller/CartController.php
+++ b/local/modules/Front/Controller/CartController.php
@@ -128,6 +128,12 @@ class CartController extends BaseFrontController
         }
 
         $this->changeViewForAjax();
+        
+        if (null != $successUrl = $this->getRequest()->query->get('success_url')) {
+            URL::getInstance()->absoluteUrl($successUrl);
+            $response = $this->generateRedirect($successUrl);
+            return $response;       
+        }
     }
 
     protected function changeViewForAjax()


### PR DESCRIPTION
This get parameter is sent in default frontOffice template and it is never used
