### PR TITLE
Fix for decimals=0 in {format_number} or {format_money}

### DIFF
--- a/core/lib/Thelia/Tools/NumberFormat.php
+++ b/core/lib/Thelia/Tools/NumberFormat.php
@@ -51,13 +51,13 @@ class NumberFormat
     {
         $lang = $this->request->getSession()->getLang();
 
-        if ($decimals == null) {
+        if ($decimals === null) {
             $decimals = $lang->getDecimals();
         }
-        if ($decPoint == null) {
+        if ($decPoint === null) {
             $decPoint = $lang->getDecimalSeparator();
         }
-        if ($thousandsSep == null) {
+        if ($thousandsSep === null) {
             $thousandsSep = $lang->getThousandsSeparator();
         }
         return number_format($number, $decimals, $decPoint, $thousandsSep);


### PR DESCRIPTION
In  {format_number} or {format_money}, using decimals=0 has no effect, because in core/lib/Thelia/Tools/NumberFormat.php ($decimals == null) is true.

The PR fixes the comparison operator to allow displaying decimal numbers with 0 decimals.
