### PR TITLE
Fix for <option> offsets not working in IE and Safari

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
@@ -53,6 +53,17 @@ class AdminUtilities extends AbstractSmartyPlugin
 
         return $data;
     }
+    
+    public function optionOffsetGenerator($params, &$smarty)
+    {
+        $label = $this->getParam($params, 'label', null);
+        
+        if (null !== $level = $this->getParam($params, [ 'l', 'level'], null)) {
+            $label = str_repeat('&nbsp;', 4 * $level) . $label;
+        }
+        
+        return $label;
+    }
 
     public function generatePositionChangeBlock($params, &$smarty)
     {
@@ -155,6 +166,7 @@ class AdminUtilities extends AbstractSmartyPlugin
         return array(
             new SmartyPluginDescriptor('function', 'admin_sortable_header', $this, 'generateSortableColumnHeader'),
             new SmartyPluginDescriptor('function', 'admin_position_block', $this, 'generatePositionChangeBlock'),
+            new SmartyPluginDescriptor('function', 'option_offset', $this, 'optionOffsetGenerator'),
         );
     }
 }

--- a/templates/backOffice/default/ajax/product-related-tab.html
+++ b/templates/backOffice/default/ajax/product-related-tab.html
@@ -32,7 +32,7 @@
 		                    <select name="folder_id" id="folder_id" class="form-control">
 		                        <option value="">{intl l='Select a folder...'}</option>
 		                        {loop name="folders" type="folder-tree" folder="0" backend_context="1" visible="*" lang="$edit_language_id" return_url=false}
-		                            <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
+		                            <option value="{$ID}">{option_offset l=$LEVEL label={$TITLE}}</option>
 		                        {/loop}
 		                    </select>
 
@@ -150,7 +150,7 @@
 		                    <select name="accessory_category_id" id="accessory_category_id" class="form-control">
 		                        <option value="">{intl l='Select a category...'}</option>
 		                        {loop name="categories" type="category-tree" category="0" backend_context="1" visible="*" lang="$edit_language_id" return_url=false}
-		                            <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
+		                            <option value="{$ID}">{option_offset l=$LEVEL label={$TITLE}}</option>
 		                        {/loop}
 		                    </select>
 
@@ -283,7 +283,7 @@
 	                            <option value="">{intl l='Select a category...'}</option>
 	                            {loop name="categories" type="category-tree" category="0" exclude=$exclude_from_tree visible="*" backend_context="1" lang="$edit_language_id" return_url=false}
 	                                <option value="{$ID}" {if $DEFAULT_CATEGORY==$ID}disabled="disabled"{/if}>
-										{option_offset l=$LEVEL label=$TITLE}{if $DEFAULT_CATEGORY==$ID}{intl l=' (default)'}{/if}
+										{option_offset l=$LEVEL label={$TITLE}}{if $DEFAULT_CATEGORY==$ID}{intl l=' (default)'}{/if}
 	                                </option>
 	                            {/loop}
 	                        </select>

--- a/templates/backOffice/default/ajax/product-related-tab.html
+++ b/templates/backOffice/default/ajax/product-related-tab.html
@@ -32,7 +32,7 @@
 		                    <select name="folder_id" id="folder_id" class="form-control">
 		                        <option value="">{intl l='Select a folder...'}</option>
 		                        {loop name="folders" type="folder-tree" folder="0" backend_context="1" visible="*" lang="$edit_language_id" return_url=false}
-		                            <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px">{$TITLE}</option>
+		                            <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
 		                        {/loop}
 		                    </select>
 
@@ -150,7 +150,7 @@
 		                    <select name="accessory_category_id" id="accessory_category_id" class="form-control">
 		                        <option value="">{intl l='Select a category...'}</option>
 		                        {loop name="categories" type="category-tree" category="0" backend_context="1" visible="*" lang="$edit_language_id" return_url=false}
-		                            <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px">{$TITLE}</option>
+		                            <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
 		                        {/loop}
 		                    </select>
 
@@ -282,8 +282,8 @@
 	                        <select name="additional_category_id" id="accessory_category_id" class="form-control">
 	                            <option value="">{intl l='Select a category...'}</option>
 	                            {loop name="categories" type="category-tree" category="0" exclude=$exclude_from_tree visible="*" backend_context="1" lang="$edit_language_id" return_url=false}
-	                                <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $DEFAULT_CATEGORY==$ID}disabled="disabled"{/if}>
-	                                    {$TITLE} {if $DEFAULT_CATEGORY==$ID}{intl l=' (default)'}{/if}
+	                                <option value="{$ID}" {if $DEFAULT_CATEGORY==$ID}disabled="disabled"{/if}>
+										{option_offset l=$LEVEL label=$TITLE}{if $DEFAULT_CATEGORY==$ID}{intl l=' (default)'}{/if}
 	                                </option>
 	                            {/loop}
 	                        </select>

--- a/templates/backOffice/default/category-edit.html
+++ b/templates/backOffice/default/category-edit.html
@@ -125,7 +125,7 @@
                                                               {/loop}
                                                               {$myparent=$PARENT}
                                                               {loop name="cat-parent" type="category-tree" visible="*" category="0" exclude={','|implode:$excludeCategories}}
-                                                                   <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $myparent == $ID}selected="selected"{/if} {if $category_id == $ID}disabled="disabled"{/if}>{$TITLE}</option>
+                                                                   <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if} {if $category_id == $ID}disabled="disabled"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
                                                               {/loop}
                                                         </select>
                                                     {/custom_render_form_field}
@@ -193,7 +193,7 @@
                                                             <select name="folder_id" id="folder_id" class="form-control">
                                                                 <option value="">{intl l='Select a folder...'}</option>
                                                                 {loop name="folders" type="folder-tree" folder="0" backend_context="1" lang="$edit_language_id"}
-                                                                    <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px">{$TITLE}</option>
+                                                                    <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
                                                                 {/loop}
                                                             </select>
                                                         </div>

--- a/templates/backOffice/default/category-edit.html
+++ b/templates/backOffice/default/category-edit.html
@@ -193,7 +193,7 @@
                                                             <select name="folder_id" id="folder_id" class="form-control">
                                                                 <option value="">{intl l='Select a folder...'}</option>
                                                                 {loop name="folders" type="folder-tree" folder="0" backend_context="1" lang="$edit_language_id"}
-                                                                    <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
+                                                                    <option value="{$ID}">{option_offset l=$LEVEL label={$TITLE}}</option>
                                                                 {/loop}
                                                             </select>
                                                         </div>

--- a/templates/backOffice/default/content-edit.html
+++ b/templates/backOffice/default/content-edit.html
@@ -135,7 +135,7 @@
 
                                                                         {$myparent=$DEFAULT_FOLDER}
                                                                         {loop name="fold-parent" type="folder-tree" visible="*" folder="0"}
-                                                                            <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $myparent == $ID}selected="selected"{/if}>{$TITLE}</option>
+                                                                            <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
                                                                         {/loop}
 
                                                                     </select>

--- a/templates/backOffice/default/content-edit.html
+++ b/templates/backOffice/default/content-edit.html
@@ -135,7 +135,7 @@
 
                                                                         {$myparent=$DEFAULT_FOLDER}
                                                                         {loop name="fold-parent" type="folder-tree" visible="*" folder="0"}
-                                                                            <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
+                                                                            <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label={$TITLE}}</option>
                                                                         {/loop}
 
                                                                     </select>

--- a/templates/backOffice/default/coupon/condition-fragments/cart-contains-categories-condition.html
+++ b/templates/backOffice/default/coupon/condition-fragments/cart-contains-categories-condition.html
@@ -8,7 +8,7 @@
     <label for="{$categories_field_name}-value">{intl l="The selected categories :"}</label>
     <select required multiple size="5" class="form-control" id="{$categories_field_name}-value" name="{$categories_field_name}[value][]">
         {loop type="category-tree" category=0 name="list-of-categories" backend_context=1 visible="*"}
-            <option style="padding-left: {$LEVEL * 20}px" value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
         {/loop}
     </select>
     <span class="label-help-block">{intl l='Use Ctrl+click to select (or deselect) more that one category'}</span>

--- a/templates/backOffice/default/coupon/condition-fragments/cart-contains-categories-condition.html
+++ b/templates/backOffice/default/coupon/condition-fragments/cart-contains-categories-condition.html
@@ -8,7 +8,7 @@
     <label for="{$categories_field_name}-value">{intl l="The selected categories :"}</label>
     <select required multiple size="5" class="form-control" id="{$categories_field_name}-value" name="{$categories_field_name}[value][]">
         {loop type="category-tree" category=0 name="list-of-categories" backend_context=1 visible="*"}
-            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label={$TITLE}}</option>
         {/loop}
     </select>
     <span class="label-help-block">{intl l='Use Ctrl+click to select (or deselect) more that one category'}</span>

--- a/templates/backOffice/default/coupon/condition-fragments/countries-condition.html
+++ b/templates/backOffice/default/coupon/condition-fragments/countries-condition.html
@@ -8,7 +8,7 @@
     <label for="{$countries_field_name}-value">{intl l="The selected countries :"}</label>
     <select required multiple size="5" class="form-control" id="{$countries_field_name}-value" name="{$countries_field_name}[value][]">
         {loop type="country" name="list-of-countries" order="alpha" backend_context=1 visible="*"}
-            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label={$TITLE}}</option>
         {/loop}
     </select>
     <span class="label-help-block">{intl l='Use Ctrl+click to select (or deselect) more that one country'}</span>

--- a/templates/backOffice/default/coupon/condition-fragments/countries-condition.html
+++ b/templates/backOffice/default/coupon/condition-fragments/countries-condition.html
@@ -8,7 +8,7 @@
     <label for="{$countries_field_name}-value">{intl l="The selected countries :"}</label>
     <select required multiple size="5" class="form-control" id="{$countries_field_name}-value" name="{$countries_field_name}[value][]">
         {loop type="country" name="list-of-countries" order="alpha" backend_context=1 visible="*"}
-            <option style="padding-left: {$LEVEL * 20}px" value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
         {/loop}
     </select>
     <span class="label-help-block">{intl l='Use Ctrl+click to select (or deselect) more that one country'}</span>

--- a/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
+++ b/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
@@ -1,3 +1,3 @@
 {loop type="product" category={$smarty.post.category_id} name="list-of-products" backend_context="1" return_url=false}
-    <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
+    <option value="{$ID}">{option_offset l=$LEVEL label={$TITLE}}</option>
 {/loop}

--- a/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
+++ b/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
@@ -1,3 +1,3 @@
 {loop type="product" category={$smarty.post.category_id} name="list-of-products" backend_context="1" return_url=false}
-    <option style="padding-left: {$LEVEL * 10}px" value="{$ID}">{$TITLE}</option>
+    <option value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
 {/loop}

--- a/templates/backOffice/default/coupon/type-fragments/base-remove-on-categories.html
+++ b/templates/backOffice/default/coupon/type-fragments/base-remove-on-categories.html
@@ -8,7 +8,7 @@
 
     <select required multiple size="10" class="form-control" id="coupon-categories-id" name="{$categories_field_name}[]">
         {loop type="category-tree" category=0 name="list-of-categories" backend_context="1" visible="*"}
-            <option style="padding-left: {$LEVEL * 10}px" value="{$ID}" {if in_array($ID, $categories_values)}selected="selected"{/if}>{$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $categories_values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
         {/loop}
     </select>
 

--- a/templates/backOffice/default/coupon/type-fragments/base-remove-on-categories.html
+++ b/templates/backOffice/default/coupon/type-fragments/base-remove-on-categories.html
@@ -8,7 +8,7 @@
 
     <select required multiple size="10" class="form-control" id="coupon-categories-id" name="{$categories_field_name}[]">
         {loop type="category-tree" category=0 name="list-of-categories" backend_context="1" visible="*"}
-            <option value="{$ID}" {if in_array($ID, $categories_values)}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
+            <option value="{$ID}" {if in_array($ID, $categories_values)}selected="selected"{/if}>{option_offset l=$LEVEL label={$TITLE}}</option>
         {/loop}
     </select>
 

--- a/templates/backOffice/default/coupon/type-fragments/base-remove-on-products.html
+++ b/templates/backOffice/default/coupon/type-fragments/base-remove-on-products.html
@@ -9,7 +9,7 @@
     <select required class="form-control" id="coupon-category-id" name="{$category_id_field_name}">
         <option value="0">{intl l="Please select..."}</option>
         {loop type="category-tree" category=0 name="list-of-category" backend_context="1" visible="*"}
-            <option value="{$ID}" {if $ID == $category_id_value}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
+            <option value="{$ID}" {if $ID == $category_id_value}selected="selected"{/if}>{option_offset l=$LEVEL label={$TITLE}}</option>
         {/loop}
     </select>
 </div>

--- a/templates/backOffice/default/coupon/type-fragments/base-remove-on-products.html
+++ b/templates/backOffice/default/coupon/type-fragments/base-remove-on-products.html
@@ -9,7 +9,7 @@
     <select required class="form-control" id="coupon-category-id" name="{$category_id_field_name}">
         <option value="0">{intl l="Please select..."}</option>
         {loop type="category-tree" category=0 name="list-of-category" backend_context="1" visible="*"}
-            <option style="padding-left: {$LEVEL * 10}px" value="{$ID}" {if $ID == $category_id_value}selected="selected"{/if}>{$TITLE}</option>
+            <option value="{$ID}" {if $ID == $category_id_value}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
         {/loop}
     </select>
 </div>

--- a/templates/backOffice/default/coupon/type-fragments/free-product.html
+++ b/templates/backOffice/default/coupon/type-fragments/free-product.html
@@ -8,7 +8,7 @@
         <select required class="form-control" id="free-product-category-id" name="{$offered_category_field_name}">
             <option value="0">{intl l="Please select..."}</option>
             {loop type="category-tree" category=0 name="list-of-category" backend_context="1" visible="*"}
-                <option style="padding-left: {$LEVEL * 10}px" value="{$ID}" {if $ID == $offered_category_value}selected="selected"{/if}>{$TITLE}</option>
+                <option value="{$ID}" {if $ID == $offered_category_value}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
             {/loop}
         </select>
     </div>

--- a/templates/backOffice/default/coupon/type-fragments/free-product.html
+++ b/templates/backOffice/default/coupon/type-fragments/free-product.html
@@ -8,7 +8,7 @@
         <select required class="form-control" id="free-product-category-id" name="{$offered_category_field_name}">
             <option value="0">{intl l="Please select..."}</option>
             {loop type="category-tree" category=0 name="list-of-category" backend_context="1" visible="*"}
-                <option value="{$ID}" {if $ID == $offered_category_value}selected="selected"{/if}>{option_offset l=$LEVEL label=$TITLE}</option>
+                <option value="{$ID}" {if $ID == $offered_category_value}selected="selected"{/if}>{option_offset l=$LEVEL label={$TITLE}}</option>
             {/loop}
         </select>
     </div>

--- a/templates/backOffice/default/folder-edit.html
+++ b/templates/backOffice/default/folder-edit.html
@@ -127,7 +127,7 @@
                                                               {/loop}
                                                               {$myparent=$PARENT}
 		                                                      {loop name="fold-parent" type="folder-tree" visible="*" folder="0" exclude={','|implode:$excludeFolders}}
-		                                                           <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if} {if $folder_id == $ID}disabled="disabled"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
+		                                                           <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if} {if $folder_id == $ID}disabled="disabled"{/if}>{option_offset l=$LEVEL+1 label={$TITLE}}</option>
 		                                                      {/loop}
 		                                                </select>
 		                                             </div>

--- a/templates/backOffice/default/folder-edit.html
+++ b/templates/backOffice/default/folder-edit.html
@@ -127,7 +127,7 @@
                                                               {/loop}
                                                               {$myparent=$PARENT}
 		                                                      {loop name="fold-parent" type="folder-tree" visible="*" folder="0" exclude={','|implode:$excludeFolders}}
-		                                                           <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $myparent == $ID}selected="selected"{/if} {if $folder_id == $ID}disabled="disabled"{/if}>{$TITLE}</option>
+		                                                           <option value="{$ID}" {if $myparent == $ID}selected="selected"{/if} {if $folder_id == $ID}disabled="disabled"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
 		                                                      {/loop}
 		                                                </select>
 		                                             </div>

--- a/templates/backOffice/default/includes/content-folder-management.html
+++ b/templates/backOffice/default/includes/content-folder-management.html
@@ -26,7 +26,7 @@
                                 <option value="">{intl l='Select a folder...'}</option>
                                 {loop name="folders" type="folder-tree" folder="0" exclude=$exclude_from_tree backend_context="1" lang="$edit_language_id" return_url=false}
                                     <option value="{$ID}" {if $DEFAULT_FOLDER==$ID}disabled="disabled"{/if}>
-                                        {option_offset l=$LEVEL label=$TITLE}{if $DEFAULT_FOLDER==$ID}{intl l=' (default)'}{/if}
+                                        {option_offset l=$LEVEL label={$TITLE}}{if $DEFAULT_FOLDER==$ID}{intl l=' (default)'}{/if}
                                     </option>
                                 {/loop}
                             </select>

--- a/templates/backOffice/default/includes/content-folder-management.html
+++ b/templates/backOffice/default/includes/content-folder-management.html
@@ -25,8 +25,8 @@
                             <select name="additional_folder_id" id="additional_folder_id" class="form-control">
                                 <option value="">{intl l='Select a folder...'}</option>
                                 {loop name="folders" type="folder-tree" folder="0" exclude=$exclude_from_tree backend_context="1" lang="$edit_language_id" return_url=false}
-                                    <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $DEFAULT_FOLDER==$ID}disabled="disabled"{/if}>
-                                        {$TITLE} {if $DEFAULT_FOLDER==$ID}{intl l=' (default)'}{/if}
+                                    <option value="{$ID}" {if $DEFAULT_FOLDER==$ID}disabled="disabled"{/if}>
+                                        {option_offset l=$LEVEL label=$TITLE}{if $DEFAULT_FOLDER==$ID}{intl l=' (default)'}{/if}
                                     </option>
                                 {/loop}
                             </select>

--- a/templates/backOffice/default/includes/product-general-tab.html
+++ b/templates/backOffice/default/includes/product-general-tab.html
@@ -64,7 +64,7 @@
                               <option value="0" disabled>{intl l="Top level"}</option>
 
                               {loop name="cat-parent" type="category-tree" category="0" visible="*" product="0" return_url=false}
-                                   <option value="{$ID}" {if $DEFAULT_CATEGORY == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
+                                   <option value="{$ID}" {if $DEFAULT_CATEGORY == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label={$TITLE}}</option>
                               {/loop}
 
                         </select>

--- a/templates/backOffice/default/includes/product-general-tab.html
+++ b/templates/backOffice/default/includes/product-general-tab.html
@@ -64,7 +64,7 @@
                               <option value="0" disabled>{intl l="Top level"}</option>
 
                               {loop name="cat-parent" type="category-tree" category="0" visible="*" product="0" return_url=false}
-                                   <option value="{$ID}" style="padding-left: {3 + $LEVEL * 20}px" {if $DEFAULT_CATEGORY == $ID}selected="selected"{/if}>{$TITLE}</option>
+                                   <option value="{$ID}" {if $DEFAULT_CATEGORY == $ID}selected="selected"{/if}>{option_offset l=$LEVEL+1 label=$TITLE}</option>
                               {/loop}
 
                         </select>

--- a/templates/backOffice/default/sale-edit.html
+++ b/templates/backOffice/default/sale-edit.html
@@ -124,7 +124,7 @@
                                         <select class="form-control" id="cat_source" name="cat_source" size="10" multiple>
                                         {loop type="category-tree" category=0 name="available-categories"  backend_context=1}
                                             {$selected = in_array($ID, $value)}
-                                            <option {if $selected}disabled class="disabled-select-option"{/if} value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
+                                            <option {if $selected}disabled class="disabled-select-option"{/if} value="{$ID}">{option_offset l=$LEVEL label={$TITLE}}</option>
                                         {/loop}
                                         </select>
                                     </div>

--- a/templates/backOffice/default/sale-edit.html
+++ b/templates/backOffice/default/sale-edit.html
@@ -124,7 +124,7 @@
                                         <select class="form-control" id="cat_source" name="cat_source" size="10" multiple>
                                         {loop type="category-tree" category=0 name="available-categories"  backend_context=1}
                                             {$selected = in_array($ID, $value)}
-                                            <option {if $selected}disabled class="disabled-select-option"{/if}style="padding-left: {$LEVEL * 20}px" value="{$ID}">{$TITLE}</option>
+                                            <option {if $selected}disabled class="disabled-select-option"{/if} value="{$ID}">{option_offset l=$LEVEL label=$TITLE}</option>
                                         {/loop}
                                         </select>
                                     </div>


### PR DESCRIPTION
This PR is a fix for select menus in IE and Safari, where the padding-left styling is not supported, thus resulting in flat selection lists :
![img-2016-11-14_11-24-37](https://cloud.githubusercontent.com/assets/2197734/20261169/fde56ee6-aa5c-11e6-9e7e-1b5c9b55a5fa.png)

A specific Smarty plugin is created, to generate the proper offset using non-breaking spaces.

![img-2016-11-14_11-25-51](https://cloud.githubusercontent.com/assets/2197734/20261207/1d7ed210-aa5d-11e6-87bb-cfe5d42f43a8.png)