### PR TITLE
Use service instead of instantiate new object

### DIFF
--- a/core/lib/Thelia/Command/ContainerAwareCommand.php
+++ b/core/lib/Thelia/Command/ContainerAwareCommand.php
@@ -96,7 +96,7 @@ class ContainerAwareCommand extends Command implements ContainerAwareInterface
 
         $requestContext = new RequestContext();
         $requestContext->fromRequest($request);
-        $url = new URL($container);
+        $url = $container->get('thelia.url.manager');
         $url->setRequestContext($requestContext);
     }
 


### PR DESCRIPTION
Use service to get URL object. It prevent any later call to this service to override request context.