### PR TITLE
Fix sorting in folder & categories view, improved sort options

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Category.php
+++ b/core/lib/Thelia/Core/Template/Loop/Category.php
@@ -89,7 +89,15 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
             new Argument(
                 'order',
                 new TypeCollection(
-                    new Type\EnumListType(array('id', 'id_reverse', 'alpha', 'alpha_reverse', 'manual', 'manual_reverse', 'visible', 'visible_reverse', 'random'))
+                    new Type\EnumListType([
+                        'id', 'id_reverse',
+                        'alpha', 'alpha_reverse',
+                        'manual', 'manual_reverse',
+                        'visible', 'visible_reverse',
+                        'created','created_reverse',
+                        'updated', 'updated_reverse',
+                        'random'
+                    ])
                 ),
                 'manual'
             ),
@@ -133,10 +141,13 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
 
         $parent = $this->getParent();
 
-        if (!is_null($parent)) {
+        if (null !== $parent) {
             $search->filterByParent($parent, Criteria::IN);
+            $positionOrderAllowed = true;
+        } else {
+            $positionOrderAllowed = false;
         }
-
+    
         $excludeParent = $this->getExcludeParent();
 
         if (!is_null($excludeParent)) {
@@ -219,6 +230,18 @@ class Category extends BaseI18nLoop implements PropelSearchLoopInterface, Search
                     break;
                 case "visible_reverse":
                     $search->orderByVisible(Criteria::DESC);
+                    break;
+                case "created":
+                    $search->addAscendingOrderByColumn('created_at');
+                    break;
+                case "created_reverse":
+                    $search->addDescendingOrderByColumn('created_at');
+                    break;
+                case "updated":
+                    $search->addAscendingOrderByColumn('updated_at');
+                    break;
+                case "updated_reverse":
+                    $search->addDescendingOrderByColumn('updated_at');
                     break;
                 case "random":
                     $search->clearOrderByColumns();

--- a/core/lib/Thelia/Core/Template/Loop/Content.php
+++ b/core/lib/Thelia/Core/Template/Loop/Content.php
@@ -80,18 +80,15 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 new TypeCollection(
                     new Type\EnumListType(
                         array(
-                            'alpha',
-                            'alpha-reverse',
-                            'manual',
-                            'manual_reverse',
+                            'id', 'id_reverse',
+                            'alpha', 'alpha-reverse', 'alpha_reverse',
+                            'manual', 'manual_reverse',
+                            'visible', 'visible_reverse',
                             'random',
                             'given_id',
-                            'created',
-                            'created_reverse',
-                            'updated',
-                            'updated_reverse',
-                            'position',
-                            'position_reverse'
+                            'created', 'created_reverse',
+                            'updated', 'updated_reverse',
+                            'position', 'position_reverse'
                         )
                     )
                 ),
@@ -227,10 +224,17 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
         foreach ($orders as $order) {
             switch ($order) {
+                case "id":
+                    $search->orderById(Criteria::ASC);
+                    break;
+                case "id_reverse":
+                    $search->orderById(Criteria::DESC);
+                    break;
                 case "alpha":
                     $search->addAscendingOrderByColumn('i18n_TITLE');
                     break;
                 case "alpha-reverse":
+                case "alpha_reverse":
                     $search->addDescendingOrderByColumn('i18n_TITLE');
                     break;
                 case "manual":
@@ -254,6 +258,12 @@ class Content extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                         $search->withColumn(ContentTableMap::ID . "='$singleId'", $givenIdMatched);
                         $search->orderBy($givenIdMatched, Criteria::DESC);
                     }
+                    break;
+                case "visible":
+                    $search->orderByVisible(Criteria::ASC);
+                    break;
+                case "visible_reverse":
+                    $search->orderByVisible(Criteria::DESC);
                     break;
                 case "random":
                     $search->clearOrderByColumns();

--- a/core/lib/Thelia/Core/Template/Loop/Folder.php
+++ b/core/lib/Thelia/Core/Template/Loop/Folder.php
@@ -69,15 +69,13 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
                 new TypeCollection(
                     new Type\EnumListType(
                         [
-                            'alpha',
-                            'alpha_reverse',
-                            'manual',
-                            'manual_reverse',
+                            'id', 'id_reverse',
+                            'alpha', 'alpha_reverse',
+                            'manual', 'manual_reverse',
+                            'visible', 'visible_reverse',
                             'random',
-                            'created',
-                            'created_reverse',
-                            'updated',
-                            'updated_reverse'
+                            'created', 'created_reverse',
+                            'updated', 'updated_reverse'
                         ]
                     )
                 ),
@@ -127,10 +125,10 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
 
         $parent = $this->getParent();
 
-        if (!is_null($parent)) {
+        if (null !== $parent) {
             $search->filterByParent($parent);
         }
-
+    
         $current = $this->getCurrent();
 
         if ($current === true) {
@@ -171,6 +169,12 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
 
         foreach ($orders as $order) {
             switch ($order) {
+                case "id":
+                    $search->orderById(Criteria::ASC);
+                    break;
+                case "id_reverse":
+                    $search->orderById(Criteria::DESC);
+                    break;
                 case "alpha":
                     $search->addAscendingOrderByColumn('i18n_TITLE');
                     break;
@@ -182,6 +186,12 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
                     break;
                 case "manual":
                     $search->orderByPosition(Criteria::ASC);
+                    break;
+                case "visible":
+                    $search->orderByVisible(Criteria::ASC);
+                    break;
+                case "visible_reverse":
+                    $search->orderByVisible(Criteria::DESC);
                     break;
                 case "random":
                     $search->clearOrderByColumns();

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -128,6 +128,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                             'updated', 'updated_reverse',
                             'ref', 'ref_reverse',
                             'visible', 'visible_reverse',
+                            'position', 'position_reverse',
                             'promo',
                             'new',
                             'random',
@@ -1083,6 +1084,12 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     break;
                 case "updated_reverse":
                     $search->addDescendingOrderByColumn('updated_at');
+                    break;
+                case "position":
+                    $search->addAscendingOrderByColumn('position_delegate');
+                    break;
+                case "position_reverse":
+                    $search->addDescendingOrderByColumn('position_delegate');
                     break;
                 case "given_id":
                     if (null === $id) {

--- a/templates/backOffice/default/folders.html
+++ b/templates/backOffice/default/folders.html
@@ -220,6 +220,7 @@
                                     current_order=$content_order
                                     order='id'
                                     reverse_order='id_reverse'
+                                    request_parameter_name='content_order'
                                     path={url path='/admin/folders' parent=$parent target='contents'}
                                     label="{intl l='ID'}"
                                     }
@@ -231,6 +232,7 @@
                                     current_order=$content_order
                                     order='alpha'
                                     reverse_order='alpha_reverse'
+                                    request_parameter_name='content_order'
                                     path={url path='/admin/folders' parent=$parent target='contents'}
                                     label="{intl l='Content title'}"
                                     }
@@ -242,6 +244,7 @@
                                     current_order=$content_order
                                     order='visible'
                                     reverse_order='visible_reverse'
+                                    request_parameter_name='content_order'
                                     path={url path='/admin/folders' parent=$parent target='contents'}
                                     label="{intl l='Online'}"
                                     }
@@ -252,6 +255,7 @@
                                     current_order=$content_order
                                     order='manual'
                                     reverse_order='manual_reverse'
+                                    request_parameter_name='content_order'
                                     path={url path='/admin/folders' parent=$parent target='contents'}
                                     label="{intl l='Position'}"
                                     }


### PR DESCRIPTION
This PR fixes sort feature in category, folder and content: some sorting criteria, such as visible or ID where not implemented in the loops.