### PR TITLE
Fix lose cart.discount on login

### DIFF
--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -451,6 +451,7 @@ class Coupon extends BaseAction implements EventSubscriberInterface
             TheliaEvents::CART_ADDITEM => array("updateOrderDiscount", 10),
             TheliaEvents::CART_UPDATEITEM => array("updateOrderDiscount", 10),
             TheliaEvents::CART_DELETEITEM => array("updateOrderDiscount", 10),
+            TheliaEvents::CUSTOMER_LOGIN => array("updateOrderDiscount", 10)
         );
     }
 


### PR DESCRIPTION
When you create your cart then apply a coupon then login the cart is duplicated but the cart.discount is not duplicated. But the coupon are still in session 
So this PR update the coupon after login to recalculate the cart discount.