### PR TITLE
Fixed "visible" argument usage, and enabled "depth" argument

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/FolderPath.php
+++ b/core/lib/Thelia/Core/Template/Loop/FolderPath.php
@@ -29,6 +29,7 @@ use Thelia\Type\BooleanOrBothType;
  * {@inheritdoc}
  * @method int getFolder()
  * @method bool|string getVisible()
+ * @method int getDepth()
  * @method string[] getOrder()
  */
 class FolderPath extends BaseI18nLoop implements ArraySearchLoopInterface
@@ -40,30 +41,32 @@ class FolderPath extends BaseI18nLoop implements ArraySearchLoopInterface
     {
         return new ArgumentCollection(
             Argument::createIntTypeArgument('folder', null, true),
-            Argument::createIntTypeArgument('depth'),
+            Argument::createIntTypeArgument('depth', PHP_INT_MAX),
             Argument::createBooleanOrBothTypeArgument('visible', true, false)
         );
     }
 
     public function buildArray()
     {
-        $id = $this->getFolder();
+        $originalId = $currentId = $this->getFolder();
         $visible = $this->getVisible();
-
-        $search = FolderQuery::create();
-
-        $this->configureI18nProcessing($search, array('TITLE'));
-
-        $search->filterById($id);
-        if ($visible !== BooleanOrBothType::ANY) {
-            $search->filterByVisible($visible);
-        }
-
+        $depth = $this->getDepth();
+    
         $results = array();
 
         $ids = array();
 
         do {
+            $search = FolderQuery::create();
+    
+            $this->configureI18nProcessing($search, array('TITLE'));
+    
+            $search->filterById($currentId);
+            
+            if ($visible !== BooleanOrBothType::ANY) {
+                $search->filterByVisible($visible);
+            }
+    
             $folder = $search->findOne();
 
             if ($folder != null) {
@@ -73,28 +76,25 @@ class FolderPath extends BaseI18nLoop implements ArraySearchLoopInterface
                     "URL" => $folder->getUrl($this->locale),
                     "LOCALE" => $this->locale,
                 );
+    
+                $currentId = $folder->getParent();
 
-                $parent = $folder->getParent();
-
-                if ($parent > 0) {
+                if ($currentId > 0) {
                     // Prevent circular refererences
-                    if (in_array($parent, $ids)) {
-                        throw new \LogicException(sprintf("Circular reference detected in folder ID=%d hierarchy (folder ID=%d appears more than one times in path)", $id, $parent));
+                    if (in_array($currentId, $ids)) {
+                        throw new \LogicException(
+                            sprintf(
+                                "Circular reference detected in folder ID=%d hierarchy (folder ID=%d appears more than one times in path)",
+                                $originalId,
+                                $currentId
+                            )
+                        );
                     }
 
-                    $ids[] = $parent;
-
-                    $search = FolderQuery::create();
-
-                    $this->configureI18nProcessing($search, array('TITLE'));
-
-                    $search->filterById($parent);
-                    if ($visible != BooleanOrBothType::ANY) {
-                        $search->filterByVisible($visible);
-                    }
+                    $ids[] = $currentId;
                 }
             }
-        } while ($folder != null && $parent > 0);
+        } while ($folder != null && $currentId > 0 && --$depth > 0);
 
         // Reverse list and build the final result
         return array_reverse($results);

--- a/core/lib/Thelia/Tools/FileDownload/FileDownloader.php
+++ b/core/lib/Thelia/Tools/FileDownload/FileDownloader.php
@@ -75,6 +75,7 @@ class FileDownloader implements FileDownloaderInterface
          */
         $con = curl_init($url);
         curl_setopt($con, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($con, CURLOPT_FOLLOWLOCATION, true);
 
         $response = curl_exec($con);
         $errno = curl_errno($con);

--- a/tests/phpunit/Thelia/Tests/Tools/FileDownloaderTest.php
+++ b/tests/phpunit/Thelia/Tests/Tools/FileDownloaderTest.php
@@ -59,11 +59,11 @@ class FileDownloaderTest extends \PHPUnit_Framework_TestCase
     
     public function testFileDownloadSuccess()
     {
-        $this->downloader->download("https://thelia.net/", "php://temp");
+        $this->downloader->download("https://github.com/", "php://temp");
     }
     
     public function testFileDownloadSuccessWithRedirect()
     {
-        $this->downloader->download("http://thelia.net/", "php://temp");
+        $this->downloader->download("https://github.com/", "php://temp");
     }
 }

--- a/tests/phpunit/Thelia/Tests/Tools/FileDownloaderTest.php
+++ b/tests/phpunit/Thelia/Tests/Tools/FileDownloaderTest.php
@@ -56,8 +56,13 @@ class FileDownloaderTest extends \PHPUnit_Framework_TestCase
     {
         $this->downloader->download("https://github.com/foo/bar/baz", "baz");
     }
-
+    
     public function testFileDownloadSuccess()
+    {
+        $this->downloader->download("https://thelia.net/", "php://temp");
+    }
+    
+    public function testFileDownloadSuccessWithRedirect()
     {
         $this->downloader->download("http://thelia.net/", "php://temp");
     }


### PR DESCRIPTION
This PR fixes the "visible" argument of folder-path and category-path loops, which was not working after the first iteration. 
The code for the "depth" element was missing in these loops, and is now written.
Additionally, the code has been simplified to prevent multiple copy of the same code block.
As thelia.net may suffer various outages and block all Travis tests, the domain used in FileDownloaderTest is now github.com
