### PR TITLE
Improved sub-folder and sub-categories count

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Folder.php
+++ b/core/lib/Thelia/Core/Template/Loop/Folder.php
@@ -43,6 +43,8 @@ use Thelia\Type\BooleanOrBothType;
  * @method string getTitle()
  * @method string[] getOrder()
  * @method bool getWithPrevNextInfo()
+ *  @method bool getNeedCountChild()
+ * @method bool getNeedContentCount()
  */
 class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoopInterface
 {
@@ -64,6 +66,8 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
             Argument::createBooleanTypeArgument('not_empty', 0),
             Argument::createBooleanOrBothTypeArgument('visible', 1),
             Argument::createAnyTypeArgument('title'),
+            Argument::createBooleanTypeArgument('need_count_child', true),
+            Argument::createBooleanTypeArgument('need_content_count', true),
             new Argument(
                 'order',
                 new TypeCollection(
@@ -236,10 +240,17 @@ class Folder extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLo
                 ->set("META_TITLE", $folder->getVirtualColumn('i18n_META_TITLE'))
                 ->set("META_DESCRIPTION", $folder->getVirtualColumn('i18n_META_DESCRIPTION'))
                 ->set("META_KEYWORDS", $folder->getVirtualColumn('i18n_META_KEYWORDS'))
-                ->set("CHILD_COUNT", $folder->countChild())
-                ->set("CONTENT_COUNT", $folder->countAllContents())
                 ->set("VISIBLE", $folder->getVisible() ? "1" : "0")
                 ->set("POSITION", $folder->getPosition());
+    
+
+            if ($this->getNeedCountChild()) {
+                $loopResultRow->set("CHILD_COUNT", $folder->countChild());
+            }
+    
+            if ($this->getNeedContentCount()) {
+                $loopResultRow->set("PRODUCT_COUNT", $folder->countAllContents());
+            }
 
             $isBackendContext = $this->getBackendContext();
 

--- a/core/lib/Thelia/Model/CategoryQuery.php
+++ b/core/lib/Thelia/Model/CategoryQuery.php
@@ -33,7 +33,7 @@ class CategoryQuery extends BaseCategoryQuery
      *
      * find all category children for a given category. an array of \Thelia\Model\Category is return
      *
-     * @param $categoryId the category id or an array of id
+     * @param int|int[]                 $categoryId the category id or an array of id
      * @param  int                      $depth      max depth you want to search
      * @param  int                      $currentPos don't change this param, it is used for recursion
      * @return \Thelia\Model\Category[]

--- a/core/lib/Thelia/Model/FolderQuery.php
+++ b/core/lib/Thelia/Model/FolderQuery.php
@@ -49,7 +49,7 @@ class FolderQuery extends BaseFolderQuery
             $currentPosition++;
 
             if ($depth == $currentPosition && $depth != 0) {
-                return;
+                return[];
             }
 
             $categories = self::create()


### PR DESCRIPTION
This PR fixes and improves counting sub categories and sub folders. The number of request is now reduced. 
The visibility status of products or contents is now considered. A new parameter of `countAllProducts()` and `countAllContents()` allow selection of counted products (all / hidden / visible - the default).
The countAllXxxx() methods behavior now complies with the documentation which states that only visible folders/products are counted.

The PR also includes a fix when a category is deleted: category and subcategory products are now deleted by dispatching a `TheliaEvents::PRODUCT_DELETE` instead of calling Product::delete(). This way, database consistency is preserved, specially regarding attributes values.