### PR TITLE
Changed ModelCriteriaTools to be less restrictive in checking column …

### DIFF
--- a/core/lib/Thelia/Model/Tools/ModelCriteriaTools.php
+++ b/core/lib/Thelia/Model/Tools/ModelCriteriaTools.php
@@ -173,7 +173,7 @@ class ModelCriteriaTools
 
                 foreach ($columns as $column) {
                     $search->withColumn(
-                        'CASE WHEN NOT ISNULL(`' . $requestedLocaleI18nAlias . '`.ID) THEN `' . $requestedLocaleI18nAlias . '`.`' . $column . '` ELSE `' . $defaultLocaleI18nAlias . '`.`' . $column . '` END',
+                        'CASE WHEN NOT ISNULL(`' . $requestedLocaleI18nAlias . '`.`' . $column . '`) THEN `' . $requestedLocaleI18nAlias . '`.`' . $column . '` ELSE `' . $defaultLocaleI18nAlias . '`.`' . $column . '` END',
                         $aliasPrefix . 'i18n_' . $column
                     );
                 }


### PR DESCRIPTION
…translation instead of row translation.

When using `ModelCriteriaTools` (e.g. in i18n loop) to build I18n propel query and automatically fallback (depends of configuration) on default locale, the old code only checked if there was a translation available (a row present) and not the content of a column that could be NULL. 

It will partially fix the issue #2333.