### PR TITLE
Fix 'search_in' in different loop see #2340

### DIFF
--- a/core/lib/Thelia/Core/Template/Element/BaseLoop.php
+++ b/core/lib/Thelia/Core/Template/Element/BaseLoop.php
@@ -369,8 +369,8 @@ abstract class BaseLoop
             if (null !== $searchTerm && null !== $searchIn) {
                 switch ($searchMode) {
                     case SearchLoopInterface::MODE_ANY_WORD:
-                        $searchCriteria = Criteria::IN;
-                        $searchTerm = explode(' ', $searchTerm);
+                        $searchCriteria = ' REGEXP ';
+                        $searchTerm = str_replace(' ','|', rtrim($searchTerm));
                         break;
                     case SearchLoopInterface::MODE_SENTENCE:
                         $searchCriteria = Criteria::LIKE;

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -199,7 +199,13 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             }
             switch ($searchInElement) {
                 case "ref":
-                    $search->filterByRef($searchTerm, $searchCriteria);
+                    $searchCriteriaRef = $searchCriteria;
+                    
+                    if($searchCriteria == ' REGEXP ') {
+                      $searchCriteriaRef = criteria::IN;
+                    }
+                    
+                    $search->filterByRef($searchTerm, $searchCriteriaRef);
                     break;
             }
         }


### PR DESCRIPTION
Fix 'search_in' in different loop if search_mode is 'any_word'
If we use criteria IN the request, the word is compared to the whole field.
I use REGEX to respect the any_word mode but it also returns the words containing the terms
Otherwise it would be necessary to write :
$searchTerm = '[[.space.]]('.str_replace(' ','|', rtrim($searchTerm)).')[[.space.]]';