### PR TITLE
Fix Cannot use Thelia\Model\Module as Module because the name is already in use

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Delivery.php
+++ b/core/lib/Thelia/Core/Template/Loop/Delivery.php
@@ -21,7 +21,6 @@ use Thelia\Model\AddressQuery;
 use Thelia\Model\AreaDeliveryModuleQuery;
 use Thelia\Model\Cart as CartModel;
 use Thelia\Model\CountryQuery;
-use Thelia\Model\Module;
 use Thelia\Model\StateQuery;
 use Thelia\Module\BaseModule;
 use Thelia\Module\DeliveryModuleInterface;


### PR DESCRIPTION
Remove "use Thelia\Model\Module" en Delivery loop

exemple : 
{loop type="delivery" name="shipping_module" backend_context="on"}
{$TITLE}
{/loop}