### PR TITLE
$return was declared as string, and used as array

### DIFF
--- a/core/lib/Thelia/Type/IntToCombinedIntsListType.php
+++ b/core/lib/Thelia/Type/IntToCombinedIntsListType.php
@@ -47,7 +47,7 @@ class IntToCombinedIntsListType extends BaseType
     public function getFormattedValue($values)
     {
         if ($this->isValid($values)) {
-            $return = '';
+            $return = [];
 
             $values = preg_replace('#[\s]#', '', $values);
             foreach (explode(',', $values) as $intToCombinedInts) {

--- a/core/lib/Thelia/Type/IntToCombinedStringsListType.php
+++ b/core/lib/Thelia/Type/IntToCombinedStringsListType.php
@@ -47,7 +47,7 @@ class IntToCombinedStringsListType extends BaseType
     public function getFormattedValue($values)
     {
         if ($this->isValid($values)) {
-            $return = '';
+            $return = [];
 
             $values = preg_replace('#[\s]#', '', $values);
             foreach (explode(',', $values) as $intToCombinedStrings) {


### PR DESCRIPTION
PHP 7 will handle the variable as a string, not as an array.

This PR fixes the problem.