### PR TITLE
Force an update of Cart model after deleting an item

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -98,12 +98,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
         $productSaleElementsId = $event->getProductSaleElementsId();
         $productId = $event->getProduct();
-    
+
         // Search for an identical item in the cart
         $findItemEvent = clone $event;
-    
+
         $dispatcher->dispatch(TheliaEvents::CART_FINDITEM, $findItemEvent);
-    
+
         $cartItem = $findItemEvent->getCartItem();
 
         if ($cartItem === null || $newness) {
@@ -135,6 +135,10 @@ class Cart extends BaseAction implements EventSubscriberInterface
                 ->filterByCartId($cart->getId())
                 ->filterById($cartItemId)
                 ->delete();
+
+            // Force an update of the Cart object to provide
+            // to other listeners an updated CartItem collection.
+            $cart->clearCartItems();
         }
     }
 


### PR DESCRIPTION
Whan a caret item is deleted by Cart::deleteItem(), the deleted cart item is not removed from the Cart object. Thus, the following listeners will not notice the change.

The PR resets the Cart internal CartItem array to force a refresh when Cart::getCartItems() will be called.