### PR TITLE
Fix manual sorting in product loop

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -609,10 +609,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             ;
         }
     
-        $search->withColumn(
-            'CASE WHEN ISNULL(`CategorySelect`.POSITION) THEN ' . PHP_INT_MAX . ' ELSE CAST(`CategorySelect`.POSITION as SIGNED) END',
-            'position_delegate'
-        );
+        $search->withColumn('`CategorySelect`.POSITION', 'position_delegate');
         $search->withColumn('`CategorySelect`.CATEGORY_ID', 'default_category_id');
         $search->withColumn('`CategorySelect`.DEFAULT_CATEGORY', 'is_default_category');
 


### PR DESCRIPTION
First of all there is no sense in that case, coz `product_category.position` column can not be NULL.
Second - with this construction there is an error (at least with php x64). 
Propel set qoutes around that value: `THEN '9223372036854775807' ELSE` and mysql set type of `position_delegate` as string and sort order becomes wrong. Like this `1 10 11 ... 18 19 2 20`
You can check it in backoffice by sorting products in category by position with products count over 20 in that cat.