### PR TITLE
Fix for wrong product reference on cart and order-invoice pages

### DIFF
--- a/templates/frontOffice/default/cart.html
+++ b/templates/frontOffice/default/cart.html
@@ -80,8 +80,10 @@
                                             {$errorStock="TRUE"}
                                             <dd>{intl l="Out of Stock"}</dd>
                                         {/if}
-                                        <dt>{intl l="No."}</dt>
-                                        <dd>{$REF}</dd>
+                                        {loop type="product_sale_elements" name="ref" id=$PRODUCT_SALE_ELEMENTS_ID}
+                                            <dt>{intl l="No."}</dt>
+                                            <dd>{$REF}</dd>
+                                        {/loop}
                                         {loop type="attribute_combination" name="product_options" product_sale_elements="$PRODUCT_SALE_ELEMENTS_ID" order="manual"}
                                             <dt>{$ATTRIBUTE_TITLE}</dt>
                                             <dd>{$ATTRIBUTE_AVAILABILITY_TITLE}</dd>

--- a/templates/frontOffice/default/order-invoice.html
+++ b/templates/frontOffice/default/order-invoice.html
@@ -106,8 +106,11 @@
                                     {else}
                                         <dd>{intl l="Out of Stock"}</dd>
                                     {/if}
-                                    <dt>{intl l="No."}</dt>
-                                    <dd>{$REF}</dd>
+                                    {loop type="product_sale_elements" name="ref" id=$PRODUCT_SALE_ELEMENTS_ID}
+                                        <dt>{intl l="No."}</dt>
+                                        <dd>{$REF}</dd>
+                                    {/loop}
+                                    
                                     {loop type="attribute_combination" name="product_options" product_sale_elements="$PRODUCT_SALE_ELEMENTS_ID"}
                                         <dt>{$ATTRIBUTE_TITLE}</dt>
                                         <dd>{$ATTRIBUTE_AVAILABILITY_TITLE}</dd>


### PR DESCRIPTION
On the cart and order-invoice pages, the product reference displayed is always the default product reference, and not the selected product sale element one.

This PR fixes the problem. 