### PR TITLE
MultiDomain same server same Thelia

### DIFF
--- a/core/lib/Thelia/Action/Lang.php
+++ b/core/lib/Thelia/Action/Lang.php
@@ -188,6 +188,12 @@ class Lang extends BaseAction implements EventSubscriberInterface
                 ->filterById($id)
                 ->update(array('Url' => $url));
         }
+
+        foreach ($event->getSameServer() as $id => $same_server) {
+            LangQuery::create()
+                ->filterById($id)
+                ->update(array('SameServer' => $same_server));
+        }
     }
 
     public function fixMissingFlag(LangEvent $event)

--- a/core/lib/Thelia/Controller/Admin/LangController.php
+++ b/core/lib/Thelia/Controller/Admin/LangController.php
@@ -54,7 +54,8 @@ class LangController extends BaseAdminController
     {
         $data = array();
         foreach (LangQuery::create()->find() as $lang) {
-            $data[LangUrlForm::LANG_PREFIX.$lang->getId()] = $lang->getUrl();
+            $data[LangUrlForm::LANG_PREFIX.'url_'.$lang->getId()] = $lang->getUrl();
+            $data[LangUrlForm::LANG_PREFIX.'sameServer_'.$lang->getId()] = $lang->getSameServer();
         }
         $langUrlForm = $this->createForm(AdminForm::LANG_URL, 'form', $data);
         $this->getParserContext()->addForm($langUrlForm);
@@ -344,7 +345,12 @@ class LangController extends BaseAdminController
             $event = new LangUrlEvent();
             foreach ($data as $key => $value) {
                 if (false !== strpos($key, LangUrlForm::LANG_PREFIX)) {
-                    $event->addUrl(substr($key, strlen(LangUrlForm::LANG_PREFIX)), $value);
+                    if (false !== strpos($key, 'url_')) {
+                        $event->addUrl(substr($key, strlen(LangUrlForm::LANG_PREFIX.'url_')), $value);
+                    }
+                    if (false !== strpos($key, 'sameServer_')) {
+                        $event->addSameServer(substr($key, strlen(LangUrlForm::LANG_PREFIX.'sameServer_')), $value);
+                    }
                 }
             }
 

--- a/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
+++ b/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
@@ -134,7 +134,7 @@ class ParamInitMiddleware implements HttpKernelInterface
                 $domainUrl = $lang->getUrl();
                 $sameServer = $lang->getSameServer();
 
-                if(null === $sameServer) {
+                if(null === $sameServer || null === $request->server->get('REDIRECT_URL')) {
                     if (!empty($domainUrl)) {
                         // if lang domain is different from current domain, redirect to the proper one
                         if (rtrim($domainUrl, "/") != $request->getSchemeAndHttpHost()) {

--- a/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
+++ b/core/lib/Thelia/Core/Stack/ParamInitMiddleware.php
@@ -132,21 +132,25 @@ class ParamInitMiddleware implements HttpKernelInterface
             // if each lang has its own domain, we redirect the user to the proper one.
             if (ConfigQuery::isMultiDomainActivated()) {
                 $domainUrl = $lang->getUrl();
+                $sameServer = $lang->getSameServer();
 
-                if (! empty($domainUrl)) {
-                    // if lang domain is different from current domain, redirect to the proper one
-                    if (rtrim($domainUrl, "/") != $request->getSchemeAndHttpHost()) {
-                        // TODO : search if http status 302 is the good one.
-                        return new RedirectResponse($domainUrl, 302);
-                    } else {
-                        //the user is currently on the proper domain, nothing to change
-                        return null;
+                if(null === $sameServer) {
+                    if (!empty($domainUrl)) {
+                        // if lang domain is different from current domain, redirect to the proper one
+                        if (rtrim($domainUrl, "/") != $request->getSchemeAndHttpHost()) {
+                            // TODO : search if http status 302 is the good one.
+                            return new RedirectResponse($domainUrl, 302);
+                        } else {
+                            //the user is currently on the proper domain, nothing to change
+                            return null;
+                        }
                     }
+
+                    Tlog::getInstance()->warning("The domain URL for language " . $lang->getTitle() . " (id " . $lang->getId() . ") is not defined.");
+
+                    return Lang::getDefaultLanguage();
                 }
-
-                Tlog::getInstance()->warning("The domain URL for language ".$lang->getTitle()." (id ".$lang->getId().") is not defined.");
-
-                return Lang::getDefaultLanguage();
+                return null;
 
             } else {
                 // one domain for all languages, the lang has to be set into session

--- a/core/lib/Thelia/Core/Template/Loop/Lang.php
+++ b/core/lib/Thelia/Core/Template/Loop/Lang.php
@@ -44,6 +44,7 @@ use TheliaSmarty\Template\Plugins\TheliaLoop;
  * @method bool getDefaultOnly()
  * @method bool getExcludeDefault()
  * @method string[] getOrder()
+ * @method bool|string getSameServer()
  */
 class Lang extends BaseLoop implements PropelSearchLoopInterface
 {
@@ -63,6 +64,7 @@ class Lang extends BaseLoop implements PropelSearchLoopInterface
             Argument::createBooleanOrBothTypeArgument('visible', true),
             Argument::createBooleanTypeArgument('default_only', false),
             Argument::createBooleanTypeArgument('exclude_default', false),
+            Argument::createBooleanOrBothTypeArgument('same_server', Type\BooleanOrBothType::ANY),
             Argument::createEnumListTypeArgument(
                 'order',
                 [
@@ -109,6 +111,10 @@ class Lang extends BaseLoop implements PropelSearchLoopInterface
 
         if (null !== $exclude = $this->getExclude()) {
             $search->filterById($exclude, Criteria::NOT_IN);
+        }
+        
+        if (Type\BooleanOrBothType::ANY !== $same_server = $this->getSameServer()) {
+            $search->filterBySameServer($same_server ? 1 : 0);
         }
 
         $orders  = $this->getOrder();
@@ -160,6 +166,7 @@ class Lang extends BaseLoop implements PropelSearchLoopInterface
                 ->set("THOUSANDS_SEPARATOR", $result->getThousandsSeparator())
                 ->set("DECIMAL_COUNT", $result->getDecimals())
                 ->set("POSITION", $result->getPosition())
+                ->set("SAME_SERVER", $result->getSameServer())
             ;
 
             $this->addOutputFields($loopResultRow, $result);

--- a/core/lib/Thelia/Form/Lang/LangUrlEvent.php
+++ b/core/lib/Thelia/Form/Lang/LangUrlEvent.php
@@ -22,14 +22,25 @@ use Thelia\Core\Event\ActionEvent;
 class LangUrlEvent extends ActionEvent
 {
     protected $url = array();
+    protected $same_server = array();
 
     public function addUrl($id, $url)
     {
         $this->url[$id] = $url;
     }
 
+    public function addSameServer($id, $value)
+    {
+        $this->same_server[$id] = $value;
+    }
+
     public function getUrl()
     {
         return $this->url;
+    }
+
+    public function getSameServer()
+    {
+        return $this->same_server;
     }
 }

--- a/core/lib/Thelia/Form/Lang/LangUrlForm.php
+++ b/core/lib/Thelia/Form/Lang/LangUrlForm.php
@@ -13,6 +13,8 @@
 namespace Thelia\Form\Lang;
 
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+use Thelia\Core\Translation\Translator;
 use Thelia\Form\BaseForm;
 use Thelia\Model\LangQuery;
 
@@ -23,7 +25,7 @@ use Thelia\Model\LangQuery;
  */
 class LangUrlForm extends BaseForm
 {
-    const LANG_PREFIX = 'url_';
+    const LANG_PREFIX = 'lang_';
 
     /**
      *
@@ -48,21 +50,33 @@ class LangUrlForm extends BaseForm
     protected function buildForm()
     {
         foreach (LangQuery::create()->find() as $lang) {
-            $this->formBuilder->add(
-                self::LANG_PREFIX.$lang->getId(),
-                'text',
-                array(
-                    'constraints' => array(
-                        new NotBlank(),
-                    ),
-                    "attr" => array(
-                        "tag" => "url",
-                        "url_id" => $lang->getId(),
-                        "url_title" => $lang->getTitle(),
-                    ),
+            $this->formBuilder
+                ->add(
+                    self::LANG_PREFIX.'url_'.$lang->getId(),
+                    'text',
+                    array(
+                        'constraints' => array(
+                            new NotBlank(),
+                        ),
+                        "attr" => array(
+                            "tag" => "url",
+                            "url_id" => $lang->getId(),
+                            "url_title" => $lang->getTitle(),
+                            "url_same_server" => $lang->getSameServer(),
+                        ),
 
+                    )
                 )
-            );
+                ->add(
+                    self::LANG_PREFIX.'sameServer_'.$lang->getId(),
+                    'checkbox',
+                    [
+                        'constraints' => [ new Type([ 'type' => 'bool']) ],
+                        'required'    => false,
+                        'attr' => [
+                          ]
+                    ]
+                );
         }
     }
 

--- a/core/lib/Thelia/Model/Base/Lang.php
+++ b/core/lib/Thelia/Model/Base/Lang.php
@@ -90,6 +90,13 @@ abstract class Lang implements ActiveRecordInterface
     protected $url;
 
     /**
+     * The value for the same_server field.
+     * Note: this column has a database default value of: false
+     * @var        boolean
+     */
+    protected $same_server;
+
+    /**
      * The value for the date_format field.
      * @var        string
      */
@@ -523,6 +530,17 @@ abstract class Lang implements ActiveRecordInterface
     }
 
     /**
+     * Get the [same_server] column value.
+     *
+     * @return   boolean
+     */
+    public function getSameServer()
+    {
+
+        return $this->same_server;
+    }
+
+    /**
      * Get the [date_format] column value.
      *
      * @return   string
@@ -776,6 +794,36 @@ abstract class Lang implements ActiveRecordInterface
 
         return $this;
     } // setUrl()
+
+    /**
+     * Sets the value of the [same_server] column.
+     * Non-boolean arguments are converted using the following rules:
+     *   * 1, '1', 'true',  'on',  and 'yes' are converted to boolean true
+     *   * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
+     * Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
+     *
+     * @param      boolean|integer|string $v The new value
+     * @return   \Thelia\Model\Lang The current object (for fluent API support)
+     */
+    public function setSameServer($v)
+    {
+        if ($v !== null) {
+            if (is_string($v)) {
+                $v = in_array(strtolower($v), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+            } else {
+                $v = (boolean) $v;
+            }
+        }
+
+        if ($this->active !== $v) {
+            $this->active = $v;
+            $this->modifiedColumns[LangTableMap::SAME_SERVER] = true;
+        }
+
+
+        return $this;
+    } // setActive()
+
 
     /**
      * Set the value of [date_format] column.
@@ -1047,6 +1095,10 @@ abstract class Lang implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues()
     {
+            if ($this->same_server !== false) {
+                return false;
+            }
+
             if ($this->active !== false) {
                 return false;
             }
@@ -1097,43 +1149,46 @@ abstract class Lang implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : LangTableMap::translateFieldName('Url', TableMap::TYPE_PHPNAME, $indexType)];
             $this->url = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : LangTableMap::translateFieldName('DateFormat', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : LangTableMap::translateFieldName('SameServer', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->same_server = (null !== $col) ? (boolean) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : LangTableMap::translateFieldName('DateFormat', TableMap::TYPE_PHPNAME, $indexType)];
             $this->date_format = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : LangTableMap::translateFieldName('TimeFormat', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : LangTableMap::translateFieldName('TimeFormat', TableMap::TYPE_PHPNAME, $indexType)];
             $this->time_format = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : LangTableMap::translateFieldName('DatetimeFormat', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : LangTableMap::translateFieldName('DatetimeFormat', TableMap::TYPE_PHPNAME, $indexType)];
             $this->datetime_format = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : LangTableMap::translateFieldName('DecimalSeparator', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : LangTableMap::translateFieldName('DecimalSeparator', TableMap::TYPE_PHPNAME, $indexType)];
             $this->decimal_separator = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : LangTableMap::translateFieldName('ThousandsSeparator', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : LangTableMap::translateFieldName('ThousandsSeparator', TableMap::TYPE_PHPNAME, $indexType)];
             $this->thousands_separator = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : LangTableMap::translateFieldName('Active', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : LangTableMap::translateFieldName('Active', TableMap::TYPE_PHPNAME, $indexType)];
             $this->active = (null !== $col) ? (boolean) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : LangTableMap::translateFieldName('Visible', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : LangTableMap::translateFieldName('Visible', TableMap::TYPE_PHPNAME, $indexType)];
             $this->visible = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : LangTableMap::translateFieldName('Decimals', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 13 + $startcol : LangTableMap::translateFieldName('Decimals', TableMap::TYPE_PHPNAME, $indexType)];
             $this->decimals = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 13 + $startcol : LangTableMap::translateFieldName('ByDefault', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 14 + $startcol : LangTableMap::translateFieldName('ByDefault', TableMap::TYPE_PHPNAME, $indexType)];
             $this->by_default = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 14 + $startcol : LangTableMap::translateFieldName('Position', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 15 + $startcol : LangTableMap::translateFieldName('Position', TableMap::TYPE_PHPNAME, $indexType)];
             $this->position = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 15 + $startcol : LangTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 16 + $startcol : LangTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, '\DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 16 + $startcol : LangTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 17 + $startcol : LangTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
@@ -1420,6 +1475,9 @@ abstract class Lang implements ActiveRecordInterface
         if ($this->isColumnModified(LangTableMap::URL)) {
             $modifiedColumns[':p' . $index++]  = '`URL`';
         }
+        if ($this->isColumnModified(LangTableMap::SAME_SERVER)) {
+            $modifiedColumns[':p' . $index++]  = '`SAME_SERVER`';
+        }
         if ($this->isColumnModified(LangTableMap::DATE_FORMAT)) {
             $modifiedColumns[':p' . $index++]  = '`DATE_FORMAT`';
         }
@@ -1481,6 +1539,9 @@ abstract class Lang implements ActiveRecordInterface
                         break;
                     case '`URL`':
                         $stmt->bindValue($identifier, $this->url, PDO::PARAM_STR);
+                        break;
+                    case '`SAME_SERVER`':
+                        $stmt->bindValue($identifier, (int) $this->same_server, PDO::PARAM_INT);
                         break;
                     case '`DATE_FORMAT`':
                         $stmt->bindValue($identifier, $this->date_format, PDO::PARAM_STR);
@@ -1596,39 +1657,42 @@ abstract class Lang implements ActiveRecordInterface
                 return $this->getUrl();
                 break;
             case 5:
-                return $this->getDateFormat();
+                return $this->getSameServer();
                 break;
             case 6:
-                return $this->getTimeFormat();
+                return $this->getDateFormat();
                 break;
             case 7:
-                return $this->getDatetimeFormat();
+                return $this->getTimeFormat();
                 break;
             case 8:
-                return $this->getDecimalSeparator();
+                return $this->getDatetimeFormat();
                 break;
             case 9:
-                return $this->getThousandsSeparator();
+                return $this->getDecimalSeparator();
                 break;
             case 10:
-                return $this->getActive();
+                return $this->getThousandsSeparator();
                 break;
             case 11:
-                return $this->getVisible();
+                return $this->getActive();
                 break;
             case 12:
-                return $this->getDecimals();
+                return $this->getVisible();
                 break;
             case 13:
-                return $this->getByDefault();
+                return $this->getDecimals();
                 break;
             case 14:
-                return $this->getPosition();
+                return $this->getByDefault();
                 break;
             case 15:
-                return $this->getCreatedAt();
+                return $this->getPosition();
                 break;
             case 16:
+                return $this->getCreatedAt();
+                break;
+            case 17:
                 return $this->getUpdatedAt();
                 break;
             default:
@@ -1665,18 +1729,19 @@ abstract class Lang implements ActiveRecordInterface
             $keys[2] => $this->getCode(),
             $keys[3] => $this->getLocale(),
             $keys[4] => $this->getUrl(),
-            $keys[5] => $this->getDateFormat(),
-            $keys[6] => $this->getTimeFormat(),
-            $keys[7] => $this->getDatetimeFormat(),
-            $keys[8] => $this->getDecimalSeparator(),
-            $keys[9] => $this->getThousandsSeparator(),
-            $keys[10] => $this->getActive(),
-            $keys[11] => $this->getVisible(),
-            $keys[12] => $this->getDecimals(),
-            $keys[13] => $this->getByDefault(),
-            $keys[14] => $this->getPosition(),
-            $keys[15] => $this->getCreatedAt(),
-            $keys[16] => $this->getUpdatedAt(),
+            $keys[5] => $this->getSameServer(),
+            $keys[6] => $this->getDateFormat(),
+            $keys[7] => $this->getTimeFormat(),
+            $keys[8] => $this->getDatetimeFormat(),
+            $keys[9] => $this->getDecimalSeparator(),
+            $keys[10] => $this->getThousandsSeparator(),
+            $keys[11] => $this->getActive(),
+            $keys[12] => $this->getVisible(),
+            $keys[13] => $this->getDecimals(),
+            $keys[14] => $this->getByDefault(),
+            $keys[15] => $this->getPosition(),
+            $keys[16] => $this->getCreatedAt(),
+            $keys[17] => $this->getUpdatedAt(),
         );
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
@@ -1740,39 +1805,42 @@ abstract class Lang implements ActiveRecordInterface
                 $this->setUrl($value);
                 break;
             case 5:
-                $this->setDateFormat($value);
+                $this->setSameServer($value);
                 break;
             case 6:
-                $this->setTimeFormat($value);
+                $this->setDateFormat($value);
                 break;
             case 7:
-                $this->setDatetimeFormat($value);
+                $this->setTimeFormat($value);
                 break;
             case 8:
-                $this->setDecimalSeparator($value);
+                $this->setDatetimeFormat($value);
                 break;
             case 9:
-                $this->setThousandsSeparator($value);
+                $this->setDecimalSeparator($value);
                 break;
             case 10:
-                $this->setActive($value);
+                $this->setThousandsSeparator($value);
                 break;
             case 11:
-                $this->setVisible($value);
+                $this->setActive($value);
                 break;
             case 12:
-                $this->setDecimals($value);
+                $this->setVisible($value);
                 break;
             case 13:
-                $this->setByDefault($value);
+                $this->setDecimals($value);
                 break;
             case 14:
-                $this->setPosition($value);
+                $this->setByDefault($value);
                 break;
             case 15:
-                $this->setCreatedAt($value);
+                $this->setPosition($value);
                 break;
             case 16:
+                $this->setCreatedAt($value);
+                break;
+            case 17:
                 $this->setUpdatedAt($value);
                 break;
         } // switch()
@@ -1804,18 +1872,19 @@ abstract class Lang implements ActiveRecordInterface
         if (array_key_exists($keys[2], $arr)) $this->setCode($arr[$keys[2]]);
         if (array_key_exists($keys[3], $arr)) $this->setLocale($arr[$keys[3]]);
         if (array_key_exists($keys[4], $arr)) $this->setUrl($arr[$keys[4]]);
-        if (array_key_exists($keys[5], $arr)) $this->setDateFormat($arr[$keys[5]]);
-        if (array_key_exists($keys[6], $arr)) $this->setTimeFormat($arr[$keys[6]]);
-        if (array_key_exists($keys[7], $arr)) $this->setDatetimeFormat($arr[$keys[7]]);
-        if (array_key_exists($keys[8], $arr)) $this->setDecimalSeparator($arr[$keys[8]]);
-        if (array_key_exists($keys[9], $arr)) $this->setThousandsSeparator($arr[$keys[9]]);
-        if (array_key_exists($keys[10], $arr)) $this->setActive($arr[$keys[10]]);
-        if (array_key_exists($keys[11], $arr)) $this->setVisible($arr[$keys[11]]);
-        if (array_key_exists($keys[12], $arr)) $this->setDecimals($arr[$keys[12]]);
-        if (array_key_exists($keys[13], $arr)) $this->setByDefault($arr[$keys[13]]);
-        if (array_key_exists($keys[14], $arr)) $this->setPosition($arr[$keys[14]]);
-        if (array_key_exists($keys[15], $arr)) $this->setCreatedAt($arr[$keys[15]]);
-        if (array_key_exists($keys[16], $arr)) $this->setUpdatedAt($arr[$keys[16]]);
+        if (array_key_exists($keys[5], $arr)) $this->setSameServer($arr[$keys[5]]);
+        if (array_key_exists($keys[6], $arr)) $this->setDateFormat($arr[$keys[6]]);
+        if (array_key_exists($keys[7], $arr)) $this->setTimeFormat($arr[$keys[7]]);
+        if (array_key_exists($keys[8], $arr)) $this->setDatetimeFormat($arr[$keys[8]]);
+        if (array_key_exists($keys[9], $arr)) $this->setDecimalSeparator($arr[$keys[9]]);
+        if (array_key_exists($keys[10], $arr)) $this->setThousandsSeparator($arr[$keys[10]]);
+        if (array_key_exists($keys[11], $arr)) $this->setActive($arr[$keys[11]]);
+        if (array_key_exists($keys[12], $arr)) $this->setVisible($arr[$keys[12]]);
+        if (array_key_exists($keys[13], $arr)) $this->setDecimals($arr[$keys[13]]);
+        if (array_key_exists($keys[14], $arr)) $this->setByDefault($arr[$keys[14]]);
+        if (array_key_exists($keys[15], $arr)) $this->setPosition($arr[$keys[15]]);
+        if (array_key_exists($keys[16], $arr)) $this->setCreatedAt($arr[$keys[16]]);
+        if (array_key_exists($keys[17], $arr)) $this->setUpdatedAt($arr[$keys[17]]);
     }
 
     /**
@@ -1832,6 +1901,7 @@ abstract class Lang implements ActiveRecordInterface
         if ($this->isColumnModified(LangTableMap::CODE)) $criteria->add(LangTableMap::CODE, $this->code);
         if ($this->isColumnModified(LangTableMap::LOCALE)) $criteria->add(LangTableMap::LOCALE, $this->locale);
         if ($this->isColumnModified(LangTableMap::URL)) $criteria->add(LangTableMap::URL, $this->url);
+        if ($this->isColumnModified(LangTableMap::SAME_SERVER)) $criteria->add(LangTableMap::SAME_SERVER, $this->same_server);
         if ($this->isColumnModified(LangTableMap::DATE_FORMAT)) $criteria->add(LangTableMap::DATE_FORMAT, $this->date_format);
         if ($this->isColumnModified(LangTableMap::TIME_FORMAT)) $criteria->add(LangTableMap::TIME_FORMAT, $this->time_format);
         if ($this->isColumnModified(LangTableMap::DATETIME_FORMAT)) $criteria->add(LangTableMap::DATETIME_FORMAT, $this->datetime_format);
@@ -1911,6 +1981,7 @@ abstract class Lang implements ActiveRecordInterface
         $copyObj->setCode($this->getCode());
         $copyObj->setLocale($this->getLocale());
         $copyObj->setUrl($this->getUrl());
+        $copyObj->setSameServer($this->getSameServer());
         $copyObj->setDateFormat($this->getDateFormat());
         $copyObj->setTimeFormat($this->getTimeFormat());
         $copyObj->setDatetimeFormat($this->getDatetimeFormat());
@@ -2636,6 +2707,7 @@ abstract class Lang implements ActiveRecordInterface
         $this->code = null;
         $this->locale = null;
         $this->url = null;
+        $this->same_server = null;
         $this->date_format = null;
         $this->time_format = null;
         $this->datetime_format = null;

--- a/core/lib/Thelia/Model/Base/LangQuery.php
+++ b/core/lib/Thelia/Model/Base/LangQuery.php
@@ -26,6 +26,7 @@ use Thelia\Model\Map\LangTableMap;
  * @method     ChildLangQuery orderByCode($order = Criteria::ASC) Order by the code column
  * @method     ChildLangQuery orderByLocale($order = Criteria::ASC) Order by the locale column
  * @method     ChildLangQuery orderByUrl($order = Criteria::ASC) Order by the url column
+ * @method     ChildLangQuery orderBySameServer($order = Criteria::ASC) Order by the same_server column
  * @method     ChildLangQuery orderByDateFormat($order = Criteria::ASC) Order by the date_format column
  * @method     ChildLangQuery orderByTimeFormat($order = Criteria::ASC) Order by the time_format column
  * @method     ChildLangQuery orderByDatetimeFormat($order = Criteria::ASC) Order by the datetime_format column
@@ -44,6 +45,7 @@ use Thelia\Model\Map\LangTableMap;
  * @method     ChildLangQuery groupByCode() Group by the code column
  * @method     ChildLangQuery groupByLocale() Group by the locale column
  * @method     ChildLangQuery groupByUrl() Group by the url column
+ * @method     ChildLangQuery groupBySameServer() Group by the same_server column
  * @method     ChildLangQuery groupByDateFormat() Group by the date_format column
  * @method     ChildLangQuery groupByTimeFormat() Group by the time_format column
  * @method     ChildLangQuery groupByDatetimeFormat() Group by the datetime_format column
@@ -77,6 +79,7 @@ use Thelia\Model\Map\LangTableMap;
  * @method     ChildLang findOneByCode(string $code) Return the first ChildLang filtered by the code column
  * @method     ChildLang findOneByLocale(string $locale) Return the first ChildLang filtered by the locale column
  * @method     ChildLang findOneByUrl(string $url) Return the first ChildLang filtered by the url column
+ * @method     ChildLang findOneBySameServer(boolean $active) Return the first ChildLang filtered by the same_server column
  * @method     ChildLang findOneByDateFormat(string $date_format) Return the first ChildLang filtered by the date_format column
  * @method     ChildLang findOneByTimeFormat(string $time_format) Return the first ChildLang filtered by the time_format column
  * @method     ChildLang findOneByDatetimeFormat(string $datetime_format) Return the first ChildLang filtered by the datetime_format column
@@ -95,6 +98,7 @@ use Thelia\Model\Map\LangTableMap;
  * @method     array findByCode(string $code) Return ChildLang objects filtered by the code column
  * @method     array findByLocale(string $locale) Return ChildLang objects filtered by the locale column
  * @method     array findByUrl(string $url) Return ChildLang objects filtered by the url column
+ * @method     array findBySameServer(boolean $active) Return ChildLang objects filtered by the same_server column
  * @method     array findByDateFormat(string $date_format) Return ChildLang objects filtered by the date_format column
  * @method     array findByTimeFormat(string $time_format) Return ChildLang objects filtered by the time_format column
  * @method     array findByDatetimeFormat(string $datetime_format) Return ChildLang objects filtered by the datetime_format column
@@ -195,7 +199,7 @@ abstract class LangQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT `ID`, `TITLE`, `CODE`, `LOCALE`, `URL`, `DATE_FORMAT`, `TIME_FORMAT`, `DATETIME_FORMAT`, `DECIMAL_SEPARATOR`, `THOUSANDS_SEPARATOR`, `ACTIVE`, `VISIBLE`, `DECIMALS`, `BY_DEFAULT`, `POSITION`, `CREATED_AT`, `UPDATED_AT` FROM `lang` WHERE `ID` = :p0';
+        $sql = 'SELECT `ID`, `TITLE`, `CODE`, `LOCALE`, `URL`, `SAME_SERVER`, `DATE_FORMAT`, `TIME_FORMAT`, `DATETIME_FORMAT`, `DECIMAL_SEPARATOR`, `THOUSANDS_SEPARATOR`, `ACTIVE`, `VISIBLE`, `DECIMALS`, `BY_DEFAULT`, `POSITION`, `CREATED_AT`, `UPDATED_AT` FROM `lang` WHERE `ID` = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -439,6 +443,33 @@ abstract class LangQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(LangTableMap::URL, $url, $comparison);
+    }
+
+    /**
+     * Filter the query on the same_server column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterBySameServer(true); // WHERE active = true
+     * $query->filterBySameServer('yes'); // WHERE active = true
+     * </code>
+     *
+     * @param     boolean|string $sameServer The value to use as filter.
+     *              Non-boolean arguments are converted using the following rules:
+     *                * 1, '1', 'true',  'on',  and 'yes' are converted to boolean true
+     *                * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
+     *              Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ChildLangQuery The current query, for fluid interface
+     */
+    public function filterBySameServer($sameServer = null, $comparison = null)
+    {
+        if (is_string($sameServer)) {
+            $sameServer = in_array(strtolower($sameServer), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+        }
+
+        return $this->addUsingAlias(LangTableMap::SAME_SERVER, $sameServer, $comparison);
     }
 
     /**

--- a/core/lib/Thelia/Model/Map/LangTableMap.php
+++ b/core/lib/Thelia/Model/Map/LangTableMap.php
@@ -96,6 +96,11 @@ class LangTableMap extends TableMap
     const URL = 'lang.URL';
 
     /**
+     * the column name for the SAME_SERVER field
+     */
+    const SAME_SERVER = 'lang.SAME_SERVER';
+
+    /**
      * the column name for the DATE_FORMAT field
      */
     const DATE_FORMAT = 'lang.DATE_FORMAT';
@@ -167,12 +172,12 @@ class LangTableMap extends TableMap
      * e.g. self::$fieldNames[self::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        self::TYPE_PHPNAME       => array('Id', 'Title', 'Code', 'Locale', 'Url', 'DateFormat', 'TimeFormat', 'DatetimeFormat', 'DecimalSeparator', 'ThousandsSeparator', 'Active', 'Visible', 'Decimals', 'ByDefault', 'Position', 'CreatedAt', 'UpdatedAt', ),
-        self::TYPE_STUDLYPHPNAME => array('id', 'title', 'code', 'locale', 'url', 'dateFormat', 'timeFormat', 'datetimeFormat', 'decimalSeparator', 'thousandsSeparator', 'active', 'visible', 'decimals', 'byDefault', 'position', 'createdAt', 'updatedAt', ),
-        self::TYPE_COLNAME       => array(LangTableMap::ID, LangTableMap::TITLE, LangTableMap::CODE, LangTableMap::LOCALE, LangTableMap::URL, LangTableMap::DATE_FORMAT, LangTableMap::TIME_FORMAT, LangTableMap::DATETIME_FORMAT, LangTableMap::DECIMAL_SEPARATOR, LangTableMap::THOUSANDS_SEPARATOR, LangTableMap::ACTIVE, LangTableMap::VISIBLE, LangTableMap::DECIMALS, LangTableMap::BY_DEFAULT, LangTableMap::POSITION, LangTableMap::CREATED_AT, LangTableMap::UPDATED_AT, ),
-        self::TYPE_RAW_COLNAME   => array('ID', 'TITLE', 'CODE', 'LOCALE', 'URL', 'DATE_FORMAT', 'TIME_FORMAT', 'DATETIME_FORMAT', 'DECIMAL_SEPARATOR', 'THOUSANDS_SEPARATOR', 'ACTIVE', 'VISIBLE', 'DECIMALS', 'BY_DEFAULT', 'POSITION', 'CREATED_AT', 'UPDATED_AT', ),
-        self::TYPE_FIELDNAME     => array('id', 'title', 'code', 'locale', 'url', 'date_format', 'time_format', 'datetime_format', 'decimal_separator', 'thousands_separator', 'active', 'visible', 'decimals', 'by_default', 'position', 'created_at', 'updated_at', ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, )
+        self::TYPE_PHPNAME       => array('Id', 'Title', 'Code', 'Locale', 'Url', 'SameServer','DateFormat', 'TimeFormat', 'DatetimeFormat', 'DecimalSeparator', 'ThousandsSeparator', 'Active', 'Visible', 'Decimals', 'ByDefault', 'Position', 'CreatedAt', 'UpdatedAt', ),
+        self::TYPE_STUDLYPHPNAME => array('id', 'title', 'code', 'locale', 'url', 'SameServer', 'dateFormat', 'timeFormat', 'datetimeFormat', 'decimalSeparator', 'thousandsSeparator', 'active', 'visible', 'decimals', 'byDefault', 'position', 'createdAt', 'updatedAt', ),
+        self::TYPE_COLNAME       => array(LangTableMap::ID, LangTableMap::TITLE, LangTableMap::CODE, LangTableMap::LOCALE, LangTableMap::URL, LangTableMap::SAME_SERVER, LangTableMap::DATE_FORMAT, LangTableMap::TIME_FORMAT, LangTableMap::DATETIME_FORMAT, LangTableMap::DECIMAL_SEPARATOR, LangTableMap::THOUSANDS_SEPARATOR, LangTableMap::ACTIVE, LangTableMap::VISIBLE, LangTableMap::DECIMALS, LangTableMap::BY_DEFAULT, LangTableMap::POSITION, LangTableMap::CREATED_AT, LangTableMap::UPDATED_AT, ),
+        self::TYPE_RAW_COLNAME   => array('ID', 'TITLE', 'CODE', 'LOCALE', 'URL', 'SAME_SERVER', 'DATE_FORMAT', 'TIME_FORMAT', 'DATETIME_FORMAT', 'DECIMAL_SEPARATOR', 'THOUSANDS_SEPARATOR', 'ACTIVE', 'VISIBLE', 'DECIMALS', 'BY_DEFAULT', 'POSITION', 'CREATED_AT', 'UPDATED_AT', ),
+        self::TYPE_FIELDNAME     => array('id', 'title', 'code', 'locale', 'url', 'same_server', 'date_format', 'time_format', 'datetime_format', 'decimal_separator', 'thousands_separator', 'active', 'visible', 'decimals', 'by_default', 'position', 'created_at', 'updated_at', ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, )
     );
 
     /**
@@ -182,12 +187,12 @@ class LangTableMap extends TableMap
      * e.g. self::$fieldKeys[self::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        self::TYPE_PHPNAME       => array('Id' => 0, 'Title' => 1, 'Code' => 2, 'Locale' => 3, 'Url' => 4, 'DateFormat' => 5, 'TimeFormat' => 6, 'DatetimeFormat' => 7, 'DecimalSeparator' => 8, 'ThousandsSeparator' => 9, 'Active' => 10, 'Visible' => 11, 'Decimals' => 12, 'ByDefault' => 13, 'Position' => 14, 'CreatedAt' => 15, 'UpdatedAt' => 16, ),
-        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'title' => 1, 'code' => 2, 'locale' => 3, 'url' => 4, 'dateFormat' => 5, 'timeFormat' => 6, 'datetimeFormat' => 7, 'decimalSeparator' => 8, 'thousandsSeparator' => 9, 'active' => 10, 'visible' => 11, 'decimals' => 12, 'byDefault' => 13, 'position' => 14, 'createdAt' => 15, 'updatedAt' => 16, ),
-        self::TYPE_COLNAME       => array(LangTableMap::ID => 0, LangTableMap::TITLE => 1, LangTableMap::CODE => 2, LangTableMap::LOCALE => 3, LangTableMap::URL => 4, LangTableMap::DATE_FORMAT => 5, LangTableMap::TIME_FORMAT => 6, LangTableMap::DATETIME_FORMAT => 7, LangTableMap::DECIMAL_SEPARATOR => 8, LangTableMap::THOUSANDS_SEPARATOR => 9, LangTableMap::ACTIVE => 10, LangTableMap::VISIBLE => 11, LangTableMap::DECIMALS => 12, LangTableMap::BY_DEFAULT => 13, LangTableMap::POSITION => 14, LangTableMap::CREATED_AT => 15, LangTableMap::UPDATED_AT => 16, ),
-        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'TITLE' => 1, 'CODE' => 2, 'LOCALE' => 3, 'URL' => 4, 'DATE_FORMAT' => 5, 'TIME_FORMAT' => 6, 'DATETIME_FORMAT' => 7, 'DECIMAL_SEPARATOR' => 8, 'THOUSANDS_SEPARATOR' => 9, 'ACTIVE' => 10, 'VISIBLE' => 11, 'DECIMALS' => 12, 'BY_DEFAULT' => 13, 'POSITION' => 14, 'CREATED_AT' => 15, 'UPDATED_AT' => 16, ),
-        self::TYPE_FIELDNAME     => array('id' => 0, 'title' => 1, 'code' => 2, 'locale' => 3, 'url' => 4, 'date_format' => 5, 'time_format' => 6, 'datetime_format' => 7, 'decimal_separator' => 8, 'thousands_separator' => 9, 'active' => 10, 'visible' => 11, 'decimals' => 12, 'by_default' => 13, 'position' => 14, 'created_at' => 15, 'updated_at' => 16, ),
-        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, )
+        self::TYPE_PHPNAME       => array('Id' => 0, 'Title' => 1, 'Code' => 2, 'Locale' => 3, 'Url' => 4, 'SameServer' => 5, 'DateFormat' => 6, 'TimeFormat' => 7, 'DatetimeFormat' => 8, 'DecimalSeparator' => 9, 'ThousandsSeparator' => 10, 'Active' => 11, 'Visible' => 12, 'Decimals' => 13, 'ByDefault' => 14, 'Position' => 15, 'CreatedAt' => 16, 'UpdatedAt' => 17, ),
+        self::TYPE_STUDLYPHPNAME => array('id' => 0, 'title' => 1, 'code' => 2, 'locale' => 3, 'url' => 4, 'sameServer' => 5, 'dateFormat' => 6, 'timeFormat' => 7, 'datetimeFormat' => 8, 'decimalSeparator' => 9, 'thousandsSeparator' => 10, 'active' => 11, 'visible' => 12, 'decimals' => 13, 'byDefault' => 14, 'position' => 15, 'createdAt' => 16, 'updatedAt' => 17, ),
+        self::TYPE_COLNAME       => array(LangTableMap::ID => 0, LangTableMap::TITLE => 1, LangTableMap::CODE => 2, LangTableMap::LOCALE => 3, LangTableMap::URL => 4, LangTableMap::SAME_SERVER => 5, LangTableMap::DATE_FORMAT => 6, LangTableMap::TIME_FORMAT => 7, LangTableMap::DATETIME_FORMAT => 8, LangTableMap::DECIMAL_SEPARATOR => 9, LangTableMap::THOUSANDS_SEPARATOR => 10, LangTableMap::ACTIVE => 11, LangTableMap::VISIBLE => 12, LangTableMap::DECIMALS => 13, LangTableMap::BY_DEFAULT => 14, LangTableMap::POSITION => 15, LangTableMap::CREATED_AT => 16, LangTableMap::UPDATED_AT => 17, ),
+        self::TYPE_RAW_COLNAME   => array('ID' => 0, 'TITLE' => 1, 'CODE' => 2, 'LOCALE' => 3, 'URL' => 4, 'SAME_SERVER' => 5, 'DATE_FORMAT' => 6, 'TIME_FORMAT' => 7, 'DATETIME_FORMAT' => 8, 'DECIMAL_SEPARATOR' => 9, 'THOUSANDS_SEPARATOR' => 10, 'ACTIVE' => 11, 'VISIBLE' => 12, 'DECIMALS' => 13, 'BY_DEFAULT' => 14, 'POSITION' => 15, 'CREATED_AT' => 16, 'UPDATED_AT' => 17, ),
+        self::TYPE_FIELDNAME     => array('id' => 0, 'title' => 1, 'code' => 2, 'locale' => 3, 'url' => 4, 'same_server' => 5, 'date_format' => 6, 'time_format' => 7, 'datetime_format' => 8, 'decimal_separator' => 9, 'thousands_separator' => 10, 'active' => 11, 'visible' => 12, 'decimals' => 13, 'by_default' => 14, 'position' => 15, 'created_at' => 16, 'updated_at' => 17, ),
+        self::TYPE_NUM           => array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, )
     );
 
     /**
@@ -211,6 +216,7 @@ class LangTableMap extends TableMap
         $this->addColumn('CODE', 'Code', 'VARCHAR', false, 10, null);
         $this->addColumn('LOCALE', 'Locale', 'VARCHAR', false, 45, null);
         $this->addColumn('URL', 'Url', 'VARCHAR', false, 255, null);
+        $this->addColumn('SAME_SERVER', 'SameServer', 'BOOLEAN', false, 1, false);
         $this->addColumn('DATE_FORMAT', 'DateFormat', 'VARCHAR', false, 45, null);
         $this->addColumn('TIME_FORMAT', 'TimeFormat', 'VARCHAR', false, 45, null);
         $this->addColumn('DATETIME_FORMAT', 'DatetimeFormat', 'VARCHAR', false, 45, null);
@@ -399,6 +405,7 @@ class LangTableMap extends TableMap
             $criteria->addSelectColumn(LangTableMap::CODE);
             $criteria->addSelectColumn(LangTableMap::LOCALE);
             $criteria->addSelectColumn(LangTableMap::URL);
+            $criteria->addSelectColumn(LangTableMap::SAME_SERVER);
             $criteria->addSelectColumn(LangTableMap::DATE_FORMAT);
             $criteria->addSelectColumn(LangTableMap::TIME_FORMAT);
             $criteria->addSelectColumn(LangTableMap::DATETIME_FORMAT);
@@ -417,6 +424,7 @@ class LangTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.CODE');
             $criteria->addSelectColumn($alias . '.LOCALE');
             $criteria->addSelectColumn($alias . '.URL');
+            $criteria->addSelectColumn($alias . '.SAME_SERVER');
             $criteria->addSelectColumn($alias . '.DATE_FORMAT');
             $criteria->addSelectColumn($alias . '.TIME_FORMAT');
             $criteria->addSelectColumn($alias . '.DATETIME_FORMAT');

--- a/setup/update/sql/2.4.0-alpha1.sql
+++ b/setup/update/sql/2.4.0-alpha1.sql
@@ -179,4 +179,8 @@ UPDATE `module` SET `mandatory` = 0, `hidden` = 0;
 UPDATE `module` SET `hidden` = 1 WHERE `code` = 'Front';
 UPDATE `module` SET `mandatory` = 1, `hidden` = 1 WHERE `code` = 'TheliaSmarty';
 
+
+-- Add same_server column in url table
+ALTER TABLE `lang` ADD `same_server` TINYINT(1) NULL DEFAULT '0' AFTER `url`;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/templates/backOffice/default/I18n/en_US.php
+++ b/templates/backOffice/default/I18n/en_US.php
@@ -168,6 +168,7 @@ return array(
     'Change this template' => 'Change this template',
     'Change this variable' => 'Change this variable',
     'Chapo' => 'Chapo',
+    'Check if it is the same server, same Thelia as the default language' => ' Check if it is the same server, same Thelia as the default language',
     'Check sale activation' => 'Check sale activation',
     'Check the support of hooks.' => 'Check the support of hooks.',
     'Check this box if you want to add this attributes to all product templates' => 'Check this box if you want to add this attributes to all product templates',

--- a/templates/backOffice/default/I18n/fr_FR.php
+++ b/templates/backOffice/default/I18n/fr_FR.php
@@ -169,6 +169,7 @@ return [
     'Change this template' => 'Modifier ce gabarit',
     'Change this variable' => 'Modifier cette variable',
     'Chapo' => 'Chapeau',
+    'Check if it is the same server, same Thelia as the default language' => 'Cochez si c\'est le même serveur, même Thelia que la langue par défaut',
     'Check sale activation' => 'Contrôler l\'activation',
     'Check the support of hooks.' => 'Vérifier le support des points d\'accroche',
     'Check this box if you want to add this attributes to all product templates' => 'Cochez cette case si vous voulez ajouter cette déclinaison à tous les gabarits de produits',

--- a/templates/backOffice/default/languages.html
+++ b/templates/backOffice/default/languages.html
@@ -157,6 +157,10 @@
                                     <td>
                                         <div class="form-group {if $error}has-error{/if}">
                                         <input type="text" class="form-control" name="{$name}" value="{$value}" placeholder="http://www.domain.com" {if $one_domain_per_lang == 0}readonly{/if}>
+                                        {$check_same_server = $attr_list.url_same_server}
+                                        {form_field field="lang_sameServer_{$attr_list.url_id}"}
+                                        <input type="checkbox" name="{$name}" {if $check_same_server}checked{/if}> {intl l='Check if it is the same server, same Thelia as the default language'}
+                                        {/form_field}
                                         </div>
                                     </td>
                                 </tr>


### PR DESCRIPTION
If you configure Thelia in multi-language multi-domain but its domains
are on the same server, same resource Thelia, the translation of the url
is not done.
This PR allows to select the domains that are on the same server as the
default language to perform the translation
![2017-04-29_11-42-56](https://cloud.githubusercontent.com/assets/7439945/25554606/97375ff4-2cd1-11e7-8945-44ad6739521f.jpg)

I add 'same_server' column in url table
en espérant ne pas avoir oublié de fichier :)