### PR TITLE
Call built-in setlocale before session start

### DIFF
--- a/core/lib/Thelia/Core/Stack/SessionMiddleware.php
+++ b/core/lib/Thelia/Core/Stack/SessionMiddleware.php
@@ -73,6 +73,8 @@ class SessionMiddleware implements HttpKernelInterface
                 self::$session = $session = $event->getSession();
             }
 
+            setlocale(LC_ALL, $session->getLang()->getLocale() . '.UTF-8');
+
             $session->start();
             $request->setSession($session);
         }


### PR DESCRIPTION
Useful for smarty `date_format` with format like `%A` for example