### PR TITLE
MultiLanguage & MultiDomain on the same server

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -134,17 +134,18 @@ class UrlGenerator extends AbstractSmartyPlugin
                 } else {
                     $lang = LangQuery::create()->findOneByCode($requestedLangCodeOrLocale);
                 }
-                $urlRewrite = RewritingUrlQuery::create()
-                    ->filterByView($view)
-                    ->filterByViewId($viewId)
-                    ->filterByViewLocale($lang->getLocale())
-                    ->findOneByRedirected(null)
-                ;
 
                 if (ConfigQuery::isMultiDomainActivated()) {
+                    $urlRewrite = RewritingUrlQuery::create()
+                        ->filterByView($view)
+                        ->filterByViewId($viewId)
+                        ->filterByViewLocale($lang->getLocale())
+                        ->findOneByRedirected(null)
+                    ;
+                    
                     $domainUrl = $lang->getUrl();
                     $path = '';
-                    if(null != $urlRewrite){
+                    if (null != $urlRewrite){
                         $path = "/".$urlRewrite->getUrl();
                     }
                     $baseUrl = $request->getBaseUrl();

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -145,7 +145,7 @@ class UrlGenerator extends AbstractSmartyPlugin
                     
                     $domainUrl = $lang->getUrl();
                     $path = '';
-                    if (null != $urlRewrite){
+                    if (null != $urlRewrite) {
                         $path = "/".$urlRewrite->getUrl();
                     }
                     $baseUrl = $request->getBaseUrl();

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -143,13 +143,11 @@ class UrlGenerator extends AbstractSmartyPlugin
                         ->findOneByRedirected(null)
                     ;
                     
-                    $domainUrl = $lang->getUrl();
                     $path = '';
                     if (null != $urlRewrite) {
                         $path = "/".$urlRewrite->getUrl();
                     }
-                    $baseUrl = $request->getBaseUrl();
-                    $url = rtrim($domainUrl, "/").$baseUrl.$path;
+                    $url = rtrim($lang->getUrl(), "/").$request->getBaseUrl().$path;
                 }
 
             }

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -22,6 +22,9 @@ use TheliaSmarty\Template\AbstractSmartyPlugin;
 use Thelia\Tools\TokenProvider;
 use Thelia\Tools\URL;
 use Thelia\Core\HttpFoundation\Request;
+use Thelia\Model\RewritingUrlQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Model\ConfigQuery;
 
 class UrlGenerator extends AbstractSmartyPlugin
 {
@@ -119,6 +122,36 @@ class UrlGenerator extends AbstractSmartyPlugin
                 $this->getArgsFromParam($params, array_merge(['noamp', 'path', 'file', 'target'], $excludeParams)),
                 $mode
             );
+            
+            $request = $this->getRequest();
+            $requestedLangCodeOrLocale = $params["lang"];
+            $view = $request->attributes->get('_view', null);
+            $viewId = $view === null ? null : $request->query->get($view . '_id', null);
+
+            if (null !== $requestedLangCodeOrLocale) {
+                if (strlen($requestedLangCodeOrLocale) > 2) {
+                    $lang = LangQuery::create()->findOneByLocale($requestedLangCodeOrLocale);
+                } else {
+                    $lang = LangQuery::create()->findOneByCode($requestedLangCodeOrLocale);
+                }
+                $urlRewrite = RewritingUrlQuery::create()
+                    ->filterByView($view)
+                    ->filterByViewId($viewId)
+                    ->filterByViewLocale($lang->getLocale())
+                    ->findOneByRedirected(null)
+                ;
+
+                if (ConfigQuery::isMultiDomainActivated()) {
+                    $domainUrl = $lang->getUrl();
+                    $path = '';
+                    if(null != $urlRewrite){
+                        $path = "/".$urlRewrite->getUrl();
+                    }
+                    $baseUrl = $request->getBaseUrl();
+                    $url = rtrim($domainUrl, "/").$baseUrl.$path;
+                }
+
+            }
         }
         return $this->applyNoAmpAndTarget($params, $url);
     }


### PR DESCRIPTION
Suite a la PR #2381 
This PR, translate the url into the requested language

example:
langue : FR  Domain: http;//www.domaineFR.com   page product: produit1
langue : EN Domain: http://www.domaineEN.com   page product: product_1

on the page : http://www.domaineFR.com/produit1
this request
```{url path="{navigate to="current"}" lang='en_US'}```
return 
``` http://www.domaineEN.com/product_1```