### PR TITLE
Added "coupon" substitutions

### DIFF
--- a/local/modules/TheliaSmarty/Config/config.xml
+++ b/local/modules/TheliaSmarty/Config/config.xml
@@ -114,6 +114,7 @@
             <argument type="service" id="thelia.taxEngine" />
             <argument type="service" id="thelia.parser.context"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="thelia.coupon.manager"/>
         </service>
 
         <service id="smarty.plugin.adminUtilities" class="TheliaSmarty\Template\Plugins\AdminUtilities">


### PR DESCRIPTION
This PR introduces coupon substitution, to get information about the coupons currently in use during the checkout process.

The proposed substitutions are documented here: http://doc.thelia.net/en/documentation/substitutions/coupon.html