### PR TITLE
Remove required on pses weight field

### DIFF
--- a/templates/backOffice/default/includes/product-prices-tab.html
+++ b/templates/backOffice/default/includes/product-prices-tab.html
@@ -427,7 +427,7 @@
                                 {/form_field}
 
                                 {form_field field='weight' value_key=$idx}
-                                <td {if $error}class="has-error"{/if}><input required class="form-control text-right input-sm" type="text" name="{$name}" value="{$value}" /></td>
+                                <td {if $error}class="has-error"{/if}><input class="form-control text-right input-sm" type="text" name="{$name}" value="{$value}" /></td>
                                 {/form_field}
 
 


### PR DESCRIPTION
I think there is no reason to have a required here because pse.weight can be NULL.