### PR TITLE
Fixed cheque payment instruction display

### DIFF
--- a/local/modules/Cheque/templates/frontOffice/default/order-placed.additional-payment-info.html
+++ b/local/modules/Cheque/templates/frontOffice/default/order-placed.additional-payment-info.html
@@ -16,6 +16,6 @@
 </blockquote>
 <p><span class="glyphicon glyphicon-warning-sign"></span> {intl d='cheque.fo.default' l="Be sure to sign your cheque !"}</p>
 
-{loop type="module-config" name="cheque-instructions" module="cheque" variable="instructions"}
+{loop type="module-config" name="cheque-instructions" module="cheque" variable="instructions" locale={lang attr='locale'}}
 <p>{$VALUE nofilter}</p>
 {/loop}

--- a/templates/backOffice/default/includes/product-prices-tab.html
+++ b/templates/backOffice/default/includes/product-prices-tab.html
@@ -427,7 +427,7 @@
                                 {/form_field}
 
                                 {form_field field='weight' value_key=$idx}
-                                <td {if $error}class="has-error"{/if}><input required class="form-control text-right input-sm" type="text" name="{$name}" value="{$value}" /></td>
+                                <td {if $error}class="has-error"{/if}><input class="form-control text-right input-sm" type="text" name="{$name}" value="{$value}" /></td>
                                 {/form_field}
 
 


### PR DESCRIPTION
The cheque instructions defined in the back-office were displayed only for en_US locales.

This PR fixes this problem, the instructions are now displayed for every locale.