### PR TITLE
Removed PHP 7.2 from Travis config (too many errors)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ php:
 - 5.6
 - 7.0
 - 7.1
-- 7.2
 - nightly
 matrix:
   allow_failures:
   - php: nightly
-  - php: 7.2
 env:
 - DB_USER=root DB_HOST=127.0.0.1
 before_script:


### PR DESCRIPTION
Testing Thelia 2 against PHP 7.2 causes too many errors (mainly due to Propel generated code), and Travis tests are taking hours to complete.

This PR removes PHP 7.2 from Travis configuration.