### PR TITLE
A way to prevent email notification to customer when customer is updated

### DIFF
--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -96,7 +96,7 @@ class Customer extends BaseAction implements EventSubscriberInterface
 
         $this->createOrUpdateCustomer($customer, $event, $dispatcher);
 
-        if (! empty($plainPassword) || $emailChanged) {
+        if ($event->getNotifyCustomerOfAccountModification() && (! empty($plainPassword) || $emailChanged)) {
             $this->mailer->sendEmailToCustomer('customer_account_changed', $customer, ['password' => $plainPassword]);
         }
     }

--- a/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
+++ b/core/lib/Thelia/Core/Event/Customer/CustomerCreateOrUpdateEvent.php
@@ -41,7 +41,11 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
     protected $company;
     protected $ref;
     protected $emailUpdateAllowed;
+
+    /** @var  bool */
     protected $notifyCustomerOfAccountCreation;
+    /** @var  bool */
+    protected $notifyCustomerOfAccountModification = true;
 
     /**
      * @param int    $title     the title customer id
@@ -63,6 +67,7 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
      * @param float  $discount
      * @param string $company
      * @param string $ref
+     * @param int $state thre State ID
      */
     public function __construct(
         $title,
@@ -86,6 +91,8 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
         $ref,
         $state = null
     ) {
+        parent::__construct();
+
         $this->address1 = $address1;
         $this->address2 = $address2;
         $this->address3 = $address3;
@@ -315,5 +322,23 @@ class CustomerCreateOrUpdateEvent extends CustomerEvent
     public function getNotifyCustomerOfAccountCreation()
     {
         return $this->notifyCustomerOfAccountCreation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getNotifyCustomerOfAccountModification()
+    {
+        return $this->notifyCustomerOfAccountModification;
+    }
+
+    /**
+     * @param bool $notifyCustomerOfAccountModification
+     * @return $this
+     */
+    public function setNotifyCustomerOfAccountModification($notifyCustomerOfAccountModification)
+    {
+        $this->notifyCustomerOfAccountModification = $notifyCustomerOfAccountModification;
+        return $this;
     }
 }


### PR DESCRIPTION
When a customer is updated, a notification email is always sent if the password or the email is changed.

This PR introduces a new flag `notifyCustomerOfAccountModification` in  the `CustomerCreateOrUpdateEvent` class, to provide modules a way to prevent sending this mail.