### PR TITLE
Fix bug when store images are missing

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
@@ -900,16 +900,20 @@ class DataAccessFunctions extends AbstractSmartyPlugin
                 }
             }
 
-            $this->dispatcher->dispatch(TheliaEvents::IMAGE_PROCESS, $event);
-
-            $template->assign('MEDIA_URL', $event->getFileUrl());
+            try {
+                $this->dispatcher->dispatch(TheliaEvents::IMAGE_PROCESS, $event);
+                $template->assign('MEDIA_URL', $event->getFileUrl());
+            } catch (\Exception $ex) {
+                Tlog::getInstance()->error($ex->getMessage());
+                $template->assign('MEDIA_URL', '');
+            }
         }
 
         if (isset($content)) {
             return $content;
+        } else {
+            return null;
         }
-
-        return null;
     }
 
 


### PR DESCRIPTION
(Fix issue #2446)
My previous PR (#2416) indeed threw an exception on the "Config > Store management" page when the images are not found.
It didn't cause problems when installing Thelia 2.3.4 from scratch as the default three images (favicon.png, logo.png and banner.jpg) were copied during the installation. But this was a problem when updating to Thelia 2.3.4 as these images are not copied.
This PR just ensures that the smarty block {local_media} doesn't throw exception anymore when the image are missing, instead the variable $MEDIA_URL will be empty.