### PR TITLE
New TheliaEvents::CART_DUPLICATED event

### DIFF
--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -402,6 +402,9 @@ final class TheliaEvents
      */
     const CART_DUPLICATED = "cart.duplicated";
 
+    /**
+     * Sent when a cart item is duplicated
+     */
     const CART_ITEM_DUPLICATE = "cart.item.duplicate";
 
     /**

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -393,8 +393,14 @@ final class TheliaEvents
 
     /**
      * sent when a new existing cat id duplicated. This append when current customer is different from current cart
+     * The old cart is already deleted from the database when this event is dispatched.
      */
     const CART_DUPLICATE = "cart.duplicate";
+
+    /**
+     * Sent when the cart is duplicated, but not yet deleted from the database.
+     */
+    const CART_DUPLICATED = "cart.duplicated";
 
     const CART_ITEM_DUPLICATE = "cart.item.duplicate";
 

--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -5,6 +5,7 @@ namespace Thelia\Model;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Cart\CartDuplicationEvent;
 use Thelia\Core\Event\Cart\CartItemDuplicationItem;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\Base\Cart as BaseCart;
@@ -80,6 +81,9 @@ class Cart extends BaseCart
                 $dispatcher->dispatch(TheliaEvents::CART_ITEM_DUPLICATE, new CartItemDuplicationItem($item, $cartItem));
             }
         }
+
+        // Dispatche the duplication event before delting the cart from the database,
+        $dispatcher->dispatch(TheliaEvents::CART_DUPLICATED, new CartDuplicationEvent($cart, $this));
 
         try {
             $this->delete();


### PR DESCRIPTION
This PR introduces a new event, `TheliaEvents::CART_DUPLICATED`, which is dispatched when the duplicated cart is created, but before the original cart is deleted from the database.

This alow modules to process the duplication event with both carts still present in the database. If the module uses tables with foreign keys to the `cart` table with cascade delete, the module table is not yet modified when this event is dispatched.

Practical example : a module stores additional cart information with a FK to the cart table, and wish to attach them to the duplicated cart. When `TheliaEvents::CART_DUPLICATED`, all data are still in the database (original cart, related module's data, and new cart).
When `TheliaEvents::CART_DUPLICATE `is dispatched, only the new cart exists in the database.