### PR TITLE
Added exclude_code argument

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/BaseSpecificModule.php
+++ b/core/lib/Thelia/Core/Template/Loop/BaseSpecificModule.php
@@ -28,7 +28,7 @@ use Thelia\Type\TypeCollection;
  * {@inheritdoc}
  * @method int getId()
  * @method int[] getExclude()
- * @method int[] getExcludeCode()
+ * @method string[] getExcludeCode()
  * @method string getCode()
  * @method string[] getOrder()
  */

--- a/core/lib/Thelia/Core/Template/Loop/BaseSpecificModule.php
+++ b/core/lib/Thelia/Core/Template/Loop/BaseSpecificModule.php
@@ -28,6 +28,7 @@ use Thelia\Type\TypeCollection;
  * {@inheritdoc}
  * @method int getId()
  * @method int[] getExclude()
+ * @method int[] getExcludeCode()
  * @method string getCode()
  * @method string[] getOrder()
  */
@@ -43,18 +44,19 @@ abstract class BaseSpecificModule extends BaseI18nLoop implements PropelSearchLo
         return new ArgumentCollection(
             Argument::createIntTypeArgument('id'),
             Argument::createIntListTypeArgument('exclude'),
+            Argument::createAnyListTypeArgument('exclude_code'),
             Argument::createAnyTypeArgument('code'),
             new Argument(
                 'order',
                 new TypeCollection(
                     new EnumType(
                         [
-                        'id',
-                        'id_reverse',
-                        'alpha',
-                        'alpha_reverse',
-                        'manual',
-                        'manual_reverse',
+                            'id',
+                            'id_reverse',
+                            'alpha',
+                            'alpha_reverse',
+                            'manual',
+                            'manual_reverse',
                         ]
                     )
                 ),
@@ -75,6 +77,10 @@ abstract class BaseSpecificModule extends BaseI18nLoop implements PropelSearchLo
 
         if (null !== $exclude = $this->getExclude()) {
             $search->filterById($exclude, Criteria::NOT_IN);
+        }
+
+        if (null !== $excludeCode = $this->getExcludeCode()) {
+            $search->filterByCode($excludeCode, Criteria::NOT_IN);
         }
 
         if (null !== $code = $this->getCode()) {


### PR DESCRIPTION
This PR adds the `exclude_code` argument to delivery and payment loops, to allow excluding a module using its code instead of its ID
