### PR TITLE
Prevent useless data copy in export

### DIFF
--- a/core/lib/Thelia/ImportExport/Export/AbstractExport.php
+++ b/core/lib/Thelia/ImportExport/Export/AbstractExport.php
@@ -147,18 +147,17 @@ abstract class AbstractExport implements \Iterator
         // but we do not permit to go back
 
         if ($this->data === null) {
-            $data = $this->getData();
+            $this->data = $this->getData();
 
-            if (is_array($data)) {
-                $this->data = $data;
+            if (is_array($this->data)) {
                 $this->dataIsArray = true;
                 reset($this->data);
 
                 return;
             }
 
-            if ($data instanceof ModelCriteria) {
-                $this->data = $data->setFormatter(ModelCriteria::FORMAT_ON_DEMAND)->keepQuery(false)->paginate(1, 1000);
+            if ($this->data instanceof ModelCriteria) {
+                $this->data = $this->data->setFormatter(ModelCriteria::FORMAT_ON_DEMAND)->keepQuery(false)->paginate(1, 1000);
                 $this->data->getIterator()->rewind();
 
                 return;


### PR DESCRIPTION
The export system is perfoming a useless array copy, just for testing purposes. This PR is removing this copy.