### PR TITLE
Fixed brand sorting by "visible" status

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Brand.php
+++ b/core/lib/Thelia/Core/Template/Loop/Brand.php
@@ -78,7 +78,9 @@ class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoo
                             'created',
                             'created-reverse',
                             'updated',
-                            'updated-reverse'
+                            'updated-reverse',
+                            'visible',
+                            'visible-reverse'
                         )
                     )
                 ),
@@ -196,6 +198,12 @@ class Brand extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoo
                     break;
                 case "updated-reverse":
                     $search->addDescendingOrderByColumn('updated_at');
+                    break;
+                case "visible":
+                    $search->orderByVisible(Criteria::ASC);
+                    break;
+                case "visible-reverse":
+                    $search->orderByVisible(Criteria::DESC);
                     break;
             }
         }

--- a/templates/backOffice/default/brands.html
+++ b/templates/backOffice/default/brands.html
@@ -75,7 +75,7 @@
 
                                         <th class="text-center">
                                             {admin_sortable_header
-                                            current_order=$content_order
+                                            current_order=$order
                                             order='visible'
                                             reverse_order='visible-reverse'
                                             path={url path='/admin/brand'}


### PR DESCRIPTION
Sorting brands by "visible" status was not working at all, and raised an exception.

This PR fixes the problem.