### PR TITLE
Update SPXD identifier for LGPL module license

### DIFF
--- a/core/lib/Thelia/Command/Skeleton/Module/composer.json
+++ b/core/lib/Thelia/Command/Skeleton/Module/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "your-vendor/%%COMPOSERNAME%%-module",
-  "license": "LGPL-3.0+",
+  "license": "LGPL-3.0-or-later",
   "type": "thelia-module",
   "require": {
     "thelia/installer": "~1.1"


### PR DESCRIPTION
`LGPL-3.0+` is not correct, `LGPL-3.0-or-later` is the good license identifier according to  [SPDX standards](https://spdx.org/licenses/LGPL-3.0-or-later.html).

Modules will now be generated with this identifier.