### PR TITLE
Missing PARENT output for CategoryPath loop

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/CategoryPath.php
+++ b/core/lib/Thelia/Core/Template/Loop/CategoryPath.php
@@ -59,34 +59,35 @@ class CategoryPath extends BaseI18nLoop implements ArraySearchLoopInterface
         $originalId = $currentId = $this->getCategory();
         $visible = $this->getVisible();
         $depth = $this->getDepth();
-    
+
         $results = array();
-    
+
         $ids = array();
-    
+
         do {
             $search = CategoryQuery::create();
-        
+
             $this->configureI18nProcessing($search, array('TITLE'));
-        
+
             $search->filterById($currentId);
-        
+
             if ($visible !== BooleanOrBothType::ANY) {
                 $search->filterByVisible($visible);
             }
-        
+
             $category = $search->findOne();
-        
+
             if ($category != null) {
                 $results[] = array(
                     "ID" => $category->getId(),
                     "TITLE" => $category->getVirtualColumn('i18n_TITLE'),
+                    "PARENT" => $category->getParent(),
                     "URL" => $category->getUrl($this->locale),
                     "LOCALE" => $this->locale,
                 );
-            
+
                 $currentId = $category->getParent();
-            
+
                 if ($currentId > 0) {
                     // Prevent circular refererences
                     if (in_array($currentId, $ids)) {
@@ -98,12 +99,12 @@ class CategoryPath extends BaseI18nLoop implements ArraySearchLoopInterface
                             )
                         );
                     }
-                
+
                     $ids[] = $currentId;
                 }
             }
         } while ($category != null && $currentId > 0 && --$depth > 0);
-    
+
         // Reverse list and build the final result
         return array_reverse($results);
     }


### PR DESCRIPTION
This PR adds the PARENT output to CategoryPath loop, which is documented, but missing in the loop code.