### PR TITLE
Missing ignored_module_hook table columns + typo

### DIFF
--- a/setup/I18n/fr_FR.php
+++ b/setup/I18n/fr_FR.php
@@ -382,7 +382,7 @@ return array(
     'Customer - order table row' => 'Client - ligne tableau commande',
     'Customer account - additional information' => 'Compte client - informations additionnelles',
     'Customer account block' => 'Bloc compte client',
-    'Customer account creation should be confirmed by email (1: yes, 0: no)' => 'La création d\'un compte client doit être confilrée par email (1: oui, 0: non)',
+    'Customer account creation should be confirmed by email (1: yes, 0: no)' => 'La création d\'un compte client doit être confirmée par email (1: oui, 0: non)',
     'Customer title' => 'civilité client',
     'Customers - JavaScript' => 'Clients - JavaScript',
     'Customers - caption' => 'Clients - légende',

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -2177,7 +2177,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
     (66, 'fr_FR', 'Nombre par défaut de résultats par page pour la liste des produits', NUll, NULL, NULL),
     (67, 'fr_FR', 'Nombre par défaut de résultats par page pour la liste des commandes', NUll, NULL, NULL),
     (68, 'fr_FR', 'Nombre par défaut de résultats par page pour la liste des clients', NUll, NULL, NULL),
-    (69, 'fr_FR', 'La création d\'un compte client doit être confilrée par email (1: oui, 0: non)', NULL, NULL, NULL),
+    (69, 'fr_FR', 'La création d\'un compte client doit être confirmée par email (1: oui, 0: non)', NULL, NULL, NULL),
     (70, 'fr_FR', 'Nombre de coupons par page dans la liste des coupons', NULL, NULL, NULL)
 ;
 

--- a/setup/update/sql/2.4.0-alpha1.sql
+++ b/setup/update/sql/2.4.0-alpha1.sql
@@ -67,7 +67,7 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
     (@max_id + 1, 'de_DE', NULL, NULL, NULL, NULL),
     (@max_id + 1, 'en_US', 'Customer account creation should be confirmed by email (1: yes, 0: no)', NULL, NULL, NULL),
     (@max_id + 1, 'es_ES', NULL, NULL, NULL, NULL),
-    (@max_id + 1, 'fr_FR', NULL, NULL, NULL, NULL)
+    (@max_id + 1, 'fr_FR', 'La création d\'un compte client doit être confirmée par email (1: oui, 0: non)', NULL, NULL, NULL)
 ;
 
 SELECT @max_id :=IFNULL(MAX(`id`),0) FROM `message`;

--- a/setup/update/sql/2.4.0-alpha2.sql
+++ b/setup/update/sql/2.4.0-alpha2.sql
@@ -18,4 +18,9 @@ END IF
 $$
 DELIMITER ;
 
+-- Missing timestamps in ignored_module_hook
+
+ALTER TABLE `ignored_module_hook` ADD `created_at` DATETIME NOT NULL;
+ALTER TABLE `ignored_module_hook` ADD `updated_at` DATETIME NOT NULL;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.4.0-alpha2.sql.tpl
+++ b/setup/update/tpl/2.4.0-alpha2.sql.tpl
@@ -18,4 +18,9 @@ END IF
 $$
 DELIMITER ;
 
+-- Missing timestamps in ignored_module_hook
+
+ALTER TABLE `ignored_module_hook` ADD `created_at` DATETIME NOT NULL;
+ALTER TABLE `ignored_module_hook` ADD `updated_at` DATETIME NOT NULL;
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
This PR fixes a schema update bug: in the `ignored_module_hook `table, `created_at `and `updated_at `columns are missing.

Additionally, a typo in the french translation has been fixed.