### PR TITLE
New feature: template inheritance

### DIFF
--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -457,7 +457,7 @@ class Order extends BaseAction implements EventSubscriberInterface
      */
     public function orderBeforePayment(OrderEvent $event, $eventName, EventDispatcherInterface $dispatcher)
     {
-        $dispatcher ->dispatch(TheliaEvents::ORDER_SEND_CONFIRMATION_EMAIL, clone $event);
+        $dispatcher->dispatch(TheliaEvents::ORDER_SEND_CONFIRMATION_EMAIL, clone $event);
 
         $dispatcher->dispatch(TheliaEvents::ORDER_SEND_NOTIFICATION_EMAIL, clone $event);
     }

--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -235,7 +235,6 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
                     $pse
                         ->setIsDefault(true)
                         ->save($con);
-
                     // Delete the related attribute combination.
                     AttributeCombinationQuery::create()
                         ->filterByProductSaleElementsId($pse->getId())
@@ -243,7 +242,6 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
                 } else {
                     // Delete the PSE
                     $pse->delete($con);
-
                     // If we deleted the default PSE, make the last created one the default
                     if ($pse->getIsDefault()) {
                         $newDefaultPse = ProductSaleElementsQuery::create()
@@ -252,7 +250,6 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
                             ->orderByCreatedAt(Criteria::DESC)
                             ->findOne($con)
                         ;
-
                         if (null !== $newDefaultPse) {
                             $newDefaultPse->setIsDefault(true)->save($con);
                         }

--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -49,35 +49,35 @@ class MessageController extends AbstractCrudController
             null  // No position update
         );
     }
-    
+
     protected function getCreationForm()
     {
         return $this->createForm(AdminForm::MESSAGE_CREATION);
     }
-    
+
     protected function getUpdateForm()
     {
         return $this->createForm(AdminForm::MESSAGE_MODIFICATION);
     }
-    
+
     protected function getCreationEvent($formData)
     {
         $createEvent = new MessageCreateEvent();
-        
+
         $createEvent
             ->setMessageName($formData['name'])
             ->setLocale($formData["locale"])
             ->setTitle($formData['title'])
             ->setSecured($formData['secured'] ? true : false)
         ;
-        
+
         return $createEvent;
     }
-    
+
     protected function getUpdateEvent($formData)
     {
         $changeEvent = new MessageUpdateEvent($formData['id']);
-        
+
         // Create and dispatch the change event
         $changeEvent
             ->setMessageName($formData['name'])
@@ -92,20 +92,20 @@ class MessageController extends AbstractCrudController
             ->setHtmlMessage($formData['html_message'])
             ->setTextMessage($formData['text_message'])
         ;
-        
+
         return $changeEvent;
     }
-    
+
     protected function getDeleteEvent()
     {
         return new MessageDeleteEvent($this->getRequest()->get('message_id'));
     }
-    
+
     protected function eventContainsObject($event)
     {
         return $event->hasMessage();
     }
-    
+
     protected function hydrateObjectForm($object)
     {
         // Prepare the data that will hydrate the form
@@ -118,34 +118,34 @@ class MessageController extends AbstractCrudController
             'subject'       => $object->getSubject(),
             'html_message'  => $object->getHtmlMessage(),
             'text_message'  => $object->getTextMessage(),
-            
+
             'html_layout_file_name'   => $object->getHtmlLayoutFileName(),
             'html_template_file_name' => $object->getHtmlTemplateFileName(),
             'text_layout_file_name'   => $object->getTextLayoutFileName(),
             'text_template_file_name' => $object->getTextTemplateFileName(),
         );
-        
+
         // Setup the object form
         return $this->createForm(AdminForm::MESSAGE_MODIFICATION, "form", $data);
     }
-    
+
     protected function getObjectFromEvent($event)
     {
         return $event->hasMessage() ? $event->getMessage() : null;
     }
-    
+
     protected function getExistingObject()
     {
         $message = MessageQuery::create()
             ->findOneById($this->getRequest()->get('message_id', 0));
-        
+
         if (null !== $message) {
             $message->setLocale($this->getCurrentEditionLocale());
         }
-        
+
         return $message;
     }
-    
+
     /**
      * @param Message $object
      * @return string
@@ -154,7 +154,7 @@ class MessageController extends AbstractCrudController
     {
         return $object->getName();
     }
-    
+
     /**
      * @param Message $object
      * @return int
@@ -163,30 +163,38 @@ class MessageController extends AbstractCrudController
     {
         return $object->getId();
     }
-    
+
     protected function renderListTemplate($currentOrder)
     {
         return $this->render('messages');
     }
-    
+
     protected function listDirectoryContent($requiredExtension)
     {
         $list = array();
-        
-        $dir = $this->getTemplateHelper()->getActiveMailTemplate()->getAbsolutePath();
-        
-        $finder = Finder::create()->files()->in($dir)->ignoreDotFiles(true)->sortByName()->name("*.$requiredExtension");
-        
+
+        $mailTemplate = $this->getTemplateHelper()->getActiveMailTemplate();
+
+        $finder = Finder::create()->files()->in($mailTemplate->getAbsolutePath());
+
+        // Also add parent template files, if any.
+        /** @var TemplateDefinition $parentTemplate */
+        foreach ($mailTemplate->getParentList() as $parentTemplate) {
+            $finder->in($parentTemplate->getAbsolutePath());
+        }
+
+        $finder->ignoreDotFiles(true)->sortByName()->name("*.$requiredExtension");
+
         foreach ($finder as $file) {
             $list[] = $file->getBasename();
         }
-        
+
         // Add modules templates
         $modules = ModuleQuery::getActivated();
         /** @var Module $module */
         foreach ($modules as $module) {
             $dir = $module->getAbsoluteTemplateBasePath() . DS . TemplateDefinition::EMAIL_SUBDIR . DS . 'default';
-            
+
             if (file_exists($dir)) {
                 $finder = Finder::create()
                     ->files()
@@ -194,7 +202,7 @@ class MessageController extends AbstractCrudController
                     ->ignoreDotFiles(true)
                     ->sortByName()
                     ->name("*.$requiredExtension");
-                
+
                 foreach ($finder as $file) {
                     $fileName = $file->getBasename();
                     if (!in_array($fileName, $list)) {
@@ -203,10 +211,10 @@ class MessageController extends AbstractCrudController
                 }
             }
         }
-        
+
         return $list;
     }
-    
+
     protected function renderEditionTemplate()
     {
         return $this->render('message-edit', array(
@@ -216,7 +224,7 @@ class MessageController extends AbstractCrudController
             'text_template_list' =>  $this->listDirectoryContent('txt'),
         ));
     }
-    
+
     protected function redirectToEditionTemplate()
     {
         return $this->generateRedirectFromRoute(
@@ -226,71 +234,71 @@ class MessageController extends AbstractCrudController
             ]
         );
     }
-    
+
     protected function redirectToListTemplate()
     {
         return $this->generateRedirectFromRoute('admin.configuration.messages.default');
     }
-    
+
     public function previewAction($messageId, $html = true)
     {
         if (null !== $response = $this->checkAuth(AdminResources::MESSAGE, [], AccessManager::VIEW)) {
             return $response;
         }
-        
+
         if (null === $message = MessageQuery::create()->findPk($messageId)) {
             $this->pageNotFound();
         }
-        
+
         $parser = $this->getParser($this->getTemplateHelper()->getActiveMailTemplate());
-        
+
         foreach ($this->getRequest()->query->all() as $key => $value) {
             $parser->assign($key, $value);
         }
-        
+
         if ($html) {
             $content = $message->setLocale($this->getCurrentEditionLocale())->getHtmlMessageBody($parser);
         } else {
             $content = $message->setLocale($this->getCurrentEditionLocale())->getTextMessageBody($parser);
         }
-        
+
         return new Response($content);
     }
-    
+
     public function previewAsHtmlAction($messageId)
     {
         return $this->previewAction($messageId);
     }
-    
+
     public function previewAsTextAction($messageId)
     {
         $response = $this->previewAction($messageId, false);
         $response->headers->add(["Content-Type" => "text/plain"]);
-        
+
         return $response;
     }
-    
+
     public function sendSampleByEmailAction($messageId)
     {
         if (null !== $response = $this->checkAuth(AdminResources::MESSAGE, [], AccessManager::VIEW)) {
             return $response;
         }
-        
+
         if (null !== $message = MessageQuery::create()->findPk($messageId)) {
             // Ajax submission: prevent CRSF control, as page is not refreshed
             $baseForm = $this->createForm(AdminForm::MESSAGE_SEND_SAMPLE, 'form', [], ['csrf_protection' => false]);
-            
+
             try {
                 $form = $this->validateForm($baseForm, "POST");
-                
+
                 $data = $form->getData();
-                
+
                 $messageParameters = [];
-                
+
                 foreach ($this->getRequest()->request->all() as $key => $value) {
                     $messageParameters[$key] = $value;
                 }
-                
+
                 $this->getMailer()->sendEmailMessage(
                     $message->getName(),
                     [ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName()],
@@ -298,7 +306,7 @@ class MessageController extends AbstractCrudController
                     $messageParameters,
                     $this->getCurrentEditionLocale()
                 );
-                
+
                 return new Response(
                     $this->getTranslator()->trans(
                         "The message has been successfully sent to %recipient.",

--- a/core/lib/Thelia/Controller/Admin/TranslationsController.php
+++ b/core/lib/Thelia/Controller/Admin/TranslationsController.php
@@ -233,7 +233,7 @@ class TranslationsController extends BaseAdminController
 
                 $domain = $template->getTranslationDomain();
 
-                // Load translations files is this template is not the current template
+                // Load translations files if this template is not the current template
                 // as it is not loaded in Thelia.php
                 if (! $this->getTemplateHelper()->isActive($template)) {
                     $this->loadTranslation($i18nDirectory, $domain);

--- a/core/lib/Thelia/Core/Hook/HookHelper.php
+++ b/core/lib/Thelia/Core/Hook/HookHelper.php
@@ -15,6 +15,7 @@ namespace Thelia\Core\Hook;
 use Thelia\Core\Template\ParserHelperInterface;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Translation\Translator;
+use Thelia\Exception\TheliaProcessException;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
@@ -39,6 +40,11 @@ class HookHelper
         $this->parserHelper = $parserHelper;
     }
 
+    /**
+     * @param int $templateType
+     * @return array
+     * @throws \Exception
+     */
     public function parseActiveTemplate($templateType = TemplateDefinition::FRONT_OFFICE)
     {
         switch ($templateType) {
@@ -54,17 +60,31 @@ class HookHelper
             case TemplateDefinition::EMAIL:
                 $tplVar = 'active-mail-template';
                 break;
+            default:
+                throw new TheliaProcessException("Unknown template type: $templateType");
         }
 
         return $this->parseTemplate($templateType, ConfigQuery::read($tplVar, 'default'));
     }
 
+    /**
+     * @param int $templateType
+     * @param string $template
+     * @return array an array of hooks descriptors
+     * @throws \Exception
+     */
     public function parseTemplate($templateType, $template)
     {
         $templateDefinition = new TemplateDefinition($template, $templateType);
 
         $hooks = array();
         $this->walkDir($templateDefinition->getAbsolutePath(), $hooks);
+
+        // Also parse parent templates
+        /** @var TemplateDefinition $parentTemplate */
+        foreach ($templateDefinition->getParentList() as $parentTemplate) {
+            $this->walkDir($parentTemplate->getAbsolutePath(), $hooks);
+        }
 
         // load language message
         $locale = Lang::getDefaultLanguage()->getLocale();
@@ -99,7 +119,6 @@ class HookHelper
      * @internal param string $currentLocale the current locale
      * @internal param string $domain the translation domain (fontoffice, backoffice, module, etc...)
      * @internal param array $strings the list of strings
-     * @return number the total number of translatable texts
      */
     public function walkDir($directory, &$hooks)
     {
@@ -199,6 +218,13 @@ class HookHelper
         return ltrim($path, '/');
     }
 
+    /**
+     * Translate Hook labels
+     *
+     * @param $context
+     * @param $key
+     * @return string
+     */
     protected function trans($context, $key)
     {
         $message = "";

--- a/core/lib/Thelia/Core/Template/Assets/AssetResolverInterface.php
+++ b/core/lib/Thelia/Core/Template/Assets/AssetResolverInterface.php
@@ -13,6 +13,7 @@
 namespace Thelia\Core\Template\Assets;
 
 use Thelia\Core\Template\ParserInterface;
+use Thelia\Core\Template\TemplateDefinition;
 
 interface AssetResolverInterface
 {
@@ -53,4 +54,29 @@ interface AssetResolverInterface
      * @return mixed the path to directory containing the file, or null if the file doesn't exists.
      */
     public function resolveAssetSourcePath($source, $templateName, $fileName, ParserInterface $parserInterface);
+
+    /**
+     * Return an asset source file path, and the template in which it was found
+     *
+     * A system of fallback enables file overriding. It will look for the template :
+     *      - in the current template in directory /modules/{module code}/
+     *      - in the module in the current template if it exists
+     *      - in the module in the default template
+     *
+     * @param  string $source a module code, or ParserInterface::TEMPLATE_ASSETS_KEY
+     * @param  string $templateName a template name, or false to use the current template
+     * @param  string $fileName the filename
+     * @param  ParserInterface $parserInterface the current template parser
+     * @param  TemplateDefinition &$templateDefinition the template where to start search.
+     *         This parameter will contain the template where the asset was found.
+     *
+     * @return mixed the path to directory containing the file, or null if the file doesn't exists.
+     */
+    public function resolveAssetSourcePathAndTemplate(
+        $source,
+        $templateName,
+        $fileName,
+        ParserInterface $parserInterface,
+        TemplateDefinition &$templateDefinition
+    );
 }

--- a/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
+++ b/core/lib/Thelia/Core/Template/Assets/AsseticAssetManager.php
@@ -13,13 +13,12 @@
 namespace Thelia\Core\Template\Assets;
 
 use Assetic\AssetManager;
-use Assetic\FilterManager;
-use Assetic\Filter;
-use Assetic\Factory\AssetFactory;
 use Assetic\AssetWriter;
-use Thelia\Model\ConfigQuery;
-use Thelia\Log\Tlog;
+use Assetic\Factory\AssetFactory;
+use Assetic\FilterManager;
 use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Log\Tlog;
+use Thelia\Model\ConfigQuery;
 
 /**
  * This class is a simple helper for generating assets using Assetic.
@@ -192,14 +191,14 @@ class AsseticAssetManager implements AssetManagerInterface
      * Decode the filters names, and initialize the Assetic FilterManager
      *
      * @param  FilterManager             $filterManager the Assetic filter manager
-     * @param  string                    $filters       a comma separated list of filter names
+     * @param  string|array              $filters       a comma separated list of filter names
      * @throws \InvalidArgumentException if a wrong filter is passed
      * @return array                     an array of filter names
      */
     protected function decodeAsseticFilters(FilterManager $filterManager, $filters)
     {
-        if (!empty($filters)) {
-            $filter_list = explode(',', $filters);
+        if (! empty($filters)) {
+            $filter_list = is_array($filters) ? $filters : explode(',', $filters);
 
             foreach ($filter_list as $filter_name) {
                 $filter_name = trim($filter_name);

--- a/core/lib/Thelia/Core/Template/Exception/InvalidDescriptorException.php
+++ b/core/lib/Thelia/Core/Template/Exception/InvalidDescriptorException.php
@@ -1,0 +1,22 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Exception;
+
+/**
+ * Class InvalidXmlDocumentException
+ * @package Thelia\Template\Exception
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class InvalidDescriptorException extends \RuntimeException
+{
+}

--- a/core/lib/Thelia/Core/Template/Exception/TemplateException.php
+++ b/core/lib/Thelia/Core/Template/Exception/TemplateException.php
@@ -1,0 +1,22 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Exception;
+
+/**
+ * Class InvalidXmlDocumentException
+ * @package Thelia\Template\Exception
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class TemplateException extends \RuntimeException
+{
+}

--- a/core/lib/Thelia/Core/Template/Parser/ParserAssetResolverFallback.php
+++ b/core/lib/Thelia/Core/Template/Parser/ParserAssetResolverFallback.php
@@ -14,6 +14,7 @@ namespace Thelia\Core\Template\Parser;
 
 use Thelia\Core\Template\Assets\AssetResolverInterface;
 use Thelia\Core\Template\ParserInterface;
+use Thelia\Core\Template\TemplateDefinition;
 
 /**
  * Class ParserAssetResolverFallback
@@ -65,6 +66,34 @@ class ParserAssetResolverFallback implements AssetResolverInterface
      */
     public function resolveAssetSourcePath($source, $templateName, $fileName, ParserInterface $parserInterface)
     {
+        throw new \RuntimeException('if you want to use a parser, please register one');
+    }
+
+
+    /**
+     * Return an asset source file path, and the template in which it was found
+     *
+     * A system of fallback enables file overriding. It will look for the template :
+     *      - in the current template in directory /modules/{module code}/
+     *      - in the module in the current template if it exists
+     *      - in the module in the default template
+     *
+     * @param  string $source a module code, or ParserInterface::TEMPLATE_ASSETS_KEY
+     * @param  string $templateName a template name, or false to use the current template
+     * @param  string $fileName the filename
+     * @param  ParserInterface $parserInterface the current template parser
+     * @param  TemplateDefinition &$templateDefinition the template where to start search.
+     *         This parameter will contain the template where the asset was found.
+     *
+     * @return mixed the path to directory containing the file, or null if the file doesn't exists.
+     */
+    public function resolveAssetSourcePathAndTemplate(
+        $source,
+        $templateName,
+        $fileName,
+        ParserInterface $parserInterface,
+        TemplateDefinition &$templateDefinition
+    ) {
         throw new \RuntimeException('if you want to use a parser, please register one');
     }
 }

--- a/core/lib/Thelia/Core/Template/ParserInterface.php
+++ b/core/lib/Thelia/Core/Template/ParserInterface.php
@@ -33,21 +33,45 @@ interface ParserInterface
     public function setStatus($status);
 
     /**
+     * Set a new template definition, and save the current one
+     *
+     * @param TemplateDefinition $templateDefinition
+     * @param bool $fallbackToDefaultTemplate if true, resources will be also searched in the "default" template
+     * @throws \SmartyException
+     */
+    public function pushTemplateDefinition(TemplateDefinition $templateDefinition, $fallbackToDefaultTemplate = false);
+
+    /**
+     * Restore the previous stored template definition, if one exists.
+     *
+     * @throws \SmartyException
+     */
+    public function popTemplateDefinition();
+
+    /**
      * Setup the parser with a template definition, which provides a template description.
      *
      * @param TemplateDefinition $templateDefinition
+     * @param  bool $fallbackToDefaultTemplate if true, also search files in hte "default" template.
      */
-    public function setTemplateDefinition(TemplateDefinition $templateDefinition);
+    public function setTemplateDefinition(TemplateDefinition $templateDefinition, $fallbackToDefaultTemplate = false);
 
     /**
      * Get template definition
      *
-     * @param bool $webAssetTemplate Allow to load asset from another template
-     *                               If the name of the template if provided
+     * @param bool|string $webAssetTemplateName false to use the current template path, or a template name to
+     *     load assets from this template instead of the current one.
      *
      * @return TemplateDefinition
      */
-    public function getTemplateDefinition($webAssetTemplate = false);
+    public function getTemplateDefinition($webAssetTemplateName = false);
+
+    /**
+     * Get the current status of the fallback to "default" feature
+     *
+     * @return bool
+     */
+    public function getFallbackToDefaultTemplate();
 
     /**
      * Add a template directory to the current template list
@@ -56,8 +80,8 @@ interface ParserInterface
      *
      * @param string $templateName      the template name
      * @param string $templateDirectory path to the template dirtectory
-     * @param string $key               ???
-     * @param bool   $unshift           ??? Etienne ?
+     * @param string $key               the template directory identifier
+     * @param bool   $unshift           if true, add template at the top of the list
      */
     public function addTemplateDirectory($templateType, $templateName, $templateDirectory, $key, $unshift = false);
 

--- a/core/lib/Thelia/Core/Template/Validator/TemplateDescriptor.php
+++ b/core/lib/Thelia/Core/Template/Validator/TemplateDescriptor.php
@@ -1,0 +1,249 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Validator;
+use Thelia\Core\Template\TemplateDefinition;
+
+/**
+ * Class TemplateDescriptor
+ *
+ * @package Thelia\Template\Descriptor
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class TemplateDescriptor
+{
+    /** @var string the template directory name (e.g. 'default') */
+    protected $name;
+
+    /** @var int the template type (front, back, pdf) */
+    protected $type;
+
+    /** @var array */
+    protected $languages = [];
+
+    /** @var array */
+    protected $descriptives = [];
+
+    /** @var string */
+    protected $theliaVersion;
+
+    /** @var string */
+    protected $version;
+
+    /** @var TemplateDefinition */
+    protected $parent = null;
+
+    /** @var string */
+    protected $documentation;
+
+    /** @var string */
+    protected $stability;
+
+    /** @var array */
+    protected $authors = [];
+
+    /**
+     * TemplateDescriptor constructor.
+     * @param string $name
+     * @param int $type
+     */
+    public function __construct($name, $type)
+    {
+        $this->name = $name;
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param int $type
+     * @return $this
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLanguages()
+    {
+        return $this->languages;
+    }
+
+    /**
+     * @param array $languages
+     * @return $this
+     */
+    public function setLanguages($languages)
+    {
+        $this->languages = $languages;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDescriptives()
+    {
+        return $this->descriptives;
+    }
+
+    /**
+     * @param array $descriptives
+     * @return $this
+     */
+    public function setDescriptives($descriptives)
+    {
+        $this->descriptives = $descriptives;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTheliaVersion()
+    {
+        return $this->theliaVersion;
+    }
+
+    /**
+     * @param string $theliaVersion
+     * @return $this
+     */
+    public function setTheliaVersion($theliaVersion)
+    {
+        $this->theliaVersion = $theliaVersion;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @param string $version
+     * @return $this
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * @return TemplateDefinition
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param TemplateDefinition $parent
+     * @return $this
+     */
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    public function hasParent()
+    {
+        return null !== $this->parent;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocumentation()
+    {
+        return $this->documentation;
+    }
+
+    /**
+     * @param string $documentation
+     * @return $this
+     */
+    public function setDocumentation($documentation)
+    {
+        $this->documentation = $documentation;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStability()
+    {
+        return $this->stability;
+    }
+
+    /**
+     * @param string $stability
+     * @return $this
+     */
+    public function setStability($stability)
+    {
+        $this->stability = $stability;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAuthors()
+    {
+        return $this->authors;
+    }
+
+    /**
+     * @param array $authors
+     * @return $this
+     */
+    public function setAuthors($authors)
+    {
+        $this->authors = $authors;
+        return $this;
+    }
+}

--- a/core/lib/Thelia/Core/Template/Validator/TemplateDescriptorValidator.php
+++ b/core/lib/Thelia/Core/Template/Validator/TemplateDescriptorValidator.php
@@ -1,0 +1,140 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Validator;
+
+use Symfony\Component\Finder\Finder;
+use Thelia\Core\Template\Exception\InvalidDescriptorException;
+use Thelia\Log\Tlog;
+
+/**
+ * Class TemplateDescriptorValidator
+ *
+ * @package Thelia\Template
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class TemplateDescriptorValidator
+{
+    protected static $versions = [
+        '1' => 'template-1_0.xsd',
+    ];
+
+    /** @var Finder */
+    protected $xsdFinder;
+
+    protected $xmlDescriptorPath;
+
+    /**
+     * TemplateDescriptorValidator constructor.
+     *
+     * @param string $xmlDescriptorPath the path to the template XML descriprot
+     */
+    public function __construct($xmlDescriptorPath)
+    {
+        $this->xmlDescriptorPath = $xmlDescriptorPath;
+
+        $this->xsdFinder = new Finder();
+        $this->xsdFinder
+            ->name('*.xsd')
+            ->in(__DIR__ . '/schema/template/');
+    }
+
+    /**
+     * @param string $version the XSD version to use,, or null to use the latest version
+     * @return $this
+     * @throw InvalidDescriptorException
+     */
+    public function validate($version = null)
+    {
+        $dom    = new \DOMDocument();
+        $errors = [];
+
+        if ($dom->load($this->xmlDescriptorPath)) {
+            /** @var \SplFileInfo $xsdFile */
+            foreach ($this->xsdFinder as $xsdFile) {
+                $xsdVersion = array_search($xsdFile->getBasename(), self::$versions);
+
+                if (false === $xsdVersion || (null !== $version && $version != $xsdVersion)) {
+                    continue;
+                }
+
+                $errors = $this->schemaValidate($dom, $xsdFile);
+
+                if (count($errors) === 0) {
+                    return $this;
+                }
+            }
+        }
+
+        throw new InvalidDescriptorException(
+            sprintf(
+                "%s file is not a valid template descriptor : %s",
+                $this->xmlDescriptorPath,
+                implode(", ", $errors)
+            )
+        );
+    }
+
+    /**
+     * Validate the schema of a XML file with a given xsd file
+     *
+     * @param \DOMDocument $dom The XML document
+     * @param \SplFileInfo $xsdFile The XSD file
+     * @return array an array of errors if validation fails, otherwise an empty array
+     */
+    protected function schemaValidate(\DOMDocument $dom, \SplFileInfo $xsdFile)
+    {
+        $errorMessages = [];
+
+        try {
+            libxml_use_internal_errors(true);
+
+            if (!$dom->schemaValidate($xsdFile->getRealPath())) {
+                $errors = libxml_get_errors();
+
+                foreach ($errors as $error) {
+                    $errorMessages[] = sprintf(
+                        'XML error "%s" [%d] (Code %d) in %s on line %d column %d' . "\n",
+                        $error->message,
+                        $error->level,
+                        $error->code,
+                        $error->file,
+                        $error->line,
+                        $error->column
+                    );
+                }
+
+                libxml_clear_errors();
+            }
+
+            libxml_use_internal_errors(false);
+        } catch (\Exception $ex) {
+            libxml_use_internal_errors(false);
+        }
+
+        return $errorMessages;
+    }
+
+    /**
+     * @return \SimpleXMLElement
+     */
+    public function getDescriptor()
+    {
+        if (file_exists($this->xmlDescriptorPath)) {
+            $this->validate();
+
+            return @simplexml_load_file($this->xmlDescriptorPath);
+        }
+
+        Tlog::getInstance()->addWarning("Template descriptor $this->xmlDescriptorPath does not exists.");
+    }
+}

--- a/core/lib/Thelia/Core/Template/Validator/TemplateValidator.php
+++ b/core/lib/Thelia/Core/Template/Validator/TemplateValidator.php
@@ -1,0 +1,209 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the Thelia package.                                     */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Thelia\Core\Template\Validator;
+
+use Thelia\Core\Template\Exception\TemplateException;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Thelia;
+use Thelia\Core\Translation\Translator;
+use Thelia\Tools\Version\Version;
+
+/**
+ * Class TemplateValidator
+ *
+ * @package Thelia\Template\Validator
+ * @author  Franck Allimant <franck@cqfdev.fr>
+ */
+class TemplateValidator
+{
+    protected $templatePath;
+
+    /** @var TemplateDescriptorValidator */
+    protected $templateDescriptor;
+
+    /** @var TemplateDefinition */
+    protected $templateDefinition;
+
+    protected $templateVersion;
+
+    /** @var array array of errors */
+    protected $errors = [];
+
+    /** @var \SimpleXMLElement  */
+    protected $xmlDescriptorContent;
+
+    /**
+     * TemplateValidator constructor.
+     * @param $templatePath
+     * @throws \Exception
+     */
+    public function __construct($templatePath)
+    {
+        $templateValidator = new TemplateDescriptorValidator($templatePath . DS . 'template.xml');
+
+        $this->xmlDescriptorContent = $templateValidator->getDescriptor();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTemplateVersion()
+    {
+        return $this->templateVersion;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param string $name the template directory name
+     * @param int $type the template type (front, back, etc.)
+     * @return TemplateDescriptor the template descriptor
+     * @throws \Exception
+     */
+    public function getTemplateDefinition($name, $type)
+    {
+        $templateDescriptor = new TemplateDescriptor($name, $type);
+
+        $templateDescriptor
+            ->setName($name)
+            ->setType($type)
+        ;
+
+        if (! empty($this->xmlDescriptorContent)) {
+            $templateDescriptor
+                ->setVersion((string)$this->xmlDescriptorContent->version)
+                ->setLanguages($this->getTemplateLanguages())
+                ->setDescriptives($this->getTemplateDescriptives())
+                ->setAuthors($this->getTemplateAuthors())
+                ->setTheliaVersion((string)$this->xmlDescriptorContent->thelia)
+                ->setStability((string)$this->xmlDescriptorContent->stability)
+                ->setDocumentation((string)$this->xmlDescriptorContent->documentation)
+            ;
+
+            $this->checkVersion($templateDescriptor);
+
+            if (! empty($this->xmlDescriptorContent->parent)) {
+                // Just try to instantiate template definition for the parent template
+                // An exception will be thrown if something goes wrong.
+                try {
+                    $templateDescriptor->setParent(
+                        new TemplateDefinition(
+                            (string) $this->xmlDescriptorContent->parent,
+                            $type
+                        )
+                    );
+                } catch (\Exception $ex) {
+                    // The Translator could not be initialized, take care of this.
+                    try {
+                        $message = Translator::getInstance()->trans(
+                            "The parent template \"%parent\" of template \"%name\" could not be found",
+                            [
+                                '%parent' => $templateDescriptor->getParent(),
+                                '%name' => $templateDescriptor->getName(),
+                            ]
+                        );
+                    } catch (\Exception $ex) {
+                        $message = sprintf(
+                            "The parent template \"%s\" of template \"%s\" could not be found",
+                            $templateDescriptor->getParent(),
+                            $templateDescriptor->getName()
+                        );
+                    }
+
+                    throw new TemplateException($message);
+                }
+            }
+        }
+
+        return $templateDescriptor;
+    }
+
+    /**
+     * @param TemplateDescriptor $templateDescriptor
+     */
+    protected function checkVersion($templateDescriptor)
+    {
+        if ($templateDescriptor->getTheliaVersion()) {
+            if (!Version::test(Thelia::THELIA_VERSION, $templateDescriptor->getTheliaVersion(), false, ">=")) {
+                // The Translator could not be initialized, take care of this.
+                try {
+                    $message = Translator::getInstance()->trans(
+                        "The template \"%name\" requires Thelia %version or newer",
+                        [
+                            '%name' => $templateDescriptor->getName(),
+                            '%version' => $templateDescriptor->getTheliaVersion()
+                        ]
+                    );
+                } catch (\Exception $ex) {
+                    $message = sprintf(
+                        "The template \"%s\" requires Thelia %s or newer",
+                        $templateDescriptor->getName(),
+                        $templateDescriptor->getTheliaVersion()
+                    );
+                }
+
+                throw new TemplateException($message);
+            }
+        }
+    }
+
+    protected function getTemplateLanguages()
+    {
+        $languages = [];
+        foreach ($this->xmlDescriptorContent->languages->language as $language) {
+            $languages[] = (string)$language;
+        }
+
+        return $languages;
+    }
+
+    protected function getTemplateDescriptives()
+    {
+        $descriptives = [];
+        foreach ($this->xmlDescriptorContent->descriptive as $descriptive) {
+            $descriptives[(string)$descriptive['locale']] = [
+                'title' => (string)$descriptive->title,
+                'subtitle' => (string)$descriptive->subtitle,
+                'description' => (string)$descriptive->description,
+                'postscriptum' => (string)$descriptive->postscriptum,
+            ];
+        }
+
+        return $descriptives;
+    }
+
+    protected function getTemplateAuthors()
+    {
+        $authors = [];
+
+        if (0 !== count($this->xmlDescriptorContent->authors->author)) {
+            foreach ($this->xmlDescriptorContent->authors->author as $author) {
+                $authors[] = [
+                    (string)$author->name,
+                    (string)$author->company,
+                    (string)$author->email,
+                    (string)$author->website
+                ];
+            }
+        }
+
+        return $authors;
+    }
+}

--- a/core/lib/Thelia/Core/Template/Validator/schema/template/template-1_0.xsd
+++ b/core/lib/Thelia/Core/Template/Validator/schema/template/template-1_0.xsd
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<xs:schema
+        xmlns="http://thelia.net/schema/dic/template"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="http://thelia.net/schema/dic/template"
+        attributeFormDefault="unqualified"
+        elementFormDefault="qualified"
+        >
+
+    <xs:element name="template">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="descriptive" minOccurs="1" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Template description,</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element type="xs:string" name="title" minOccurs="1" maxOccurs="1"/>
+                            <xs:element type="xs:string" name="subtitle" minOccurs="0" maxOccurs="1"/>
+                            <xs:element type="xs:string" name="description" minOccurs="0" maxOccurs="1"/>
+                            <xs:element type="xs:string" name="postscriptum" minOccurs="0" maxOccurs="1"/>
+                        </xs:sequence>
+                        <xs:attribute type="xs:string" name="locale">
+                            <xs:annotation>
+                                <xs:documentation>An ISO 639 locale code</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="parent" type="xs:string" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The template extended by this template. Missing html files and assets will be searched in this template</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="languages">
+                    <xs:annotation>
+                        <xs:documentation>Languages supported by this template : fr_FR, en_US, ...</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="language" minOccurs="1" maxOccurs="unbounded">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:pattern value="[a-z]{2}_[A-Z]{2}"/>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element type="xs:string" name="version">
+                    <xs:annotation>
+                        <xs:documentation>Template version</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="authors" maxOccurs="1" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>Template authors</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="author" maxOccurs="unbounded" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element type="xs:string" name="name" minOccurs="1" maxOccurs="1"/>
+                                        <xs:element type="xs:string" name="company" minOccurs="0" maxOccurs="1"/>
+                                        <xs:element type="xs:string" name="email" minOccurs="1" maxOccurs="1"/>
+                                        <xs:element type="xs:anyURI" name="website" minOccurs="0" maxOccurs="1"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="tags" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Template tags</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element type="xs:string" name="tag" minOccurs="0" maxOccurs="unbounded" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="thelia" minOccurs="0" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>minimum required version of Thelia in 'dot' format (for example 1.2.3.4)</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="stability">
+                    <xs:annotation>
+                        <xs:documentation>current template stability: alpha, beta, rc, prod</xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="alpha"/>
+                            <xs:enumeration value="beta"/>
+                            <xs:enumeration value="rc"/>
+                            <xs:enumeration value="prod"/>
+                            <xs:enumeration value="other"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+
+                <xs:element type="xs:string" name="documentation" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The name of the directory containing te documentation, relative to this template directory.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element type="xs:anyURI" name="urlmiseajour" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>URL to test if a new version of the template exists. Will be called with two get parameters : template name, current version</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element type="xs:anyURI" name="updateurl" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>URL to download the new version of the template. Will be called with two get parameters : template name, current version</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/AdminUtilities.php
@@ -34,37 +34,47 @@ class AdminUtilities extends AbstractSmartyPlugin
         $this->templateHelper = $templateHelper;
     }
 
+    /**
+     * @param \Smarty $smarty
+     * @param string $templateName
+     * @param array $variablesArray
+     * @return string
+     * @throws \Exception
+     * @throws \SmartyException
+     */
     protected function fetchSnippet($smarty, $templateName, $variablesArray)
     {
-        $data = '';
-
-        $snippet_path = sprintf(
-            '%s/%s/%s.html',
-            THELIA_TEMPLATE_DIR,
-            $this->templateHelper->getActiveAdminTemplate()->getPath(),
-            $templateName
+        $snippet_content = file_get_contents(
+            $this->templateHelper->getActiveAdminTemplate()->getTemplateFilePath(
+                $templateName . '.html'
+            )
         );
 
-        if (false !== $snippet_content = file_get_contents($snippet_path)) {
-            $smarty->assign($variablesArray);
+        $smarty->assign($variablesArray);
 
-            $data = $smarty->fetch(sprintf('string:%s', $snippet_content));
-        }
+        $data = $smarty->fetch(sprintf('string:%s', $snippet_content));
 
         return $data;
     }
-    
+
     public function optionOffsetGenerator($params, &$smarty)
     {
         $label = $this->getParam($params, 'label', null);
-        
+
         if (null !== $level = $this->getParam($params, [ 'l', 'level'], null)) {
             $label = str_repeat('&nbsp;', 4 * $level) . $label;
         }
-        
+
         return $label;
     }
 
+    /**
+     * @param $params
+     * @param $smarty
+     * @return mixed|string
+     * @throws \Exception
+     * @throws \SmartyException
+     */
     public function generatePositionChangeBlock($params, &$smarty)
     {
         // The required permissions
@@ -116,8 +126,10 @@ class AdminUtilities extends AbstractSmartyPlugin
      * Generates the link of a sortable column header
      *
      * @param  array   $params
-     * @param  unknown $smarty
+     * @param  \Smarty $smarty
      * @return string  no text is returned.
+     * @throws \Exception
+     * @throws \SmartyException
      */
     public function generateSortableColumnHeader($params, &$smarty)
     {

--- a/local/modules/TheliaSmarty/Template/Plugins/Module.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Module.php
@@ -13,10 +13,9 @@
 namespace TheliaSmarty\Template\Plugins;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Thelia\Core\Template\Smarty\Plugins\an;
-use TheliaSmarty\Template\SmartyPluginDescriptor;
-use TheliaSmarty\Template\AbstractSmartyPlugin;
 use Thelia\Model\ModuleQuery;
+use TheliaSmarty\Template\AbstractSmartyPlugin;
+use TheliaSmarty\Template\SmartyPluginDescriptor;
 
 class Module extends AbstractSmartyPlugin
 {
@@ -41,18 +40,21 @@ class Module extends AbstractSmartyPlugin
      * - countvar : this is the name of a template variable where the number of found modules includes will be assigned.
      *
      * @param array                     $params
-     * @param \Smarty_Internal_Template $template
+     * @param \Smarty_Internal_Template $parser
      * @internal param \Thelia\Core\Template\Smarty\Plugins\unknown $smarty
      *
      * @return string
+     *
+     * @throws \Exception
+     * @throws \SmartyException
      */
-    public function theliaModule($params, \Smarty_Internal_Template $template)
+    public function theliaModule($params, \Smarty_Internal_Template $parser)
     {
         $content = null;
         $count = 0;
         if (false !== $location = $this->getParam($params, 'location', false)) {
             if ($this->debug === true && $this->requestStack->getCurrentRequest()->get('SHOW_INCLUDE')) {
-                echo sprintf('<div style="background-color: #C82D26; color: #fff; border-color: #000000; border: solid;">%s</div>', $location);
+                echo sprintf('<div style="background-color: #C82D26; color: #fff; border: solid #000000;">%s</div>', $location);
             }
 
             $moduleLimit = $this->getParam($params, 'module', null);
@@ -80,11 +82,11 @@ class Module extends AbstractSmartyPlugin
         }
 
         if (false !== $countvarname = $this->getParam($params, 'countvar', false)) {
-            $template->assign($countvarname, $count);
+            $parser->assign($countvarname, $count);
         }
 
         if (! empty($content)) {
-            return $template->fetch(sprintf("string:%s", $content));
+            return $parser->fetch(sprintf("string:%s", $content));
         }
 
         return "";
@@ -93,7 +95,7 @@ class Module extends AbstractSmartyPlugin
     /**
      * Define the various smarty plugins hendled by this class
      *
-     * @return an array of smarty plugin descriptors
+     * @return array of smarty plugin descriptors
      */
     public function getPluginDescriptors()
     {

--- a/templates/backOffice/default/admin-layout.tpl
+++ b/templates/backOffice/default/admin-layout.tpl
@@ -4,8 +4,6 @@
     {check_auth role="ADMIN" resource="{block name="check-resource"}{/block}" module="{block name="check-module"}{/block}" access="{block name="check-access"}{/block}" login_tpl="/admin/login"}
 {/block}
 
-{block name="no-return-functions"}{/block}
-
 {* -- Define some stuff for Smarty ------------------------------------------ *}
 {config_load file='variables.conf'}
 
@@ -14,6 +12,8 @@
 
 {* Set the default translation domain, that will be used by {intl} when the 'd' parameter is not set *}
 {default_translation_domain domain='bo.default'}
+
+{block name="no-return-functions"}{/block}
 
 <!DOCTYPE html>
 <html lang="{$lang_code}">
@@ -83,7 +83,7 @@
                 </div>
                 <!-- /.navbar-header -->
 
-                <ul class="nav navbar-top-links navbar-right">                
+                <ul class="nav navbar-top-links navbar-right">
                     {hook name="main.topbar-top" }
                     
                     <li>
@@ -93,7 +93,7 @@
                         <button class="dropdown-toggle" data-toggle="dropdown">
                             <span class="glyphicon glyphicon-user"></span> {admin attr="firstname"} {admin attr="lastname"}
                             <span class="caret"></span>
-                        </button>                        
+                        </button>
                         <ul class="dropdown-menu dropdown-menu-right">
                             <li><a class="profile" href="{url path='admin/configuration/administrators/view'}"><span class="glyphicon glyphicon-edit"></span> {intl l="Profil"}</a></li>
                             <li><a class="logout" href="{url path='admin/logout'}" title="{intl l='Close administation session'}"><span class="glyphicon glyphicon-off"></span> {intl l="Logout"}</a></li>
@@ -130,7 +130,7 @@
                 {hook name="main.after-topbar" location="after_topbar" }
             </nav>
 
-            <div id="page-wrapper">                        
+            <div id="page-wrapper">
                 
                 <div class="row">
                     <div class="col-lg-12">
@@ -147,7 +147,7 @@
                     {block name="main-content"}Put here the content of the template{/block}
                 </div>
                 
-                {hook name="main.after-content" location="after_content"}                
+                {hook name="main.after-content" location="after_content"}
                 
             </div>
         {/loop}

--- a/templates/backOffice/default/template.xml
+++ b/templates/backOffice/default/template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://thelia.net/schema/dic/template"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://thelia.net/schema/dic/template http://thelia.net/schema/dic/template/template-1_0.xsd">
+    <descriptive locale="fr">
+        <title>Template back office par défaut</title>
+    </descriptive>
+    <descriptive locale="en">
+        <title>Default back-office template</title>
+    </descriptive>
+    <languages>
+        <language>ar_SA</language>
+        <language>cs_CZ</language>
+        <language>de_DE</language>
+        <language>el_GR</language>
+        <language>en_US</language>
+        <language>es_ES</language>
+        <language>fa_IR</language>
+        <language>fr_FR</language>
+        <language>hu_HU</language>
+        <language>id_ID</language>
+        <language>it_IT</language>
+        <language>nl_NL</language>
+        <language>pl_PL</language>
+        <language>pt_BR</language>
+        <language>pt_PT</language>
+        <language>ru_RU</language>
+        <language>sk_SK</language>
+        <language>tr_TR</language>
+        <language>uk_UA</language>
+    </languages>
+    <version>1.0.0</version>
+    <authors>
+        <author>
+            <name>Thelia team</name>
+            <company>thelia.net</company>
+            <email>contact@thelia.net</email>
+            <website>thelia.net</website>
+        </author>
+    </authors>
+    <thelia>2.4.0</thelia>
+    <stability>prod</stability>
+</template>

--- a/templates/email/default/template.xml
+++ b/templates/email/default/template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://thelia.net/schema/dic/template"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://thelia.net/schema/dic/template http://thelia.net/schema/dic/template/template-1_0.xsd">
+    <descriptive locale="fr">
+        <title>Template e-mail par défaut</title>
+    </descriptive>
+    <descriptive locale="en">
+        <title>Default email template</title>
+    </descriptive>
+    <languages>
+        <language>ar_SA</language>
+        <language>cs_CZ</language>
+        <language>de_DE</language>
+        <language>el_GR</language>
+        <language>en_US</language>
+        <language>es_ES</language>
+        <language>fa_IR</language>
+        <language>fr_FR</language>
+        <language>hu_HU</language>
+        <language>id_ID</language>
+        <language>it_IT</language>
+        <language>nl_NL</language>
+        <language>pl_PL</language>
+        <language>pt_BR</language>
+        <language>pt_PT</language>
+        <language>ru_RU</language>
+        <language>sk_SK</language>
+        <language>tr_TR</language>
+        <language>uk_UA</language>
+    </languages>
+    <version>1.0.0</version>
+    <authors>
+        <author>
+            <name>Thelia team</name>
+            <company>thelia.net</company>
+            <email>contact@thelia.net</email>
+            <website>thelia.net</website>
+        </author>
+    </authors>
+    <thelia>2.4.0</thelia>
+    <stability>prod</stability>
+</template>

--- a/templates/frontOffice/default/template.xml
+++ b/templates/frontOffice/default/template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://thelia.net/schema/dic/template"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://thelia.net/schema/dic/template http://thelia.net/schema/dic/template/template-1_0.xsd">
+    <descriptive locale="fr">
+        <title>Template front office par défaut</title>
+    </descriptive>
+    <descriptive locale="en">
+        <title>Default front office template</title>
+    </descriptive>
+    <languages>
+        <language>ar_SA</language>
+        <language>cs_CZ</language>
+        <language>de_DE</language>
+        <language>el_GR</language>
+        <language>en_US</language>
+        <language>es_ES</language>
+        <language>fa_IR</language>
+        <language>fr_FR</language>
+        <language>hu_HU</language>
+        <language>id_ID</language>
+        <language>it_IT</language>
+        <language>nl_NL</language>
+        <language>pl_PL</language>
+        <language>pt_BR</language>
+        <language>pt_PT</language>
+        <language>ru_RU</language>
+        <language>sk_SK</language>
+        <language>tr_TR</language>
+        <language>uk_UA</language>
+    </languages>
+    <version>1.0.0</version>
+    <authors>
+        <author>
+            <name>Thelia team</name>
+            <company>thelia.net</company>
+            <email>contact@thelia.net</email>
+            <website>thelia.net</website>
+        </author>
+    </authors>
+    <thelia>2.4.0</thelia>
+    <stability>prod</stability>
+</template>

--- a/templates/pdf/default/template.xml
+++ b/templates/pdf/default/template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template xmlns="http://thelia.net/schema/dic/template"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://thelia.net/schema/dic/template http://thelia.net/schema/dic/template/template-1_0.xsd">
+    <descriptive locale="fr">
+        <title>Template PDF par défaut</title>
+    </descriptive>
+    <descriptive locale="en">
+        <title>Default PDF template</title>
+    </descriptive>
+    <languages>
+        <language>ar_SA</language>
+        <language>cs_CZ</language>
+        <language>de_DE</language>
+        <language>el_GR</language>
+        <language>en_US</language>
+        <language>es_ES</language>
+        <language>fa_IR</language>
+        <language>fr_FR</language>
+        <language>hu_HU</language>
+        <language>id_ID</language>
+        <language>it_IT</language>
+        <language>nl_NL</language>
+        <language>pl_PL</language>
+        <language>pt_BR</language>
+        <language>pt_PT</language>
+        <language>ru_RU</language>
+        <language>sk_SK</language>
+        <language>tr_TR</language>
+        <language>uk_UA</language>
+    </languages>
+    <version>1.0.0</version>
+    <authors>
+        <author>
+            <name>Thelia team</name>
+            <company>thelia.net</company>
+            <email>contact@thelia.net</email>
+            <website>thelia.net</website>
+        </author>
+    </authors>
+    <thelia>2.4.0</thelia>
+    <stability>prod</stability>
+</template>

--- a/tests/phpunit/Thelia/Tests/Api/ProductSaleElementsControllerTest.php
+++ b/tests/phpunit/Thelia/Tests/Api/ProductSaleElementsControllerTest.php
@@ -181,7 +181,23 @@ class ProductSaleElementsControllerTest extends ApiTestCase
 
         $content = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals('3.99', $content[0]['PRICE']);
+        // Find the item we've juste created in the result list
+        $pse = null;
+
+        if (count($content) > 1) {
+            foreach ($content as $item) {
+                if ($item['REF'] == 'foo') {
+                    $pse = $item;
+                    break;
+                }
+            }
+        } elseif (count($content) == 1) {
+            $pse = $content[0];
+        }
+
+        $this->assertNotNull($pse);
+
+        $this->assertEquals('3.99', $pse['PRICE']);
 
         return $content['0']['ID'];
     }


### PR DESCRIPTION
This PR introduces a new feature, the template inheritance. You can now create a new template, and redefine only the required files instead of copying the whole template.

To do so, you have to create in your template directory a template descriptor file, named `template.xml`, which contains some information about your template: 
```
<?xml version="1.0" encoding="UTF-8"?>
<template xmlns="http://thelia.net/schema/dic/template"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://thelia.net/schema/dic/template http://thelia.net/schema/dic/template/template-1_0.xsd">
    <descriptive locale="fr">
        <title>Ce template back-offcie hérite de "default"</title>
    </descriptive>
    <descriptive locale="en">
        <title>This back-offcie template inherits from the "default" template</title>
    </descriptive>
    <parent>default</parent>
    <languages>
        <language>en_US</language>
        <language>fr_FR</language>
    </languages>
    <version>1.0.0</version>
    <authors>
        <author>
            <name>Thelia team</name>
            <company>thelia.net</company>
            <email>contact@thelia.net</email>
            <website>thelia.net</website>
        </author>
    </authors>
    <thelia>2.4.0</thelia>
    <stability>prod</stability>
</template>
```
The schema is very similar to the modules descriptor. The important element here is `parent`, which identifies the parent template, which should be an existing template of the same type (fo, bo, pdf, mail) as the child template. In our example, the new template inherits from the `default` template.

All template files are inherited, including the assets, the translations and the module overrides.

However, you can define specific translations for your template, and use them by declaring a default translation domain in your template files, for example `{default_translation_domain domain='bo.your_template_name'}`, or using the `domain `(abbreviated `d`) parameter of the `intl `Smarty function :` {intl l='Edit a customer' d='bo.your_template_name'}`

You can also use your own assets, as in a regular template. Use a `{declare_assets directory='your_asset_directory'}` if your CSS or JS references relative resources, so that they could be copied in the web/assets directory.

Additionally, you can also override the assets of your parent if you're using the same asset directory structure. For example, if you want to override the `assets/css/styles.css`  of your parent, create a  `assets/css/styles.css` in your template, and it will override the parent's one.

 :warning: Don't forget to clear the cache when manipulating templates, as template and/or assets information may be cached by Thelia.

The ParserInterface interface has now 2 new methods :
- `pushTemplateDefinition(TemplateDefinition $templateDefinition, $fallbackToDefaultTemplate)` to set a new template definition, while saving the current one
- `popTemplateDefinition()` to restore a previously pushed template

These methods are useful to temporary set a template (for sending a mail, for example), and then restore the current front or back template.