### PR TITLE
Un-comment of exception processing in the processUpdateAction()

### DIFF
--- a/core/lib/Thelia/Controller/Admin/AbstractCrudController.php
+++ b/core/lib/Thelia/Controller/Admin/AbstractCrudController.php
@@ -481,9 +481,9 @@ abstract class AbstractCrudController extends BaseAdminController
         } catch (FormValidationException $ex) {
             // Form cannot be validated
             $error_msg = $this->createStandardFormValidationErrorMessage($ex);
-        /*} catch (\Exception $ex) {
+        } catch (\Exception $ex) {
             // Any other error
-            $error_msg = $ex->getMessage();*/
+            $error_msg = $ex->getMessage();
         }
 
         if (false !== $error_msg) {


### PR DESCRIPTION
The exception processing was commented out in the processUpdateAction() method. This PR removes the comment, as the exception should be processed.