### PR TITLE
FreeOrder: round total amount to avoid problems with floats

### DIFF
--- a/local/modules/FreeOrder/FreeOrder.php
+++ b/local/modules/FreeOrder/FreeOrder.php
@@ -23,7 +23,7 @@ class FreeOrder extends BaseModule implements PaymentModuleInterface
 {
     public function isValidPayment()
     {
-        return $this->getCurrentOrderTotalAmount() == 0;
+        return round($this->getCurrentOrderTotalAmount(), 4) == 0;
     }
 
     public function pay(Order $order)


### PR DESCRIPTION
Fix issue from isValidPayment() with round total amount to avoid problems with floats.  