### PR TITLE
Remove unnecessary openssl extension install step

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -4,13 +4,12 @@ COPY docker-php-pecl-install /usr/local/bin/
 RUN apt-get update && apt-get install -y \
  libfreetype6-dev \
  libjpeg62-turbo-dev \
- openssl \
  libpng12-dev \
  libicu-dev \
  git \
  zip \
  libzip-dev \
-    && docker-php-ext-install intl pdo_mysql openssl mbstring zip calendar \
+    && docker-php-ext-install intl pdo_mysql mbstring zip calendar \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd \
     && docker-php-pecl-install xdebug-2.3.3


### PR DESCRIPTION
openssl extension install step is not necessary since the current php:5.6-apache docker image already ships openssl support.

phpinfo() configure command output from php:5.6-apache image:

``
 './configure'   '--build=x86_64-linux-gnu' '--with-config-file-path=/usr/local/etc/php'  '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' '--disable-cgi'  '--enable-ftp' '--enable-mbstring' '--enable-mysqlnd' '--with-curl'  '--with-libedit' '--with-openssl' '--with-zlib'  '--with-libdir=lib/x86_64-linux-gnu' '--with-apxs2'  'build_alias=x86_64-linux-gnu' 'CFLAGS=-fstack-protector-strong '-fpic'  '-fpie' '-O2'' 'LDFLAGS=-Wl,-O1 '-Wl,--hash-style=both' '-pie''  'CPPFLAGS=-fstack-protector-strong '-fpic' '-fpie' '-O2''
``

Fixes #2496 