### PR TITLE
Using better headers to generate PDF response

### DIFF
--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -100,7 +100,11 @@ abstract class BaseController
             $status,
             array(
                 'Content-type' => "application/pdf",
-                'Content-Disposition' => $browser === false ? sprintf('Attachment;filename=%s.pdf', $fileName) : '',
+                'Content-Disposition' =>sprintf(
+                    '%s; filename=%s.pdf',
+                    boolval($browser) === false ? 'attachment' : 'inline',
+                    $fileName
+                )
             )
         );
     }


### PR DESCRIPTION
This PR changes the PDF response headers, to get a correct filename even when the PDF is viewed inside the browser.