### PR TITLE
Fix a path generation issue in Propel class generators

### DIFF
--- a/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/ImplementationClassTrait.php
+++ b/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/ImplementationClassTrait.php
@@ -31,7 +31,7 @@ trait ImplementationClassTrait
 
         return $fs->makePathRelative(
             THELIA_CACHE_DIR
-            . (defined('THELIA_PROPEL_BUILDER_ENVIRONMENT') ? ('/' . THELIA_PROPEL_BUILDER_ENVIRONMENT) : '')
+            . (defined('THELIA_PROPEL_BUILDER_ENVIRONMENT') ? THELIA_PROPEL_BUILDER_ENVIRONMENT : '')
             . '/propel/model/'
             . parent::getClassFilePath(),
             THELIA_ROOT

--- a/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/StubClassTrait.php
+++ b/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/StubClassTrait.php
@@ -31,12 +31,12 @@ trait StubClassTrait
 
         if ($this->getPackage() === 'Thelia.Model') {
             return $fs->makePathRelative(
-                THELIA_LIB . '/../' . parent::getClassFilePath(),
+                THELIA_LIB . '../' . parent::getClassFilePath(),
                 THELIA_ROOT
             );
         } else {
             return $fs->makePathRelative(
-                THELIA_MODULE_DIR . '/' . parent::getClassFilePath(),
+                THELIA_MODULE_DIR . parent::getClassFilePath(),
                 THELIA_ROOT
             );
         }


### PR DESCRIPTION
The `endPath` arguments passed to `Symfony\Component\Filesystem\Filesystem::makePathRelative()` had a double path separator.
For the path that has a `..` this caused an issue with path generation: the `..` segment was not properly applied because of this double separator.

Fixes #2490