### PR TITLE
Smarty upgrade to version 3.1.33

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "swiftmailer/swiftmailer": "5.4.*",
         "oyejorge/less.php": "1.7.*",
         "michelf/php-markdown": "1.6.*",
-        "smarty/smarty": "3.1.20",
+        "smarty/smarty": "3.1.33",
         "ramsey/array_column": "~1.1",
         "propel/propel": "dev-thelia",
         "commerceguys/addressing": "0.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "516cdb06bac91fc4a0a3f9d0bb304e2b",
+    "content-hash": "28af2243aa5a0be9c6cf9cafffe94c75",
     "packages": [
         {
             "name": "commerceguys/addressing",
@@ -924,16 +924,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.20",
+            "version": "v3.1.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "cef27602bba3acd00ae14a8804ebd086e75e65e3"
+                "reference": "dd55b23121e55a3b4f1af90a707a6c4e5969530f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/cef27602bba3acd00ae14a8804ebd086e75e65e3",
-                "reference": "cef27602bba3acd00ae14a8804ebd086e75e65e3",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/dd55b23121e55a3b4f1af90a707a6c4e5969530f",
+                "reference": "dd55b23121e55a3b4f1af90a707a6c4e5969530f",
                 "shasum": ""
             },
             "require": {
@@ -946,10 +946,8 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "libs/Smarty.class.php",
-                    "libs/SmartyBC.class.php",
-                    "libs/sysplugins/smarty_security.php"
+                "files": [
+                    "libs/bootstrap.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -975,7 +973,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2014-10-31T04:12:39+00:00"
+            "time": "2018-09-12T20:54:16+00:00"
         },
         {
             "name": "spipu/html2pdf",


### PR DESCRIPTION
This PR upgrades Smarty to version 3.1.33 to provide PHP 7.2 compatibility.

As from this version (see https://github.com/smarty-php/smarty/pull/368/files), we cannot pass parameters by reference to plugin methods, declarations like `public function categoryDataAccess($params, &$smarty)` will throw the error "Warning: Parameter 2 to <method> expected to be a reference, value given", because Smarty uses internally call_user_func_array() to call plugins methods.

To solve this problem, "function"-type plugins method calls are wrapped by \TheliaSmarty\Template\AbstractSmartyPlugin::__call() method to provide compatibility with existing Smarty plugins.

Additionally, to safely disable modules, an unknown loop type in templates code (e.g. `{loop type="some-non-existent-loop-type" ... }`) will no longer throw an error in **production** mode (an error message is added to the log). In development mode, the error is still thrown.