### PR TITLE
PHP 7.2 forms buildForm() signature fix

### DIFF
--- a/core/lib/Thelia/Condition/ConditionEvaluator.php
+++ b/core/lib/Thelia/Condition/ConditionEvaluator.php
@@ -55,71 +55,41 @@ class ConditionEvaluator
      */
     public function variableOpComparison($v1, $o, $v2)
     {
-        if ($o == Operators::DIFFERENT) {
-            return ($v1 != $v2);
-        }
-
         switch ($o) {
+            case Operators::DIFFERENT:
+                // !=
+                return ($v1 != $v2);
+
             case Operators::SUPERIOR:
                 // >
-                if ($v1 > $v2) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return ($v1 > $v2);
+
             case Operators::SUPERIOR_OR_EQUAL:
                 // >=
-                if ($v1 >= $v2) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return ($v1 >= $v2);
+
             case Operators::INFERIOR:
                 // <
-                if ($v1 < $v2) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return ($v1 < $v2);
+
             case Operators::INFERIOR_OR_EQUAL:
                 // <=
-                if ($v1 <= $v2) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return ($v1 <= $v2);
+
             case Operators::EQUAL:
                 // ==
-                if ($v1 == $v2) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return ($v1 == $v2);
+
             case Operators::IN:
                 // in
-                if (in_array($v1, $v2)) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return (in_array($v1, $v2));
+
             case Operators::OUT:
                 // not in
-                if (!in_array($v1, $v2)) {
-                    return true;
-                } else {
-                    continue;
-                }
-                break;
+                return (!in_array($v1, $v2));
+
             default:
                 throw new \Exception('Unrecognized operator ' . $o);
         }
-
-        return false;
     }
 }

--- a/core/lib/Thelia/Form/Api/Customer/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/Api/Customer/CustomerUpdateForm.php
@@ -10,29 +10,219 @@
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
 
-namespace Thelia\Form\Api\Customer;
+namespace Thelia\Form;
 
-use Thelia\Form\CustomerUpdateForm as BaseCustomerUpdateForm;
+use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Core\Translation\Translator;
 
 /**
  * Class CustomerUpdateForm
- * @package Thelia\Form\Api\Customer
+ * @package Thelia\Form
  * @author Manuel Raynaud <manu@raynaud.io>
  */
-class CustomerUpdateForm extends BaseCustomerUpdateForm
+class CustomerUpdateForm extends BaseForm
 {
-    public function buildForm($backendContext = false)
-    {
-        parent::buildForm($backendContext);
+    use AddressCountryValidationTrait;
 
+    /**
+     * @return null|void
+     */
+    protected function buildForm()
+    {
         $this->formBuilder
-            ->add('lang_id', 'lang_id')
-            ->add('id', 'customer_id')
+            ->add(
+                'update_logged_in_user',
+                'integer'// In a front office context, update the in-memory logged-in user data
+            )
+            ->add("company", "text", array(
+                "label" => Translator::getInstance()->trans("Company"),
+                "label_attr" => array(
+                    "for" => "company",
+                ),
+                "required" => false,
+            ))
+            ->add("firstname", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label" => Translator::getInstance()->trans("First Name"),
+                "label_attr" => array(
+                    "for" => "firstname",
+                ),
+            ))
+            ->add("lastname", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label" => Translator::getInstance()->trans("Last Name"),
+                "label_attr" => array(
+                    "for" => "lastname",
+                ),
+            ))
+            ->add("email", "email", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Email(),
+                ),
+                "label" => Translator::getInstance()->trans("Email address"),
+                "label_attr" => array(
+                    "for" => "email",
+                ),
+            ))
+            ->add("email_confirm", "email", array(
+                "constraints" => array(
+                    new Constraints\Email(),
+                    new Constraints\Callback(array(
+                        "methods" => array(
+                            array($this, "verifyEmailField"),
+                        )
+                    )),
+                ),
+                "label" => Translator::getInstance()->trans("Confirm Email address"),
+                "label_attr" => array(
+                    "for" => "email_confirm",
+                ),
+            ))
+            ->add("password", "text", array(
+                "label" => Translator::getInstance()->trans("Password"),
+                "required" => false,
+                "label_attr" => array(
+                    "for" => "password",
+                    "help" => Translator::getInstance()->trans('Leave blank to keep current customer password')
+                ),
+            ))
+            ->add("address1", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label_attr" => array(
+                    "for" => "address",
+                ),
+                "label" => Translator::getInstance()->trans("Street Address "),
+            ))
+            ->add("address2", "text", array(
+                "required" => false,
+                "label" => Translator::getInstance()->trans("Address Line 2"),
+                "label_attr" => array(
+                    "for" => "address2",
+                ),
+            ))
+            ->add("address3", "text", array(
+                "required" => false,
+                "label" => Translator::getInstance()->trans("Address Line 3"),
+                "label_attr" => array(
+                    "for" => "address3",
+                ),
+            ))
+            ->add("phone", "text", array(
+                "label" => Translator::getInstance()->trans("Phone"),
+                "label_attr" => array(
+                    "for" => "phone",
+                ),
+                "required" => false,
+            ))
+            ->add("cellphone", "text", array(
+                "label" => Translator::getInstance()->trans("Cellphone"),
+                "label_attr" => array(
+                    "for" => "cellphone",
+                ),
+                "required" => false,
+            ))
+            ->add("zipcode", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Callback(array(
+                        "methods" => array(
+                            array($this, "verifyZipCode")
+                        ),
+                    )),
+                ),
+                "label" => Translator::getInstance()->trans("Zip code"),
+                "label_attr" => array(
+                    "for" => "zipcode",
+                ),
+            ))
+            ->add("city", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label" => Translator::getInstance()->trans("City"),
+                "label_attr" => array(
+                    "for" => "city",
+                ),
+            ))
+            ->add("country", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label" => Translator::getInstance()->trans("Country"),
+                "label_attr" => array(
+                    "for" => "country",
+                ),
+            ))
+            ->add("state", "text", array(
+                "required" => false,
+                "constraints" => array(
+                    new Constraints\Callback(array(
+                        "methods" => array(
+                            array($this, "verifyState")
+                        ),
+                    )),
+                ),
+                "label" => Translator::getInstance()->trans("State *"),
+                "label_attr" => array(
+                    "for" => "state",
+                ),
+            ))
+            ->add("title", "text", array(
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                ),
+                "label" => Translator::getInstance()->trans("Title"),
+                "label_attr" => array(
+                    "for" => "title",
+                ),
+            ))
+            ->add('discount', 'text', array(
+                'label' => Translator::getInstance()->trans('permanent discount (in percent)'),
+                'label_attr' => array(
+                    'for' => 'discount',
+                ),
+            ))
+            ->add('reseller', 'checkbox', array(
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Reseller'),
+                'label_attr' => array(
+                    'for' => 'reseller',
+                ),
+            ))
+            ->add('lang_id', 'integer', array(
+                'required' => false,
+                'label' => Translator::getInstance()->trans('Preferred language'),
+                'label_attr' => array(
+                    'for' => 'lang_id',
+                ),
+            ))
         ;
     }
 
+    public function verifyEmailField($value, ExecutionContextInterface $context)
+    {
+        $data = $context->getRoot()->getData();
+
+        if (isset($data["email_confirm"]) && $data["email"] != $data["email_confirm"]) {
+            $context->addViolation(
+                Translator::getInstance()->trans("email confirmation is not the same as email field")
+            );
+        }
+    }
+
+    /**
+     * @return string the name of you form. This name must be unique
+     */
     public function getName()
     {
-        return '';
+        return "thelia_customer_update";
     }
 }

--- a/core/lib/Thelia/Form/Api/Customer/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/Api/Customer/CustomerUpdateForm.php
@@ -10,219 +10,29 @@
 /*      file that was distributed with this source code.                             */
 /*************************************************************************************/
 
-namespace Thelia\Form;
+namespace Thelia\Form\Api\Customer;
 
-use Symfony\Component\Validator\Constraints;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Thelia\Core\Translation\Translator;
+use Thelia\Form\CustomerUpdateForm as BaseCustomerUpdateForm;
 
 /**
  * Class CustomerUpdateForm
- * @package Thelia\Form
+ * @package Thelia\Form\Api\Customer
  * @author Manuel Raynaud <manu@raynaud.io>
  */
-class CustomerUpdateForm extends BaseForm
+class CustomerUpdateForm extends BaseCustomerUpdateForm
 {
-    use AddressCountryValidationTrait;
-
-    /**
-     * @return null|void
-     */
-    protected function buildForm()
+    public function buildForm()
     {
+        parent::buildForm();
+
         $this->formBuilder
-            ->add(
-                'update_logged_in_user',
-                'integer'// In a front office context, update the in-memory logged-in user data
-            )
-            ->add("company", "text", array(
-                "label" => Translator::getInstance()->trans("Company"),
-                "label_attr" => array(
-                    "for" => "company",
-                ),
-                "required" => false,
-            ))
-            ->add("firstname", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label" => Translator::getInstance()->trans("First Name"),
-                "label_attr" => array(
-                    "for" => "firstname",
-                ),
-            ))
-            ->add("lastname", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label" => Translator::getInstance()->trans("Last Name"),
-                "label_attr" => array(
-                    "for" => "lastname",
-                ),
-            ))
-            ->add("email", "email", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                    new Constraints\Email(),
-                ),
-                "label" => Translator::getInstance()->trans("Email address"),
-                "label_attr" => array(
-                    "for" => "email",
-                ),
-            ))
-            ->add("email_confirm", "email", array(
-                "constraints" => array(
-                    new Constraints\Email(),
-                    new Constraints\Callback(array(
-                        "methods" => array(
-                            array($this, "verifyEmailField"),
-                        )
-                    )),
-                ),
-                "label" => Translator::getInstance()->trans("Confirm Email address"),
-                "label_attr" => array(
-                    "for" => "email_confirm",
-                ),
-            ))
-            ->add("password", "text", array(
-                "label" => Translator::getInstance()->trans("Password"),
-                "required" => false,
-                "label_attr" => array(
-                    "for" => "password",
-                    "help" => Translator::getInstance()->trans('Leave blank to keep current customer password')
-                ),
-            ))
-            ->add("address1", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label_attr" => array(
-                    "for" => "address",
-                ),
-                "label" => Translator::getInstance()->trans("Street Address "),
-            ))
-            ->add("address2", "text", array(
-                "required" => false,
-                "label" => Translator::getInstance()->trans("Address Line 2"),
-                "label_attr" => array(
-                    "for" => "address2",
-                ),
-            ))
-            ->add("address3", "text", array(
-                "required" => false,
-                "label" => Translator::getInstance()->trans("Address Line 3"),
-                "label_attr" => array(
-                    "for" => "address3",
-                ),
-            ))
-            ->add("phone", "text", array(
-                "label" => Translator::getInstance()->trans("Phone"),
-                "label_attr" => array(
-                    "for" => "phone",
-                ),
-                "required" => false,
-            ))
-            ->add("cellphone", "text", array(
-                "label" => Translator::getInstance()->trans("Cellphone"),
-                "label_attr" => array(
-                    "for" => "cellphone",
-                ),
-                "required" => false,
-            ))
-            ->add("zipcode", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                    new Constraints\Callback(array(
-                        "methods" => array(
-                            array($this, "verifyZipCode")
-                        ),
-                    )),
-                ),
-                "label" => Translator::getInstance()->trans("Zip code"),
-                "label_attr" => array(
-                    "for" => "zipcode",
-                ),
-            ))
-            ->add("city", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label" => Translator::getInstance()->trans("City"),
-                "label_attr" => array(
-                    "for" => "city",
-                ),
-            ))
-            ->add("country", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label" => Translator::getInstance()->trans("Country"),
-                "label_attr" => array(
-                    "for" => "country",
-                ),
-            ))
-            ->add("state", "text", array(
-                "required" => false,
-                "constraints" => array(
-                    new Constraints\Callback(array(
-                        "methods" => array(
-                            array($this, "verifyState")
-                        ),
-                    )),
-                ),
-                "label" => Translator::getInstance()->trans("State *"),
-                "label_attr" => array(
-                    "for" => "state",
-                ),
-            ))
-            ->add("title", "text", array(
-                "constraints" => array(
-                    new Constraints\NotBlank(),
-                ),
-                "label" => Translator::getInstance()->trans("Title"),
-                "label_attr" => array(
-                    "for" => "title",
-                ),
-            ))
-            ->add('discount', 'text', array(
-                'label' => Translator::getInstance()->trans('permanent discount (in percent)'),
-                'label_attr' => array(
-                    'for' => 'discount',
-                ),
-            ))
-            ->add('reseller', 'checkbox', array(
-                'required' => false,
-                'label' => Translator::getInstance()->trans('Reseller'),
-                'label_attr' => array(
-                    'for' => 'reseller',
-                ),
-            ))
-            ->add('lang_id', 'integer', array(
-                'required' => false,
-                'label' => Translator::getInstance()->trans('Preferred language'),
-                'label_attr' => array(
-                    'for' => 'lang_id',
-                ),
-            ))
+            ->add('lang_id', 'lang_id')
+            ->add('id', 'customer_id')
         ;
     }
 
-    public function verifyEmailField($value, ExecutionContextInterface $context)
-    {
-        $data = $context->getRoot()->getData();
-
-        if (isset($data["email_confirm"]) && $data["email"] != $data["email_confirm"]) {
-            $context->addViolation(
-                Translator::getInstance()->trans("email confirmation is not the same as email field")
-            );
-        }
-    }
-
-    /**
-     * @return string the name of you form. This name must be unique
-     */
     public function getName()
     {
-        return "thelia_customer_update";
+        return '';
     }
 }

--- a/core/lib/Thelia/Form/Api/Product/ProductCreationForm.php
+++ b/core/lib/Thelia/Form/Api/Product/ProductCreationForm.php
@@ -26,10 +26,9 @@ class ProductCreationForm extends BaseProductCreationForm
     use StandardDescriptionFieldsTrait;
 
     /**
-     * @param bool $change_mode
      * @inherited
      */
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $translator = Translator::getInstance();
         BaseProductCreationForm::buildForm();

--- a/core/lib/Thelia/Form/ConfigCreationForm.php
+++ b/core/lib/Thelia/Form/ConfigCreationForm.php
@@ -21,17 +21,14 @@ class ConfigCreationForm extends BaseForm
 {
     protected function buildForm()
     {
-        $name_constraints = array(new Constraints\NotBlank());
-
-        if (!$change_mode) {
-            $name_constraints[] = new Constraints\Callback(array(
-                "methods" => array(array($this, "checkDuplicateName")),
-            ));
-        }
-
         $this->formBuilder
             ->add("name", "text", array(
-                "constraints" => $name_constraints,
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Callback(array(
+                        "methods" => array(array($this, "checkDuplicateName")),
+                    ))
+                ),
                 "label" => Translator::getInstance()->trans('Name *'),
                 "label_attr" => array(
                     "for" => "name",

--- a/core/lib/Thelia/Form/ConfigCreationForm.php
+++ b/core/lib/Thelia/Form/ConfigCreationForm.php
@@ -19,7 +19,7 @@ use Thelia\Core\Translation\Translator;
 
 class ConfigCreationForm extends BaseForm
 {
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $name_constraints = array(new Constraints\NotBlank());
 

--- a/core/lib/Thelia/Form/CountryModificationForm.php
+++ b/core/lib/Thelia/Form/CountryModificationForm.php
@@ -20,7 +20,7 @@ class CountryModificationForm extends CountryCreationForm
 
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add('id', 'hidden', ['constraints' => [new GreaterThan(['value' => 0])]])

--- a/core/lib/Thelia/Form/CurrencyCreationForm.php
+++ b/core/lib/Thelia/Form/CurrencyCreationForm.php
@@ -12,7 +12,6 @@
 
 namespace Thelia\Form;
 
-use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Thelia\Core\Translation\Translator;
@@ -20,7 +19,7 @@ use Thelia\Model\CurrencyQuery;
 
 class CurrencyCreationForm extends BaseForm
 {
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $defaultCurrency = CurrencyQuery::create()->findOneByByDefault(true);
 

--- a/core/lib/Thelia/Form/CurrencyModificationForm.php
+++ b/core/lib/Thelia/Form/CurrencyModificationForm.php
@@ -18,7 +18,7 @@ class CurrencyModificationForm extends CurrencyCreationForm
 {
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add("id", "hidden", array("constraints" => array(new GreaterThan(array('value' => 0)))))

--- a/core/lib/Thelia/Form/CustomerUpdateForm.php
+++ b/core/lib/Thelia/Form/CustomerUpdateForm.php
@@ -26,10 +26,9 @@ class CustomerUpdateForm extends BaseForm
     use AddressCountryValidationTrait;
 
     /**
-     * @param bool $backendContext
      * @return null|void
      */
-    protected function buildForm($backendContext = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add(

--- a/core/lib/Thelia/Form/HookModificationForm.php
+++ b/core/lib/Thelia/Form/HookModificationForm.php
@@ -26,7 +26,7 @@ class HookModificationForm extends HookCreationForm
 
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add("id", "hidden", array("constraints" => array(new GreaterThan(array('value' => 0)))))

--- a/core/lib/Thelia/Form/MailingSystemModificationForm.php
+++ b/core/lib/Thelia/Form/MailingSystemModificationForm.php
@@ -21,7 +21,7 @@ use Thelia\Core\Translation\Translator;
  */
 class MailingSystemModificationForm extends BaseForm
 {
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add("enabled", "checkbox", array(

--- a/core/lib/Thelia/Form/MessageCreationForm.php
+++ b/core/lib/Thelia/Form/MessageCreationForm.php
@@ -20,19 +20,16 @@ use Thelia\Core\Translation\Translator;
 
 class MessageCreationForm extends BaseForm
 {
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
-        $name_constraints = array(new Constraints\NotBlank());
-
-        if (!$change_mode) {
-            $name_constraints[] = new Constraints\Callback(array(
-                "methods" => array(array($this, "checkDuplicateName")),
-            ));
-        }
-
         $this->formBuilder
             ->add("name", "text", array(
-                "constraints" => $name_constraints,
+                "constraints" => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Callback(array(
+                        "methods" => array(array($this, "checkDuplicateName")),
+                    ))
+                ),
                 "label" => Translator::getInstance()->trans('Name'),
                 "label_attr" => array(
                     "for" => "name",

--- a/core/lib/Thelia/Form/ModuleInstallForm.php
+++ b/core/lib/Thelia/Form/ModuleInstallForm.php
@@ -33,7 +33,7 @@ class ModuleInstallForm extends BaseForm
 
     protected $modulePath = null;
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add(

--- a/core/lib/Thelia/Form/ProductCreationForm.php
+++ b/core/lib/Thelia/Form/ProductCreationForm.php
@@ -20,7 +20,12 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class ProductCreationForm extends BaseForm
 {
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
+    {
+        $this->doBuildForm(false);
+    }
+
+    protected function doBuildForm($change_mode)
     {
         $this->formBuilder
             ->add("ref", "text", array(

--- a/core/lib/Thelia/Form/ProductModificationForm.php
+++ b/core/lib/Thelia/Form/ProductModificationForm.php
@@ -23,9 +23,9 @@ class ProductModificationForm extends ProductCreationForm
 {
     use StandardDescriptionFieldsTrait;
 
-    protected function buildForm($change_mode = true)
+    protected function buildForm()
     {
-        parent::buildForm($change_mode);
+        parent::doBuildForm(true);
 
         $this->formBuilder
             ->add("id", "integer", array(

--- a/core/lib/Thelia/Form/ProfileCreationForm.php
+++ b/core/lib/Thelia/Form/ProfileCreationForm.php
@@ -27,7 +27,7 @@ class ProfileCreationForm extends BaseForm
 {
     use StandardDescriptionFieldsTrait;
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add("locale", "text", array(

--- a/core/lib/Thelia/Form/ProfileModificationForm.php
+++ b/core/lib/Thelia/Form/ProfileModificationForm.php
@@ -26,7 +26,7 @@ class ProfileModificationForm extends ProfileCreationForm
 {
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add("id", "hidden", array(

--- a/core/lib/Thelia/Form/ProfileUpdateModuleAccessForm.php
+++ b/core/lib/Thelia/Form/ProfileUpdateModuleAccessForm.php
@@ -28,7 +28,7 @@ class ProfileUpdateModuleAccessForm extends BaseForm
 {
     const MODULE_ACCESS_FIELD_PREFIX = "module";
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add("id", "hidden", array(

--- a/core/lib/Thelia/Form/ProfileUpdateResourceAccessForm.php
+++ b/core/lib/Thelia/Form/ProfileUpdateResourceAccessForm.php
@@ -28,7 +28,7 @@ class ProfileUpdateResourceAccessForm extends BaseForm
 {
     const RESOURCE_ACCESS_FIELD_PREFIX = "resource";
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add("id", "hidden", array(

--- a/core/lib/Thelia/Form/TaxCreationForm.php
+++ b/core/lib/Thelia/Form/TaxCreationForm.php
@@ -33,7 +33,7 @@ class TaxCreationForm extends BaseForm
 
     protected static $typeList = [];
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         if (!$this->container) {
             throw new \LogicException(

--- a/core/lib/Thelia/Form/TaxModificationForm.php
+++ b/core/lib/Thelia/Form/TaxModificationForm.php
@@ -25,7 +25,7 @@ class TaxModificationForm extends TaxCreationForm
 {
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add("id", "hidden", array(

--- a/core/lib/Thelia/Form/TaxRuleCreationForm.php
+++ b/core/lib/Thelia/Form/TaxRuleCreationForm.php
@@ -18,7 +18,7 @@ class TaxRuleCreationForm extends BaseForm
 {
     use StandardDescriptionFieldsTrait;
 
-    protected function buildForm($change_mode = false)
+    protected function buildForm()
     {
         $this->formBuilder
             ->add("locale", "hidden", array(

--- a/core/lib/Thelia/Form/TaxRuleModificationForm.php
+++ b/core/lib/Thelia/Form/TaxRuleModificationForm.php
@@ -20,7 +20,7 @@ class TaxRuleModificationForm extends TaxRuleCreationForm
 {
     protected function buildForm()
     {
-        parent::buildForm(true);
+        parent::buildForm();
 
         $this->formBuilder
             ->add("id", "hidden", array(


### PR DESCRIPTION
This PR fixes the buildForm() method signature, that should not have any parameter to comply to BaseForm decaration.

It also fixes a wrong usage of "continue" in ConditionEvaluator