### PR TITLE
Lang should be active and currency visible to be used in front office

### DIFF
--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -134,8 +134,6 @@ class RequestListener implements EventSubscriberInterface
      * @param Request $request
      * @param Session $session
      * @param EventDispatcherInterface $dispatcher
-     *
-     * @return array
      */
     protected function getRememberMeCustomer(Request $request, Session $session, EventDispatcherInterface $dispatcher)
     {
@@ -207,7 +205,10 @@ class RequestListener implements EventSubscriberInterface
         // Set the current language according to locale preference
         $locale = $user->getLocale();
 
-        if (null === $lang = LangQuery::create()->findOneByLocale($locale)) {
+        if (null === $lang = LangQuery::create()
+                ->filterByActive(true)
+                ->filterByLocale($locale)
+                ->findOne($locale)) {
             $lang = Lang::getDefaultLanguage();
         }
 
@@ -246,6 +247,7 @@ class RequestListener implements EventSubscriberInterface
 
             // Set previous URL, if defined
             if (null !== $referrer) {
+                /** @var Session $session */
                 $session = $request->getSession();
 
                 if (ConfigQuery::isMultiDomainActivated()) {
@@ -282,6 +284,7 @@ class RequestListener implements EventSubscriberInterface
         if ($request->query->has("currency")) {
             if (null !== $find = CurrencyQuery::create()
                     ->filterById($request->getSession()->getCurrency(true)->getId(), Criteria::NOT_EQUAL)
+                    ->filterByVisible(true)
                     ->filterByCode($request->query->get("currency"))
                     ->findOne()
             ) {

--- a/core/lib/Thelia/Core/Security/User/UserInterface.php
+++ b/core/lib/Thelia/Core/Security/User/UserInterface.php
@@ -99,4 +99,13 @@ interface UserInterface
      * @param string $serial
      */
     public function setSerial($serial);
+
+
+    /**
+     * Get the user preferred locale
+     *
+     * @return string the locale
+     */
+    public function getLocale();
+
 }

--- a/core/lib/Thelia/Model/Api.php
+++ b/core/lib/Thelia/Model/Api.php
@@ -140,4 +140,10 @@ class Api extends BaseApi implements UserInterface
     {
         throw new \RuntimeException("setSerial is not implemented");
     }
+
+    public function getLocale()
+    {
+        throw new \RuntimeException("getLocale is not implemented");
+
+    }
 }

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -344,6 +344,15 @@ class Customer extends BaseCustomer implements UserInterface
         return $this->getRememberMeSerial();
     }
 
+    /**
+     * @return string
+     * @throws PropelException
+     */
+    public function getLocale()
+    {
+        return $this->getLangModel()->getLocale();
+    }
+
     public function hasOrder()
     {
         $order = OrderQuery::create()


### PR DESCRIPTION
This PR fixes a problem with lang and currency, that could be set in front-office even if they're inactive (for a lang) or not visible (for currency).

For example, https://your.tld/?currency=USD will set the USD as the front currency even if USD is not visible.

As "inactive" is not defined for currencies, the "visible" status is used to decide if a currency is allowed in front office.

Additionally, this PR add the getLocale() method to Thelia\Core\Security\User\UserInterface, as this method is used in Thelia\Core\EventListener\RequestListener::applyUserLocale and Thelia\Controller\Admin\SessionController::applyUserLocale