### PR TITLE
 Order status management improvement

### DIFF
--- a/core/lib/Thelia/Model/OrderProductQuery.php
+++ b/core/lib/Thelia/Model/OrderProductQuery.php
@@ -21,12 +21,16 @@ class OrderProductQuery extends BaseOrderProductQuery
         $productRef,
         \DateTime $startDate = null,
         \DateTime $endDate = null,
-        $orderStatus = array(2, 3, 4),
+        $orderStatusIdList = null,
         $customerId = null
     ) {
         $query = self::create('op');
 
-        if (null !== $customerId || null !== $startDate || null !== $endDate || count($orderStatus) > 0) {
+        if (null === $orderStatusIdList) {
+            $orderStatusIdList = OrderStatusQuery::getPaidStatusIdList();
+        }
+
+        if (null !== $customerId || null !== $startDate || null !== $endDate || count($orderStatusIdList) > 0) {
             $subQuery = $query->useOrderQuery();
 
             if (null !== $customerId) {
@@ -47,8 +51,8 @@ class OrderProductQuery extends BaseOrderProductQuery
                 );
             }
 
-            if (count($orderStatus) > 0) {
-                $subQuery->filterByStatusId($orderStatus, Criteria::IN);
+            if (count($orderStatusIdList) > 0) {
+                $subQuery->filterByStatusId($orderStatusIdList, Criteria::IN);
             }
 
             $subQuery->endUse();

--- a/core/lib/Thelia/Model/OrderQuery.php
+++ b/core/lib/Thelia/Model/OrderQuery.php
@@ -57,6 +57,12 @@ class OrderQuery extends BaseOrderQuery
         return $stats;
     }
 
+    /**
+     * @param $month
+     * @param $year
+     * @return array
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
     public static function getFirstOrdersStats($month, $year)
     {
         $numberOfDay = cal_days_in_month(CAL_GREGORIAN, $month, $year);
@@ -87,9 +93,10 @@ class OrderQuery extends BaseOrderQuery
     /**
      * @param \DateTime $startDate
      * @param \DateTime $endDate
-     * @param           $includeShipping
+     * @param bool $includeShipping
      *
-     * @return int
+     * @return float|int
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public static function getSaleStats(\DateTime $startDate, \DateTime $endDate, $includeShipping)
     {
@@ -134,7 +141,7 @@ class OrderQuery extends BaseOrderQuery
             $amount += $query->findOne();
         }
 
-        return null === $amount ? 0 : round($amount, 2);
+        return null === $amount ? 0 : $amount;
     }
 
     protected static function baseSaleStats(\DateTime $startDate, \DateTime $endDate, $modelAlias = null)
@@ -142,7 +149,7 @@ class OrderQuery extends BaseOrderQuery
         return self::create($modelAlias)
             ->filterByCreatedAt(sprintf("%s 00:00:00", $startDate->format('Y-m-d')), Criteria::GREATER_EQUAL)
             ->filterByCreatedAt(sprintf("%s 23:59:59", $endDate->format('Y-m-d')), Criteria::LESS_EQUAL)
-            ->filterByStatusId([2, 3, 4], Criteria::IN);
+            ->filterByStatusId(OrderStatusQuery::getPaidStatusIdList(), Criteria::IN);
     }
 
 

--- a/core/lib/Thelia/Model/OrderQuery.php
+++ b/core/lib/Thelia/Model/OrderQuery.php
@@ -21,6 +21,12 @@ use Thelia\Model\Map\OrderTableMap;
  */
 class OrderQuery extends BaseOrderQuery
 {
+    /**
+     * @param $month
+     * @param $year
+     * @return array
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
     public static function getMonthlySaleStats($month, $year)
     {
         $numberOfDay = cal_days_in_month(CAL_GREGORIAN, $month, $year);
@@ -144,6 +150,12 @@ class OrderQuery extends BaseOrderQuery
         return null === $amount ? 0 : $amount;
     }
 
+    /**
+     * @param \DateTime $startDate
+     * @param \DateTime $endDate
+     * @param string $modelAlias
+     * @return OrderQuery
+     */
     protected static function baseSaleStats(\DateTime $startDate, \DateTime $endDate, $modelAlias = null)
     {
         return self::create($modelAlias)
@@ -156,12 +168,16 @@ class OrderQuery extends BaseOrderQuery
     /**
      * @param \DateTime $startDate
      * @param \DateTime $endDate
-     * @param           $status
+     * @param int[]     $status
      *
      * @return int
      */
-    public static function getOrderStats(\DateTime $startDate, \DateTime $endDate, $status = array(1, 2, 3, 4))
+    public static function getOrderStats(\DateTime $startDate, \DateTime $endDate, $status = null)
     {
+        if ($status === null) {
+            $status = OrderStatusQuery::getPaidStatusIdList();
+        }
+
         return self::create()
             ->filterByStatusId($status, Criteria::IN)
             ->filterByCreatedAt(sprintf("%s 00:00:00", $startDate->format('Y-m-d')), Criteria::GREATER_EQUAL)

--- a/core/lib/Thelia/Model/OrderStatusQuery.php
+++ b/core/lib/Thelia/Model/OrderStatusQuery.php
@@ -3,6 +3,7 @@
 namespace Thelia\Model;
 
 use Thelia\Model\Base\OrderStatusQuery as BaseOrderStatusQuery;
+use Thelia\Model\Exception\InvalidArgumentException;
 
 /**
  * Skeleton subclass for performing query and update operations on the 'order_status' table.
@@ -16,34 +17,158 @@ use Thelia\Model\Base\OrderStatusQuery as BaseOrderStatusQuery;
  */
 class OrderStatusQuery extends BaseOrderStatusQuery
 {
+    protected static $statusIdListsCache = [];
+    protected static $statusModelCache = [];
+
     public static function getNotPaidStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_NOT_PAID);
+        return self::getStatusModelFromCode(OrderStatus::CODE_NOT_PAID);
     }
 
     public static function getPaidStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_PAID);
+        return self::getStatusModelFromCode(OrderStatus::CODE_PAID);
     }
 
     public static function getProcessingStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_PROCESSING);
+        return self::getStatusModelFromCode(OrderStatus::CODE_PROCESSING);
     }
 
     public static function getSentStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_SENT);
+        return self::getStatusModelFromCode(OrderStatus::CODE_SENT);
     }
 
     public static function getCancelledStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_CANCELED);
+        return self::getStatusModelFromCode(OrderStatus::CODE_CANCELED);
     }
 
     public static function getRefundedStatus()
     {
-        return OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_REFUNDED);
+        return self::getStatusModelFromCode(OrderStatus::CODE_REFUNDED);
+    }
+
+    public static function getStatusModelFromCode($statusCode)
+    {
+        if (! isset(self::$statusModelCache[$statusCode])) {
+            self::$statusModelCache[$statusCode] = OrderStatusQuery::create()->findOneByCode($statusCode);
+        }
+
+        return self::$statusModelCache[$statusCode];
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as not paid
+     *
+     * @return array
+     */
+    public static function getNotPaidStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_NOT_PAID);
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as paid
+     *
+     * @return array
+     */
+    public static function getPaidStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_PAID);
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as in process
+     *
+     * @return array
+     */
+    public static function getProcessingStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_PROCESSING);
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as sent
+     *
+     * @return array
+     */
+    public static function getSentStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_SENT);
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as canceled
+     *
+     * @return array
+     */
+    public static function getCanceledStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_CANCELED);
+    }
+
+    /**
+     * Return the list of order status IDs for which an order is considered as refunded
+     *
+     * @return array
+     */
+    public static function getRefundedStatusIdList()
+    {
+        return self::getStatusIdList(OrderStatus::CODE_REFUNDED);
+    }
+
+    /**
+     * Return a list of status IDs which match $statusCode value.
+     *
+     * @param string $statusCode the satus code
+     * @return array
+     */
+    public static function getStatusIdList($statusCode)
+    {
+        if (! isset(self::$statusIdListsCache[$statusCode])) {
+            $statusIdList = [];
+
+            $statusList = OrderStatusQuery::create()->find();
+
+            /** @var OrderStatus $status */
+            foreach ($statusList as $status) {
+                switch ($statusCode) {
+                    case OrderStatus::CODE_NOT_PAID:
+                        $match = $status->isNotPaid(false);
+                        break;
+                    case OrderStatus::CODE_PAID:
+                        $match = $status->isPaid(false);
+                        break;
+
+                    case OrderStatus::CODE_PROCESSING:
+                        $match = $status->isProcessing(false);
+                        break;
+
+                    case OrderStatus::CODE_SENT:
+                        $match = $status->isSent(false);
+                        break;
+                    case OrderStatus::CODE_CANCELED:
+                        $match = $status->isCancelled(false);
+                        break;
+                    case OrderStatus::CODE_REFUNDED:
+                        $match = $status->isRefunded(false);
+                        break;
+
+                    default:
+                        throw new InvalidArgumentException("Status code '$statusCode' is not a valid value.");
+                }
+
+                if ($match) {
+                    $statusIdList[] = $status->getId();
+                }
+            }
+
+            self::$statusIdListsCache[$statusCode] = $statusIdList;
+        }
+
+        return self::$statusIdListsCache[$statusCode];
     }
 }
 // OrderStatusQuery

--- a/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
@@ -37,6 +37,7 @@ use Thelia\Model\ModuleConfigQuery;
 use Thelia\Model\ModuleQuery;
 use Thelia\Model\Order;
 use Thelia\Model\OrderQuery;
+use Thelia\Model\OrderStatusQuery;
 use Thelia\Model\ProductQuery;
 use Thelia\Model\Tools\ModelCriteriaTools;
 use Thelia\TaxEngine\TaxEngine;
@@ -602,7 +603,7 @@ class DataAccessFunctions extends AbstractSmartyPlugin
                 return OrderQuery::getSaleStats($startDate, $endDate, $includeShipping);
                 break;
             case 'orders':
-                return OrderQuery::getOrderStats($startDate, $endDate, array(1,2,3,4));
+                return OrderQuery::getOrderStats($startDate, $endDate, OrderStatusQuery::getPaidStatusIdList());
                 break;
         }
 


### PR DESCRIPTION
This PR improves the order status management, and provides methods to avoid hard coded status usages, such has `Thelia\Model\OrderStatusQuery::getPaidStatusIdList()` which returns all orders status IDs for which the order is paid.

TODO : When a new order status is defined in the back-office, it should declare which of the "canonical" status are covered.