### PR TITLE
Shipping zones button is no longer extra small in module list

### DIFF
--- a/templates/backOffice/default/includes/module-block.html
+++ b/templates/backOffice/default/includes/module-block.html
@@ -145,7 +145,7 @@
                                 {$btnstyle="btn-danger"}
                             {/elseloop}
 
-                            <a class="{if ! $ACTIVE}disabled {/if} btn {$btnstyle} btn-xs config-btn-{$ID} btn-area-config" title="{$title}" href="{url path="/admin/configuration/shipping_zones/update/%id" id=$ID}">{$icon nofilter}{intl l="Shipping zones"}</a>
+                            <a class="{if ! $ACTIVE}disabled {/if} btn {$btnstyle} config-btn-{$ID} btn-area-config" title="{$title}" href="{url path="/admin/configuration/shipping_zones/update/%id" id=$ID}">{$icon nofilter}{intl l="Shipping zones"}</a>
                         {/if}
 
                         {$buttons = []}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2197734/50725644-b708f300-1100-11e9-9239-fe56648a7359.png)
