### PR TITLE
MailerFactory::send() is now wrapped in an exception handler

### DIFF
--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -35,18 +35,18 @@ class MailerFactory
      * @var \Swift_Mailer
      */
     protected $swiftMailer;
-    
+
     protected $dispatcher;
     protected $parser;
-    
+
     public function __construct(EventDispatcherInterface $dispatcher, ParserInterface $parser)
     {
         $this->dispatcher = $dispatcher;
         $this->parser    = $parser;
-        
+
         $transporterEvent = new MailTransporterEvent();
         $this->dispatcher->dispatch(TheliaEvents::MAILTRANSPORTER_CONFIG, $transporterEvent);
-        
+
         if ($transporterEvent->hasTransporter()) {
             $transporter = $transporterEvent->getTransporter();
         } else {
@@ -56,14 +56,14 @@ class MailerFactory
                 $transporter = \Swift_MailTransport::newInstance();
             }
         }
-        
+
         $this->swiftMailer = new \Swift_Mailer($transporter);
     }
-    
+
     private function configureSmtp()
     {
         $smtpTransporter = \Swift_SmtpTransport::newInstance(ConfigQuery::getSmtpHost(), ConfigQuery::getSmtpPort());
-        
+
         if (ConfigQuery::getSmtpEncryption()) {
             $smtpTransporter->setEncryption(ConfigQuery::getSmtpEncryption());
         }
@@ -82,10 +82,10 @@ class MailerFactory
         if (ConfigQuery::getSmtpSourceIp()) {
             $smtpTransporter->setSourceIp(ConfigQuery::getSmtpSourceIp());
         }
-        
+
         return $smtpTransporter;
     }
-    
+
     /**
      * @param \Swift_Mime_Message $message
      * @param null $failedRecipients
@@ -95,7 +95,7 @@ class MailerFactory
     {
         return $this->swiftMailer->send($message, $failedRecipients);
     }
-    
+
     /**
      * @return \Swift_Mailer
      */
@@ -103,7 +103,7 @@ class MailerFactory
     {
         return $this->swiftMailer;
     }
-    
+
     /**
      * Return a new message instance
      *
@@ -113,7 +113,7 @@ class MailerFactory
     {
         return \Swift_Message::newInstance();
     }
-    
+
     /**
      * Send a message to the customer.
      *
@@ -125,7 +125,7 @@ class MailerFactory
     {
         // Always add the customer ID to the parameters
         $messageParameters['customer_id'] = $customer->getId();
-        
+
         $this->sendEmailMessage(
             $messageCode,
             [ ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName() ],
@@ -134,7 +134,7 @@ class MailerFactory
             $customer->getCustomerLang()->getLocale()
         );
     }
-    
+
     /**
      * Send a message to the shop managers.
      *
@@ -145,16 +145,16 @@ class MailerFactory
     public function sendEmailToShopManagers($messageCode, $messageParameters = [], $replyTo = [])
     {
         $storeName = ConfigQuery::getStoreName();
-        
+
         // Build the list of email recipients
         $recipients = ConfigQuery::getNotificationEmailsList();
-        
+
         $to = [];
-        
+
         foreach ($recipients as $recipient) {
             $to[$recipient] = $storeName;
         }
-        
+
         $this->sendEmailMessage(
             $messageCode,
             [ConfigQuery::getStoreEmail() => $storeName],
@@ -166,7 +166,7 @@ class MailerFactory
             $replyTo
         );
     }
-    
+
     /**
      * Send a message to the customer.
      *
@@ -182,25 +182,31 @@ class MailerFactory
     public function sendEmailMessage($messageCode, $from, $to, $messageParameters = [], $locale = null, $cc = [], $bcc = [], $replyTo = [])
     {
         $store_email = ConfigQuery::getStoreEmail();
-        
+
         if (! empty($store_email)) {
             if (! empty($to)) {
-                $instance = $this->createEmailMessage($messageCode, $from, $to, $messageParameters, $locale, $cc, $bcc, $replyTo);
-                
-                $sentCount = $this->send($instance, $failedRecipients);
-                
-                if ($sentCount == 0) {
+                try {
+                    $instance = $this->createEmailMessage($messageCode, $from, $to, $messageParameters, $locale, $cc, $bcc);
+
+                    $sentCount = $this->send($instance, $failedRecipients);
+
+                    if ($sentCount == 0) {
+                        Tlog::getInstance()->addError(
+                            Translator::getInstance()->trans(
+                                "Failed to send message %code. Failed recipients: %failed_addresses",
+                                [
+                                    '%code' => $messageCode,
+                                    '%failed_addresses' => is_array($failedRecipients) ? implode(
+                                        ',',
+                                        $failedRecipients
+                                    ) : 'none'
+                                ]
+                            )
+                        );
+                    }
+                } catch (\Exception $ex) {
                     Tlog::getInstance()->addError(
-                        Translator::getInstance()->trans(
-                            "Failed to send message %code. Failed recipients: %failed_addresses",
-                            [
-                                '%code' => $messageCode,
-                                '%failed_addresses' => is_array($failedRecipients) ? implode(
-                                    ',',
-                                    $failedRecipients
-                                ) : 'none'
-                            ]
-                        )
+                        "Error while sending email message $messageCode: " . $ex->getMessage()
                     );
                 }
             } else {
@@ -210,7 +216,7 @@ class MailerFactory
             Tlog::getInstance()->addError("Can't send email message $messageCode: store email address is not defined.");
         }
     }
-    
+
     /**
      * Create a SwiftMessage instance from a given message code.
      *
@@ -224,6 +230,7 @@ class MailerFactory
      * @param  array  $replyTo           Reply to addresses. An array of (email-address => name) [optional]
      *
      * @return \Swift_Message the generated and built message.
+     * @throws \SmartyException
      */
     public function createEmailMessage($messageCode, $from, $to, $messageParameters = [], $locale = null, $cc = [], $bcc = [], $replyTo = [])
     {
@@ -231,25 +238,25 @@ class MailerFactory
             if ($locale === null) {
                 $locale = Lang::getDefaultLanguage()->getLocale();
             }
-            
+
             $message->setLocale($locale);
-            
+
             // Assign parameters
             foreach ($messageParameters as $name => $value) {
                 $this->parser->assign($name, $value);
             }
-            
+
             $this->parser->assign('locale', $locale);
-            
+
             $instance = $this->getMessageInstance();
-            
+
             $this->setupMessageHeaders($instance, $from, $to, $cc, $bcc, $replyTo);
-            
+
             $message->buildMessage($this->parser, $instance);
-            
+
             return $instance;
         }
-        
+
         throw new \RuntimeException(
             Translator::getInstance()->trans(
                 "Failed to load message with code '%code%', propably because it does'nt exists.",
@@ -257,7 +264,7 @@ class MailerFactory
             )
         );
     }
-    
+
     /**
      * Create a SwiftMessage instance from text
      *
@@ -275,11 +282,11 @@ class MailerFactory
     public function createSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc = [], $bcc = [], $replyTo = [])
     {
         $instance = $this->getMessageInstance();
-        
+
         $this->setupMessageHeaders($instance, $from, $to, $cc, $bcc, $replyTo);
-        
+
         $instance->setSubject($subject);
-        
+
         // If we do not have an HTML message
         if (empty($htmlMessage)) {
             // Message body is the text message
@@ -287,16 +294,16 @@ class MailerFactory
         } else {
             // The main body is the HTML messahe
             $instance->setBody($htmlBody, 'text/html');
-            
+
             // Use the text as a message part, if we have one.
             if (! empty($textMessage)) {
                 $instance->addPart($textBody, 'text/plain');
             }
         }
-        
+
         return $instance;
     }
-    
+
     /**
      * @param  array  $from              From addresses. An array of (email-address => name)
      * @param  array  $to                To addresses. An array of (email-address => name)
@@ -312,10 +319,10 @@ class MailerFactory
     public function sendSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc = [], $bcc = [], $replyTo = [], &$failedRecipients = null)
     {
         $instance = $this->createSimpleEmailMessage($from, $to, $subject, $htmlBody, $textBody, $cc, $bcc, $replyTo);
-        
+
         return $this->send($instance, $failedRecipients);
     }
-    
+
     /**
      * @param \Swift_Message $instance
      * @param  array  $from              From addresses. An array of (email-address => name)
@@ -330,22 +337,22 @@ class MailerFactory
         foreach ($from as $address => $name) {
             $instance->addFrom($address, $name);
         }
-        
+
         // Add to addresses
         foreach ($to as $address => $name) {
             $instance->addTo($address, $name);
         }
-        
+
         // Add cc addresses
         foreach ($cc as $address => $name) {
             $instance->addCc($address, $name);
         }
-        
+
         // Add bcc addresses
         foreach ($bcc as $address => $name) {
             $instance->addBcc($address, $name);
         }
-        
+
         // Add reply to addresses
         foreach ($replyTo as $address => $name) {
             $instance->addReplyTo($address, $name);

--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -186,7 +186,7 @@ class MailerFactory
         if (! empty($store_email)) {
             if (! empty($to)) {
                 try {
-                    $instance = $this->createEmailMessage($messageCode, $from, $to, $messageParameters, $locale, $cc, $bcc);
+                    $instance = $this->createEmailMessage($messageCode, $from, $to, $messageParameters, $locale, $cc, $bcc, $replyTo);
 
                     $sentCount = $this->send($instance, $failedRecipients);
 


### PR DESCRIPTION
To prevent uncaught exception to break the order processing, the MailerFactory::send() method is now wrapped in an exception handler. The customer will not longer receive a technical error report (Oops, ...) if a mail could no be sent. Instead, an error message is added to the log file. 