### PR TITLE
Pagination fix

### DIFF
--- a/templates/frontOffice/default/brand.html
+++ b/templates/frontOffice/default/brand.html
@@ -90,42 +90,8 @@
                     <hr/>
 
                     {assign var="amount" value={count type="product" brand=$ID}}
-                    <div class="toolbar toolbar-top" role="toolbar">
-                        <div class="sorter-container clearfix">
-                            <span class="amount">{if ($amount > 1)}{intl l="%nb Items" nb=$amount}{else}{intl l="%nb Item" nb=$amount}{/if}</span>
 
-                            <span class="limiter">
-                                <label for="limit-top">{intl l="Show"}</label>
-                                <select id="limit-top" name="limit">
-                                    <option value="{url current="1" limit="4"}" {if $limit==4}selected{/if}>4</option>
-                                    <option value="{url current="1" limit="8"}" {if $limit==8}selected{/if}>8</option>
-                                    <option value="{url current="1" limit="12"}" {if $limit==12}selected{/if}>12</option>
-                                    <option value="{url current="1" limit="50"}" {if $limit==50}selected{/if}>50</option>
-                                    <option value="{url current="1" limit="100000"}" {if $limit==100000}selected{/if}>{intl l="All"}</option>
-                                </select>
-                                <span class="per-page">{intl l="per page"}</span>
-                            </span><!-- /.limiter -->
-
-                            <span class="sort-by">
-                                <label for="sortby-top">{intl l="Sort By"}</label>
-                                <select id="sortby-top" name="sortby">
-                                    {*<option value="{url path="{brand attr="url"}" order="manual"}">{intl l="Position"}</option>*}
-                                    <option value="{url current="1" limit=$limit order="alpha"}" {if $product_order=="alpha"}selected{/if}>{intl l="Name ascending"}</option>
-                                    <option value="{url current="1" limit=$limit order="alpha_reverse"}" {if $product_order=="alpha_reverse"}selected{/if}>{intl l="Name descending"}</option>
-                                    <option value="{url current="1" limit=$limit order="min_price"}" {if $product_order=="min_price"}selected{/if}>{intl l="Price ascending"}</option>
-                                    <option value="{url current="1" limit=$limit order="max_price"}" {if $product_order=="max_price"}selected{/if}>{intl l="Price descending"}</option>
-                                </select>
-                            </span><!-- /.sort-by -->
-
-                            <span class="view-mode">
-                                <span class="view-mode-label sr-only">{intl l="View as"}:</span>
-                                <span class="view-mode-btn">
-                                    <a href="{url current="1" mode="grid"}" data-toggle="view" role="button" title="{intl l='Grid'}" rel="nofollow" class="btn btn-default btn-grid"><i class="fa fa-th"></i></a>
-                                    <a href="{url current="1" mode="list"}" data-toggle="view" role="button" title="{intl l="List"}" rel="nofollow" class="btn btn-default btn-list"><i class="fa fa-th-list"></i></a>
-                                </span>
-                            </span><!-- /.view-mode -->
-                        </div><!-- /.sorter -->
-                    </div><!-- /.sorter-container -->
+                    {include file="includes/toolbar.html" toolbar="top" limit=$limit order=$product_order amount={$amount}}
 
                     <div id="category-products">
                         <div class="products-content">
@@ -137,41 +103,7 @@
                         </div>
                     </div><!-- /#category-products -->
 
-                    <div class="toolbar toolbar-bottom" role="toolbar">
-                        {if $amount > $limit}
-                            <div class="pagination-container clearfix" role="pagination" aria-labelledby="pagination-label-{$toolbar}}">
-                                <strong id="pagination-label-{$toolbar}}" class="pagination-label sr-only">{intl l="Pagination"}</strong>
-                                <ul class="pagination pagination-sm">
-                                    {if $product_page le 1}
-                                        <li class="disabled">
-                                            <span class="prev"><i class="fa fa-caret-left"></i></span>
-                                        </li>
-                                    {else}
-                                        <li>
-                                            <a href="{url current="1" page={$product_page-1} }" title="{intl l="Previous"}" class="prev"><i class="fa fa-caret-left"></i></a>
-                                        </li>
-                                    {/if}
-
-                                    {pageloop rel="product_list"}
-                                        <li{if $PAGE eq $CURRENT} class="active"{/if}>
-                                            <a href="{url current="1" page=$PAGE }"> {$PAGE} </a>
-                                        </li>
-                                        {if $PAGE eq $LAST}
-                                            {if $CURRENT eq $LAST}
-                                                <li class="disabled">
-                                                    <span class="next"><i class="fa fa-caret-right"></i></span>
-                                                </li>
-                                            {else}
-                                                <li>
-                                                    <a href="{url current="1" page={$NEXT} }" title="{intl l="Next"}" class="next"><i class="fa fa-caret-right"></i></a>
-                                                </li>
-                                            {/if}
-                                        {/if}
-                                    {/pageloop}
-                                </ul>
-                            </div>
-                        {/if}
-                    </div><!-- /.toolbar toolbar-bottom -->
+                    {include file="includes/toolbar.html" toolbar="bottom" amount={$amount}}
                 {/ifloop}
 
                 {elseloop rel="product_list"}

--- a/templates/frontOffice/default/category.html
+++ b/templates/frontOffice/default/category.html
@@ -100,88 +100,22 @@
 
             {ifloop rel="product_list"}
                 {$amount={count type="product" category=$category_id}}
-                <div class="toolbar toolbar-top" role="toolbar">
-                    <div class="sorter-container clearfix">
-                    <span class="amount">{if ($amount > 1)}{intl l="%nb Items" nb={$amount}}{else}{intl l="%nb Item" nb={$amount}}{/if}</span>
 
-                    <span class="limiter">
-                        <label for="limit-top">{intl l="Show"}</label>
-                        <select id="limit-top" name="limit">
-                            <option value="{url current="1" page=1 limit="4"}" {if $limit==4}selected{/if}>4</option>
-                            <option value="{url current="1" page=1 limit="8"}" {if $limit==8}selected{/if}>8</option>
-                            <option value="{url current="1" page=1 limit="12"}" {if $limit==12}selected{/if}>12</option>
-                            <option value="{url current="1" page=1 limit="50"}" {if $limit==50}selected{/if}>50</option>
-                            <option value="{url current="1" page=1 limit="100000"}" {if $limit==100000}selected{/if}>{intl l="All"}</option>
-                        </select>
-                        <span class="per-page">{intl l="per page"}</span>
-                    </span><!-- /.limiter -->
+                {include file="includes/toolbar.html" toolbar="top" limit=$limit order=$product_order amount={$amount}}
 
-                    <span class="sort-by">
-                        <label for="sortby-top">{intl l="Sort By"}</label>
-                        <select id="sortby-top" name="sortby">
-                            {*<option value="{url path="{category attr="url"}" order="manual"}">{intl l="Position"}</option>*}
-                            <option value="{url current="1" limit=$limit order="alpha"}" {if $product_order=="alpha"}selected{/if}>{intl l="Name ascending"}</option>
-                            <option value="{url current="1" limit=$limit order="alpha_reverse"}" {if $product_order=="alpha_reverse"}selected{/if}>{intl l="Name descending"}</option>
-                            <option value="{url current="1" limit=$limit order="min_price"}" {if $product_order=="min_price"}selected{/if}>{intl l="Price ascending"}</option>
-                            <option value="{url current="1" limit=$limit order="max_price"}" {if $product_order=="max_price"}selected{/if}>{intl l="Price descending"}</option>
-                        </select>
-                    </span><!-- /.sort-by -->
-
-                    <span class="view-mode">
-                        <span class="view-mode-label sr-only">{intl l="View as"}:</span>
-                        <span class="view-mode-btn">
-                            <a href="{url current="1" mode="grid"}" data-toggle="view" role="button" title="{intl l="Grid"}" rel="nofollow" class="btn btn-default btn-grid"><i class="fa fa-th"></i></a>
-                            <a href="{url current="1" mode="list"}" data-toggle="view" role="button" title="{intl l="List"}" rel="nofollow" class="btn btn-default btn-list"><i class="fa fa-th-list"></i></a>
-                        </span>
-                    </span><!-- /.view-mode -->
-
-                </div><!-- /.sorter -->
-            </div>
-            <div id="category-products">
-                <div class="products-content">
-                    <ul class="list-unstyled row">
-                        {loop type="product" name="product_list" category=$category_id limit=$limit page=$product_page order=$product_order}
-                            {include file="includes/single-product.html" product_id=$ID hasBtn=true hasDescription=true hasQuickView=true width="218" height="146"}
-                        {/loop}
-                    </ul>
-                </div>
-            </div><!-- /#category-products -->
-            <div class="toolbar toolbar-bottom" role="toolbar">
-                {if $amount > $limit}
-                    <div class="pagination-container clearfix" role="pagination" aria-labelledby="pagination-label-{$toolbar}}">
-                        <strong id="pagination-label-{$toolbar}}" class="pagination-label sr-only">{intl l="Pagination"}</strong>
-                        <ul class="pagination pagination-sm">
-                            {if $product_page le 1}
-                                <li class="disabled">
-                                    <span class="prev"><i class="fa fa-caret-left"></i></span>
-                                </li>
-                            {else}
-                                <li>
-                                    <a href="{url current="1" page={$product_page-1} }" title="{intl l="Previous"}" class="prev"><i class="fa fa-caret-left"></i></a>
-                                </li>
-                            {/if}
-
-                            {pageloop rel="product_list"}
-                                <li{if $PAGE eq $CURRENT} class="active"{/if}>
-                                    <a href="{url current="1" page=$PAGE }"> {$PAGE} </a>
-                                </li>
-                                {if $PAGE eq $LAST}
-                                    {if $CURRENT eq $LAST}
-                                        <li class="disabled">
-                                            <span class="next"><i class="fa fa-caret-right"></i></span>
-                                        </li>
-                                    {else}
-                                        <li>
-                                            <a href="{url current="1" page={$NEXT} }" title="{intl l="Next"}" class="next"><i class="fa fa-caret-right"></i></a>
-                                        </li>
-                                    {/if}
-                                {/if}
-                            {/pageloop}
+                <div id="category-products">
+                    <div class="products-content">
+                        <ul class="list-unstyled row">
+                            {loop type="product" name="product_list" category=$category_id limit=$limit page=$product_page order=$product_order}
+                                {include file="includes/single-product.html" product_id=$ID hasBtn=true hasDescription=true hasQuickView=true width="218" height="146"}
+                            {/loop}
                         </ul>
                     </div>
-                {/if}
-            </div><!-- /.toolbar toolbar-bottom -->
+                </div><!-- /#category-products -->
+
+                {include file="includes/toolbar.html" toolbar="bottom" amount={$amount}}
             {/ifloop}
+
             {elseloop rel="product_list"}
                 <div class="alert alert-warning">
                     {intl l="No products available in this category"}
@@ -189,7 +123,6 @@
             {/elseloop}
 
             {hook name="category.content-bottom" category="$category_id"}
-
         </article>
 
         <aside class="col-left col-md-3 col-md-pull-9" role="complementary" itemscope itemtype="http://schema.org/WPSideBar">

--- a/templates/frontOffice/default/includes/toolbar.html
+++ b/templates/frontOffice/default/includes/toolbar.html
@@ -55,7 +55,7 @@
                     <li{if $PAGE eq $CURRENT} class="active"{/if}>
                         <a href="{url current="1" page=$PAGE }"> {$PAGE} </a>
                     </li>
-                    {if $PAGE eq $LAST}
+                    {if $PAGE eq $END}
                         {if $CURRENT eq $LAST}
                             <li class="disabled">
                                 <span class="next"><i class="fa fa-caret-right"></i></span>


### PR DESCRIPTION
This PR fixes a pagination bug: the `>` button is displayed only when the page number is less than 10.
It also optimizes the category and brand page, when the pagination and toolbar code was still  present. It is now replaced by including `includes/toolbars.html`