### PR TITLE
Allow use of CDN (e.g. alternate URL) on assets and documents

### DIFF
--- a/core/lib/Thelia/Action/BaseCachedFile.php
+++ b/core/lib/Thelia/Action/BaseCachedFile.php
@@ -20,6 +20,7 @@ use Thelia\Core\Event\File\FileToggleVisibilityEvent;
 use Thelia\Core\Event\UpdateFilePositionEvent;
 use Thelia\Exception\FileException;
 use Thelia\Files\FileManager;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\Map\ProductImageTableMap;
 use Thelia\Tools\URL;
 
@@ -46,9 +47,14 @@ abstract class BaseCachedFile extends BaseAction
      */
     protected $fileManager;
 
+    /** @var null|string */
+    protected $cdnBaseUrl;
+
     public function __construct(FileManager $fileManager)
     {
         $this->fileManager = $fileManager;
+
+        $this->cdnBaseUrl = ConfigQuery::read('cdn.documents-base-url', null);
     }
 
     /**
@@ -104,7 +110,7 @@ abstract class BaseCachedFile extends BaseAction
     {
         $path = $this->getCachePathFromWebRoot($subdir);
 
-        return URL::getInstance()->absoluteUrl(sprintf("%s/%s", $path, $safe_filename), null, URL::PATH_TO_FILE);
+        return URL::getInstance()->absoluteUrl(sprintf("%s/%s", $path, $safe_filename), null, URL::PATH_TO_FILE, $this->cdnBaseUrl);
     }
 
     /**

--- a/core/lib/Thelia/Action/BaseCachedFile.php
+++ b/core/lib/Thelia/Action/BaseCachedFile.php
@@ -63,6 +63,14 @@ abstract class BaseCachedFile extends BaseAction
     abstract protected function getCacheDirFromWebRoot();
 
     /**
+     * @param string $url the fully qualified CDN URL that will be used to create doucments URL.
+     */
+    public function setCdnBaseUrl($url)
+    {
+        $this->cdnBaseUrl = $url;
+    }
+
+    /**
      * Clear the file cache. Is a subdirectory is specified, only this directory is cleared.
      * If no directory is specified, the whole cache is cleared.
      * Only files are deleted, directories will remain.

--- a/core/lib/Thelia/Action/Document.php
+++ b/core/lib/Thelia/Action/Document.php
@@ -102,7 +102,7 @@ class Document extends BaseCachedFile implements EventSubscriberInterface
 
         // Update the event with file path and file URL
         $event->setDocumentPath($documentUrl);
-        $event->setDocumentUrl(URL::getInstance()->absoluteUrl($documentUrl, null, URL::PATH_TO_FILE));
+        $event->setDocumentUrl(URL::getInstance()->absoluteUrl($documentUrl, null, URL::PATH_TO_FILE, $this->cdnBaseUrl));
     }
 
     /**

--- a/core/lib/Thelia/Action/Image.php
+++ b/core/lib/Thelia/Action/Image.php
@@ -217,14 +217,14 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
                                     $image->effects()->colorize($the_color);
                                 }
                                 break;
-                                
+
                             case 'blur':
                                 if (isset($params[1])) {
                                     $blur_level = intval($params[1]);
 
                                     $image->effects()->blur($blur_level);
                                 }
-                                break;                                      
+                                break;
                         }
                     }
 
@@ -259,8 +259,8 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
         $event->setCacheFilepath($cacheFilePath);
         $event->setCacheOriginalFilepath($originalImagePathInCache);
 
-        $event->setFileUrl(URL::getInstance()->absoluteUrl($processed_image_url, null, URL::PATH_TO_FILE));
-        $event->setOriginalFileUrl(URL::getInstance()->absoluteUrl($original_image_url, null, URL::PATH_TO_FILE));
+        $event->setFileUrl(URL::getInstance()->absoluteUrl($processed_image_url, null, URL::PATH_TO_FILE, $this->cdnBaseUrl));
+        $event->setOriginalFileUrl(URL::getInstance()->absoluteUrl($original_image_url, null, URL::PATH_TO_FILE, $this->cdnBaseUrl));
     }
 
     /**

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -127,31 +127,29 @@ class URL
      * @param string  $path       the relative path
      * @param array   $parameters An array of parameters
      * @param boolean $path_only  if true (PATH_TO_FILE), getIndexPage() will  not be added
+     * @param string $alternateBaseUrl  if not null, this URL is unsed instead of the base URL. Useful for creating CDN URLs
      *
      * @return string The generated URL
      */
-    public function absoluteUrl($path, array $parameters = null, $path_only = self::WITH_INDEX_PAGE)
+    public function absoluteUrl($path, array $parameters = null, $path_only = self::WITH_INDEX_PAGE, $alternateBaseUrl = null)
     {
         // Already absolute ?
         if (substr($path, 0, 4) != 'http') {
-            // Prevent duplication of the subdirectory name when Thelia is installed in a subdirectory.
-            // This happens when $path was calculated with Router::generate(), which returns an absolute URL,
-            // starting at web server root. For example, if Thelia is installed in /thelia2, we got something like /thelia2/my/path
-            // As base URL also contains /thelia2 (e.g. http://some.server.com/thelia2), we end up with
-            // http://some.server.com/thelia2/thelia2/my/path, instead of http://some.server.com/thelia2/my/path
-            // We have to compensate for this.
-            $rcbu = $this->requestContext->getBaseUrl();
+            if (empty($alternateBaseUrl)) {
+                // Prevent duplication of the subdirectory name when Thelia is installed in a subdirectory.
+                // This happens when $path was calculated with Router::generate(), which returns an absolute URL,
+                // starting at web server root. For example, if Thelia is installed in /thelia2, we got something like /thelia2/my/path
+                // As base URL also contains /thelia2 (e.g. http://some.server.com/thelia2), we end up with
+                // http://some.server.com/thelia2/thelia2/my/path, instead of http://some.server.com/thelia2/my/path
+                // We have to compensate for this.
+                $rcbu = $this->requestContext->getBaseUrl();
 
-            $hasSubdirectory = ! empty($rcbu) && (0 === strpos($path, $rcbu));
+                $hasSubdirectory = !empty($rcbu) && (0 === strpos($path, $rcbu));
 
-            $base_url = $this->getBaseUrl($hasSubdirectory);
-
-            /* Seems no longer required
-            // TODO fix this ugly patch
-            if (strpos($path, "index_dev.php")) {
-                $path = str_replace('index_dev.php', '', $path);
+                $base_url = $this->getBaseUrl($hasSubdirectory);
+            } else {
+                $base_url = $alternateBaseUrl;
             }
-            */
 
             // If only a path is requested, be sure to remove the script name (index.php or index_dev.php), if any.
             if ($path_only == self::PATH_TO_FILE) {

--- a/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
+++ b/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
@@ -44,6 +44,14 @@ class SmartyAssetsResolver implements AssetResolverInterface
     }
 
     /**
+     * @param string $url the fully qualified CDN URL that will be used to create doucments URL.
+     */
+    public function setCdnBaseUrl($url)
+    {
+        $this->cdnBaseUrl = $url;
+    }
+
+    /**
      * Generate an asset URL
      *
      * @param string $source a module code, or ParserInterface::TEMPLATE_ASSETS_KEY

--- a/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
+++ b/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
@@ -23,9 +23,11 @@ use Thelia\Tools\URL;
 
 class SmartyAssetsResolver implements AssetResolverInterface
 {
-    private $path_relative_to_web_root;
+    protected $path_relative_to_web_root;
 
-    private $assetsManager;
+    protected $assetsManager;
+
+    protected $cdnBaseUrl;
 
     /**
      * Creates a new SmartyAssetsManager instance
@@ -37,6 +39,8 @@ class SmartyAssetsResolver implements AssetResolverInterface
         $this->path_relative_to_web_root = ConfigQuery::read('asset_dir_from_web_root', 'assets');
 
         $this->assetsManager = $assetsManager;
+
+        $this->cdnBaseUrl = ConfigQuery::read('cdn.assets-base-url', null);
     }
 
     /**
@@ -70,7 +74,7 @@ class SmartyAssetsResolver implements AssetResolverInterface
                 THELIA_WEB_DIR . $this->path_relative_to_web_root,
                 $templateDefinition->getPath(),
                 $source,
-                URL::getInstance()->absoluteUrl($this->path_relative_to_web_root, null, URL::PATH_TO_FILE /* path only */),
+                URL::getInstance()->absoluteUrl($this->path_relative_to_web_root, null, URL::PATH_TO_FILE /* path only */, $this->cdnBaseUrl),
                 $type,
                 $filters,
                 $debug

--- a/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/UrlGenerator.php
@@ -72,7 +72,10 @@ class UrlGenerator extends AbstractSmartyPlugin
         } else {
             $defaultRouter = null;
         }
+
         $routerId = $this->getParam($params, 'router', $defaultRouter);
+
+        $baseUrl = $this->getParam($params, 'base_url', null);
 
         if ($current) {
             $path = $this->getRequest()->getPathInfo();
@@ -120,9 +123,10 @@ class UrlGenerator extends AbstractSmartyPlugin
             $url = URL::getInstance()->absoluteUrl(
                 $path,
                 $this->getArgsFromParam($params, array_merge(['noamp', 'path', 'file', 'target'], $excludeParams)),
-                $mode
+                $mode,
+                $baseUrl
             );
-            
+
             $request = $this->getRequest();
             $requestedLangCodeOrLocale = $params["lang"];
             $view = $request->attributes->get('_view', null);
@@ -142,7 +146,7 @@ class UrlGenerator extends AbstractSmartyPlugin
                         ->filterByViewLocale($lang->getLocale())
                         ->findOneByRedirected(null)
                     ;
-                    
+
                     $path = '';
                     if (null != $urlRewrite) {
                         $path = "/".$urlRewrite->getUrl();
@@ -214,7 +218,7 @@ class UrlGenerator extends AbstractSmartyPlugin
         $to = $this->getParam($params, 'to', null);
 
         $toMethod = $this->getNavigateToMethod($to);
-     
+
         $url = URL::getInstance()->absoluteUrl(
             $this->$toMethod(),
             $this->getArgsFromParam($params, ['noamp', 'to', 'target']),

--- a/setup/insert.sql.tpl
+++ b/setup/insert.sql.tpl
@@ -77,7 +77,10 @@ INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, 
 (67, 'number_default_results_per_page.order_list', '20', 0, 0, NOW(), NOW()),
 (68, 'number_default_results_per_page.customer_list', '20', 0, 0, NOW(), NOW()),
 (69, 'customer_email_confirmation', '0', 0, 0, NOW(), NOW()),
-(70, 'number_default_results_per_page.coupon_list', '20', 0, 0, NOW(), NOW())
+(70, 'number_default_results_per_page.coupon_list', '20', 0, 0, NOW(), NOW()),
+(71, 'cdn.documents-base-url', '', 0, 0, NOW(), NOW()),
+(72, 'cdn.assets-base-url', '', 0, 0, NOW(), NOW())
+
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `hidden`, `mandatory`, `created_at`, `updated_at`) VALUES
@@ -2011,7 +2014,9 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
     (67, '{$locale}', {intl l='Number by default of results per page for order list' locale=$locale}, NUll, NULL, NULL),
     (68, '{$locale}', {intl l='Number by default of results per page for customer list' locale=$locale}, NUll, NULL, NULL),
     (69, '{$locale}', {intl l='Customer account creation should be confirmed by email (1: yes, 0: no)' locale=$locale}, NULL, NULL, NULL),
-    (70, '{$locale}', {intl l='Default number of coupons per page on coupon list' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},{/if}
+    (70, '{$locale}', {intl l='Default number of coupons per page on coupon list' locale=$locale}, NULL, NULL, NULL),
+    (71, '{$locale}', {intl l='The URL of the assets CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL),
+    (72, '{$locale}', {intl l='The URL of the images and documents CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},{/if}
 
 {/foreach}
 ;

--- a/tests/phpunit/Thelia/Tests/Tools/URLTest.php
+++ b/tests/phpunit/Thelia/Tests/Tools/URLTest.php
@@ -104,6 +104,25 @@ class URLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/thelia/index.php/path/to/action', $url);
     }
 
+    public function testAbsoluteUrlAlternateBase()
+    {
+        $this->context->setBaseUrl('/');
+        $url = URL::getInstance()->absoluteUrl('/path/to/action', null, URL::WITH_INDEX_PAGE, 'https://mycdn.myshop.tld/');
+        $this->assertEquals('https://mycdn.myshop.tld/path/to/action', $url);
+
+        $this->context->setBaseUrl('/thelia/');
+        $url = URL::getInstance()->absoluteUrl('/path/to/action',null, URL::WITH_INDEX_PAGE, 'https://mycdn.myshop.tld/');
+        $this->assertEquals('https://mycdn.myshop.tld/path/to/action', $url);
+
+        $this->context->setBaseUrl('/thelia');
+        $url = URL::getInstance()->absoluteUrl('/path/to/action',null, URL::WITH_INDEX_PAGE, 'https://mycdn.myshop.tld/');
+        $this->assertEquals('https://mycdn.myshop.tld/path/to/action', $url);
+
+        $this->context->setBaseUrl('/thelia/index.php');
+        $url = URL::getInstance()->absoluteUrl('/path/to/action', null, URL::WITH_INDEX_PAGE, 'https://mycdn.myshop.tld/');
+        $this->assertEquals('https://mycdn.myshop.tld/path/to/action', $url);
+    }
+
     public function testAbsoluteUrlOnAbsolutePath()
     {
         $this->context->setBaseUrl('/thelia/index.php');

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -2,6 +2,11 @@ Options +FollowSymlinks -Indexes
 
 AddDefaultCharset UTF-8
 
+# If you defined a CDN that is an alias of your shop domaine, be sure to uncomment this line, and change "*" by your
+# shop hostname. For example, if your shop hostname is www.theshop.tld, use : Header set Access-Control-Allow-Origin "www.theshop.tld".
+# You may also use Access-Control-Allow-Origin "*" to allow all origins.
+#Header set Access-Control-Allow-Origin "*"
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
 


### PR DESCRIPTION
This PR allow the use of a CDN (or at least alternate domain) on assets, documents and images URLs.

Two configuration variables are defined, `cdn.assets-base-url` and `cdn.documents-base-url`. If these variables are not empty, the provided URL is used instead of the shop base URL. For example, if the shop URL is https://myshop.tld, and the `cdn.assets-base-url` is https://cdn.myshop.tld, all assets will be searched on https://cdn.myshop.tld/assets/...

`cdn.assets-base-url` is used by TheliaSmarty\Template\Assets\SmartyAssetsResolver, and `cdn.documents-base-url` by Thelia\Action\BaseCachedFile

A basic usage of this feature is speeding-up page loading, by defining CDNs URLs as aliases of the shop main URL.

The classes that use `cdn.*` variables have a setCdnBaseUrl() method, to allow on the fly change of the CDNs URL if needed, for example when a real CDN exists :)

The {url} Smarty function has a new `base_url` parameter, which allow creation of CDN URLs from the template. Example : `{url file="assets-dist/js/vendors/tarteaucitron/tarteaucitron.js" base_url={config key='cdn.assets-base-url'}}`



