### PR TITLE
Addd sort options to PSE loop, and allow to return all PSE

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -21,8 +21,8 @@ use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Exception\TaxEngineException;
-use Thelia\Model\CurrencyQuery;
 use Thelia\Model\Currency as CurrencyModel;
+use Thelia\Model\CurrencyQuery;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Type;
@@ -83,6 +83,8 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
                             'min_price', 'max_price',
                             'promo', 'new',
                             'weight', 'weight_reverse',
+                            'created', 'created_reverse',
+                            'updated', 'updated_reverse',
                             'random'
                         )
                     )
@@ -102,19 +104,14 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
 
         if (! is_null($id)) {
             $search->filterById($id, Criteria::IN);
-        } elseif (! is_null($product)) {
-            $search->filterByProductId($product, Criteria::EQUAL);
-        } elseif (! is_null($ref)) {
-            $search->filterByRef($ref, Criteria::EQUAL);
-        } else {
-            $searchTerm = $this->getArgValue('search_term');
-            $searchIn   = $this->getArgValue('search_in');
+        }
 
-            if (null === $searchTerm || null === $searchIn) {
-                throw new \InvalidArgumentException(
-                    "Either 'id', 'product', 'ref', 'search_term/search_in' argument should be present"
-                );
-            }
+        if (! is_null($product)) {
+            $search->filterByProductId($product, Criteria::EQUAL);
+        }
+
+        if (! is_null($ref)) {
+            $search->filterByRef($ref, Criteria::EQUAL);
         }
 
         $promo = $this->getPromo();
@@ -174,6 +171,18 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
                     break;
                 case "weight_reverse":
                     $search->orderByWeight(Criteria::DESC);
+                    break;
+                case "created":
+                    $search->addAscendingOrderByColumn('created_at');
+                    break;
+                case "created_reverse":
+                    $search->addDescendingOrderByColumn('created_at');
+                    break;
+                case "updated":
+                    $search->addAscendingOrderByColumn('updated_at');
+                    break;
+                case "updated_reverse":
+                    $search->addDescendingOrderByColumn('updated_at');
                     break;
                 case "random":
                     $search->clearOrderByColumns();


### PR DESCRIPTION
This PR add 4 sort options to the PSE loop : 
- created,
- created_reverse,
- updated,
- updated_reverse,

It is now possible to get all PSE from the loop. Previsously, and product ID, a PSE ID, a PSE reference or a search term was mandatory.

