### PR TITLE
Propel schema generation is now protected from concurrency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         "symfony/polyfill-php71": "^1.0",
         "symfony/polyfill-php72": "^1.0",
         "spipu/html2pdf": "^5.0",
-        "symfony/polyfill-php73": "^1.0"
+        "symfony/polyfill-php73": "^1.0",
+        "symfony/lock": "^3.4"
     },
     "require-dev": {
         "fzaninotto/faker": "1.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37a07fbc7cfc4fd302c903cc4519811d",
+    "content-hash": "a7ed883eefab911a873938b735ca3a29",
     "packages": [
         {
             "name": "commerceguys/addressing",
@@ -2174,6 +2174,68 @@
                 "localization"
             ],
             "time": "2017-11-16T17:55:54+00:00"
+        },
+        {
+            "name": "symfony/lock",
+            "version": "v3.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/lock.git",
+                "reference": "c9b09fe759e803fb0ff51218f48bf1c2328e1133"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/c9b09fe759e803fb0ff51218f48bf1c2328e1133",
+                "reference": "c9b09fe759e803fb0ff51218f48bf1c2328e1133",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0",
+                "symfony/polyfill-php70": "~1.0"
+            },
+            "require-dev": {
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Lock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Jérémy Derussé",
+                    "email": "jeremy@derusse.com"
+                }
+            ],
+            "description": "Symfony Lock Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cas",
+                "flock",
+                "locking",
+                "mutex",
+                "redlock",
+                "semaphore"
+            ],
+            "time": "2019-01-01T17:35:40+00:00"
         },
         {
             "name": "symfony/options-resolver",


### PR DESCRIPTION
This PR uses the Lock Symfony component to protect the Propel schema generation from concurrent requests.