### PR TITLE
Disabled output compression when generating site map

### DIFF
--- a/local/modules/Front/Controller/SitemapController.php
+++ b/local/modules/Front/Controller/SitemapController.php
@@ -80,22 +80,24 @@ class SitemapController extends BaseFrontController {
         $cacheExpire = intval(ConfigQuery::read("sitemap_ttl", '7200')) ?: 7200;
 
         $cacheDriver = new FilesystemCache($cacheDir);
-        if (!($this->checkAdmin() && "" !== $flush)){
+        if (!($this->checkAdmin() && "" !== $flush)) {
             $cacheContent = $cacheDriver->fetch($cacheKey);
         } else {
             $cacheDriver->delete($cacheKey);
         }
 
         // if not in cache
-        if (false === $cacheContent){
-            // render the view
-            $cacheContent = $this->renderRaw(
-                "sitemap",
-                array(
+        if (false === $cacheContent) {
+            // Render the view. Compression causes problems and is deactivated.
+            $cacheContent = $this->getParser(null)->render(
+                'sitemap.html',
+                [
                     "_lang_" => $lang,
                     "_context_" => $context
-                )
+                ],
+                false
             );
+
             // save cache
             $cacheDriver->save($cacheKey, $cacheContent, $cacheExpire);
         }
@@ -128,7 +130,7 @@ class SitemapController extends BaseFrontController {
      * @return bool
      */
     protected function checkAdmin(){
-       return $this->getSecurityContext()->hasAdminUser();
+        return $this->getSecurityContext()->hasAdminUser();
     }
 
 
@@ -147,4 +149,4 @@ class SitemapController extends BaseFrontController {
         return (null !== $lang);
     }
 
-} 
+}


### PR DESCRIPTION
With larges sitemaps (3000 + products) output compression may cause a blank result.

This PR disable output compression for sitemap generation.