### PR TITLE
Autoriser le slash à la fin de URI

### DIFF
--- a/core/lib/Thelia/Core/HttpFoundation/Request.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Request.php
@@ -63,7 +63,7 @@ class Request extends BaseRequest
         $pathLength = strlen($pathInfo);
 
         if ($pathInfo !== '/' && $pathInfo[$pathLength - 1] === '/'
-            && (bool) ConfigQuery::read('allow_slash_ended_uri', false)
+            && !(bool) ConfigQuery::read('allow_slash_ended_uri', false)
         ) {
             if (null === $this->resolvedPathInfo) {
                 $this->resolvedPathInfo = substr($pathInfo, 0, $pathLength - 1); // Remove the slash


### PR DESCRIPTION
Bonjour, 
si les url catégories se finissent par un slash, alors les filtres et la pagination ne fonctionne pas puisque ça essaie d'aller sur une url sans le slash à la fin. 
Soit dans "Paramètres de configuration" je dois mettre la variable "allow_slash_ended_uri" à 0 pour garder le slash mais je ne trouve pas ça logique (puisqu'il faut normalement mettre 1 pour autoriser à avoir le slash à la fin) soit il faut modifier la condition qui vérifie cette variable.