### PR TITLE
Remove Tlog in Propel init

### DIFF
--- a/core/lib/Thelia/Core/PropelInitService.php
+++ b/core/lib/Thelia/Core/PropelInitService.php
@@ -389,8 +389,6 @@ class PropelInitService
                 $theliaDatabaseConnection->useDebug(true);
             }
         } catch (\Throwable $th) {
-            Tlog::getInstance()->error("Failed to initialize Propel : " . $th->getMessage());
-
             throw $th;
         } finally {
             // Release cache generation lock

--- a/core/lib/Thelia/Core/PropelInitService.php
+++ b/core/lib/Thelia/Core/PropelInitService.php
@@ -389,6 +389,9 @@ class PropelInitService
                 $theliaDatabaseConnection->useDebug(true);
             }
         } catch (\Throwable $th) {
+            $fs = new Filesystem();
+            $fs->remove(THELIA_CACHE_DIR . $this->environment);
+            $fs->remove($this->getPropelModelDir());
             throw $th;
         } finally {
             // Release cache generation lock


### PR DESCRIPTION
Can't use Tlog here because if Propel fail to init the ConfigQuery class is not generated.
And Tlog need ConfigQuery to be initialized.