### PR TITLE
Fix #2592 Add Delivery address in order loop search in

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -150,9 +150,17 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                     $search->filterByOrderAddressRelatedByInvoiceOrderAddressId(
                         OrderAddressQuery::create()->filterByFirstname($searchTerm, $searchCriteria)->find()
                     );
+                    $search->_or();
+                    $search->filterByOrderAddressRelatedByDeliveryOrderAddressId(
+                        OrderAddressQuery::create()->filterByFirstname($searchTerm, $searchCriteria)->find()
+                    );
                     break;
                 case 'customer_lastname':
                     $search->filterByOrderAddressRelatedByInvoiceOrderAddressId(
+                        OrderAddressQuery::create()->filterByLastname($searchTerm, $searchCriteria)->find()
+                    );
+                    $search->_or();
+                    $search->filterByOrderAddressRelatedByDeliveryOrderAddressId(
                         OrderAddressQuery::create()->filterByLastname($searchTerm, $searchCriteria)->find()
                     );
                     break;


### PR DESCRIPTION
When you use search_in in order loop for search by customer firstname or lastname, it search only with invoice address, this PR add delivery address in search.