### PR TITLE
A 'change.pse' event is triggered on PSE value change

### DIFF
--- a/templates/frontOffice/default/assets/src/js/thelia.js
+++ b/templates/frontOffice/default/assets/src/js/thelia.js
@@ -122,7 +122,7 @@ var pseManager = (function($){
         if (undefined !== pse) {
             if ($pse.useFallback) {
                 $pse.fallbak.val(pse.id);
-            } else if (undefined !== pse) {
+            } else {
                 for (var i = 0; i < pse.combinations.length; i++) {
                     combinationValueId = pse.combinations[i];
                     $pse['options'][PSE_COMBINATIONS_VALUE[combinationValueId][1]].val(pse.combinations[i]) // jshint ignore:line
@@ -154,7 +154,8 @@ var pseManager = (function($){
                 }
             }
 
-            $pse.id.val(pseId);
+            // Trigger a change event to give the modules a change to detect PSE ID change.
+            $pse.id.val(pseId).trigger('change.pse', pseId);
             $pse.pseId = pseId;
         }
 


### PR DESCRIPTION
To allow module's JS too be notified of a PSE value change, the 'change.pse' event is now triggered, allowing something like : 

```
<script>
$(function() {
   $('#pse-id').on('change.pse', function(event, pseId) {
        alert('pse id is now ' + pseId);
    });
});
</script>
```