### PR TITLE
Fix Tlog on reponse when ConfigQuery is not generated on cache

### DIFF
--- a/core/lib/Thelia/Core/HttpFoundation/Response.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Response.php
@@ -33,6 +33,7 @@ class Response extends BaseResponse
      */
     public function sendContent()
     {
+	//ConfigQuery can be not already generated in cache so we must check it
         if (class_exists('ConfigQuery')) {
             Tlog::getInstance()->write($this->content);
         }

--- a/core/lib/Thelia/Core/HttpFoundation/Response.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Response.php
@@ -14,6 +14,8 @@ namespace Thelia\Core\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 use Thelia\Log\Tlog;
+use Thelia\Model\ConfigQuery;
+
 
 /**
  * extends Thelia\Core\HttpFoundation\Response for adding some helpers
@@ -31,7 +33,9 @@ class Response extends BaseResponse
      */
     public function sendContent()
     {
-        Tlog::getInstance()->write($this->content);
+        if (class_exists('ConfigQuery')) {
+            Tlog::getInstance()->write($this->content);
+        }
 
         parent::sendContent();
     }


### PR DESCRIPTION
There is an error when trying to sendContent from Response but ConfigQuery Model is not generated in cache this is due to Tlog. 
For example on index_dev.php when your IP is not in the list you got a 500 instead of 403.

This PR check if ConfigQuery exist before doing Tlog.