### PR TITLE
Fix I18n when strictly mode is enable and only one I18n is present

### DIFF
--- a/core/lib/Thelia/Model/Tools/ModelCriteriaTools.php
+++ b/core/lib/Thelia/Model/Tools/ModelCriteriaTools.php
@@ -73,30 +73,10 @@ class ModelCriteriaTools
                 );
                 $requestedLocaleJoin->setJoinType($forceReturn === false ? Criteria::INNER_JOIN : Criteria::LEFT_JOIN);
 
-                $defaultLocaleJoin = new Join();
-                $defaultLocaleJoin->addExplicitCondition(
-                    $localeAlias,
-                    $foreignKey,
-                    null,
-                    $foreignTable . '_i18n',
-                    'ID',
-                    $defaultLocaleI18nAlias
-                );
-
                 $search->addJoinObject($requestedLocaleJoin, $requestedLocaleI18nAlias)
                     ->addJoinCondition(
                         $requestedLocaleI18nAlias,
                         '`' . $requestedLocaleI18nAlias . '`.LOCALE = ?',
-                        $requestedLocale,
-                        null,
-                        \PDO::PARAM_STR
-                    )
-                ;
-
-                $search->addJoinObject($defaultLocaleJoin, $defaultLocaleI18nAlias)
-                    ->addJoinCondition(
-                        $defaultLocaleI18nAlias,
-                        '`' . $defaultLocaleI18nAlias . '`.LOCALE <> ?',
                         $requestedLocale,
                         null,
                         \PDO::PARAM_STR


### PR DESCRIPTION
This fix the issue #2678 by removing a non-sense join in propel query