### PR TITLE
Fix tax rule collection query build when a state ID is passed to getTaxCalculatorCollection()

### DIFF
--- a/core/lib/Thelia/Model/TaxRuleQuery.php
+++ b/core/lib/Thelia/Model/TaxRuleQuery.php
@@ -24,9 +24,10 @@ class TaxRuleQuery extends BaseTaxRuleQuery
 
     /**
      * @param TaxRule $taxRule
-     * @param Country $country
-     *
-     * @return array|mixed|\Propel\Runtime\Collection\ObjectCollection
+     * @param Country|null $country
+     * @param State|null $state
+     * @return array|mixed|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|\Propel\Runtime\Collection\ObjectCollection|Tax[]
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function getTaxCalculatorCollection(TaxRule $taxRule, Country $country = null, State $state = null)
     {
@@ -48,16 +49,17 @@ class TaxRuleQuery extends BaseTaxRuleQuery
             $taxRuleQuery->filterByCountry($country, Criteria::EQUAL);
         }
 
+        $synthetizedSateId = $state;
+
         if (null !== $state) {
             $taxRuleCount = clone $taxRuleQuery;
 
-            $taxRuleCount->filterByStateId($state->getId(), Criteria::EQUAL)
-                ->count();
-
-            if (0 === $taxRuleCount) {
-                $taxRuleQuery->filterByStateId(null, Criteria::EQUAL);
+            if (0 === $taxRuleCount->filterByStateId($state->getId(), Criteria::EQUAL)->count()) {
+                $synthetizedSateId = null;
             }
         }
+
+        $taxRuleQuery->filterByStateId($synthetizedSateId, Criteria::EQUAL);
 
         $search = TaxQuery::create()
             ->filterByTaxRuleCountry($taxRuleQuery->find())


### PR DESCRIPTION
When a state ID is provided to the getTaxCalculatorCollection() method, the builded query was wrong, leading to applying a tax multiple times, or not applying a tax at all.