### PR TITLE
An empty cart is not a virtual cart

### DIFF
--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -202,6 +202,7 @@ class Cart extends BaseCart
      * Tell if the cart contains only virtual products
      *
      * @return bool
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function isVirtual()
     {
@@ -211,11 +212,13 @@ class Cart extends BaseCart
             }
 
             $product = $cartItem->getProductSaleElements()->getProduct();
-            if (!$product->getVirtual()) {
+
+            if (! $product->getVirtual()) {
                 return false;
             }
         }
 
-        return true;
+        // An empty cart is not virtual.
+        return $this->getCartItems()->count() > 0;
     }
 }


### PR DESCRIPTION
This PR fixes a problem with Cart::isVirtual() method, which returns `true` when a cart is empty. It shoud return `false` as an eppty cart is not virtual. It is just empty.