### PR TITLE
Added apply_customer_discount_on_promo_prices config variable

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -21,6 +21,7 @@ use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Exception\TaxEngineException;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\Currency as CurrencyModel;
 use Thelia\Model\CurrencyQuery;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
@@ -260,12 +261,14 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
                 $taxedPrice = null;
             }
 
-            $promoPrice = $PSEValue->getPromoPrice('price_PROMO_PRICE', $discount);
+            $promoDiscount = ConfigQuery::getApplyCustomerDiscountOnPromoPrices() ? $discount : 0;
+
+            $promoPrice = $PSEValue->getPromoPrice('price_PROMO_PRICE', $promoDiscount);
             try {
                 $taxedPromoPrice = $PSEValue->getTaxedPromoPrice(
                     $taxCountry,
                     'price_PROMO_PRICE',
-                    $discount
+                    $promoDiscount
                 );
             } catch (TaxEngineException $e) {
                 $taxedPromoPrice = null;

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -326,5 +326,15 @@ class ConfigQuery extends BaseConfigQuery
     {
         return self::read("minimum_admin_password_length", 4);
     }
+
+    /**
+     * Return true if customer discount is applicable to promo prices
+     *
+     * @return mixed
+     */
+    public static function getApplyCustomerDiscountOnPromoPrices()
+    {
+        return self::read('apply_customer_discount_on_promo_prices', true);
+    }
 }
 // ConfigQuery

--- a/core/lib/Thelia/Model/ProductSaleElements.php
+++ b/core/lib/Thelia/Model/ProductSaleElements.php
@@ -121,7 +121,9 @@ class ProductSaleElements extends BaseProductSaleElements
 
         if ($discount > 0) {
             $price = $price * (1-($discount/100));
-            $promoPrice = $promoPrice * (1-($discount/100));
+            if (ConfigQuery::getApplyCustomerDiscountOnPromoPrices()) {
+                $promoPrice = $promoPrice * (1 - ($discount / 100));
+            }
         }
 
         $productPriceTools = new ProductPriceTools($price, $promoPrice);

--- a/setup/insert.sql.tpl
+++ b/setup/insert.sql.tpl
@@ -79,8 +79,8 @@ INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, 
 (69, 'customer_email_confirmation', '0', 0, 0, NOW(), NOW()),
 (70, 'number_default_results_per_page.coupon_list', '20', 0, 0, NOW(), NOW()),
 (71, 'cdn.documents-base-url', '', 0, 0, NOW(), NOW()),
-(72, 'cdn.assets-base-url', '', 0, 0, NOW(), NOW())
-
+(72, 'cdn.assets-base-url', '', 0, 0, NOW(), NOW()),
+(73, 'apply_customer_discount_on_promo_prices', '1', 0, 0, NOW(), NOW())
 ;
 
 INSERT INTO `module` (`id`, `code`, `type`, `activate`, `position`, `full_namespace`, `hidden`, `mandatory`, `created_at`, `updated_at`) VALUES
@@ -2016,8 +2016,8 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
     (69, '{$locale}', {intl l='Customer account creation should be confirmed by email (1: yes, 0: no)' locale=$locale}, NULL, NULL, NULL),
     (70, '{$locale}', {intl l='Default number of coupons per page on coupon list' locale=$locale}, NULL, NULL, NULL),
     (71, '{$locale}', {intl l='The URL of the assets CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL),
-    (72, '{$locale}', {intl l='The URL of the images and documents CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},{/if}
-
+    (72, '{$locale}', {intl l='The URL of the images and documents CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL),
+    (73, '{$locale}', {intl l='Set this variable to 1 to avoid cumulating the customer discount with the sale products.' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},{/if}
 {/foreach}
 ;
 

--- a/setup/update/tpl/2.4.0.sql.tpl
+++ b/setup/update/tpl/2.4.0.sql.tpl
@@ -1,0 +1,28 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+UPDATE `config` SET `value`='2.4.0' WHERE `name`='thelia_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_major_version';
+UPDATE `config` SET `value`='4' WHERE `name`='thelia_minus_version';
+UPDATE `config` SET `value`='0' WHERE `name`='thelia_release_version';
+UPDATE `config` SET `value`='' WHERE `name`='thelia_extra_version';
+
+# New configuration variables
+# ---------------------------
+
+SELECT @max_id := IFNULL(MAX(`id`),0) FROM `config`;
+
+INSERT INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
+(@max_id + 1, 'cdn.documents-base-url', '', 0, 0, NOW(), NOW()),
+(@max_id + 2, 'cdn.assets-base-url', '', 0, 0, NOW(), NOW()),
+(@max_id + 3, 'apply_customer_discount_on_promo_prices', '1', 0, 0, NOW(), NOW())
+;
+
+INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `postscriptum`) VALUES
+{foreach $locales as $locale}
+ (@max_id + 1, '{$locale}', {intl l='The URL of the assets CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL),
+ (@max_id + 2, '{$locale}', {intl l='The URL of the images and documents CDN (leave empty is you\'re not using a CDN for assets).' locale=$locale}, NULL, NULL, NULL),
+ (@max_id + 3, '{$locale}', {intl l='Set this variable to 1 to avoid cumulating the customer discount with the sale products.' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},{/if}
+{/foreach}
+;
+
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
This PR intriduces a new configuration variable `apply_customer_discount_on_promo_prices`. If this variable is 1 (the default), customer discount, if any, is used to calculate the promo price of the products.

If this variable is 0, the customer discount is not used, and the product promo price is unchanged.