### PR TITLE
Fix Url are not rewritten if no locale in url

### DIFF
--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -347,6 +347,10 @@ class URL
             // fallback for old parameter
             $viewLocale = $request->query->get('locale', null);
         }
+        if (null === $viewLocale) {
+            // fallback to session or default language
+            $viewLocale = $request->getSession()->getLang()->getLocale();
+        }
 
         return $viewLocale;
     }


### PR DESCRIPTION
In view url like `?view=category&category_id=1`   if we have no `locale` or `lang` parameter the url is not rewritten even if we have an url in DB.
This PR get current session lang to search url if we don't have a "language" parameter.