### PR TITLE
Fix model generation at module activation

### DIFF
--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -161,7 +161,7 @@ class Thelia extends Kernel
         );
 
         $cacheRefresh = false;
-        $propelConnectionAvailable = $propelInitService->init(false, $cacheRefresh);
+        $propelConnectionAvailable = $this->initializePropelService(false, $cacheRefresh);
 
         if ($propelConnectionAvailable) {
             $theliaDatabaseConnection = Propel::getConnection('thelia');
@@ -185,6 +185,34 @@ class Thelia extends Kernel
         if (self::isInstalled()) {
             $this->getContainer()->get('event_dispatcher')->dispatch(TheliaEvents::BOOT);
         }
+    }
+
+    /**
+     * @param $forcePropelCacheGeneration
+     * @param $cacheRefresh
+     * @return bool
+     * @throws \Throwable
+     */
+    public function initializePropelService($forcePropelCacheGeneration, &$cacheRefresh)
+    {
+        $cacheRefresh = false;
+
+        // initialize Propel, building its cache if necessary
+        $propelSchemaLocator = new SchemaLocator(
+            THELIA_CONF_DIR,
+            THELIA_MODULE_DIR
+        );
+
+        $propelInitService = new PropelInitService(
+            $this->getEnvironment(),
+            $this->isDebug(),
+            $this->getEnvParameters(),
+            $propelSchemaLocator
+        );
+
+        $cacheRefresh = false;
+
+        return $propelInitService->init($forcePropelCacheGeneration, $cacheRefresh);
     }
 
     /**

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -160,7 +160,6 @@ class Thelia extends Kernel
             $propelSchemaLocator
         );
 
-        $cacheRefresh = false;
         $propelConnectionAvailable = $this->initializePropelService(false, $cacheRefresh);
 
         if ($propelConnectionAvailable) {
@@ -209,8 +208,6 @@ class Thelia extends Kernel
             $this->getEnvParameters(),
             $propelSchemaLocator
         );
-
-        $cacheRefresh = false;
 
         return $propelInitService->init($forcePropelCacheGeneration, $cacheRefresh);
     }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -22,8 +22,6 @@ use Thelia\Core\Event\Hook\HookCreateAllEvent;
 use Thelia\Core\Event\Hook\HookUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Session\Session;
-use Thelia\Core\Propel\Schema\SchemaLocator;
-use Thelia\Core\PropelInitService;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Thelia;
 use Thelia\Core\Translation\Translator;

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -22,7 +22,10 @@ use Thelia\Core\Event\Hook\HookCreateAllEvent;
 use Thelia\Core\Event\Hook\HookUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\Propel\Schema\SchemaLocator;
+use Thelia\Core\PropelInitService;
 use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Thelia;
 use Thelia\Core\Translation\Translator;
 use Thelia\Exception\ModuleException;
 use Thelia\Log\Tlog;
@@ -70,15 +73,28 @@ class BaseModule implements BaseModuleInterface
     // Do no use this attribute directly, use getModuleModel() instead.
     private $moduleModel = null;
 
+    /**
+     * @param Module $moduleModel
+     * @throws \Propel\Runtime\Exception\PropelException
+     * @throws \Throwable
+     */
     public function activate($moduleModel = null)
     {
         if (null === $moduleModel) {
             $moduleModel = $this->getModuleModel();
         }
 
-        if ($moduleModel->getActivate() == self::IS_NOT_ACTIVATED) {
+        if ($moduleModel->getActivate() === self::IS_NOT_ACTIVATED) {
             $moduleModel->setActivate(self::IS_ACTIVATED);
             $moduleModel->save();
+
+            // Refresh propel cache to be sure that module's model is created
+            // when the module's initialization methods will be called.
+
+            /** @var Thelia $theliaKernel */
+            $theliaKernel = $this->container->get('kernel');
+
+            $theliaKernel->initializePropelService(true, $cacheRefresh);
 
             $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
             $con->beginTransaction();

--- a/tests/phpunit/Thelia/Tests/ContainerAwareTestCase.php
+++ b/tests/phpunit/Thelia/Tests/ContainerAwareTestCase.php
@@ -65,6 +65,8 @@ abstract class ContainerAwareTestCase extends \PHPUnit_Framework_TestCase
 
         $container->set("request_stack", $requestStack);
 
+        $container->set("kernel", $this->getKernel());
+
         new Translator($container);
         $container->set("thelia.securitycontext", new SecurityContext($requestStack));
 
@@ -113,7 +115,13 @@ abstract class ContainerAwareTestCase extends \PHPUnit_Framework_TestCase
      */
     public function getKernel()
     {
-        $kernel = $this->createMock("Symfony\Component\HttpKernel\KernelInterface");
+        $kernel = $this->createMock("\Thelia\Core\Thelia");
+
+        // Stub propel initialization service
+        $kernel
+            ->expects($this->any())
+            ->method('initializePropelService')
+        ;
 
         return $kernel;
     }


### PR DESCRIPTION
This PR fixes a problem when a module is activated: the `postActivation()` or `preActivation()` methods may use the module's model classes, for example to check if module schema exists in the database. But when these methods are called, the propel cache has not been generated, and the model Base and Map classes don't exist yet in the Propel cache.

A propel cache generation is now forced after the module activation state has been saved in the database, but before calls to `postActivation()` or `preActivation()`

