### PR TITLE
Fix total prices and taxes in order edit page

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/OrderProduct.php
+++ b/core/lib/Thelia/Core/Template/Loop/OrderProduct.php
@@ -120,28 +120,31 @@ class OrderProduct extends BaseLoop implements PropelSearchLoopInterface
             $tax = $orderProduct->getVirtualColumn('TOTAL_TAX');
             $promoTax = $orderProduct->getVirtualColumn('TOTAL_PROMO_TAX');
 
-            $totalTax = round($tax * $orderProduct->getQuantity(), 2);
-            $totalPromoTax = round($promoTax * $orderProduct->getQuantity(), 2);
-
             // To prevent price changes in pre-2.4 orders, use the legacy calculation method
             if ($orderProduct->getOrderId() <= $lastLegacyRoundingOrderId) {
+                $totalTax = round($tax * $orderProduct->getQuantity(), 2);
+                $totalPromoTax = round($promoTax * $orderProduct->getQuantity(), 2);
+
                 $taxedPrice = $orderProduct->getPrice() + $orderProduct->getVirtualColumn('TOTAL_TAX');
                 $taxedPromoPrice = $orderProduct->getPromoPrice() + $orderProduct->getVirtualColumn('TOTAL_PROMO_TAX');
 
-                $totalPrice = $orderProduct->getPrice()*$orderProduct->getQuantity();
-                $totalPromoPrice = $orderProduct->getPromoPrice()*$orderProduct->getQuantity();
+                $totalPrice = $orderProduct->getPrice() * $orderProduct->getQuantity();
+                $totalPromoPrice = $orderProduct->getPromoPrice() * $orderProduct->getQuantity();
             } else {
+                $totalTax = round($tax, 2) * $orderProduct->getQuantity();
+                $totalPromoTax = round($promoTax, 2) * $orderProduct->getQuantity();
+
                 $taxedPrice = $orderProduct->getPrice() + $tax;
                 $taxedPromoPrice = $orderProduct->getPromoPrice() + $promoTax;
 
                 // Price calculation should use the same rounding method as in CartItem::getTotalTaxedPromoPrice()
                 // For each order line, we first round the taxed price, then we multiply by the quantity.
-                $totalPrice = round($orderProduct->getPrice() * $orderProduct->getQuantity(), 2);
-                $totalPromoPrice = round($orderProduct->getPromoPrice() * $orderProduct->getQuantity(), 2);
+                $totalPrice = round($orderProduct->getPrice(), 2) * $orderProduct->getQuantity();
+                $totalPromoPrice = round($orderProduct->getPromoPrice(), 2) * $orderProduct->getQuantity();
             }
 
-            $totalTaxedPrice = round($taxedPrice * $orderProduct->getQuantity(), 2);
-            $totalTaxedPromoPrice = round($taxedPromoPrice * $orderProduct->getQuantity(), 2);
+            $totalTaxedPrice = round($taxedPrice, 2) * $orderProduct->getQuantity();
+            $totalTaxedPromoPrice = round($taxedPromoPrice, 2) * $orderProduct->getQuantity();
 
             $loopResultRow->set('ID', $orderProduct->getId())
                 ->set('REF', $orderProduct->getProductRef())

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -166,9 +166,9 @@ class Order extends BaseOrder
             $query = '
                 SELECT 
                     SUM(
+                        '.OrderProductTableMap::COL_QUANTITY.'
+                        *
                         ROUND(
-                            '.OrderProductTableMap::COL_QUANTITY.'
-                            *
                             ( 
                                 IF('.OrderProductTableMap::COL_WAS_IN_PROMO.'=1, '.OrderProductTableMap::COL_PROMO_PRICE.', '.OrderProductTableMap::COL_PRICE.')
                                 +
@@ -181,9 +181,9 @@ class Order extends BaseOrder
                         )
                     ) as total_taxed_price,
                     SUM(
+                        '.OrderProductTableMap::COL_QUANTITY.'
+                        *
                         ROUND(
-                            '.OrderProductTableMap::COL_QUANTITY.'
-                            *
                             IF(
                                 '.OrderProductTableMap::COL_WAS_IN_PROMO.'=1,
                                 '.OrderProductTableMap::COL_PROMO_PRICE.',

--- a/templates/backOffice/default/order-edit.html
+++ b/templates/backOffice/default/order-edit.html
@@ -153,7 +153,7 @@
                                                         {$taxes[{$TAX_RULE_TITLE}] = 0}
                                                     {/if}
 
-                                                    {$taxes[{$TAX_RULE_TITLE}] = $taxes[{$TAX_RULE_TITLE}] + floatval($REAL_PRICE_TAX) * $QUANTITY}
+                                                    {$taxes[{$TAX_RULE_TITLE}] = $taxes[{$TAX_RULE_TITLE}] + ($REAL_PRICE_TAX|round:2) * $QUANTITY}
 
                                                     {hook name="order-edit.before-order-product-row" location="before-order-product-row" order_id=$order_id order_product_id=$ID}
                                                     <tr>


### PR DESCRIPTION
Fixes the item tax total, item total and order total prices.
Error was making the round of sums of single prices. Corrected it by changing it to the sum of rounds of single prices.