### PR TITLE
Fix cart error with virtual products

### DIFF
--- a/local/modules/Front/Controller/CartController.php
+++ b/local/modules/Front/Controller/CartController.php
@@ -230,9 +230,11 @@ class CartController extends BaseFrontController
 
                     $postage = $deliveryPostageEvent->getPostage();
 
-                    $orderEvent->setPostage($postage->getAmount());
-                    $orderEvent->setPostageTax($postage->getAmountTax());
-                    $orderEvent->setPostageTaxRuleTitle($postage->getTaxRuleTitle());
+                    if ( ! is_null($postage = $deliveryPostageEvent->getPostage()))  {
+                        $orderEvent->setPostage($postage->getAmount());
+                        $orderEvent->setPostageTax($postage->getAmountTax());
+                        $orderEvent->setPostageTaxRuleTitle($postage->getTaxRuleTitle());
+                    }
 
                     $this->getDispatcher()->dispatch(TheliaEvents::ORDER_SET_POSTAGE, $orderEvent);
                 } catch (\Exception $ex) {

--- a/local/modules/Front/Controller/CartController.php
+++ b/local/modules/Front/Controller/CartController.php
@@ -230,7 +230,7 @@ class CartController extends BaseFrontController
 
                     $postage = $deliveryPostageEvent->getPostage();
 
-                    if ( ! is_null($postage = $deliveryPostageEvent->getPostage()))  {
+                    if (null !== $postage)  {
                         $orderEvent->setPostage($postage->getAmount());
                         $orderEvent->setPostageTax($postage->getAmountTax());
                         $orderEvent->setPostageTaxRuleTitle($postage->getTaxRuleTitle());


### PR DESCRIPTION
La page panier renvoyait une erreur bloquante lorsqu'un produit virtuel y était présent.