### PR TITLE
Deep cloning of template definition

### DIFF
--- a/local/modules/TheliaSmarty/Template/SmartyParser.php
+++ b/local/modules/TheliaSmarty/Template/SmartyParser.php
@@ -416,7 +416,7 @@ class SmartyParser extends Smarty implements ParserInterface
      */
     public function getTemplateDefinition($webAssetTemplateName = false)
     {
-        // Deep cloen of template definition. We could change the template descriptor of template definition,
+        // Deep clone of template definition. We could change the template descriptor of template definition,
         // and we don't want to change the current template definition.
 
         /** @var TemplateDefinition $ret */

--- a/local/modules/TheliaSmarty/Template/SmartyParser.php
+++ b/local/modules/TheliaSmarty/Template/SmartyParser.php
@@ -416,7 +416,11 @@ class SmartyParser extends Smarty implements ParserInterface
      */
     public function getTemplateDefinition($webAssetTemplateName = false)
     {
-        $ret = clone $this->templateDefinition;
+        // Deep cloen of template definition. We could change the template descriptor of template definition,
+        // and we don't want to change the current template definition.
+
+        /** @var TemplateDefinition $ret */
+        $ret = unserialize(serialize($this->templateDefinition));
 
         if (false !== $webAssetTemplateName) {
             $customPath = str_replace($ret->getName(), $webAssetTemplateName, $ret->getPath());


### PR DESCRIPTION
The template definition, is not deeply cloned, which may cause unexpected side effects on template search when using `template` parameter of `stylesheet`, `javascript` and `image` Smarty functions, like this :

`{stylesheet file='/assets/css/fontawesome/font-awesome.less' filters='less' source='Tinymce' template='my_template'}`