### PR TITLE
Fix csv export for multiline

### DIFF
--- a/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
+++ b/core/lib/Thelia/Core/Serializer/Serializer/CSVSerializer.php
@@ -134,24 +134,31 @@ class CSVSerializer extends AbstractSerializer
 
         clearstatcache(true, $fileObject->getPathname());
     }
-
+    
+    
     public function unserialize(\SplFileObject $fileObject)
     {
         $data = [];
 
-        foreach ($fileObject as $index => $row) {
+        $index = 0;
+        while(null !== $row = $fileObject->fgetcsv($this->delimiter, $this->enclosure)) {
+            $index++;
             if (empty($row)) {
                 continue;
             }
 
-            if ($index === 0) {
-                $this->headers = str_getcsv($row, $this->delimiter, $this->enclosure);
+            if ($index === 1) {
+                $this->headers = $row;
+                continue;
+            }
+
+            if (count($row) !== count($this->headers)) {
                 continue;
             }
 
             $data[] = array_combine(
                 $this->headers,
-                str_getcsv($row, $this->delimiter, $this->enclosure)
+                $row
             );
         }
 


### PR DESCRIPTION
When you want export csv with a content that contains some new line character the serializer with foreach ($fileObject as $index => $row) { will count each lines as row.

With $fileObject->fgetcsv($this->delimiter, $this->enclosure) a row is a csv line and not file line.