### PR TITLE
Fix export end date calculation

### DIFF
--- a/core/lib/Thelia/Handler/ExportHandler.php
+++ b/core/lib/Thelia/Handler/ExportHandler.php
@@ -182,11 +182,13 @@ class ExportHandler
             );
         }
         if ($rangeDate['end'] && !($rangeDate['end'] instanceof \DateTime)) {
+            // Get the the first day of the selected month, and substract 1 day to get the last day of previous month
             $rangeDate['end'] = \DateTime::createFromFormat(
                 'Y-m-d H:i:s',
-                $rangeDate['end']['year'] . '-' . (\intval($rangeDate['end']['month']) + 1) . '-0 23:59:59'
-            );
+                $rangeDate['end']['year'] . '-' . $rangeDate['end']['month'] . '-1 23:59:59'
+            )->sub(new \DateInterval('P1D'));
         }
+
         $instance->setRangeDate($rangeDate);
 
         // Process export

--- a/core/lib/Thelia/Handler/ExportHandler.php
+++ b/core/lib/Thelia/Handler/ExportHandler.php
@@ -182,11 +182,13 @@ class ExportHandler
             );
         }
         if ($rangeDate['end'] && !($rangeDate['end'] instanceof \DateTime)) {
-            // Get the the first day of the selected month, and substract 1 day to get the last day of previous month
+            // To get the last day of selected month, go to the first day of next month and substract 1 day
             $rangeDate['end'] = \DateTime::createFromFormat(
                 'Y-m-d H:i:s',
                 $rangeDate['end']['year'] . '-' . $rangeDate['end']['month'] . '-1 23:59:59'
-            )->sub(new \DateInterval('P1D'));
+            )
+            ->add(new \DateInterval('P1M'))
+            ->sub(new \DateInterval('P1D'));
         }
 
         $instance->setRangeDate($rangeDate);

--- a/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
@@ -161,8 +161,8 @@ class OrderExport extends JsonFileAbstractExport
 
         $stmt = $con->prepare($query);
         $stmt->bindValue('locale', $locale);
-        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d'));
-        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d'));
+        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d H:i:s'));
+        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d H:i:s'));
         $stmt->execute();
 
         $filename = THELIA_CACHE_DIR . '/export/' . 'order.json';


### PR DESCRIPTION
The export end date calculation was wrong, and gave wrong results (e.g. 2021-01-28 instead of 2021-01-31).