### PR TITLE
Update cart.php - restoreCurrentCart

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -343,7 +343,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         if (null === $cart) {
             $cart = $this->dispatchNewCart($dispatcher);
         }
-
+        $this->getSession()->setCurrency($cart->getCurrency());
         $cartRestoreEvent->setCart($cart);
     }
 


### PR DESCRIPTION
Pour que la devise sélectionnée soit reprise en même temps que le panier (quand on arrive sur le site), sinon on a des prix de produit d'une devise anciennement sélectionné mais le site est sur la devise par défaut.