### PR TITLE
FIX conflict between ContactEvent->name and Event->name

### DIFF
--- a/core/lib/Thelia/Core/Event/Contact/ContactEvent.php
+++ b/core/lib/Thelia/Core/Event/Contact/ContactEvent.php
@@ -36,7 +36,7 @@ class ContactEvent extends ActionEvent
     protected $email;
 
     /** @var string */
-    protected $name;
+    protected $fullname;
 
     public function __construct(Form $form)
     {
@@ -45,7 +45,7 @@ class ContactEvent extends ActionEvent
         $this->subject = $form->get('subject')->getData();
         $this->message = $form->get('message')->getData();
         $this->email = $form->get('email')->getData();
-        $this->name = $form->get('name')->getData();
+        $this->fullname = $form->get('fullname')->getData();
     }
 
     /**
@@ -105,18 +105,18 @@ class ContactEvent extends ActionEvent
     /**
      * @return string
      */
-    public function getName()
+    public function getFullname()
     {
-        return $this->name;
+        return $this->fullname;
     }
 
     /**
-     * @param string $name
+     * @param string $fullname
      * @return ContactEvent
      */
-    public function setName($name)
+    public function setFullname($fullname)
     {
-        $this->name = $name;
+        $this->fullname = $fullname;
         return $this;
     }
 

--- a/core/lib/Thelia/Form/ContactForm.php
+++ b/core/lib/Thelia/Form/ContactForm.php
@@ -46,7 +46,7 @@ class ContactForm extends FirewallForm
     protected function buildForm()
     {
         $this->formBuilder
-            ->add('name', 'text', array(
+            ->add('fullname', 'text', array(
                 'constraints' => array(
                     new NotBlank(),
                 ),

--- a/local/modules/Front/Controller/ContactController.php
+++ b/local/modules/Front/Controller/ContactController.php
@@ -44,7 +44,7 @@ class ContactController extends BaseFrontController
     public function sendAction()
     {
         $contactForm = $this->createForm(FrontForm::CONTACT);
-        
+
         try {
             $form = $this->validateForm($contactForm);
 
@@ -53,35 +53,35 @@ class ContactController extends BaseFrontController
             $this->dispatch(TheliaEvents::CONTACT_SUBMIT, $event);
 
             $this->getMailer()->sendSimpleEmailMessage(
-                [ ConfigQuery::getStoreEmail() => $event->getName() ],
+                [ ConfigQuery::getStoreEmail() => $event->getFullname() ],
                 [ ConfigQuery::getStoreEmail() => ConfigQuery::getStoreName() ],
                 $event->getSubject(),
                 '',
                 $event->getMessage(),
                 [],
                 [],
-                [ $event->getEmail() => $event->getName() ]
+                [ $event->getEmail() => $event->getFullname() ]
             );
 
             if ($contactForm->hasSuccessUrl()) {
                 return $this->generateSuccessRedirect($contactForm);
             }
-            
+
             return $this->generateRedirectFromRoute('contact.success');
-            
+
         } catch (FormValidationException $e) {
             $error_message = $e->getMessage();
         }
-        
+
         Tlog::getInstance()->error(sprintf('Error during sending contact mail : %s', $error_message));
-        
+
         $contactForm->setErrorMessage($error_message);
-        
+
         $this->getParserContext()
             ->addForm($contactForm)
             ->setGeneralError($error_message)
         ;
-        
+
         // Redirect to error URL if defined
         if ($contactForm->hasErrorUrl()) {
             return $this->generateErrorRedirect($contactForm);

--- a/templates/frontOffice/default/contact.html
+++ b/templates/frontOffice/default/contact.html
@@ -33,7 +33,7 @@
                     </div>
                     <div class="panel-body">
                         <div class="row">
-                        {form_field field="name"}
+                        {form_field field="fullname"}
                             <div class="form-group group-name col-sm-6{if $error} has-error{/if}">
                                 <label class="control-label" for="{$label_attr.for}">{$label}{if $required} <span class="required">*</span>{/if}</label>
                                 <div class="control-input">


### PR DESCRIPTION
#2829 Changed the name of `ContactForm `field `name `to `fullname `in order to avoid a conflict between the `$name` property of `ContactEvent ` and the `$name` property of its parent `Event`.