### PR TITLE
Enhancement of ContactEvent when ContactForm fields are modified

### DIFF
--- a/core/lib/Thelia/Core/Event/Contact/ContactEvent.php
+++ b/core/lib/Thelia/Core/Event/Contact/ContactEvent.php
@@ -41,11 +41,14 @@ class ContactEvent extends ActionEvent
     public function __construct(Form $form)
     {
         $this->form = $form;
+    }
 
-        $this->subject = $form->get('subject')->getData();
-        $this->message = $form->get('message')->getData();
-        $this->email = $form->get('email')->getData();
-        $this->name = $form->get('name')->getData();
+    /**
+     * @return Form
+     */
+    public function getForm()
+    {
+        return $this->form;
     }
 
     /**

--- a/local/modules/Front/Controller/ContactController.php
+++ b/local/modules/Front/Controller/ContactController.php
@@ -44,11 +44,12 @@ class ContactController extends BaseFrontController
     public function sendAction()
     {
         $contactForm = $this->createForm(FrontForm::CONTACT);
-        
+
         try {
             $form = $this->validateForm($contactForm);
 
             $event = new ContactEvent($form);
+            $event->bindForm($form);
 
             $this->dispatch(TheliaEvents::CONTACT_SUBMIT, $event);
 
@@ -66,22 +67,22 @@ class ContactController extends BaseFrontController
             if ($contactForm->hasSuccessUrl()) {
                 return $this->generateSuccessRedirect($contactForm);
             }
-            
+
             return $this->generateRedirectFromRoute('contact.success');
-            
+
         } catch (FormValidationException $e) {
             $error_message = $e->getMessage();
         }
-        
+
         Tlog::getInstance()->error(sprintf('Error during sending contact mail : %s', $error_message));
-        
+
         $contactForm->setErrorMessage($error_message);
-        
+
         $this->getParserContext()
             ->addForm($contactForm)
             ->setGeneralError($error_message)
         ;
-        
+
         // Redirect to error URL if defined
         if ($contactForm->hasErrorUrl()) {
             return $this->generateErrorRedirect($contactForm);


### PR DESCRIPTION
-  If some of the basic fields (name/email/subject/message) are removed from `ContactForm `(for example with `FORM_AFTER_BUILD `event), prevents php error from `$form->get('name')` in `ContactEvent`
-  If some custom fields are added to `ContactForm `, allows to retrieve data from these fields in `ContactEvent `(which is not possible in the current code)