### PR TITLE
Fix #2877

### DIFF
--- a/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
+++ b/local/modules/TheliaSmarty/Template/Assets/SmartyAssetsResolver.php
@@ -64,6 +64,11 @@ class SmartyAssetsResolver implements AssetResolverInterface
      */
     public function resolveAssetURL($source, $file, $type, ParserInterface $parserInterface, $filters = [], $debug = false, $declaredAssetsDirectory = null, $sourceTemplateName = false)
     {
+        // Shortcut external uri resolving
+        if (preg_match('#^(https?:)?//#', $file)) {
+            return $file;
+        }
+
         $url = '';
 
         // Normalize path separator


### PR DESCRIPTION
This small addition allows SmartyAssetsResolver to resolve external file, allowing addJs, addCss and other methods using assets to load external file through a public CDN.

These file paths will now be allowed:
```
// Secured full uri with SSL
https://cdn.jsdelivr.net/npm/fullcalendar@5.9.0/main.min.js

// Unsecure full uri
https://cdn.jsdelivr.net/npm/fullcalendar@5.9.0/main.min.js

// automatically resolves secure or insecure full uri
//cdn.jsdelivr.net/npm/fullcalendar@5.9.0/main.min.js
```