### PR TITLE
fix: sometimes arguments in loop is not correct  due to static proper…

### DIFF
--- a/core/lib/Thelia/Core/Template/Element/BaseLoop.php
+++ b/core/lib/Thelia/Core/Template/Element/BaseLoop.php
@@ -161,6 +161,12 @@ abstract class BaseLoop implements BaseLoopInterface
         }
 
         $this->args = self::$loopDefinitionsArgs[$class];
+
+        // reset all arguments to default value, as argument list is cached in a static variable and holds
+        // values defined by previous loop usage across loop instances.
+        foreach ($this->args as $arg) {
+            $arg->setValue($arg->default);
+        }
     }
 
     /**


### PR DESCRIPTION
Reset all loop arguments to default value, when creating a new instance argument, argument list is cached in a static variable and holds values defined by previous loop usage across loop instances.