### PR TITLE
Added cross-env for the build to work in Windows

### DIFF
--- a/templates/frontOffice/modern/package.json
+++ b/templates/frontOffice/modern/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "cross-env NODE_ENV=dev encore dev-server --port 8081 --host 0.0.0.0",
-    "build": "NODE_ENV=production encore production"
+    "build": "cross-env NODE_ENV=production encore production"
   },
   "browserslist": {
     "development": [


### PR DESCRIPTION
Without `cross-env`, the build is not working on Windows.