### PR TITLE
Fixed front/back template handling in webpack_encore.yaml

### DIFF
--- a/core/lib/Thelia/Config/Resources/config.xml
+++ b/core/lib/Thelia/Config/Resources/config.xml
@@ -95,7 +95,9 @@
         <service id="Psr\Container\ContainerInterface" alias="service_container"/>
 
         <!-- Thelia template helper -->
-        <service id="thelia.template_helper" class="Thelia\Core\Template\TheliaTemplateHelper" public="true"/>
+        <service id="thelia.template_helper" class="Thelia\Core\Template\TheliaTemplateHelper" public="true">
+          <argument>%kernel.cache_dir%</argument>
+        </service>
 
         <!--  URL maganement -->
         <service id="Thelia\Tools\URL" >

--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -42,9 +42,9 @@ return static function (ContainerConfigurator $configurator): void {
         ->autowire()
         ->autoconfigure();
 
-    foreach (Thelia::getTemplateComponentsDirectories() as $var => $dir) {
-        if (is_dir($dir['resource'])) {
-            $serviceConfigurator->load($dir['namespace'], $dir['resource'])
+    foreach (Thelia::getTemplateComponentsDirectories() as $namespace => $resource) {
+        if (is_dir($resource)) {
+            $serviceConfigurator->load($namespace, $resource)
                 ->autowire()
                 ->autoconfigure();
         }

--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -13,12 +13,13 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Thelia\Core\Service\ConfigCacheService;
+use Thelia\Core\Thelia;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
-return function (ContainerConfigurator $configurator): void {
+return static function (ContainerConfigurator $configurator): void {
     $serviceConfigurator = $configurator->services();
 
     $serviceConfigurator->defaults()
@@ -37,16 +38,16 @@ return function (ContainerConfigurator $configurator): void {
                 THELIA_LIB.'/Command/Skeleton/Module/I18n/*.php',
                 THELIA_LIB.'/Config/**/*.php',
             ]
-        )->autowire()
+        )
+        ->autowire()
         ->autoconfigure();
 
-    if (isset($_SERVER['ACTIVE_ADMIN_TEMPLATE'])) {
-        $serviceConfigurator->load('backOffice\\', THELIA_ROOT.'templates/backOffice'.DS.$_SERVER['ACTIVE_ADMIN_TEMPLATE'].DS.'components')
-            ->autowire()->autoconfigure();
-    }
-    if (isset($_SERVER['ACTIVE_FRONT_TEMPLATE'])) {
-        $serviceConfigurator->load('frontOffice\\', THELIA_ROOT.'templates/frontOffice'.DS.$_SERVER['ACTIVE_FRONT_TEMPLATE'].DS.'components')
-            ->autowire()->autoconfigure();
+    foreach (Thelia::getTemplateComponentsDirectories() as $var => $dir) {
+        if (is_dir($dir['resource'])) {
+            $serviceConfigurator->load($dir['namespace'], $dir['resource'])
+                ->autowire()
+                ->autoconfigure();
+        }
     }
 
     if (ConfigQuery::isSmtpEnable()) {

--- a/core/lib/Thelia/Core/Template/TemplateDefinition.php
+++ b/core/lib/Thelia/Core/Template/TemplateDefinition.php
@@ -29,7 +29,7 @@ class TemplateDefinition
     public const EMAIL_SUBDIR = 'email';
 
     public const FRONT_OFFICE_CONFIG_NAME = 'active-front-template';
-    public const BACK_OFFICE_CONFIG_NAME = 'active-back-template';
+    public const BACK_OFFICE_CONFIG_NAME = 'active-admin-template';
     public const PDF_CONFIG_NAME = 'active-pdf-template';
     public const EMAIL_CONFIG_NAME = 'active-email-template';
 

--- a/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
@@ -163,10 +163,9 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
     /**
      * Clear the cache if the front or admin template is changed in the back-office.
      *
-     * @param ConfigUpdateEvent $event
      * @return void
      */
-    public function clearCache(ConfigUpdateEvent $event, string $eventName, EventDispatcherInterface $dispatcher)
+    public function clearCache(ConfigUpdateEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
     {
         if (
             (null === $config = ConfigQuery::create()->findPk($event->getConfigId()))
@@ -193,5 +192,4 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
             TheliaEvents::CONFIG_SETVALUE => ['clearCache', 130],
         ];
     }
-
 }

--- a/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
@@ -12,10 +12,25 @@
 
 namespace Thelia\Core\Template;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\Cache\CacheEvent;
+use Thelia\Core\Event\Config\ConfigUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\ConfigQuery;
 
-class TheliaTemplateHelper implements TemplateHelperInterface
+class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberInterface
 {
+    protected $kernelCacheDir;
+
+    /**
+     * @param $kernelCacheDir
+     */
+    public function __construct($kernelCacheDir)
+    {
+        $this->kernelCacheDir = $kernelCacheDir;
+    }
+
     /**
      * @return TemplateDefinition
      */
@@ -144,4 +159,39 @@ class TheliaTemplateHelper implements TemplateHelperInterface
 
         return $list;
     }
+
+    /**
+     * Clear the cache if the front or admin template is changed in the back-office.
+     *
+     * @param ConfigUpdateEvent $event
+     * @return void
+     */
+    public function clearCache(ConfigUpdateEvent $event, string $eventName, EventDispatcherInterface $dispatcher)
+    {
+        if (
+            (null === $config = ConfigQuery::create()->findPk($event->getConfigId()))
+            ||
+            ($config->getValue() === $event->getValue())
+            ||
+            ($config->getName() !== TemplateDefinition::BACK_OFFICE_CONFIG_NAME
+             &&
+             $config->getName() !== TemplateDefinition::FRONT_OFFICE_CONFIG_NAME)
+        ) {
+            return;
+        }
+
+        $cacheEvent = new CacheEvent($this->kernelCacheDir);
+        $dispatcher->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            TheliaEvents::CONFIG_SETVALUE => ['clearCache', 130],
+        ];
+    }
+
 }

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -49,6 +49,7 @@ use Thelia\Condition\Implementation\ConditionInterface;
 use Thelia\Controller\ControllerInterface;
 use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\DependencyInjection\Loader\XmlFileLoader;
+use Thelia\Core\DependencyInjection\TheliaContainer;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Hook\BaseHookInterface;
 use Thelia\Core\Propel\Schema\SchemaLocator;
@@ -58,7 +59,6 @@ use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Coupon\Type\CouponInterface;
-use Thelia\Exception\TheliaProcessException;
 use Thelia\Form\FormInterface;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
@@ -66,7 +66,6 @@ use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 use Thelia\Module\ModuleManagement;
 use TheliaSmarty\Template\SmartyParser;
-use Thelia\Core\DependencyInjection\TheliaContainer;
 
 class Thelia extends Kernel
 {
@@ -109,20 +108,14 @@ class Thelia extends Kernel
     public static function getTemplateComponentsDirectories(): array
     {
         return [
-            'ACTIVE_ADMIN_TEMPLATE' => [
-                'namespace' => 'backOffice\\',
-                'resource' => THELIA_TEMPLATE_DIR
-                    .TemplateDefinition::BACK_OFFICE_SUBDIR.DS
-                    .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
-                    .'components'
-            ],
-            'ACTIVE_FRONT_TEMPLATE' => [
-                'namespace' => 'frontOffice\\',
-                'resource' => THELIA_TEMPLATE_DIR
+            'backOffice\\' => THELIA_TEMPLATE_DIR
+                .TemplateDefinition::BACK_OFFICE_SUBDIR.DS
+                .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
+                .'components',
+            'frontOffice\\' => THELIA_TEMPLATE_DIR
                     .TemplateDefinition::FRONT_OFFICE_SUBDIR.DS
                     .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
                     .'components'
-            ]
         ];
     }
 
@@ -559,9 +552,9 @@ class Thelia extends Kernel
             // Register templates 'component' directories in a class loader.
             $templateClassLoader = new ClassLoader();
 
-            foreach (self::getTemplateComponentsDirectories() as $varName => $dir) {
-                if (is_dir($dir['resource'])) {
-                    $templateClassLoader->addPsr4($dir['namespace'], $dir['resource']);
+            foreach (self::getTemplateComponentsDirectories() as $namespace => $resource) {
+                if (is_dir($resource)) {
+                    $templateClassLoader->addPsr4($namespace, $resource);
                 }
             }
 

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -58,6 +58,7 @@ use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Coupon\Type\CouponInterface;
+use Thelia\Exception\TheliaProcessException;
 use Thelia\Form\FormInterface;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
@@ -65,6 +66,7 @@ use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 use Thelia\Module\ModuleManagement;
 use TheliaSmarty\Template\SmartyParser;
+use Thelia\Core\DependencyInjection\TheliaContainer;
 
 class Thelia extends Kernel
 {
@@ -88,13 +90,8 @@ class Thelia extends Kernel
     {
         $loader = new ClassLoader();
 
-        $loader->addPsr4('', THELIA_ROOT."var/cache/{$environment}/propel/model");
-        if (isset($_SERVER['ACTIVE_ADMIN_TEMPLATE'])) {
-            $loader->addPsr4('backOffice\\', THELIA_ROOT."templates/backOffice/{$_SERVER['ACTIVE_ADMIN_TEMPLATE']}/components");
-        }
-        if (isset($_SERVER['ACTIVE_FRONT_TEMPLATE'])) {
-            $loader->addPsr4('frontOffice\\', THELIA_ROOT."templates/frontOffice/{$_SERVER['ACTIVE_FRONT_TEMPLATE']}/components");
-        }
+        $loader->addPsr4('', THELIA_ROOT . "var/cache/{$environment}/propel/model");
+
         $loader->addPsr4('TheliaMain\\', THELIA_ROOT."var/cache/{$environment}/propel/database/TheliaMain");
         $loader->register();
 
@@ -103,6 +100,30 @@ class Thelia extends Kernel
         if ($debug) {
             Debug::enable();
         }
+    }
+
+    /** Get the front and back templates "components" directory path.
+     *
+     * @return array
+     */
+    public static function getTemplateComponentsDirectories(): array
+    {
+        return [
+            'ACTIVE_ADMIN_TEMPLATE' => [
+                'namespace' => 'backOffice\\',
+                'resource' => THELIA_TEMPLATE_DIR
+                    .TemplateDefinition::BACK_OFFICE_SUBDIR.DS
+                    .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
+                    .'components'
+            ],
+            'ACTIVE_FRONT_TEMPLATE' => [
+                'namespace' => 'frontOffice\\',
+                'resource' => THELIA_TEMPLATE_DIR
+                    .TemplateDefinition::FRONT_OFFICE_SUBDIR.DS
+                    .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
+                    .'components'
+            ]
+        ];
     }
 
     /**
@@ -125,6 +146,10 @@ class Thelia extends Kernel
     protected function configureContainer(ContainerConfigurator $container): void
     {
         $container->parameters()->set('thelia_default_template', 'default');
+
+        $container->parameters()->set('thelia_front_template', ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME));
+        $container->parameters()->set('thelia_backoffice_template', ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME));
+
         $container->import(__DIR__.'/../Config/Resources/*.yaml');
         $container->import(__DIR__.'/../Config/Resources/{packages}/*.yaml');
         $container->import(__DIR__.'/../Config/Resources/{packages}/'.$this->environment.'/*.yaml');
@@ -232,7 +257,7 @@ class Thelia extends Kernel
      */
     protected function getContainerBaseClass(): string
     {
-        return '\Thelia\Core\DependencyInjection\TheliaContainer';
+        return TheliaContainer::class;
     }
 
     protected function initializeContainer(): void
@@ -530,6 +555,17 @@ class Thelia extends Kernel
                     );
                 }
             }
+
+            // Register templates 'component' directories in a class loader.
+            $templateClassLoader = new ClassLoader();
+
+            foreach (self::getTemplateComponentsDirectories() as $varName => $dir) {
+                if (is_dir($dir['resource'])) {
+                    $templateClassLoader->addPsr4($dir['namespace'], $dir['resource']);
+                }
+            }
+
+            $templateClassLoader->register();
 
             $parser = $container->getDefinition(SmartyParser::class);
 

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -89,9 +89,9 @@ class Thelia extends Kernel
     {
         $loader = new ClassLoader();
 
-        $loader->addPsr4('', THELIA_ROOT . "var/cache/{$environment}/propel/model");
+        $loader->addPsr4('', THELIA_ROOT."var/cache/{$environment}/propel/model");
 
-        $loader->addPsr4('TheliaMain\\', THELIA_ROOT . "var/cache/{$environment}/propel/database/TheliaMain");
+        $loader->addPsr4('TheliaMain\\', THELIA_ROOT."var/cache/{$environment}/propel/database/TheliaMain");
         $loader->register();
 
         parent::__construct($environment, $debug);
@@ -103,7 +103,6 @@ class Thelia extends Kernel
 
     /** Get the front and back templates "components" directory path.
      *
-     * @return array
      */
     public static function getTemplateComponentsDirectories(): array
     {

--- a/core/lib/Thelia/Core/Thelia.php
+++ b/core/lib/Thelia/Core/Thelia.php
@@ -91,7 +91,7 @@ class Thelia extends Kernel
 
         $loader->addPsr4('', THELIA_ROOT . "var/cache/{$environment}/propel/model");
 
-        $loader->addPsr4('TheliaMain\\', THELIA_ROOT."var/cache/{$environment}/propel/database/TheliaMain");
+        $loader->addPsr4('TheliaMain\\', THELIA_ROOT . "var/cache/{$environment}/propel/database/TheliaMain");
         $loader->register();
 
         parent::__construct($environment, $debug);
@@ -113,9 +113,9 @@ class Thelia extends Kernel
                 .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
                 .'components',
             'frontOffice\\' => THELIA_TEMPLATE_DIR
-                    .TemplateDefinition::FRONT_OFFICE_SUBDIR.DS
-                    .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
-                    .'components'
+                .TemplateDefinition::FRONT_OFFICE_SUBDIR.DS
+                .ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default').DS
+                .'components',
         ];
     }
 


### PR DESCRIPTION
The front template could only be defined in a `.env` file (not in the BO) because `config/packages/webpack_encore.yaml` uses only `ACTIVE_FRONT_TEMPLATE` and `ACTIVE_ADMIN_TEMPLATE` variables.

This PR fixes the problem, by defining two container parameters `thelia_front_template` and `thelia_backoffice_template`, that are now used in `config/packages/webpack_encore.yaml`  instead of the variables defined in `.env` files.

Additionally, the PR fixes the autoloading of classes defined in `components` directories of the back and front templates, where only `ACTIVE_FRONT_TEMPLATE` and `ACTIVE_ADMIN_TEMPLATE` variables were used, just as explained above.