### PR TITLE
Remove default debug log on propel init

### DIFF
--- a/core/lib/Thelia/Core/PropelInitService.php
+++ b/core/lib/Thelia/Core/PropelInitService.php
@@ -413,9 +413,6 @@ class PropelInitService
             $theliaDatabaseConnection->setAttribute(ConnectionWrapper::PROPEL_ATTR_CACHE_PREPARES, true);
 
             if ($this->debug) {
-                // In debug mode, we have to initialize Tlog at this point, as this class uses Propel
-                Tlog::getInstance()->setLevel(Tlog::DEBUG);
-
                 Propel::getServiceContainer()->setLogger('defaultLogger', Tlog::getInstance());
                 $theliaDatabaseConnection->useDebug(true);
             }

--- a/core/lib/Thelia/Log/Tlog.php
+++ b/core/lib/Thelia/Log/Tlog.php
@@ -75,7 +75,7 @@ class Tlog implements LoggerInterface
     protected $destinations = [];
 
     protected $mode_back_office = false;
-    protected $level = self::MUET;
+    protected $level = self::ERROR;
     protected $prefix = '';
     protected $files = [];
     protected $all_files = false;


### PR DESCRIPTION
When on debug model, propel force Tlog to be on debug level but this cause a lot of logs, and it becomes unreadable.
This PR stop forcing debug level and let the user choose it by config.