### PR TITLE
Fix for modules without configuration page that appear with a configuration page in the modules list

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -342,7 +342,7 @@ class Module extends BaseI18nLoop implements PropelSearchLoopInterface
         }
 
         $routing = @file_get_contents($module->getAbsoluteConfigPath().DS.'routing.xml');
-        if ($routing && preg_match('@[\'"]/?admin/module/' . $module->getCode() . '[\'"]@', $routing)) {
+        if ($routing && preg_match('@[\'"]/?admin/module/'.$module->getCode().'[\'"]@', $routing)) {
             return true;
         }
 

--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -342,7 +342,7 @@ class Module extends BaseI18nLoop implements PropelSearchLoopInterface
         }
 
         $routing = @file_get_contents($module->getAbsoluteConfigPath().DS.'routing.xml');
-        if ($routing && strpos($routing, '/admin/module/'.$module->getCode()) !== false) {
+        if ($routing && preg_match('@[\'"]/?admin/module/' . $module->getCode() . '[\'"]@', $routing)) {
             return true;
         }
 


### PR DESCRIPTION
This PR solves a problem where a module without configuration page appears with a configuration page in the modules list. This is caused by a regex that is not discriminating enough on the rooting in the moduleHasConfigurationInterface method of Module.php.
Indeed, if a module had some files whose path BEGAN with "/admin/module/{CODE}", it was recognized as configurable.
From now on, the file must have EXACTLY this path to be considered as being configurable.