### PR TITLE
Harmonization of superglobals

### DIFF
--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -80,7 +80,7 @@ return static function (ContainerConfigurator $configurator): void {
                 \call_user_func([$module->getFullNamespace(), 'configureContainer'], $configurator);
                 \call_user_func([$module->getFullNamespace(), 'configureServices'], $serviceConfigurator);
             } catch (\Exception $e) {
-                if ($_ENV['APP_DEBUG']) {
+                if ($_SERVER['APP_DEBUG']) {
                     throw $e;
                 }
                 Tlog::getInstance()->addError(

--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -342,7 +342,7 @@ class Module extends BaseI18nLoop implements PropelSearchLoopInterface
         }
 
         $routing = @file_get_contents($module->getAbsoluteConfigPath().DS.'routing.xml');
-        if ($routing && preg_match('@[\'"]/?admin/module/' . $module->getCode() . '[\'"]@', $routing)) {
+        if ($routing && preg_match('@[\'"]/?admin/module/'.$module->getCode().'[\'"]@', $routing)) {
             return true;
         }
 

--- a/core/lib/Thelia/Core/Template/Loop/Module.php
+++ b/core/lib/Thelia/Core/Template/Loop/Module.php
@@ -342,7 +342,7 @@ class Module extends BaseI18nLoop implements PropelSearchLoopInterface
         }
 
         $routing = @file_get_contents($module->getAbsoluteConfigPath().DS.'routing.xml');
-        if ($routing && strpos($routing, '/admin/module/'.$module->getCode()) !== false) {
+        if ($routing && preg_match('@[\'"]/?admin/module/' . $module->getCode() . '[\'"]@', $routing)) {
             return true;
         }
 


### PR DESCRIPTION
This PR solves a malfunction due to a non-harmonization of the superglobals $_ENV and $_SERVER in the services.php file. They are now defined in $_SERVER.