### PR TITLE
Superglobals harmonization in services.php

### DIFF
--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -80,7 +80,7 @@ return static function (ContainerConfigurator $configurator): void {
                 \call_user_func([$module->getFullNamespace(), 'configureContainer'], $configurator);
                 \call_user_func([$module->getFullNamespace(), 'configureServices'], $serviceConfigurator);
             } catch (\Exception $e) {
-                if ($_ENV['APP_DEBUG']) {
+                if ($_SERVER['APP_DEBUG']) {
                     throw $e;
                 }
                 Tlog::getInstance()->addError(


### PR DESCRIPTION
This PR solves a malfunction due to a non-harmonization of the superglobals $_ENV and $_SERVER in the services.php file. They are now defined in $_SERVER.