### PR TITLE
DockerFile: Php image changed to php:8.2-fpm-alpine

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.2-fpm-alpine
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Composer


### PR DESCRIPTION
Après utilisation de la commande "composer create-project thelia/thelia-project YourProject 2.5.3", j'ai souhaité lancer un projet thelia avec docker. 

Dans le DockerFile, l'image PHP est actuellement php:8.1-fpm-alpine. Hors, pour thelia 2.5 la documentation indique une compatibilité avec Php8.2 : 
![thelia25 comp php82](https://github.com/thelia/thelia/assets/98172410/7b2effbc-8144-4953-859c-6be9db16e570)

Je soumets donc un équivalent d'image PHP prenant en compte la version 8.2.