### PR TITLE
fix: change default tttl for apache mod_expires

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -40,17 +40,17 @@ AddDefaultCharset UTF-8
 
 <IfModule mod_expires.c>
   ExpiresActive on
-  ExpiresByType image/gif "access plus 1 month"
-  ExpiresByType image/jpeg "access plus 1 month"
-  ExpiresByType image/png "access plus 1 month"
-  ExpiresByType image/x-icon "access plus 1 month"
-  ExpiresByType application/x-javascript "access plus 1 month"
-  ExpiresByType application/javascript "access plus 1 month"
-  ExpiresByType image/webp "access plus 1 month"
-  ExpiresByType image/svg+xml "access plus 1 month"
-  ExpiresByType text/css "access plus 1 month"
+  ExpiresByType image/gif "access plus 1 year"
+  ExpiresByType image/jpeg "access plus 1 year"
+  ExpiresByType image/png "access plus 1 year"
+  ExpiresByType image/x-icon "access plus 1 year"
+  ExpiresByType application/x-javascript "access plus 1 year"
+  ExpiresByType application/javascript "access plus 1 year"
+  ExpiresByType image/webp "access plus 1 year"
+  ExpiresByType image/svg+xml "access plus 1 year"
+  ExpiresByType text/css "access plus 1 year"
   <FilesMatch "\.(ttf|otf|eot|svg|woff|woff2)$" >
-    ExpiresDefault "access plus 1 month"
+    ExpiresDefault "access plus 1 year"
   </FilesMatch>
 </IfModule>
 


### PR DESCRIPTION
For assets, Google recommends caching for at least one year.

Source : https://developer.chrome.com/docs/lighthouse/performance/uses-long-cache-ttl?utm_source=lighthouse&utm_medium=devtools&hl=fr