### PR TITLE
Fix a wrong loop instantiation (new + init instread of new)

### DIFF
--- a/core/lib/Thelia/Controller/Admin/ProductController.php
+++ b/core/lib/Thelia/Controller/Admin/ProductController.php
@@ -1820,7 +1820,10 @@ class ProductController extends AbstractSeoCrudController
      */
     protected function createLoopInstance(EventDispatcherInterface $eventDispatcher, $loopClass)
     {
-        return new $loopClass(
+        /** @var Image|Document $instance */
+        $instance = new $loopClass();
+
+        $instance->init(
             $this->container,
             $this->container->get('request_stack'),
             $eventDispatcher,
@@ -1829,6 +1832,8 @@ class ProductController extends AbstractSeoCrudController
             $this->container->getParameter('Thelia.parser.loops'),
             $this->container->getParameter('kernel.environment')
         );
+
+        return $instance;
     }
 
     protected function arrayHasEntries(array $data, array $entries)


### PR DESCRIPTION
Loop have no longer a constructor, instead they are using the init() method to initialize internal attributes, since b724e507.

Thus, constructions such as `$a = new ImageLoop(...)` is no longer valid. One's shoud use : 

```
$a = new Image();
$a->init(...)
```