### PR TITLE
Allow to modify PDF filename in TheliaEvents::GENERATE_PDF

### DIFF
--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -102,7 +102,7 @@ abstract class BaseController implements ControllerInterface
                 'Content-type' => 'application/pdf',
                 'Content-Disposition' => sprintf(
                     '%s; filename=%s.pdf',
-                    (bool) $browser === false ? 'attachment' : 'inline',
+                    false === (bool) $browser ? 'attachment' : 'inline',
                     $fileName
                 ),
             ]
@@ -256,9 +256,9 @@ abstract class BaseController implements ControllerInterface
      * @param BaseForm $aBaseForm      the form
      * @param string   $expectedMethod the expected method, POST or GET, or null for any of them
      *
-     * @throws FormValidationException is the form contains error, or the method is not the right one
-     *
      * @return \Symfony\Component\Form\Form Form the symfony form object
+     *
+     * @throws FormValidationException is the form contains error, or the method is not the right one
      */
     protected function validateForm(BaseForm $aBaseForm, $expectedMethod = null)
     {
@@ -308,9 +308,9 @@ abstract class BaseController implements ControllerInterface
         try {
             $pdfEvent = new PdfEvent($html);
 
-			$pdfEvent->setTemplateName($fileName);
-			$pdfEvent->setFilename($order->getRef());
-			$pdfEvent->setObject($order);
+            $pdfEvent->setTemplateName($fileName);
+            $pdfEvent->setFilename($order->getRef());
+            $pdfEvent->setObject($order);
 
             $eventDispatcher->dispatch($pdfEvent, TheliaEvents::GENERATE_PDF);
 
@@ -327,17 +327,11 @@ abstract class BaseController implements ControllerInterface
             );
         }
 
-        throw new TheliaProcessException(
-            $this->getTranslator()->trans(
-                "We're sorry, this PDF invoice is not available at the moment."
-            )
-        );
+        throw new TheliaProcessException($this->getTranslator()->trans("We're sorry, this PDF invoice is not available at the moment."));
     }
 
     /**
      * Search success url in a form if present, in the query string otherwise.
-     *
-     * @param BaseForm $form
      *
      * @return mixed|string|null
      */
@@ -348,8 +342,6 @@ abstract class BaseController implements ControllerInterface
 
     /**
      * Search error url in a form if present, in the query string otherwise.
-     *
-     * @param BaseForm $form
      *
      * @return mixed|string|null
      */
@@ -370,7 +362,7 @@ abstract class BaseController implements ControllerInterface
     {
         $url = null;
 
-        if ($form != null) {
+        if (null != $form) {
             $url = $form->getFormDefinedUrl($parameterName);
         } else {
             $url = $this->container->get('request_stack')->getCurrentRequest()->get($parameterName);
@@ -415,8 +407,6 @@ abstract class BaseController implements ControllerInterface
     /**
      * create an instance of RedirectReponse if a success url is present, return null otherwise.
      *
-     * @param BaseForm $form
-     *
      * @return \Symfony\Component\HttpFoundation\Response|null
      */
     protected function generateSuccessRedirect(BaseForm $form = null)
@@ -430,8 +420,6 @@ abstract class BaseController implements ControllerInterface
 
     /**
      * create an instance of RedirectReponse if a success url is present, return null otherwise.
-     *
-     * @param BaseForm $form
      *
      * @return \Symfony\Component\HttpFoundation\Response|null
      */
@@ -469,13 +457,13 @@ abstract class BaseController implements ControllerInterface
      * @param mixed  $parameters    An array of parameters
      * @param int    $referenceType The type of reference to be generated (one of the constants)
      *
+     * @return string The generated URL
+     *
      * @throws RouteNotFoundException              If the named route doesn't exist
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route
      * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
      *                                             it does not match the requirement
      * @throws \InvalidArgumentException           When the router doesn't exist
-     *
-     * @return string The generated URL
      *
      * @see \Thelia\Controller\BaseController::getRouteFromRouter()
      */
@@ -497,13 +485,13 @@ abstract class BaseController implements ControllerInterface
      * @param mixed  $parameters    An array of parameters
      * @param int    $referenceType The type of reference to be generated (one of the constants)
      *
+     * @return string The generated URL
+     *
      * @throws RouteNotFoundException              If the named route doesn't exist
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route
      * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
      *                                             it does not match the requirement
      * @throws \InvalidArgumentException           When the router doesn't exist
-     *
-     * @return string The generated URL
      */
     protected function getRouteFromRouter(
         $routerName,
@@ -514,7 +502,7 @@ abstract class BaseController implements ControllerInterface
         /** @var Router $router */
         $router = $this->getRouter($routerName);
 
-        if ($router == null) {
+        if (null == $router) {
             throw new \InvalidArgumentException(sprintf("Router '%s' does not exists.", $routerName));
         }
 
@@ -532,9 +520,9 @@ abstract class BaseController implements ControllerInterface
     /**
      * Return a 404 error.
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
      * @return \Thelia\Core\HttpFoundation\Response
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     protected function pageNotFound()
     {

--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -308,10 +308,14 @@ abstract class BaseController implements ControllerInterface
         try {
             $pdfEvent = new PdfEvent($html);
 
+			$pdfEvent->setTemplateName($fileName);
+			$pdfEvent->setFilename($order->getRef());
+			$pdfEvent->setObject($order);
+
             $eventDispatcher->dispatch($pdfEvent, TheliaEvents::GENERATE_PDF);
 
             if ($pdfEvent->hasPdf()) {
-                return $this->pdfResponse($pdfEvent->getPdf(), $order->getRef(), 200, $browser);
+                return $this->pdfResponse($pdfEvent->getPdf(), $pdfEvent->getFileName(), 200, $browser);
             }
         } catch (\Exception $e) {
             Tlog::getInstance()->error(
@@ -333,6 +337,8 @@ abstract class BaseController implements ControllerInterface
     /**
      * Search success url in a form if present, in the query string otherwise.
      *
+     * @param BaseForm $form
+     *
      * @return mixed|string|null
      */
     protected function retrieveSuccessUrl(BaseForm $form = null)
@@ -342,6 +348,8 @@ abstract class BaseController implements ControllerInterface
 
     /**
      * Search error url in a form if present, in the query string otherwise.
+     *
+     * @param BaseForm $form
      *
      * @return mixed|string|null
      */
@@ -407,6 +415,8 @@ abstract class BaseController implements ControllerInterface
     /**
      * create an instance of RedirectReponse if a success url is present, return null otherwise.
      *
+     * @param BaseForm $form
+     *
      * @return \Symfony\Component\HttpFoundation\Response|null
      */
     protected function generateSuccessRedirect(BaseForm $form = null)
@@ -420,6 +430,8 @@ abstract class BaseController implements ControllerInterface
 
     /**
      * create an instance of RedirectReponse if a success url is present, return null otherwise.
+     *
+     * @param BaseForm $form
      *
      * @return \Symfony\Component\HttpFoundation\Response|null
      */

--- a/core/lib/Thelia/Core/Event/PdfEvent.php
+++ b/core/lib/Thelia/Core/Event/PdfEvent.php
@@ -35,17 +35,17 @@ class PdfEvent extends ActionEvent
     protected $object;
 
     /**
-     * @param string $content     html content to transform into pdf
-     * @param string $orientation page orientation, same as TCPDF
-     * @param string $format      The format used for pages, same as TCPDF
-     * @param string $lang        Lang : fr, en, it...
-     * @param bool   $unicode     TRUE means that the input text is unicode (default = true)
-     * @param string $encoding    charset encoding; default is UTF-8
-     * @param array  $marges      Default marges (left, top, right, bottom)
-     * @param string $fontName    Default font name
-     * @param string $fileName    Default file name
-     * @param string $templateName    Default template name
-     * @param string $object    Default object
+     * @param string $content      html content to transform into pdf
+     * @param string $orientation  page orientation, same as TCPDF
+     * @param string $format       The format used for pages, same as TCPDF
+     * @param string $lang         Lang : fr, en, it...
+     * @param bool   $unicode      TRUE means that the input text is unicode (default = true)
+     * @param string $encoding     charset encoding; default is UTF-8
+     * @param array  $marges       Default marges (left, top, right, bottom)
+     * @param string $fontName     Default font name
+     * @param string $fileName     Default file name
+     * @param string $templateName Default template name
+     * @param string $object       Default object
      */
     public function __construct(
         $content,
@@ -217,7 +217,7 @@ class PdfEvent extends ActionEvent
         return $this;
     }
 
-	public function getFileName()
+    public function getFileName()
     {
         return $this->fileName;
     }
@@ -234,7 +234,7 @@ class PdfEvent extends ActionEvent
         return $this;
     }
 
-	public function getTemplateName()
+    public function getTemplateName()
     {
         return $this->templateName;
     }
@@ -251,7 +251,7 @@ class PdfEvent extends ActionEvent
         return $this;
     }
 
-	public function getObject()
+    public function getObject()
     {
         return $this->object;
     }

--- a/core/lib/Thelia/Core/Event/PdfEvent.php
+++ b/core/lib/Thelia/Core/Event/PdfEvent.php
@@ -32,6 +32,7 @@ class PdfEvent extends ActionEvent
     protected $fontName;
     protected $fileName;
     protected $templateName;
+    protected $object;
 
     /**
      * @param string $content     html content to transform into pdf
@@ -44,6 +45,7 @@ class PdfEvent extends ActionEvent
      * @param string $fontName    Default font name
      * @param string $fileName    Default file name
      * @param string $templateName    Default template name
+     * @param string $object    Default object
      */
     public function __construct(
         $content,
@@ -55,7 +57,8 @@ class PdfEvent extends ActionEvent
         array $marges = [0, 0, 0, 0],
         $fontName = 'freesans',
         $fileName = null,
-        $templateName = null
+        $templateName = null,
+        $object = null
     ) {
         $this->content = $content;
         $this->orientation = $orientation;
@@ -67,6 +70,7 @@ class PdfEvent extends ActionEvent
         $this->fontName = $fontName;
         $this->fileName = $fileName;
         $this->templateName = $templateName;
+        $this->object = $object;
     }
 
     /**
@@ -253,7 +257,7 @@ class PdfEvent extends ActionEvent
     }
 
     /**
-     * @param string $templateName
+     * @param string $object
      *
      * @return $this
      */

--- a/core/lib/Thelia/Core/Event/PdfEvent.php
+++ b/core/lib/Thelia/Core/Event/PdfEvent.php
@@ -30,6 +30,8 @@ class PdfEvent extends ActionEvent
     protected $encoding;
     protected $marges;
     protected $fontName;
+    protected $fileName;
+    protected $templateName;
 
     /**
      * @param string $content     html content to transform into pdf
@@ -40,6 +42,8 @@ class PdfEvent extends ActionEvent
      * @param string $encoding    charset encoding; default is UTF-8
      * @param array  $marges      Default marges (left, top, right, bottom)
      * @param string $fontName    Default font name
+     * @param string $fileName    Default file name
+     * @param string $templateName    Default template name
      */
     public function __construct(
         $content,
@@ -49,7 +53,9 @@ class PdfEvent extends ActionEvent
         $unicode = true,
         $encoding = 'UTF-8',
         array $marges = [0, 0, 0, 0],
-        $fontName = 'freesans'
+        $fontName = 'freesans',
+        $fileName = null,
+        $templateName = null
     ) {
         $this->content = $content;
         $this->orientation = $orientation;
@@ -59,6 +65,8 @@ class PdfEvent extends ActionEvent
         $this->encoding = $encoding;
         $this->marges = $marges;
         $this->fontName = $fontName;
+        $this->fileName = $fileName;
+        $this->templateName = $templateName;
     }
 
     /**
@@ -201,6 +209,57 @@ class PdfEvent extends ActionEvent
     public function setFontName($fontName)
     {
         $this->fontName = $fontName;
+
+        return $this;
+    }
+
+	public function getFileName()
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return $this
+     */
+    public function setFileName($fileName)
+    {
+        $this->fileName = $fileName;
+
+        return $this;
+    }
+
+	public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+
+    /**
+     * @param string $templateName
+     *
+     * @return $this
+     */
+    public function setTemplateName($templateName)
+    {
+        $this->templateName = $templateName;
+
+        return $this;
+    }
+
+	public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @param string $templateName
+     *
+     * @return $this
+     */
+    public function setObject($object)
+    {
+        $this->object = $object;
 
         return $this;
     }


### PR DESCRIPTION
Example (after PR), in module with TheliaEvents::GENERATE_PDF => ['generatePdf', XXX], : 
```
public function generatePdf(PdfEvent $event)
	{
		$templateName = $event->getTemplateName();
		$object = $event->getObject();
		if(is_a($object,'Thelia\Model\Order')){
			switch($templateName){
				case "invoice":
					$event->setFileName($object->getInvoiceRef());
				break;
				case "delivery":
					$event->setFileName($object->getDeliveryRef());
				break;
				default :
					//other order pdfs
				break;
			}
		}// not order pdfs
	}
```
