### PR TITLE
Give the possibility to modify the PDF filename

### DIFF
--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -307,6 +307,9 @@ abstract class BaseController implements ControllerInterface
 
         try {
             $pdfEvent = new PdfEvent($html);
+            $pdfEvent->setTemplateName($fileName);
+            $pdfEvent->setFileName($order->getRef());
+            $pdfEvent->setObject($order);
 
             $eventDispatcher->dispatch($pdfEvent, TheliaEvents::GENERATE_PDF);
 

--- a/core/lib/Thelia/Core/Event/PdfEvent.php
+++ b/core/lib/Thelia/Core/Event/PdfEvent.php
@@ -30,6 +30,9 @@ class PdfEvent extends ActionEvent
     protected $encoding;
     protected $marges;
     protected $fontName;
+    protected $templateName;
+    protected $fileName;
+    protected $object;
 
     /**
      * @param string $content     html content to transform into pdf
@@ -40,6 +43,9 @@ class PdfEvent extends ActionEvent
      * @param string $encoding    charset encoding; default is UTF-8
      * @param array  $marges      Default marges (left, top, right, bottom)
      * @param string $fontName    Default font name
+     * @param string $templateName
+     * @param string $fileName
+     * @param string $object
      */
     public function __construct(
         $content,
@@ -49,7 +55,10 @@ class PdfEvent extends ActionEvent
         $unicode = true,
         $encoding = 'UTF-8',
         array $marges = [0, 0, 0, 0],
-        $fontName = 'freesans'
+        $fontName = 'freesans',
+        $templateName = null,
+        $fileName = null,
+        $object = null
     ) {
         $this->content = $content;
         $this->orientation = $orientation;
@@ -59,6 +68,9 @@ class PdfEvent extends ActionEvent
         $this->encoding = $encoding;
         $this->marges = $marges;
         $this->fontName = $fontName;
+        $this->templateName = $templateName;
+        $this->fileName = $fileName;
+        $this->object = $object;
     }
 
     /**
@@ -204,4 +216,56 @@ class PdfEvent extends ActionEvent
 
         return $this;
     }
+
+    public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+
+    /**
+     * @param string $templateName
+     *
+     * @return $this
+     */
+    public function setTemplateName($templateName)
+    {
+        $this->templateName = $templateName;
+
+        return $this;
+    }
+
+    public function getFileName()
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * @param string $fileName
+     *
+     * @return $this
+     */
+    public function setFileName($fileName)
+    {
+        $this->fileName = $fileName;
+
+        return $this;
+    }
+
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @param string $object
+     *
+     * @return $this
+     */
+    public function setObject($object)
+    {
+        $this->object = $object;
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Add 3 variables in PdfEvent : 
```
* @param string $templateName
* @param string $fileName
* @param string $object
```

Add default values to this variables in BaseController before dispatch event : 
```
$pdfEvent->setTemplateName($fileName);
$pdfEvent->setFileName($order->getRef());
$pdfEvent->setObject($order);
```

Now in event listener, we habe the possibility to modify Pdf filename.

For example : 

`TheliaEvents::GENERATE_PDF => ['generatePdf', 256],`

```
public function generatePdf(PdfEvent $event)
{
	$templateName = $event->getTemplateName();
	$object = $event->getObject();
	if(is_a($object,'Thelia\Model\Order')){
		switch($templateName){
			case "invoice":
				$event->setFileName($object->getInvoiceRef());
			break;
			case "delivery":
				$event->setFileName($object->getDeliveryRef());
			break;
		}
	}
}
```