### PR TITLE
feat: improve URL management in cache for images to avoid 404 errors

### DIFF
--- a/core/lib/Thelia/Action/Image.php
+++ b/core/lib/Thelia/Action/Image.php
@@ -100,7 +100,7 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
         }
 
         // Find cached file path
-        $cacheFilePath = $this->getCacheFilePath($subdir, $sourceFile, $event->isOriginalImage(), $event->getOptionsHash());
+        $cacheFilePath = $this->getCacheFilePath($subdir, $sourceFile, $event->isOriginalImage());
 
         // Alternative image path is for browser that don't support webp
         $alternativeImagePath = null;
@@ -175,6 +175,9 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
         // compute the full resolution image path in cache
         $originalImageUrl = $this->getCacheFileURL($subdir, basename($originalImagePathInCache));
 
+        if ($event->getOptionsHash() !== null) {
+            $processedImageUrl .= '?v='.$event->getOptionsHash();
+        }
         // Update the event with file path and file URL
         $event->setCacheFilepath($cacheFilePath);
         $event->setCacheOriginalFilepath($originalImagePathInCache);


### PR DESCRIPTION
- Changed hash-based cache keys to include query parameters directly
- This feature improves URL management and prevents potential 404 errors caused by clear image cache