### PR TITLE
Fix Export product TTC

### DIFF
--- a/core/lib/Thelia/ImportExport/Export/Type/ProductTaxedPricesExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/ProductTaxedPricesExport.php
@@ -91,6 +91,10 @@ class ProductTaxedPricesExport extends JsonFileAbstractExport
     {
         $data = parent::current();
 
+        if (empty($data)) {
+            return $data;
+        }
+
         if (\array_key_exists('tax_rule_i18n_id', $data)) {
             $taxRule = TaxRuleQuery::create()
                 ->filterById($data['tax_rule_i18n_id'])


### PR DESCRIPTION
For some reason, sometimes `$data` is empty and cause an exception that cancel the export