### PR TITLE
Fix wrong .env location in TinyMCE filemanager config

### DIFF
--- a/local/modules/Tinymce/Resources/js/tinymce/filemanager/config/config.php
+++ b/local/modules/Tinymce/Resources/js/tinymce/filemanager/config/config.php
@@ -64,7 +64,11 @@ if (file_exists(__DIR__.'/../../../../../../../../bootstrap.php')) {
     require_once __DIR__.'/../../../../vendor/autoload.php';
 }
 
-(new \Symfony\Component\Dotenv\Dotenv())->bootEnv(__DIR__.'/../../../../../../../../.env');
+if (file_exists(__DIR__.'/../../../../../../../../.env')) {
+    (new \Symfony\Component\Dotenv\Dotenv())->bootEnv(__DIR__ . '/../../../../../../../../.env');
+} elseif (file_exists(__DIR__.'/../../../../.env')) {
+    (new \Symfony\Component\Dotenv\Dotenv())->bootEnv(__DIR__ . '/../../../../.env');
+}
 
 $thelia = new App\Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();


### PR DESCRIPTION
When TinyMCE JS scripts are copied to the web directory, the path to the .env file is not the same as when TinyMCE scripts are symlinked.

This PR fixes the problem.