### PR TITLE
An admin not logged in to the BO is redirected to the requested page after logging in

### DIFF
--- a/core/lib/Thelia/Core/EventListener/ControllerListener.php
+++ b/core/lib/Thelia/Core/EventListener/ControllerListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Controller\Admin\BaseAdminController;
+use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Translation\Translator;
 use Thelia\Exception\AdminAccessDenied;
@@ -27,11 +28,8 @@ use Thelia\Exception\AdminAccessDenied;
  */
 class ControllerListener implements EventSubscriberInterface
 {
-    protected $securityContext;
-
-    public function __construct(SecurityContext $securityContext)
+    public function __construct(protected SecurityContext $securityContext)
     {
-        $this->securityContext = $securityContext;
     }
 
     public function adminFirewall(ControllerEvent $event): void
@@ -39,12 +37,25 @@ class ControllerListener implements EventSubscriberInterface
         $controller = $event->getController();
         // check if an admin is logged in
         if (\is_array($controller) && $controller[0] instanceof BaseAdminController) {
-            if (false === $this->securityContext->hasAdminUser() && $event->getRequest()->attributes->get('not-logged') != 1) {
+            if (false === $this->securityContext->hasAdminUser() && (int) $event->getRequest()->attributes->get('not-logged') !== 1) {
+                // Store the requested URL in the session
+                $event->getRequest()->getSession()->set('admin_requested_url', $event->getRequest()->getRequestUri());
+
                 throw new AdminAccessDenied(
                     Translator::getInstance()->trans(
                         "You're not currently connected to the administration panel. Please log in to access this page"
                     )
                 );
+            }
+
+            if ($this->securityContext->hasAdminUser()) {
+                $session = $event->getRequest()->getSession();
+
+                // If we have a requested URL, redirect the user to this URL
+                if ($session->has('admin_requested_url') && null !== $url = $session->get('admin_requested_url')) {
+                    $session->remove('admin_requested_url');
+                    throw new RedirectException($url);
+                }
             }
         }
     }
@@ -52,7 +63,7 @@ class ControllerListener implements EventSubscriberInterface
     /**
      * @api
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => [


### PR DESCRIPTION
When a logged out admin user requests a BO page, they are redirected to the error page that asks for a login.

The original request page is lost and once logged in, the admin has to access that page manually.

This PR stores the requested page and redirects the admin to that page once logged in.