### PR TITLE
Fix test for pasting as text

### DIFF
--- a/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
+++ b/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
@@ -46,7 +46,7 @@
         {/loop}
 
         {loop type="module-config" name="dummy" module="tinymce" variable="force_pasting_as_text" default_value="0"}
-            {if $VALUE != 0}
+            {if $VALUE}
                 // Force pasting as text
                 paste_auto_cleanup_on_paste : true,
                 paste_remove_styles: true,


### PR DESCRIPTION
The text $VALUE != 0 is always false, and user was always pasting text without attributes (bold, italic, links, etc.)