### PR TITLE
Fix precedence of event variable values

### DIFF
--- a/core/lib/Thelia/Core/Hook/BaseHook.php
+++ b/core/lib/Thelia/Core/Hook/BaseHook.php
@@ -114,7 +114,7 @@ abstract class BaseHook implements BaseHookInterface
 
             // Concatenate arguments and template variables,
             // giving the precedence to arguments.
-            $allArguments = $event->getTemplateVars() + $event->getArguments();
+            $allArguments = array_merge($event->getTemplateVars(), $event->getArguments());
 
             foreach ($templates as $template) {
                 [$type, $filepath] = $this->getTemplateParams($template);


### PR DESCRIPTION
` $allArguments = $event->getTemplateVars() + $event->getArguments();` gives prority to values in $event->getTemplateVars(), but we want to override the values with $event->getArguments().

array_merge solves the problem.