### PR TITLE
Fix argument set to null if empty('')

### DIFF
--- a/core/lib/Thelia/Core/Template/Element/BaseLoop.php
+++ b/core/lib/Thelia/Core/Template/Element/BaseLoop.php
@@ -290,6 +290,8 @@ abstract class BaseLoop implements LoopInterface
                             '%name' => $loopName,
                         ]
                     );
+                } else {
+                    $argument->setValue($value);
                 }
             } elseif ($value !== null && !$argument->type->isValid($value)) {
                 /* check type */


### PR DESCRIPTION
This PR fixes a very old bug : If a optional (non mandatory) loop argument (`tag`) is empty (`tag=''`), it is left to `null` when arguments are processed (`$this->getTag()` is null instead of '')