### PR TITLE
Fixed the build of module list when editing module hook

### DIFF
--- a/core/lib/Thelia/Form/ModuleHookCreationForm.php
+++ b/core/lib/Thelia/Form/ModuleHookCreationForm.php
@@ -151,7 +151,7 @@ class ModuleHookCreationForm extends BaseForm
                     $title = $module->setLocale('en_US')->getTitle();
                 }
 
-                $title = $module->getCode() . ' - ' . $title;
+                $title = $module->getCode().' - '.$title;
 
                 $choices[$title] = $module->getId();
             }


### PR DESCRIPTION
This PR fixes the building of the module list displayed by the module &lt;select&gt;

1. The current language was ignored, and the en_US version of the module title was always displayed.
2. The module code was not displayed in the option text.
3. List was sorted by values (id) instead of keys (option label)

The correct select content :

<img width="789" height="434" alt="image" src="https://github.com/user-attachments/assets/2de3cd9a-f034-4014-940c-58f05eafca81" />

