### PR TITLE
Remove redundant symfony/polyfill-php73 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "smarty/smarty": "~4.5.0",
         "commerceguys/addressing": "1.1.*",
         "symfony/cache": "6.4.*",
-        "symfony/polyfill-php73": "^1.0",
         "symfony/lock": "6.4.*",
         "thelia/propel": "dev-thelia-2.5",
         "symfony/mime": "6.4.*",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php73`, but also `php: >= 8.2`, so the polyfill requirement doesn't seem necessary anymore?