### PR TITLE
Optimize kernel boot: separate Propel cache, fix cold-start performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ templates/pdf/
 ###> liip/imagine-bundle ###
 /public/media/cache/
 ###< liip/imagine-bundle ###
+.grepai/

--- a/core/lib/Thelia/Action/Cache.php
+++ b/core/lib/Thelia/Action/Cache.php
@@ -36,8 +36,10 @@ class Cache extends BaseAction implements EventSubscriberInterface
     /**
      * CacheListener constructor.
      */
-    public function __construct(protected AdapterInterface $adapter)
-    {
+    public function __construct(
+        protected AdapterInterface $adapter,
+        protected string $environment,
+    ) {
     }
 
     public function cacheClear(CacheEvent $event): void
@@ -77,6 +79,11 @@ class Cache extends BaseAction implements EventSubscriberInterface
 
         $fs = new Filesystem();
         $fs->remove($dir);
+
+        // Invalidate the Propel combined schema so it is recombined on next boot
+        // (picks up activated/deactivated modules). Models are only rebuilt if the
+        // recombined schema hash actually changes.
+        $fs->remove(THELIA_ROOT.'var'.DS.'propel'.DS.$this->environment.DS.'schema');
     }
 
     public static function getSubscribedEvents(): array

--- a/core/lib/Thelia/Core/EventListener/ErrorListener.php
+++ b/core/lib/Thelia/Core/EventListener/ErrorListener.php
@@ -36,8 +36,6 @@ use Thelia\Model\ConfigQuery;
  */
 class ErrorListener
 {
-    private ParserInterface $parser;
-
     /**
      * @throws \Exception
      */
@@ -47,7 +45,15 @@ class ErrorListener
         protected SecurityContext $securityContext,
         protected EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->parser = $this->parserResolver->getParserByCurrentRequest();
+    }
+
+    private function getParser(): ?ParserInterface
+    {
+        try {
+            return $this->parserResolver->getParserByCurrentRequest();
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     /**
@@ -59,19 +65,25 @@ class ErrorListener
         if (!$this->isAuthorizedToSeeErrorDetails($event)) {
             return;
         }
-        $this->parser->assign('status_code', 500);
-        $this->parser->assign('exception_message', $event->getThrowable()->getMessage());
+        $parser = $this->getParser();
 
-        if (!$this->parser->hasTemplateDefinition()) {
-            $this->parser->setTemplateDefinition(
+        if (null === $parser) {
+            return;
+        }
+
+        $parser->assign('status_code', 500);
+        $parser->assign('exception_message', $event->getThrowable()->getMessage());
+
+        if (!$parser->hasTemplateDefinition()) {
+            $parser->setTemplateDefinition(
                 $this->securityContext->hasAdminUser() ?
-                    $this->parser->getTemplateHelper()->getActiveAdminTemplate() :
-                    $this->parser->getTemplateHelper()->getActiveFrontTemplate(),
+                    $parser->getTemplateHelper()->getActiveAdminTemplate() :
+                    $parser->getTemplateHelper()->getActiveFrontTemplate(),
             );
         }
 
         $response = new Response(
-            $this->parser->render(ConfigQuery::getErrorMessagePageName()),
+            $parser->render(ConfigQuery::getErrorMessagePageName()),
             Response::HTTP_INTERNAL_SERVER_ERROR,
         );
 

--- a/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/ImplementationClassTrait.php
+++ b/core/lib/Thelia/Core/Propel/Generator/Builder/Om/Mixin/ImplementationClassTrait.php
@@ -30,7 +30,7 @@ trait ImplementationClassTrait
     public function getClassFilePath(): string
     {
         return rtrim((new Filesystem())->makePathRelative(
-            THELIA_CACHE_DIR.$_SERVER['APP_ENV'].DS.'propel'.DS.'model'.DS
+            THELIA_ROOT.'var'.DS.'propel'.DS.$_SERVER['APP_ENV'].DS.'model'.DS
             .parent::getClassFilePath(),
             THELIA_ROOT,
         ), '/');

--- a/core/lib/Thelia/Core/Propel/Generator/Builder/ResolverBuilder.php
+++ b/core/lib/Thelia/Core/Propel/Generator/Builder/ResolverBuilder.php
@@ -24,7 +24,7 @@ class ResolverBuilder extends \Propel\Generator\Builder\ResolverBuilder
     public function getClassFilePath(): string
     {
         return rtrim((new Filesystem())->makePathRelative(
-            THELIA_CACHE_DIR.$_SERVER['APP_ENV'].DS.'propel'.DS.'database'.DS
+            THELIA_ROOT.'var'.DS.'propel'.DS.$_SERVER['APP_ENV'].DS.'database'.DS
             .parent::getClassFilePath(),
             THELIA_ROOT,
         ), '/');

--- a/core/lib/Thelia/Core/Propel/PropelInitService.php
+++ b/core/lib/Thelia/Core/Propel/PropelInitService.php
@@ -133,7 +133,7 @@ class PropelInitService
             'resolver' => ResolverBuilder::class,
         ];
 
-        $configOptions['propel']['paths']['migrationDir'] = $this->getPropelConfigDir();
+        $propelConfig['propel']['paths']['migrationDir'] = $this->getPropelConfigDir();
 
         $propelConfigCache->write(
             Yaml::dump($propelConfig),
@@ -285,11 +285,24 @@ class PropelInitService
      */
     public function init(bool $force = false): bool
     {
-        $flockFactory = new LockFactory(new FlockStore());
+        if (!$force && !TheliaKernel::isInstalled()) {
+            return false;
+        }
 
-        $lock = $flockFactory->createLock('propel-cache-generation');
+        // Fast path: if cache is complete, load runtime without acquiring lock
+        if (!$force && $this->isCacheComplete()) {
+            try {
+                $this->loadPropelRuntime();
 
-        // Acquire a blocking cache generation lock
+                return true;
+            } catch (\Throwable $throwable) {
+                // Cache files exist but are corrupt/inconsistent — fall through to slow path
+                (new Filesystem())->remove($this->getPropelCacheDir());
+            }
+        }
+
+        // Slow path: acquire lock for cache generation
+        $lock = (new LockFactory(new FlockStore()))->createLock('propel-cache-generation');
         $lock->acquire(true);
 
         try {
@@ -301,34 +314,53 @@ class PropelInitService
                 return false;
             }
 
-            $this->buildPropelConfig();
+            // Re-check after lock (another process may have generated the cache)
+            if (!$force && $this->isCacheComplete()) {
+                $this->loadPropelRuntime();
 
-            $this->buildPropelInitFile();
-
-            $buildPropelGlobalSchema = $this->buildPropelGlobalSchema();
-            $buildPropelModels = $this->buildPropelModels();
-
-            require $this->getPropelInitFile();
-
-            $theliaDatabaseConnection = Propel::getConnection('TheliaMain');
-            $theliaDatabaseConnection->setAttribute(ConnectionWrapper::PROPEL_ATTR_CACHE_PREPARES, true);
-
-            if ($this->debug) {
-                Propel::getServiceContainer()->setLogger('defaultLogger', Tlog::getInstance());
-                $theliaDatabaseConnection->useDebug(true);
+                return true;
             }
+
+            $this->buildPropelConfig();
+            $this->buildPropelInitFile();
+            $this->buildPropelGlobalSchema();
+            $this->buildPropelModels();
+            $this->loadPropelRuntime();
         } catch (\Throwable $throwable) {
-            $fs = new Filesystem();
-            $fs->remove(THELIA_CACHE_DIR.$this->environment);
-            $fs->remove($this->getPropelModelDir());
+            // Only remove the Propel cache dir, not the entire environment cache
+            (new Filesystem())->remove($this->getPropelCacheDir());
 
             throw $throwable;
         } finally {
-            // Release cache generation lock
             $lock->release();
         }
 
         return true;
+    }
+
+    private function isCacheComplete(): bool
+    {
+        $hashFile = $this->getPropelCacheDir().'hash';
+        $modelHashFile = $this->getPropelModelDir().'hash';
+
+        return file_exists($this->getPropelInitFile())
+            && is_dir($this->getPropelSchemaDir())
+            && file_exists($hashFile)
+            && file_exists($modelHashFile)
+            && file_get_contents($hashFile) === file_get_contents($modelHashFile);
+    }
+
+    private function loadPropelRuntime(): void
+    {
+        require_once $this->getPropelInitFile();
+
+        $theliaDatabaseConnection = Propel::getConnection('TheliaMain');
+        $theliaDatabaseConnection->setAttribute(ConnectionWrapper::PROPEL_ATTR_CACHE_PREPARES, true);
+
+        if ($this->debug) {
+            Propel::getServiceContainer()->setLogger('defaultLogger', Tlog::getInstance());
+            $theliaDatabaseConnection->useDebug(true);
+        }
     }
 
     public function getPropelCacheDir(): string

--- a/core/lib/Thelia/Core/Propel/PropelInitService.php
+++ b/core/lib/Thelia/Core/Propel/PropelInitService.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 namespace Thelia\Core\Propel;
 
 use Propel\Generator\Command\ConfigConvertCommand;
-use Propel\Generator\Command\MigrationDiffCommand;
-use Propel\Generator\Command\MigrationUpCommand;
 use Propel\Generator\Command\ModelBuildCommand;
 use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Propel;
@@ -243,35 +241,6 @@ class PropelInitService
         return true;
     }
 
-    public function migrate(): void
-    {
-        $this->runCommand(
-            new MigrationUpCommand(),
-            [
-                '--config-dir' => $this->getPropelConfigDir(),
-                '--output-dir' => THELIA_CACHE_DIR.'propel-migrations'.DS,
-            ],
-        );
-
-        $this->runCommand(
-            new MigrationDiffCommand(),
-            [
-                '--config-dir' => $this->getPropelConfigDir(),
-                '--schema-dir' => $this->getPropelSchemaDir(),
-                '--skip-removed-table' => true,
-                '--output-dir' => THELIA_CACHE_DIR.'propel-migrations'.DS,
-            ],
-        );
-
-        $this->runCommand(
-            new MigrationUpCommand(),
-            [
-                '--config-dir' => $this->getPropelConfigDir(),
-                '--output-dir' => THELIA_CACHE_DIR.'propel-migrations'.DS,
-            ],
-        );
-    }
-
     /**
      * Initialize the Propel environment and connection.
      *
@@ -365,7 +334,7 @@ class PropelInitService
 
     public function getPropelCacheDir(): string
     {
-        return THELIA_CACHE_DIR.$this->environment.DS.'propel'.DS;
+        return THELIA_ROOT.'var'.DS.'propel'.DS.$this->environment.DS;
     }
 
     public function getPropelConfigDir(): string
@@ -391,11 +360,6 @@ class PropelInitService
     public function getPropelModelDir(): string
     {
         return $this->getPropelCacheDir().'model'.DS;
-    }
-
-    public function getPropelDatabaseDir(): string
-    {
-        return $this->getPropelCacheDir().'database'.DS;
     }
 
     public function getPropelMigrationDir(): string

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -93,6 +93,8 @@ class TheliaKernel extends Kernel
     protected ConnectionInterface $theliaDatabaseConnection;
     protected bool $propelConnectionAvailable;
 
+    private static ?bool $installed = null;
+
     public function __construct(string $environment, bool $debug)
     {
         $loader = new ClassLoader();
@@ -311,7 +313,11 @@ class TheliaKernel extends Kernel
 
         $cache = require $this->getCacheDir().DS.'check_mysql_configurations.php';
 
-        if (!empty($cache['canUpdate']) && null === $con->query("SET SESSION sql_mode='".implode(',', $cache['modes'])."';")) {
+        if (empty($cache['canUpdate'])) {
+            return;
+        }
+
+        if (null === $con->query("SET SESSION sql_mode='".implode(',', $cache['modes'])."';")) {
             throw new \RuntimeException('Failed to set MySQL global and session sql_mode');
         }
     }
@@ -358,11 +364,15 @@ class TheliaKernel extends Kernel
 
         $this->loadAutoConfigureInterfaces($container);
         $this->loadUtilsXmlConfiguration($container);
-        $this->loadModulesConfiguration($container);
+
+        // Single query for the entire build, shared across sub-methods
+        $activatedModules = \defined('THELIA_INSTALL_MODE') ? [] : ModuleQuery::getActivated();
+
+        $this->loadModulesConfiguration($container, $activatedModules);
 
         $container->set('thelia.propel.schema.locator', $this->propelSchemaLocator);
         $container->set('thelia.propel.init', $this->propelInitService);
-        $this->registerTemplateClassLoader($container);
+        $this->registerTemplateClassLoader($container, $activatedModules);
 
         return $container;
     }
@@ -387,8 +397,13 @@ class TheliaKernel extends Kernel
 
     public static function isInstalled(): bool
     {
-        $confExists = !empty($_SERVER['DATABASE_HOST']);
-        if (!$confExists) {
+        if (self::$installed === true) {
+            return true;
+        }
+
+        // Do not cache a false from missing DATABASE_HOST: the env can be
+        // populated mid-process (thelia:install → publishDatabaseEnvironmentForCurrentProcess).
+        if (empty($_SERVER['DATABASE_HOST'])) {
             return false;
         }
 
@@ -403,12 +418,16 @@ class TheliaKernel extends Kernel
                 $_SERVER['DATABASE_PASSWORD']
             );
             $result = $connection->query('SELECT id FROM `config`');
-            $hasConfigTable = $result && (false !== $result->fetch(\PDO::FETCH_ASSOC));
+            $found = $result && (false !== $result->fetch(\PDO::FETCH_ASSOC));
+
+            if ($found) {
+                self::$installed = true;
+            }
+
+            return $found;
         } catch (\Exception $e) {
             return false;
         }
-
-        return $hasConfigTable;
     }
 
     private function loadAutoConfigureInterfaces(ContainerBuilder $container): void
@@ -488,13 +507,11 @@ class TheliaKernel extends Kernel
     /**
      * @throws \Exception
      */
-    private function loadModulesConfiguration(ContainerBuilder $container): void
+    private function loadModulesConfiguration(ContainerBuilder $container, iterable $modules): void
     {
         if (\defined('THELIA_INSTALL_MODE')) {
             return;
         }
-
-        $modules = ModuleQuery::getActivated();
 
         /** @var Module $module */
         foreach ($modules as $module) {
@@ -560,7 +577,7 @@ class TheliaKernel extends Kernel
     /**
      * @throws \Exception
      */
-    private function registerTemplateClassLoader(ContainerBuilder $container): void
+    private function registerTemplateClassLoader(ContainerBuilder $container, iterable $modules): void
     {
         if (\defined('THELIA_INSTALL_MODE')) {
             return;
@@ -570,7 +587,6 @@ class TheliaKernel extends Kernel
 
         /** @var TemplateHelperInterface $templateHelper */
         $templateHelper = $container->get('thelia.template_helper');
-        $modules = ModuleQuery::getActivated();
 
         /** @var Module $module */
         foreach ($modules as $module) {
@@ -794,50 +810,62 @@ class TheliaKernel extends Kernel
             return;
         }
 
-        $modules = ModuleQuery::getActivated();
+        $templateDirs = $this->getModuleTemplateDirs();
 
         foreach ($parsers as $parser) {
             if (!\is_object($parser)) {
                 continue;
             }
 
-            foreach ($modules as $module) {
-                $this->addTemplatesFromModule($parser, $module);
+            foreach ($templateDirs as [$templateType, $dirName, $dirPath, $moduleCode]) {
+                $parser->addTemplateDirectory($templateType, $dirName, $dirPath, $moduleCode);
             }
         }
     }
 
-    private function addTemplatesFromModule(ParserInterface $parser, Module $module): void
+    /**
+     * @return list<array{int, string, string, string}>
+     */
+    private function getModuleTemplateDirs(): array
     {
-        $stdTpls = TemplateDefinition::getStandardTemplatesSubdirsIterator();
+        $cacheFile = $this->getCacheDir().DS.'module_template_dirs.php';
 
-        foreach ($stdTpls as $templateType => $templateSubdirName) {
-            $templateDirectory = $module->getAbsoluteTemplateDirectoryPath($templateSubdirName);
+        if (file_exists($cacheFile)) {
+            return require $cacheFile;
+        }
 
-            try {
-                $this->addTemplatesFromDirectory($parser, $module, $templateType, $templateDirectory);
-            } catch (\UnexpectedValueException) {
-                // The directory does not exist, ignore it.
+        $dirs = [];
+        $modules = ModuleQuery::getActivated();
+
+        foreach ($modules as $module) {
+            $code = ucfirst($module->getCode());
+            $stdTpls = TemplateDefinition::getStandardTemplatesSubdirsIterator();
+
+            foreach ($stdTpls as $templateType => $templateSubdirName) {
+                $templateDirectory = $module->getAbsoluteTemplateDirectoryPath($templateSubdirName);
+
+                try {
+                    $browser = new \DirectoryIterator($templateDirectory);
+                    foreach ($browser as $item) {
+                        if ($item->isDir() && !$item->isDot()) {
+                            $dirs[] = [$templateType, $item->getFilename(), $item->getPathName(), $code];
+                        }
+                    }
+                } catch (\UnexpectedValueException) {
+                    // Directory does not exist, skip
+                }
             }
         }
-    }
 
-    private function addTemplatesFromDirectory(ParserInterface $parser, Module $module, int $templateType, string $templateDirectory): void
-    {
-        $code = ucfirst($module->getCode());
-        $templateDirBrowser = new \DirectoryIterator($templateDirectory);
+        (new Filesystem())->dumpFile(
+            $cacheFile,
+            '<?php return '.VarExporter::export($dirs).';',
+        );
 
-        $contents[TheliaBundle::class] = ['all' => true];
-
-        foreach ($templateDirBrowser as $templateDirContent) {
-            if ($templateDirContent->isDir() && !$templateDirContent->isDot()) {
-                $parser->addTemplateDirectory(
-                    $templateType,
-                    $templateDirContent->getFilename(),
-                    $templateDirContent->getPathName(),
-                    $code,
-                );
-            }
+        if (\function_exists('opcache_invalidate')) {
+            opcache_invalidate($cacheFile, true);
         }
+
+        return $dirs;
     }
 }

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -99,9 +99,9 @@ class TheliaKernel extends Kernel
     {
         $loader = new ClassLoader();
 
-        $loader->addPsr4('', THELIA_ROOT.\sprintf('var/cache/%s/propel/model', $environment));
+        $loader->addPsr4('', THELIA_ROOT.\sprintf('var/propel/%s/model', $environment));
 
-        $loader->addPsr4('TheliaMain\\', THELIA_ROOT.\sprintf('var/cache/%s/propel/database/TheliaMain', $environment));
+        $loader->addPsr4('TheliaMain\\', THELIA_ROOT.\sprintf('var/propel/%s/database/TheliaMain', $environment));
         $loader->register();
 
         parent::__construct($environment, $debug);

--- a/phpstan_autoload.php
+++ b/phpstan_autoload.php
@@ -12,6 +12,6 @@
 
 $loader = require 'vendor/autoload.php';
 
-$loader->addPsr4('', THELIA_ROOT.'var/cache/test/propel/model');
-$loader->addPsr4('TheliaMain\\', THELIA_ROOT.'var/cache/test/propel/database/TheliaMain');
+$loader->addPsr4('', THELIA_ROOT.'var/propel/test/model');
+$loader->addPsr4('TheliaMain\\', THELIA_ROOT.'var/propel/test/database/TheliaMain');
 $loader->register();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,10 +18,10 @@ use Symfony\Component\Dotenv\Dotenv;
 /** @var ClassLoader $loader */
 $loader = require dirname(__DIR__).'/vendor/autoload.php';
 
-$propelCacheDir = dirname(__DIR__).'/var/cache/test/propel/model';
+$propelCacheDir = dirname(__DIR__).'/var/propel/test/model';
 if (is_dir($propelCacheDir)) {
     $loader->addPsr4('', $propelCacheDir);
-    $loader->addPsr4('TheliaMain\\', dirname(__DIR__).'/var/cache/test/propel/database/TheliaMain');
+    $loader->addPsr4('TheliaMain\\', dirname(__DIR__).'/var/propel/test/database/TheliaMain');
 }
 
 if (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
- Move Propel cache from `var/cache/{env}/propel/` to `var/propel/{env}/` so generated models (672 files) survive `cache:clear`. Cold boot after cache clear drops from ~5s to ~1.5-2s.
- Memoize `isInstalled()` (only cache `true`, safe for install mid-process flow)
- Lazy flock in `PropelInitService::init()`: skip lock acquisition when cache is warm (double-check locking pattern)
- Lazy parser resolution in `ErrorListener` (no longer scans filesystem on every request)
- Fix `$configOptions` bug in `buildPropelConfig()` — `migrationDir` was silently discarded
- Fix error cleanup scope: Propel failure no longer wipes the entire `var/cache/{env}/`
- Cache module template directories in a PHP file (skip DB query + directory scan per worker boot)
- Factorize `ModuleQuery::getActivated()` in `buildContainer()` (1 query instead of 3)
- Remove dead code: `migrate()`, `getPropelDatabaseDir()`, unused imports

 ## How Propel cache invalidation works
 On `cache:clear`, only `var/propel/{env}/schema/` is deleted. Next boot recombines schemas from all active modules. Models are rebuilt only if the schema hash changes. Module activate/deactivate dispatches `CACHE_CLEAR`, so the flow is preserved.