### PR TITLE
Add test infrastructure and functional test suite for Thelia 3

### DIFF
--- a/bin/test-prepare
+++ b/bin/test-prepare
@@ -1,0 +1,171 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Prepares a clean test database without booting the Symfony kernel.
+ *
+ * Usage:
+ *   php bin/test-prepare
+ *   ddev exec php bin/test-prepare
+ *
+ * Steps:
+ *   1. Create database (if not exists)
+ *   2. Apply core schema (thelia.sql) + reference data (insert.sql)
+ *   3. Register and activate all available modules
+ *   4. Apply module schemas (TheliaMain.sql + update/*.sql)
+ */
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+use Thelia\Core\Install\Database;
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+$host     = $_SERVER['DATABASE_HOST'] ?? '';
+$port     = $_SERVER['DATABASE_PORT'] ?? '3306';
+$user     = $_SERVER['DATABASE_USER'] ?? '';
+$password = $_SERVER['DATABASE_PASSWORD'] ?? '';
+$dbName   = $_SERVER['DATABASE_NAME'] ?? '';
+
+if ('' === $host || '' === $dbName) {
+    fwrite(STDERR, "ERROR: DATABASE_HOST and DATABASE_NAME must be set.\n");
+    exit(1);
+}
+
+if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
+    fwrite(STDERR, "ERROR: DATABASE_NAME contains invalid characters: {$dbName}\n");
+    exit(1);
+}
+
+// ── Step 1: Create database ──────────────────────────────────────────
+
+echo "Creating database \"{$dbName}\"...\n";
+
+$pdo = new PDO("mysql:host={$host};port={$port}", $user, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+$pdo->exec("CREATE DATABASE IF NOT EXISTS `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+// ── Step 2: Core schema + reference data ─────────────────────────────
+
+$pdo = new PDO("mysql:host={$host};dbname={$dbName};port={$port}", $user, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+
+$database = new Database($pdo);
+$setupDir = THELIA_SETUP_DIRECTORY;
+
+echo "Applying core schema...\n";
+$database->insertSql(null, [$setupDir.'thelia.sql']);
+$database->insertSql(null, [$setupDir.'insert.sql']);
+
+// ── Step 3: Register modules ─────────────────────────────────────────
+
+echo "Registering modules...\n";
+
+$moduleDirs = array_filter([THELIA_MODULE_DIR, THELIA_LOCAL_MODULE_DIR], 'is_dir');
+$position = 0;
+
+$insertModule = $pdo->prepare(
+    'INSERT INTO `module` (`code`, `version`, `type`, `category`, `activate`, `position`, `full_namespace`, `mandatory`, `hidden`, `created_at`)
+     VALUES (:code, :version, 1, :category, 1, :position, :namespace, :mandatory, :hidden, NOW())
+     ON DUPLICATE KEY UPDATE `activate` = 1, `full_namespace` = VALUES(`full_namespace`), `version` = VALUES(`version`)'
+);
+
+foreach ($moduleDirs as $baseDir) {
+    foreach (new DirectoryIterator($baseDir) as $entry) {
+        if (!$entry->isDir() || $entry->isDot()) {
+            continue;
+        }
+
+        $moduleXml = $entry->getPathname().'/Config/module.xml';
+        if (!file_exists($moduleXml)) {
+            continue;
+        }
+
+        $xml = @simplexml_load_file($moduleXml);
+        if (false === $xml) {
+            continue;
+        }
+
+        $code = $entry->getFilename();
+        $namespace = (string) ($xml->fullnamespace ?? $code.'\\'.$code);
+        $version = (string) ($xml->version ?? '0.0.1');
+        $category = (string) ($xml->type ?? 'classic');
+        $mandatory = (int) ($xml->mandatory ?? 0);
+        $hidden = (int) ($xml->hidden ?? 0);
+
+        $insertModule->execute([
+            'code' => $code,
+            'version' => $version,
+            'category' => $category,
+            'position' => ++$position,
+            'namespace' => $namespace,
+            'mandatory' => $mandatory,
+            'hidden' => $hidden,
+        ]);
+    }
+}
+
+echo "  {$position} module(s) registered\n";
+
+// ── Step 4: Apply module schemas ─────────────────────────────────────
+
+echo "Applying module schemas...\n";
+
+$ignorableCodes = [1050, 1060, 1061, 1068, 1826];
+$moduleCount = 0;
+
+foreach ($moduleDirs as $baseDir) {
+    foreach (new DirectoryIterator($baseDir) as $entry) {
+        if (!$entry->isDir() || $entry->isDot()) {
+            continue;
+        }
+
+        $mainSql = $entry->getPathname().'/Config/TheliaMain.sql';
+        if (!file_exists($mainSql)) {
+            continue;
+        }
+
+        $moduleName = $entry->getFilename();
+        $files = [$mainSql];
+
+        $updateDir = $entry->getPathname().'/Config/update';
+        if (is_dir($updateDir)) {
+            $updates = glob($updateDir.'/*.sql') ?: [];
+            usort($updates, static fn (string $a, string $b) => version_compare(basename($a, '.sql'), basename($b, '.sql')));
+            $files = array_merge($files, $updates);
+        }
+
+        foreach ($files as $file) {
+            $sql = file_get_contents($file);
+            foreach (array_filter(explode(";\n", $sql)) as $statement) {
+                $statement = trim($statement);
+                if ('' === $statement) {
+                    continue;
+                }
+                try {
+                    $pdo->exec($statement);
+                } catch (PDOException $e) {
+                    $code = (int) ($e->errorInfo[1] ?? 0);
+                    if (in_array($code, $ignorableCodes, true)) {
+                        continue;
+                    }
+                    if (1005 === $code && str_contains($e->getMessage(), 'errno: 121')) {
+                        continue;
+                    }
+                    // Non-fatal: log and continue to next statement
+                    fwrite(STDERR, "  WARN {$moduleName}/".basename($file).": {$e->getMessage()}\n");
+                }
+            }
+        }
+
+        ++$moduleCount;
+    }
+}
+
+echo "  {$moduleCount} module schema(s) applied\n";
+echo "\nDone: database \"{$dbName}\" is ready.\n";

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,18 @@
         "unit": [
             "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuit unit"
         ],
+        "test:prepare": [
+            "@phpc bin/console thelia:database:create --env=test",
+            "@phpc bin/console thelia:database:populate --env=test",
+            "@phpc bin/console module:schema:apply --all --env=test",
+            "@phpc bin/console cache:warmup --env=test"
+        ],
+        "test:unit": [
+            "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite unit"
+        ],
+        "test:integration": [
+            "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite functional"
+        ],
         "test": [
             "@cache-clear",
             "@demo-database",

--- a/composer.json
+++ b/composer.json
@@ -70,34 +70,25 @@
         "phpstan": [
             "@phpc ./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=-1"
         ],
-        "unit": [
-            "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuit unit"
-        ],
         "test:prepare": [
-            "@phpc bin/console thelia:database:create --env=test",
-            "@phpc bin/console thelia:database:populate --env=test",
-            "@phpc bin/console module:schema:apply --all --env=test",
+            "@phpc bin/test-prepare",
             "@phpc bin/console cache:warmup --env=test"
         ],
         "test:unit": [
-            "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite unit"
+            "@phpc ./vendor/bin/phpunit --testsuite unit"
         ],
         "test:integration": [
-            "@phpc ./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite functional"
+            "@phpc ./vendor/bin/phpunit --testsuite functional"
         ],
         "test": [
-            "@cache-clear",
-            "@demo-database",
-            "@unit"
+            "@test:prepare",
+            "@test:unit",
+            "@test:integration"
         ],
         "ci": [
             "@cs-diff",
             "@phpstan",
             "@test"
-        ],
-        "csi": [
-            "@cs-diff",
-            "@ci"
         ],
         "cache-clear": [
             "rm -Rf var/cache/*"

--- a/core/lib/Thelia/Api/Resource/AttributeTemplate.php
+++ b/core/lib/Thelia/Api/Resource/AttributeTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Thelia package.
  * http://www.thelia.net

--- a/core/lib/Thelia/Api/Resource/FeatureTemplate.php
+++ b/core/lib/Thelia/Api/Resource/FeatureTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Thelia package.
  * http://www.thelia.net

--- a/core/lib/Thelia/Api/Resource/PaymentModule.php
+++ b/core/lib/Thelia/Api/Resource/PaymentModule.php
@@ -18,7 +18,6 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Serializer\Annotation\Ignore;
 use Thelia\Api\State\Provider\PaymentModuleProvider;
 use Thelia\Model\Map\ModuleTableMap;
 
@@ -169,7 +168,6 @@ class PaymentModule extends AbstractTranslatableResource
         return $this;
     }
 
-    #[Ignore]
     public static function getPropelRelatedTableMap(): ?TableMap
     {
         return new ModuleTableMap();

--- a/core/lib/Thelia/Api/Resource/PropelResourceInterface.php
+++ b/core/lib/Thelia/Api/Resource/PropelResourceInterface.php
@@ -16,7 +16,6 @@ namespace Thelia\Api\Resource;
 
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Map\TableMap;
-use Symfony\Component\Serializer\Annotation\Ignore;
 
 interface PropelResourceInterface
 {
@@ -32,6 +31,5 @@ interface PropelResourceInterface
 
     public function setResourceAddon(string $addonName, ?ResourceAddonInterface $addon): self;
 
-    #[Ignore]
     public static function getPropelRelatedTableMap(): ?TableMap;
 }

--- a/core/lib/Thelia/Api/Resource/ResourceAddonInterface.php
+++ b/core/lib/Thelia/Api/Resource/ResourceAddonInterface.php
@@ -30,7 +30,7 @@ interface ResourceAddonInterface
 
     public static function extendQuery(ModelCriteria $query, ?Operation $operation = null, array $context = []): void;
 
-    public function setContext(array $context = []): ResourceAddonInterface;
+    public function setContext(array $context = []): self;
 
     public function getContext(): array;
 

--- a/core/lib/Thelia/Api/Resource/ResourceAddonInterface.php
+++ b/core/lib/Thelia/Api/Resource/ResourceAddonInterface.php
@@ -18,14 +18,11 @@ use ApiPlatform\Metadata\Operation;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Map\TableMap;
-use Symfony\Component\Serializer\Annotation\Ignore;
 
 interface ResourceAddonInterface
 {
-    #[Ignore]
     public static function getResourceParent(): string;
 
-    #[Ignore]
     public static function getPropelRelatedTableMap(): ?TableMap;
 
     public static function extendQuery(ModelCriteria $query, ?Operation $operation = null, array $context = []): void;

--- a/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
@@ -122,6 +122,7 @@ class ProductSaleElementsAccessService
         }
 
         $event = $this->eventDispatcher->dispatch(new AttributeAvProductEvent($attributes));
+
         return $event->getAttributes();
     }
 }

--- a/core/lib/Thelia/Command/DatabaseCreateCommand.php
+++ b/core/lib/Thelia/Command/DatabaseCreateCommand.php
@@ -48,6 +48,12 @@ final class DatabaseCreateCommand extends Command
             return Command::FAILURE;
         }
 
+        if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
+            $io->error(\sprintf('DATABASE_NAME contains invalid characters: "%s"', $dbName));
+
+            return Command::FAILURE;
+        }
+
         $dsn = \sprintf('mysql:host=%s;port=%s', $host, $port);
 
         try {

--- a/core/lib/Thelia/Command/DatabaseCreateCommand.php
+++ b/core/lib/Thelia/Command/DatabaseCreateCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Creates the Thelia database if it does not exist.
+ *
+ * Designed for CI and test environments: non-interactive, idempotent,
+ * reads connection info from environment variables only.
+ */
+#[AsCommand(
+    name: 'thelia:database:create',
+    description: 'Create the Thelia database if it does not exist',
+)]
+final class DatabaseCreateCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $host = $_SERVER['DATABASE_HOST'] ?? '';
+        $port = $_SERVER['DATABASE_PORT'] ?? '3306';
+        $user = $_SERVER['DATABASE_USER'] ?? '';
+        $password = $_SERVER['DATABASE_PASSWORD'] ?? '';
+        $dbName = $_SERVER['DATABASE_NAME'] ?? '';
+
+        if ('' === $host || '' === $dbName) {
+            $io->error('DATABASE_HOST and DATABASE_NAME environment variables are required.');
+
+            return Command::FAILURE;
+        }
+
+        $dsn = \sprintf('mysql:host=%s;port=%s', $host, $port);
+
+        try {
+            $pdo = new \PDO($dsn, $user, $password, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+        } catch (\PDOException $e) {
+            $io->error(\sprintf(
+                'Could not connect to MySQL at %s:%s as "%s": %s',
+                $host,
+                $port,
+                $user,
+                $e->getMessage(),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        $pdo->exec(\sprintf(
+            'CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+            $dbName,
+        ));
+
+        $io->success(\sprintf('Database "%s" is ready.', $dbName));
+
+        return Command::SUCCESS;
+    }
+}

--- a/core/lib/Thelia/Command/DatabasePopulateCommand.php
+++ b/core/lib/Thelia/Command/DatabasePopulateCommand.php
@@ -48,8 +48,8 @@ final class DatabasePopulateCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $schemaOnly = $input->getOption('schema-only');
-        $seedOnly = $input->getOption('seed-only');
+        $schemaOnly = (bool) $input->getOption('schema-only');
+        $seedOnly = (bool) $input->getOption('seed-only');
 
         if ($schemaOnly && $seedOnly) {
             $io->error('Options --schema-only and --seed-only are mutually exclusive.');
@@ -69,7 +69,7 @@ final class DatabasePopulateCommand extends Command
             return Command::FAILURE;
         }
 
-        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $port, $dbName);
+        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $dbName, $port);
 
         try {
             $pdo = new \PDO($dsn, $user, $password, [
@@ -120,7 +120,14 @@ final class DatabasePopulateCommand extends Command
 
         foreach ($files as $file) {
             $io->text(\sprintf('Executing %s...', basename($file)));
-            $database->insertSql(null, [$file]);
+
+            try {
+                $database->insertSql(null, [$file]);
+            } catch (\RuntimeException $e) {
+                $io->error(\sprintf('Failed to execute %s: %s', basename($file), $e->getMessage()));
+
+                return Command::FAILURE;
+            }
         }
 
         $io->success(\sprintf('Database "%s" populated successfully.', $dbName));

--- a/core/lib/Thelia/Command/DatabasePopulateCommand.php
+++ b/core/lib/Thelia/Command/DatabasePopulateCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Thelia\Core\Install\Database;
+
+/**
+ * Applies the core schema (thelia.sql) and reference data (insert.sql)
+ * to an existing database.
+ *
+ * Non-interactive, designed for CI and test environments.
+ * Does not write config files, does not create admin users,
+ * does not handle modules — use module:schema:apply for that.
+ */
+#[AsCommand(
+    name: 'thelia:database:populate',
+    description: 'Apply core schema and reference data to the database',
+)]
+final class DatabasePopulateCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addOption('schema-only', null, InputOption::VALUE_NONE, 'Apply only thelia.sql (schema), skip insert.sql (reference data)')
+            ->addOption('seed-only', null, InputOption::VALUE_NONE, 'Apply only insert.sql (reference data), skip thelia.sql (schema)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $schemaOnly = $input->getOption('schema-only');
+        $seedOnly = $input->getOption('seed-only');
+
+        if ($schemaOnly && $seedOnly) {
+            $io->error('Options --schema-only and --seed-only are mutually exclusive.');
+
+            return Command::FAILURE;
+        }
+
+        $host = $_SERVER['DATABASE_HOST'] ?? '';
+        $port = $_SERVER['DATABASE_PORT'] ?? '3306';
+        $user = $_SERVER['DATABASE_USER'] ?? '';
+        $password = $_SERVER['DATABASE_PASSWORD'] ?? '';
+        $dbName = $_SERVER['DATABASE_NAME'] ?? '';
+
+        if ('' === $host || '' === $dbName) {
+            $io->error('DATABASE_HOST and DATABASE_NAME environment variables are required.');
+
+            return Command::FAILURE;
+        }
+
+        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $port, $dbName);
+
+        try {
+            $pdo = new \PDO($dsn, $user, $password, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+        } catch (\PDOException $e) {
+            $io->error(\sprintf(
+                'Could not connect to database "%s" at %s:%s: %s',
+                $dbName,
+                $host,
+                $port,
+                $e->getMessage(),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        if (!\defined('THELIA_SETUP_DIRECTORY')) {
+            $io->error('THELIA_SETUP_DIRECTORY constant is not defined. Ensure core/bootstrap.php is loaded.');
+
+            return Command::FAILURE;
+        }
+
+        $database = new Database($pdo);
+
+        $files = [];
+        if (!$seedOnly) {
+            $schemaFile = THELIA_SETUP_DIRECTORY.'thelia.sql';
+            if (!file_exists($schemaFile)) {
+                $io->error(\sprintf('Schema file not found: %s', $schemaFile));
+
+                return Command::FAILURE;
+            }
+            $files[] = $schemaFile;
+        }
+
+        if (!$schemaOnly) {
+            $insertFile = THELIA_SETUP_DIRECTORY.'insert.sql';
+            if (!file_exists($insertFile)) {
+                $io->error(\sprintf('Seed file not found: %s', $insertFile));
+
+                return Command::FAILURE;
+            }
+            $files[] = $insertFile;
+        }
+
+        $io->section('Populating database');
+
+        foreach ($files as $file) {
+            $io->text(\sprintf('Executing %s...', basename($file)));
+            $database->insertSql(null, [$file]);
+        }
+
+        $io->success(\sprintf('Database "%s" populated successfully.', $dbName));
+
+        return Command::SUCCESS;
+    }
+}

--- a/core/lib/Thelia/Command/MaintenancePurgeCommand.php
+++ b/core/lib/Thelia/Command/MaintenancePurgeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Thelia package.
  * http://www.thelia.net
@@ -52,7 +54,7 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
 
             $deletedCartNoOrder = $this->cartPurger->purgeCartsWithoutOrder($cartNoOrderDays);
 
-            $output->writeln(sprintf(
+            $output->writeln(\sprintf(
                 '<comment>Carts without order (>%d days):</comment> <info>%d deleted</info>',
                 $cartNoOrderDays,
                 $deletedCartNoOrder
@@ -65,7 +67,7 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
 
             $deletedAnonymousCarts = $this->cartPurger->purgeAnonymousCarts($cartAnonymousDays);
 
-            $output->writeln(sprintf(
+            $output->writeln(\sprintf(
                 '<comment>Anonymous carts (>%d days):</comment> <info>%d deleted</info>',
                 $cartAnonymousDays,
                 $deletedAnonymousCarts
@@ -78,7 +80,7 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
 
             $deletedAdminLogs = $this->adminLogPurger->purgeAdminLogs($adminLogsDays);
 
-            $output->writeln(sprintf(
+            $output->writeln(\sprintf(
                 '<comment>Admin logs (>%d days):</comment> <info>%d deleted</info>',
                 $adminLogsDays,
                 $deletedAdminLogs
@@ -93,7 +95,7 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
 
             $output->writeln('<info>Maintenance purge completed successfully.</info>');
         } catch (\Exception $ex) {
-            $output->writeln(sprintf('<error>Error: %s</error>', $ex->getMessage()));
+            $output->writeln(\sprintf('<error>Error: %s</error>', $ex->getMessage()));
 
             return 1;
         }

--- a/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
+++ b/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Applies module SQL schemas (TheliaMain.sql + update/*.sql) to the database.
+ *
+ * Reproduces what modules do in postActivation() + update(), but as
+ * an explicit, non-interactive, idempotent command for CI environments.
+ *
+ * Each SQL statement is executed individually with error handling:
+ * "table/column/index already exists" errors are silently ignored
+ * to ensure idempotent re-runs.
+ */
+#[AsCommand(
+    name: 'module:schema:apply',
+    description: 'Apply SQL schema for one or all modules',
+)]
+final class ModuleSchemaApplyCommand extends Command
+{
+    /** MySQL error codes that are safe to ignore for idempotent execution. */
+    private const IGNORABLE_MYSQL_CODES = [
+        1050, // Table already exists
+        1060, // Duplicate column name
+        1061, // Duplicate key name
+        1068, // Multiple primary key defined
+    ];
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('module', InputArgument::OPTIONAL, 'Module name (e.g. CustomerFamily)')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Apply schemas for all modules that have a TheliaMain.sql')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'List SQL files that would be executed without executing them')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $module = $input->getArgument('module');
+        $all = $input->getOption('all');
+        $dryRun = $input->getOption('dry-run');
+
+        if (!$module && !$all) {
+            $io->error('Provide a module name or use --all.');
+
+            return Command::FAILURE;
+        }
+
+        if ($module && $all) {
+            $io->error('Provide either a module name or --all, not both.');
+
+            return Command::FAILURE;
+        }
+
+        $host = $_SERVER['DATABASE_HOST'] ?? '';
+        $port = $_SERVER['DATABASE_PORT'] ?? '3306';
+        $user = $_SERVER['DATABASE_USER'] ?? '';
+        $password = $_SERVER['DATABASE_PASSWORD'] ?? '';
+        $dbName = $_SERVER['DATABASE_NAME'] ?? '';
+
+        if ('' === $host || '' === $dbName) {
+            $io->error('DATABASE_HOST and DATABASE_NAME environment variables are required.');
+
+            return Command::FAILURE;
+        }
+
+        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $port, $dbName);
+
+        try {
+            $pdo = new \PDO($dsn, $user, $password, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+        } catch (\PDOException $e) {
+            $io->error(\sprintf('Could not connect to database: %s', $e->getMessage()));
+
+            return Command::FAILURE;
+        }
+
+        if ($all) {
+            $modules = $this->discoverModules();
+
+            if ([] === $modules) {
+                $io->warning('No modules with TheliaMain.sql found.');
+
+                return Command::SUCCESS;
+            }
+
+            $io->section(\sprintf('Found %d module(s) with SQL schema', \count($modules)));
+
+            $hasError = false;
+            foreach ($modules as $moduleName => $modulePath) {
+                if (!$this->applyModuleSchema($io, $pdo, $moduleName, $modulePath, $dryRun)) {
+                    $hasError = true;
+                }
+            }
+
+            return $hasError ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        $modulePath = $this->findModulePath($module);
+        if (null === $modulePath) {
+            $io->error(\sprintf('Module "%s" not found in module directories.', $module));
+
+            return Command::FAILURE;
+        }
+
+        if (!file_exists($modulePath.'/Config/TheliaMain.sql')) {
+            $io->error(\sprintf('No TheliaMain.sql found for module "%s".', $module));
+
+            return Command::FAILURE;
+        }
+
+        return $this->applyModuleSchema($io, $pdo, $module, $modulePath, $dryRun)
+            ? Command::SUCCESS
+            : Command::FAILURE;
+    }
+
+    /**
+     * @return array<string, string> moduleName => modulePath
+     */
+    private function discoverModules(): array
+    {
+        $modules = [];
+
+        $dirs = [
+            \defined('THELIA_MODULE_DIR') ? THELIA_MODULE_DIR : '',
+            \defined('THELIA_LOCAL_MODULE_DIR') ? THELIA_LOCAL_MODULE_DIR : '',
+        ];
+
+        foreach (array_filter($dirs) as $baseDir) {
+            if (!is_dir($baseDir)) {
+                continue;
+            }
+
+            $entries = scandir($baseDir);
+            if (false === $entries) {
+                continue;
+            }
+
+            foreach ($entries as $entry) {
+                if ('.' === $entry || '..' === $entry) {
+                    continue;
+                }
+
+                $modulePath = $baseDir.$entry;
+                if (is_dir($modulePath) && file_exists($modulePath.'/Config/TheliaMain.sql')) {
+                    $modules[$entry] = $modulePath;
+                }
+            }
+        }
+
+        return $modules;
+    }
+
+    private function findModulePath(string $moduleName): ?string
+    {
+        $dirs = [
+            \defined('THELIA_LOCAL_MODULE_DIR') ? THELIA_LOCAL_MODULE_DIR : '',
+            \defined('THELIA_MODULE_DIR') ? THELIA_MODULE_DIR : '',
+        ];
+
+        foreach (array_filter($dirs) as $baseDir) {
+            $path = $baseDir.$moduleName;
+            if (is_dir($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    private function applyModuleSchema(SymfonyStyle $io, \PDO $pdo, string $moduleName, string $modulePath, bool $dryRun): bool
+    {
+        $files = [];
+
+        $mainSql = $modulePath.'/Config/TheliaMain.sql';
+        if (file_exists($mainSql)) {
+            $files[] = $mainSql;
+        }
+
+        $updateDir = $modulePath.'/Config/update';
+        if (is_dir($updateDir)) {
+            $updateFiles = glob($updateDir.'/*.sql');
+            if (false !== $updateFiles && [] !== $updateFiles) {
+                usort($updateFiles, static function (string $a, string $b): int {
+                    return version_compare(basename($a, '.sql'), basename($b, '.sql'));
+                });
+                $files = array_merge($files, $updateFiles);
+            }
+        }
+
+        if ($dryRun) {
+            $io->text(\sprintf('<info>%s</info>: %d file(s)', $moduleName, \count($files)));
+            foreach ($files as $file) {
+                $io->text(\sprintf('  - %s', basename($file)));
+            }
+
+            return true;
+        }
+
+        $io->text(\sprintf('<info>%s</info>: applying %d file(s)...', $moduleName, \count($files)));
+
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            if (false === $content) {
+                $io->error(\sprintf('Cannot read file: %s', $file));
+
+                return false;
+            }
+
+            $statements = $this->splitSql($content);
+            $skipped = 0;
+
+            foreach ($statements as $statement) {
+                $statement = trim($statement);
+                if ('' === $statement) {
+                    continue;
+                }
+
+                try {
+                    $pdo->exec($statement);
+                } catch (\PDOException $e) {
+                    if (\in_array((int) $e->errorInfo[1], self::IGNORABLE_MYSQL_CODES, true)) {
+                        ++$skipped;
+                        continue;
+                    }
+
+                    $io->error(\sprintf(
+                        'Error in %s/%s: [%s] %s',
+                        $moduleName,
+                        basename($file),
+                        $e->getCode(),
+                        $e->getMessage(),
+                    ));
+
+                    return false;
+                }
+            }
+
+            if ($skipped > 0 && $io->isVerbose()) {
+                $io->text(\sprintf('  <comment>%s</comment>: %d statement(s) skipped (already applied)', basename($file), $skipped));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Split raw SQL content into individual statements.
+     *
+     * Handles DELIMITER blocks used by stored procedures/triggers.
+     * Same logic as Database::prepareSql() but accessible here.
+     *
+     * @return string[]
+     */
+    private function splitSql(string $sql): array
+    {
+        $sql = str_replace(";',", '-CODE-', $sql);
+        $sql = trim($sql);
+
+        preg_match_all('#DELIMITER (.+?)\n(.+?)DELIMITER ;#s', $sql, $m);
+
+        foreach ($m[0] as $k => $v) {
+            $stored = str_replace([';', $m[1][$k]], ['|', ";\n"], $m[2][$k]);
+            $sql = str_replace($v, $stored, $sql);
+        }
+
+        $statements = [];
+        foreach (explode(";\n", $sql) as $part) {
+            $statements[] = str_replace(['-CODE-', '|'], [";',", ';'], $part);
+        }
+
+        return $statements;
+    }
+}

--- a/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
+++ b/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
@@ -44,6 +44,7 @@ final class ModuleSchemaApplyCommand extends Command
         1060, // Duplicate column name
         1061, // Duplicate key name
         1068, // Multiple primary key defined
+        1826, // Duplicate FK constraint name (MySQL 8.0+)
     ];
 
     protected function configure(): void
@@ -206,9 +207,7 @@ final class ModuleSchemaApplyCommand extends Command
         if (is_dir($updateDir)) {
             $updateFiles = glob($updateDir.'/*.sql');
             if (false !== $updateFiles && [] !== $updateFiles) {
-                usort($updateFiles, static function (string $a, string $b): int {
-                    return version_compare(basename($a, '.sql'), basename($b, '.sql'));
-                });
+                usort($updateFiles, static fn (string $a, string $b): int => version_compare(basename($a, '.sql'), basename($b, '.sql')));
                 $files = array_merge($files, $updateFiles);
             }
         }
@@ -244,7 +243,7 @@ final class ModuleSchemaApplyCommand extends Command
                 try {
                     $pdo->exec($statement);
                 } catch (\PDOException $e) {
-                    if (\in_array((int) $e->errorInfo[1], self::IGNORABLE_MYSQL_CODES, true)) {
+                    if ($this->isIgnorableError($e)) {
                         ++$skipped;
                         continue;
                     }
@@ -267,6 +266,23 @@ final class ModuleSchemaApplyCommand extends Command
         }
 
         return true;
+    }
+
+    private function isIgnorableError(\PDOException $e): bool
+    {
+        $mysqlCode = (int) ($e->errorInfo[1] ?? 0);
+
+        if (\in_array($mysqlCode, self::IGNORABLE_MYSQL_CODES, true)) {
+            return true;
+        }
+
+        // MySQL 1005 "Can't create table" with InnoDB errno 121 = duplicate FK constraint name.
+        // Common when TheliaMain.sql and update/*.sql define overlapping constraints.
+        if (1005 === $mysqlCode && str_contains($e->getMessage(), 'errno: 121')) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
+++ b/core/lib/Thelia/Command/ModuleSchemaApplyCommand.php
@@ -58,9 +58,11 @@ final class ModuleSchemaApplyCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        /** @var string|null $module */
         $module = $input->getArgument('module');
-        $all = $input->getOption('all');
-        $dryRun = $input->getOption('dry-run');
+        $all = (bool) $input->getOption('all');
+        $dryRun = (bool) $input->getOption('dry-run');
 
         if (!$module && !$all) {
             $io->error('Provide a module name or use --all.');
@@ -86,7 +88,7 @@ final class ModuleSchemaApplyCommand extends Command
             return Command::FAILURE;
         }
 
-        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $port, $dbName);
+        $dsn = \sprintf('mysql:host=%s;dbname=%s;port=%s', $host, $dbName, $port);
 
         try {
             $pdo = new \PDO($dsn, $user, $password, [
@@ -283,6 +285,10 @@ final class ModuleSchemaApplyCommand extends Command
         preg_match_all('#DELIMITER (.+?)\n(.+?)DELIMITER ;#s', $sql, $m);
 
         foreach ($m[0] as $k => $v) {
+            if ('|' === $m[1][$k]) {
+                throw new \RuntimeException('Cannot use "|" as SQL delimiter: '.$v);
+            }
+
             $stored = str_replace([';', $m[1][$k]], ['|', ";\n"], $m[2][$k]);
             $sql = str_replace($v, $stored, $sql);
         }

--- a/core/lib/Thelia/Core/Event/Attribute/AttributeAvProductEvent.php
+++ b/core/lib/Thelia/Core/Event/Attribute/AttributeAvProductEvent.php
@@ -1,5 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Core\Event\Attribute;
 
 use Thelia\Core\Event\ActionEvent;
@@ -18,9 +30,10 @@ class AttributeAvProductEvent extends ActionEvent
         return $this->attributes;
     }
 
-    public function setAttributes(array $attributes): AttributeAvProductEvent
+    public function setAttributes(array $attributes): self
     {
         $this->attributes = $attributes;
+
         return $this;
     }
 }

--- a/core/lib/Thelia/Core/Event/Maintenance/MaintenancePurgeEvent.php
+++ b/core/lib/Thelia/Core/Event/Maintenance/MaintenancePurgeEvent.php
@@ -1,5 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Core\Event\Maintenance;
 
 use Symfony\Contracts\EventDispatcher\Event;

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -69,7 +69,6 @@ use Thelia\Core\Security\UserProvider\CustomerUserProvider;
 use Thelia\Core\Serializer\SerializerInterface;
 use Thelia\Core\Template\Element\LoopInterface;
 use Thelia\Core\Template\Parser\ParserResolver;
-use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Core\Translation\Translator;

--- a/core/lib/Thelia/Core/Translation/Translator.php
+++ b/core/lib/Thelia/Core/Translation/Translator.php
@@ -23,7 +23,7 @@ class Translator extends BaseTranslator
     public const GLOBAL_FALLBACK_DOMAIN = 'global';
     public const GLOBAL_FALLBACK_KEY = '%s.%s';
 
-    protected static self $instance;
+    protected static ?self $instance = null;
 
     public function __construct(protected RequestStack $requestStack)
     {

--- a/core/lib/Thelia/Domain/Admin/Service/AdminLogPurger.php
+++ b/core/lib/Thelia/Domain/Admin/Service/AdminLogPurger.php
@@ -1,5 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Domain\Admin\Service;
 
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -22,6 +34,6 @@ class AdminLogPurger
 
     private function getThresholdDate(int $days): \DateTime
     {
-        return (new \DateTime())->modify(sprintf('-%d days', $days));
+        return (new \DateTime())->modify(\sprintf('-%d days', $days));
     }
 }

--- a/core/lib/Thelia/Domain/Cart/Service/CartPurger.php
+++ b/core/lib/Thelia/Domain/Cart/Service/CartPurger.php
@@ -1,5 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Domain\Cart\Service;
 
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -47,6 +59,6 @@ class CartPurger
 
     private function getThresholdDate(int $days): \DateTime
     {
-        return (new \DateTime())->modify(sprintf('-%d days', $days));
+        return (new \DateTime())->modify(\sprintf('-%d days', $days));
     }
 }

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Test;
+
+use Thelia\Model\Admin;
+use Thelia\Model\AdminQuery;
+use Thelia\Model\Category;
+use Thelia\Model\CategoryQuery;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\Currency;
+use Thelia\Model\CurrencyQuery;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerTitle;
+use Thelia\Model\CustomerTitleQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleQuery;
+
+/**
+ * Creates test entities with sensible defaults.
+ *
+ * Reference entities (Lang, Currency, etc.) use findOrCreate: they return
+ * existing seed data when available, avoiding duplicates.
+ *
+ * Structural/business entities use an internal counter for unique fields.
+ */
+final class FixtureFactory
+{
+    private int $counter = 0;
+
+    private function next(): int
+    {
+        return ++$this->counter;
+    }
+
+    // ------------------------------------------------------------------
+    // Reference entities (findOrCreate)
+    // ------------------------------------------------------------------
+
+    public function lang(array $overrides = []): Lang
+    {
+        $existing = LangQuery::create()->findOne();
+        if (null !== $existing && [] === $overrides) {
+            return $existing;
+        }
+
+        $lang = new Lang();
+        $lang->setTitle($overrides['title'] ?? 'English');
+        $lang->setCode($overrides['code'] ?? 'en');
+        $lang->setLocale($overrides['locale'] ?? 'en_US');
+        $lang->setActive($overrides['active'] ?? true);
+        $lang->setVisible($overrides['visible'] ?? 1);
+        $lang->setByDefault($overrides['byDefault'] ?? 0);
+        $lang->setDateFormat($overrides['dateFormat'] ?? 'Y-m-d');
+        $lang->setTimeFormat($overrides['timeFormat'] ?? 'H:i:s');
+        $lang->setDatetimeFormat($overrides['datetimeFormat'] ?? 'Y-m-d H:i:s');
+        $lang->setDecimalSeparator($overrides['decimalSeparator'] ?? '.');
+        $lang->setThousandsSeparator($overrides['thousandsSeparator'] ?? ',');
+        $lang->setDecimals($overrides['decimals'] ?? '2');
+        $lang->save();
+
+        return $lang;
+    }
+
+    public function currency(array $overrides = []): Currency
+    {
+        $existing = CurrencyQuery::create()->findOne();
+        if (null !== $existing && [] === $overrides) {
+            return $existing;
+        }
+
+        $currency = new Currency();
+        $currency->setCode($overrides['code'] ?? 'EUR');
+        $currency->setSymbol($overrides['symbol'] ?? '€');
+        $currency->setRate($overrides['rate'] ?? 1.0);
+        $currency->setVisible($overrides['visible'] ?? 1);
+        $currency->setByDefault($overrides['byDefault'] ?? 0);
+        $currency->save();
+
+        return $currency;
+    }
+
+    public function customerTitle(array $overrides = []): CustomerTitle
+    {
+        $existing = CustomerTitleQuery::create()->findOne();
+        if (null !== $existing && [] === $overrides) {
+            return $existing;
+        }
+
+        $n = $this->next();
+        $title = new CustomerTitle();
+        $title->setPosition($overrides['position'] ?? (string) $n);
+        $title->setByDefault($overrides['byDefault'] ?? 0);
+        $title->save();
+
+        return $title;
+    }
+
+    public function country(array $overrides = []): Country
+    {
+        $existing = CountryQuery::create()->findOne();
+        if (null !== $existing && [] === $overrides) {
+            return $existing;
+        }
+
+        $country = new Country();
+        $country->setIsocode($overrides['isocode'] ?? 'FR');
+        $country->setIsoalpha2($overrides['isoalpha2'] ?? 'FR');
+        $country->setIsoalpha3($overrides['isoalpha3'] ?? 'FRA');
+        $country->setVisible($overrides['visible'] ?? 1);
+        $country->setShopCountry($overrides['shopCountry'] ?? true);
+        $country->save();
+
+        return $country;
+    }
+
+    public function taxRule(array $overrides = []): TaxRule
+    {
+        $existing = TaxRuleQuery::create()->findOne();
+        if (null !== $existing && [] === $overrides) {
+            return $existing;
+        }
+
+        $taxRule = new TaxRule();
+        $taxRule->setIsDefault($overrides['isDefault'] ?? false);
+        $taxRule->save();
+
+        return $taxRule;
+    }
+
+    // ------------------------------------------------------------------
+    // Structural entities
+    // ------------------------------------------------------------------
+
+    public function category(array $overrides = []): Category
+    {
+        $category = new Category();
+        $category->setParent($overrides['parent'] ?? 0);
+        $category->setVisible($overrides['visible'] ?? 1);
+        $category->setPosition($overrides['position'] ?? $this->next());
+        $category->save();
+
+        return $category;
+    }
+
+    // ------------------------------------------------------------------
+    // Business entities (dependencies are explicit)
+    // ------------------------------------------------------------------
+
+    public function product(
+        Category $category,
+        TaxRule $taxRule,
+        array $overrides = [],
+    ): Product {
+        $n = $this->next();
+
+        $product = new Product();
+        $product->setRef($overrides['ref'] ?? 'PROD-'.$n);
+        $product->setTaxRuleId($taxRule->getId());
+        $product->setVisible($overrides['visible'] ?? 1);
+        $product->setPosition($overrides['position'] ?? $n);
+        $product->save();
+
+        // Assign to default category
+        $product->addCategory($category);
+        $product->save();
+
+        return $product;
+    }
+
+    public function customer(
+        CustomerTitle $title,
+        array $overrides = [],
+    ): Customer {
+        $n = $this->next();
+
+        $customer = new Customer();
+        $customer->createOrUpdateWithoutAddress(
+            titleId: $title->getId(),
+            firstname: $overrides['firstname'] ?? 'John',
+            lastname: $overrides['lastname'] ?? 'Doe',
+            email: $overrides['email'] ?? 'customer-'.$n.'@test.com',
+            plainPassword: $overrides['password'] ?? 'password',
+        );
+
+        return $customer;
+    }
+
+    public function admin(array $overrides = []): Admin
+    {
+        $n = $this->next();
+
+        $admin = new Admin();
+        $admin->setFirstname($overrides['firstname'] ?? 'Admin');
+        $admin->setLastname($overrides['lastname'] ?? 'Test');
+        $admin->setLogin($overrides['login'] ?? 'admin-'.$n);
+        $admin->setPassword($overrides['password'] ?? 'password');
+        $admin->setLocale($overrides['locale'] ?? 'en_US');
+        $admin->setEmail($overrides['email'] ?? 'admin-'.$n.'@test.com');
+        $admin->save();
+
+        return $admin;
+    }
+}

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 
 namespace Thelia\Test;
 
+use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Model\Admin;
-use Thelia\Model\AdminQuery;
 use Thelia\Model\Category;
-use Thelia\Model\CategoryQuery;
 use Thelia\Model\Country;
 use Thelia\Model\CountryQuery;
 use Thelia\Model\Currency;
@@ -28,7 +27,6 @@ use Thelia\Model\CustomerTitleQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\LangQuery;
 use Thelia\Model\Product;
-use Thelia\Model\ProductQuery;
 use Thelia\Model\TaxRule;
 use Thelia\Model\TaxRuleQuery;
 
@@ -38,11 +36,17 @@ use Thelia\Model\TaxRuleQuery;
  * Reference entities (Lang, Currency, etc.) use findOrCreate: they return
  * existing seed data when available, avoiding duplicates.
  *
- * Structural/business entities use an internal counter for unique fields.
+ * All writes go through the injected connection so that
+ * IntegrationTestCase's transaction rollback catches them.
  */
 final class FixtureFactory
 {
     private int $counter = 0;
+
+    public function __construct(
+        private readonly ConnectionInterface $connection,
+    ) {
+    }
 
     private function next(): int
     {
@@ -55,7 +59,7 @@ final class FixtureFactory
 
     public function lang(array $overrides = []): Lang
     {
-        $existing = LangQuery::create()->findOne();
+        $existing = LangQuery::create()->findOne($this->connection);
         if (null !== $existing && [] === $overrides) {
             return $existing;
         }
@@ -73,14 +77,14 @@ final class FixtureFactory
         $lang->setDecimalSeparator($overrides['decimalSeparator'] ?? '.');
         $lang->setThousandsSeparator($overrides['thousandsSeparator'] ?? ',');
         $lang->setDecimals($overrides['decimals'] ?? '2');
-        $lang->save();
+        $lang->save($this->connection);
 
         return $lang;
     }
 
     public function currency(array $overrides = []): Currency
     {
-        $existing = CurrencyQuery::create()->findOne();
+        $existing = CurrencyQuery::create()->findOne($this->connection);
         if (null !== $existing && [] === $overrides) {
             return $existing;
         }
@@ -91,14 +95,14 @@ final class FixtureFactory
         $currency->setRate($overrides['rate'] ?? 1.0);
         $currency->setVisible($overrides['visible'] ?? 1);
         $currency->setByDefault($overrides['byDefault'] ?? 0);
-        $currency->save();
+        $currency->save($this->connection);
 
         return $currency;
     }
 
     public function customerTitle(array $overrides = []): CustomerTitle
     {
-        $existing = CustomerTitleQuery::create()->findOne();
+        $existing = CustomerTitleQuery::create()->findOne($this->connection);
         if (null !== $existing && [] === $overrides) {
             return $existing;
         }
@@ -107,14 +111,14 @@ final class FixtureFactory
         $title = new CustomerTitle();
         $title->setPosition($overrides['position'] ?? (string) $n);
         $title->setByDefault($overrides['byDefault'] ?? 0);
-        $title->save();
+        $title->save($this->connection);
 
         return $title;
     }
 
     public function country(array $overrides = []): Country
     {
-        $existing = CountryQuery::create()->findOne();
+        $existing = CountryQuery::create()->findOne($this->connection);
         if (null !== $existing && [] === $overrides) {
             return $existing;
         }
@@ -125,21 +129,21 @@ final class FixtureFactory
         $country->setIsoalpha3($overrides['isoalpha3'] ?? 'FRA');
         $country->setVisible($overrides['visible'] ?? 1);
         $country->setShopCountry($overrides['shopCountry'] ?? true);
-        $country->save();
+        $country->save($this->connection);
 
         return $country;
     }
 
     public function taxRule(array $overrides = []): TaxRule
     {
-        $existing = TaxRuleQuery::create()->findOne();
+        $existing = TaxRuleQuery::create()->findOne($this->connection);
         if (null !== $existing && [] === $overrides) {
             return $existing;
         }
 
         $taxRule = new TaxRule();
         $taxRule->setIsDefault($overrides['isDefault'] ?? false);
-        $taxRule->save();
+        $taxRule->save($this->connection);
 
         return $taxRule;
     }
@@ -154,7 +158,7 @@ final class FixtureFactory
         $category->setParent($overrides['parent'] ?? 0);
         $category->setVisible($overrides['visible'] ?? 1);
         $category->setPosition($overrides['position'] ?? $this->next());
-        $category->save();
+        $category->save($this->connection);
 
         return $category;
     }
@@ -175,11 +179,10 @@ final class FixtureFactory
         $product->setTaxRuleId($taxRule->getId());
         $product->setVisible($overrides['visible'] ?? 1);
         $product->setPosition($overrides['position'] ?? $n);
-        $product->save();
+        $product->save($this->connection);
 
-        // Assign to default category
         $product->addCategory($category);
-        $product->save();
+        $product->save($this->connection);
 
         return $product;
     }
@@ -191,13 +194,12 @@ final class FixtureFactory
         $n = $this->next();
 
         $customer = new Customer();
-        $customer->createOrUpdateWithoutAddress(
-            titleId: $title->getId(),
-            firstname: $overrides['firstname'] ?? 'John',
-            lastname: $overrides['lastname'] ?? 'Doe',
-            email: $overrides['email'] ?? 'customer-'.$n.'@test.com',
-            plainPassword: $overrides['password'] ?? 'password',
-        );
+        $customer->setTitleId($title->getId());
+        $customer->setFirstname($overrides['firstname'] ?? 'John');
+        $customer->setLastname($overrides['lastname'] ?? 'Doe');
+        $customer->setEmail($overrides['email'] ?? 'customer-'.$n.'@test.com');
+        $customer->setPassword($overrides['password'] ?? 'password');
+        $customer->save($this->connection);
 
         return $customer;
     }
@@ -213,7 +215,7 @@ final class FixtureFactory
         $admin->setPassword($overrides['password'] ?? 'password');
         $admin->setLocale($overrides['locale'] ?? 'en_US');
         $admin->setEmail($overrides['email'] ?? 'admin-'.$n.'@test.com');
-        $admin->save();
+        $admin->save($this->connection);
 
         return $admin;
     }

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -41,7 +41,7 @@ use Thelia\Model\TaxRuleQuery;
  */
 final class FixtureFactory
 {
-    private int $counter = 0;
+    private static int $counter = 0;
 
     public function __construct(
         private readonly ConnectionInterface $connection,
@@ -50,7 +50,7 @@ final class FixtureFactory
 
     private function next(): int
     {
-        return ++$this->counter;
+        return ++self::$counter;
     }
 
     // ------------------------------------------------------------------
@@ -170,19 +170,27 @@ final class FixtureFactory
     public function product(
         Category $category,
         TaxRule $taxRule,
+        Currency $currency,
         array $overrides = [],
     ): Product {
         $n = $this->next();
 
         $product = new Product();
-        $product->setRef($overrides['ref'] ?? 'PROD-'.$n);
-        $product->setTaxRuleId($taxRule->getId());
-        $product->setVisible($overrides['visible'] ?? 1);
-        $product->setPosition($overrides['position'] ?? $n);
-        $product->save($this->connection);
+        $product
+            ->setRef($overrides['ref'] ?? 'PROD-'.$n)
+            ->setVisible($overrides['visible'] ?? 1)
+            ->setPosition($overrides['position'] ?? $n);
 
-        $product->addCategory($category);
-        $product->save($this->connection);
+        // Product::create() handles the full creation in a transaction:
+        // persist the product, assign default category, create default PSE + price.
+        $product->create(
+            $category->getId(),
+            $overrides['basePrice'] ?? 10.0,
+            $currency->getId(),
+            $taxRule->getId(),
+            $overrides['baseWeight'] ?? 0.0,
+            $overrides['baseQuantity'] ?? 0,
+        );
 
         return $product;
     }

--- a/core/lib/Thelia/Test/IntegrationTestCase.php
+++ b/core/lib/Thelia/Test/IntegrationTestCase.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Test;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Thelia\Core\TheliaKernel;
+use Thelia\Core\Translation\Translator;
+
+/**
+ * Base class for Thelia integration tests.
+ *
+ * Boots the kernel, initializes Translator, and wraps each test in a
+ * transaction rolled back in tearDown() for full isolation.
+ *
+ * Prerequisites (run before the test suite):
+ *   bin/console thelia:database:create --env=test
+ *   bin/console thelia:database:populate --env=test
+ *   bin/console cache:warmup --env=test
+ *
+ * Constraints:
+ *   - Auto-increment values are NOT rolled back: never hardcode IDs.
+ *   - The kernel is static across tests: do not mutate the container.
+ *   - DDL/TRUNCATE tests must set $useTransaction = false and clean up manually.
+ */
+abstract class IntegrationTestCase extends KernelTestCase
+{
+    protected bool $useTransaction = true;
+
+    private ?ConnectionInterface $connection = null;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        if (!TheliaKernel::isInstalled()) {
+            $this->markTestSkipped(
+                'Test database not available. Run: '
+                .'bin/console thelia:database:create --env=test '
+                .'&& bin/console thelia:database:populate --env=test',
+            );
+        }
+
+        try {
+            Translator::getInstance();
+        } catch (\RuntimeException) {
+            static::getContainer()->get('thelia.translator');
+        }
+
+        if ($this->useTransaction) {
+            $this->connection = Propel::getConnection('TheliaMain');
+            $this->connection->beginTransaction();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->useTransaction && $this->connection instanceof ConnectionInterface && $this->connection->inTransaction()) {
+            $this->connection->rollBack();
+        }
+
+        $this->connection = null;
+
+        parent::tearDown();
+    }
+
+    protected function getService(string $id): object
+    {
+        return static::getContainer()->get($id);
+    }
+
+    protected function getPropelConnection(): ConnectionInterface
+    {
+        return Propel::getConnection('TheliaMain');
+    }
+}

--- a/core/lib/Thelia/Test/IntegrationTestCase.php
+++ b/core/lib/Thelia/Test/IntegrationTestCase.php
@@ -17,19 +17,19 @@ namespace Thelia\Test;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Propel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Thelia\Core\TheliaKernel;
 use Thelia\Core\Translation\Translator;
 
 /**
  * Base class for Thelia integration tests.
  *
- * Boots the kernel, initializes Translator, and wraps each test in a
- * transaction rolled back in tearDown() for full isolation.
+ * Boots the kernel, initializes singletons (Translator, URL), pushes a
+ * minimal Request, and wraps each test in a transaction rolled back in
+ * tearDown() for full isolation.
  *
  * Prerequisites (run before the test suite):
- *   bin/console thelia:database:create --env=test
- *   bin/console thelia:database:populate --env=test
- *   bin/console cache:warmup --env=test
+ *   php bin/test-prepare
  *
  * Constraints:
  *   - Auto-increment values are NOT rolled back: never hardcode IDs.
@@ -48,16 +48,30 @@ abstract class IntegrationTestCase extends KernelTestCase
 
         if (!TheliaKernel::isInstalled()) {
             $this->markTestSkipped(
-                'Test database not available. Run: '
-                .'bin/console thelia:database:create --env=test '
-                .'&& bin/console thelia:database:populate --env=test',
+                'Test database not available. Run: php bin/test-prepare',
             );
         }
 
+        $container = static::getContainer();
+
+        // Initialize singletons that business code accesses statically
         try {
             Translator::getInstance();
         } catch (\RuntimeException) {
-            static::getContainer()->get('thelia.translator');
+            $container->get('thelia.translator');
+        }
+
+        try {
+            \Thelia\Tools\URL::getInstance();
+        } catch (\RuntimeException) {
+            $container->get('thelia.url.manager');
+        }
+
+        // Push a minimal Request so that modules accessing the request stack
+        // (e.g. CustomerFamily, OpenApi) don't crash on null.
+        $requestStack = $container->get('request_stack');
+        if (null === $requestStack->getCurrentRequest()) {
+            $requestStack->push(Request::create('http://localhost'));
         }
 
         if ($this->useTransaction) {
@@ -79,7 +93,9 @@ abstract class IntegrationTestCase extends KernelTestCase
 
     /**
      * @template T of object
+     *
      * @param class-string<T> $id
+     *
      * @return T
      */
     protected function getService(string $id): object

--- a/core/lib/Thelia/Test/IntegrationTestCase.php
+++ b/core/lib/Thelia/Test/IntegrationTestCase.php
@@ -77,6 +77,11 @@ abstract class IntegrationTestCase extends KernelTestCase
         parent::tearDown();
     }
 
+    /**
+     * @template T of object
+     * @param class-string<T> $id
+     * @return T
+     */
     protected function getService(string $id): object
     {
         return static::getContainer()->get($id);
@@ -85,5 +90,10 @@ abstract class IntegrationTestCase extends KernelTestCase
     protected function getPropelConnection(): ConnectionInterface
     {
         return Propel::getConnection('TheliaMain');
+    }
+
+    protected function createFixtureFactory(): FixtureFactory
+    {
+        return new FixtureFactory($this->getPropelConnection());
     }
 }

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -34,7 +34,7 @@ class URL
     public const PATH_TO_FILE = true;
     public const WITH_INDEX_PAGE = false;
 
-    protected static self $instance;
+    protected static ?self $instance = null;
 
     /** @var string a cache for the base URL scheme */
     private ?string $baseUrlScheme = null;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
 
         <!-- ###+ symfony/framework-bundle ### -->
         <server name="APP_ENV" value="test" force="true" />
+        <server name="APP_DEBUG" value="0" force="true" />
         <env name="APP_SECRET" value="287f2178af9e0c250e8219a9df833504"/>
         <!-- ###- symfony/framework-bundle ### -->
         <!-- ###+ lexik/jwt-authentication-bundle ### -->

--- a/tests/Functional/Action/CategoryActionTest.php
+++ b/tests/Functional/Action/CategoryActionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Action;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Category\CategoryCreateEvent;
+use Thelia\Core\Event\Category\CategoryUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CategoryQuery;
+use Thelia\Test\IntegrationTestCase;
+
+final class CategoryActionTest extends IntegrationTestCase
+{
+    private EventDispatcherInterface $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dispatcher = $this->getService(EventDispatcherInterface::class);
+    }
+
+    public function testCreateCategoryPersistsAndAssignsId(): void
+    {
+        $event = new CategoryCreateEvent();
+        $event->setTitle('Test Category');
+        $event->setLocale('en_US');
+        $event->setParent(0);
+        $event->setVisible(1);
+
+        $this->dispatcher->dispatch($event, TheliaEvents::CATEGORY_CREATE);
+
+        $category = $event->getCategory();
+        self::assertNotNull($category);
+        self::assertNotNull($category->getId());
+        self::assertSame(0, $category->getParent());
+        self::assertSame(1, $category->getVisible());
+
+        $reloaded = CategoryQuery::create()->findPk($category->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame('Test Category', $reloaded->setLocale('en_US')->getTitle());
+    }
+
+    public function testUpdateCategoryChangesFields(): void
+    {
+        $createEvent = new CategoryCreateEvent();
+        $createEvent->setTitle('Original');
+        $createEvent->setLocale('en_US');
+        $createEvent->setParent(0);
+        $createEvent->setVisible(1);
+        $this->dispatcher->dispatch($createEvent, TheliaEvents::CATEGORY_CREATE);
+
+        $categoryId = $createEvent->getCategory()->getId();
+
+        $updateEvent = new CategoryUpdateEvent($categoryId);
+        $updateEvent->setTitle('Updated Title');
+        $updateEvent->setLocale('en_US');
+        $updateEvent->setParent(0);
+        $updateEvent->setVisible(0);
+        $updateEvent->setDescription('A description');
+        $updateEvent->setDefaultTemplateId(0);
+
+        $this->dispatcher->dispatch($updateEvent, TheliaEvents::CATEGORY_UPDATE);
+
+        $reloaded = CategoryQuery::create()->findPk($categoryId);
+        self::assertNotNull($reloaded);
+        $reloaded->setLocale('en_US');
+        self::assertSame('Updated Title', $reloaded->getTitle());
+        self::assertSame('A description', $reloaded->getDescription());
+        self::assertSame(0, $reloaded->getVisible());
+        self::assertNull($reloaded->getDefaultTemplateId());
+    }
+
+    public function testCreateNestedCategory(): void
+    {
+        $parentEvent = new CategoryCreateEvent();
+        $parentEvent->setTitle('Parent');
+        $parentEvent->setLocale('en_US');
+        $parentEvent->setParent(0);
+        $parentEvent->setVisible(1);
+        $this->dispatcher->dispatch($parentEvent, TheliaEvents::CATEGORY_CREATE);
+
+        $parentId = $parentEvent->getCategory()->getId();
+
+        $childEvent = new CategoryCreateEvent();
+        $childEvent->setTitle('Child');
+        $childEvent->setLocale('en_US');
+        $childEvent->setParent($parentId);
+        $childEvent->setVisible(1);
+        $this->dispatcher->dispatch($childEvent, TheliaEvents::CATEGORY_CREATE);
+
+        $child = $childEvent->getCategory();
+        self::assertSame($parentId, $child->getParent());
+    }
+}

--- a/tests/Functional/Action/CurrencyActionTest.php
+++ b/tests/Functional/Action/CurrencyActionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Action;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Currency\CurrencyCreateEvent;
+use Thelia\Core\Event\Currency\CurrencyUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CurrencyQuery;
+use Thelia\Test\IntegrationTestCase;
+
+final class CurrencyActionTest extends IntegrationTestCase
+{
+    private EventDispatcherInterface $dispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dispatcher = $this->getService(EventDispatcherInterface::class);
+    }
+
+    public function testCreateCurrencyPersistsWithUppercaseCode(): void
+    {
+        $event = new CurrencyCreateEvent();
+        $event
+            ->setCurrencyName('Swiss Franc')
+            ->setLocale('en_US')
+            ->setSymbol('CHF')
+            ->setFormat('#,###.##')
+            ->setCode('chf')
+            ->setRate(0.92);
+
+        $this->dispatcher->dispatch($event, TheliaEvents::CURRENCY_CREATE);
+
+        $currency = $event->getCurrency();
+        self::assertNotNull($currency);
+        self::assertSame('CHF', $currency->getCode(), 'Code must be uppercased by the listener');
+        self::assertEqualsWithDelta(0.92, (float) $currency->getRate(), 0.001);
+    }
+
+    public function testUpdateCurrencyRate(): void
+    {
+        $createEvent = new CurrencyCreateEvent();
+        $createEvent
+            ->setCurrencyName('British Pound')
+            ->setLocale('en_US')
+            ->setSymbol('£')
+            ->setCode('GBP')
+            ->setRate(0.85);
+        $this->dispatcher->dispatch($createEvent, TheliaEvents::CURRENCY_CREATE);
+
+        $currencyId = $createEvent->getCurrency()->getId();
+
+        $updateEvent = new CurrencyUpdateEvent($currencyId);
+        $updateEvent
+            ->setCurrencyName('British Pound Sterling')
+            ->setLocale('en_US')
+            ->setSymbol('£')
+            ->setCode('GBP')
+            ->setRate(0.88);
+        $this->dispatcher->dispatch($updateEvent, TheliaEvents::CURRENCY_UPDATE);
+
+        $reloaded = CurrencyQuery::create()->findPk($currencyId);
+        self::assertNotNull($reloaded);
+        self::assertSame('British Pound Sterling', $reloaded->setLocale('en_US')->getName());
+        self::assertEqualsWithDelta(0.88, (float) $reloaded->getRate(), 0.001);
+    }
+
+    public function testFirstCurrencyBecomesDefault(): void
+    {
+        // Remove all currencies first to test the "first = default" behavior
+        CurrencyQuery::create()->deleteAll();
+
+        $event = new CurrencyCreateEvent();
+        $event
+            ->setCurrencyName('Test Default')
+            ->setLocale('en_US')
+            ->setSymbol('$')
+            ->setCode('TST')
+            ->setRate(1.0);
+        $this->dispatcher->dispatch($event, TheliaEvents::CURRENCY_CREATE);
+
+        self::assertTrue(
+            (bool) $event->getCurrency()->getByDefault(),
+            'First currency created should be the default'
+        );
+    }
+}

--- a/tests/Functional/Action/CustomerActionTest.php
+++ b/tests/Functional/Action/CustomerActionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Action;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Customer\CustomerCreateOrUpdateMinimalEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CustomerQuery;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+final class CustomerActionTest extends IntegrationTestCase
+{
+    private EventDispatcherInterface $dispatcher;
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dispatcher = $this->getService(EventDispatcherInterface::class);
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testCreateMinimalCustomerPersistsWithHashedPassword(): void
+    {
+        $title = $this->factory->customerTitle();
+
+        $event = new CustomerCreateOrUpdateMinimalEvent();
+        $event
+            ->setTitle($title->getId())
+            ->setFirstname('Jane')
+            ->setLastname('Doe')
+            ->setEmail('jane.doe@test.com')
+            ->setPassword('secret123');
+
+        $this->dispatcher->dispatch($event, TheliaEvents::CREATE_CUSTOMER_MINIMAL);
+
+        $customer = $event->getCustomer();
+        self::assertNotNull($customer);
+        self::assertNotNull($customer->getId());
+
+        $reloaded = CustomerQuery::create()->findPk($customer->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame('Jane', $reloaded->getFirstname());
+        self::assertSame('Doe', $reloaded->getLastname());
+        self::assertSame('jane.doe@test.com', $reloaded->getEmail());
+
+        self::assertNotSame('secret123', $reloaded->getPassword());
+        self::assertTrue(password_verify('secret123', $reloaded->getPassword()));
+        self::assertSame('PASSWORD_BCRYPT', $reloaded->getAlgo());
+    }
+
+    public function testCreateMinimalCustomerWithDiscount(): void
+    {
+        $title = $this->factory->customerTitle();
+
+        $event = new CustomerCreateOrUpdateMinimalEvent();
+        $event
+            ->setTitle($title->getId())
+            ->setFirstname('John')
+            ->setLastname('Discount')
+            ->setEmail('discount@test.com')
+            ->setPassword('password')
+            ->setDiscount(15.5)
+            ->setReseller(true);
+
+        $this->dispatcher->dispatch($event, TheliaEvents::CREATE_CUSTOMER_MINIMAL);
+
+        $customer = $event->getCustomer();
+        self::assertNotNull($customer);
+        self::assertEqualsWithDelta(15.5, (float) $customer->getDiscount(), 0.01);
+        self::assertTrue((bool) $customer->getReseller());
+    }
+
+    public function testTransactionRollbackIsolatesTests(): void
+    {
+        $title = $this->factory->customerTitle();
+
+        $event = new CustomerCreateOrUpdateMinimalEvent();
+        $event
+            ->setTitle($title->getId())
+            ->setFirstname('Isolated')
+            ->setLastname('Test')
+            ->setEmail('isolated@test.com')
+            ->setPassword('password');
+
+        $this->dispatcher->dispatch($event, TheliaEvents::CREATE_CUSTOMER_MINIMAL);
+
+        $id = $event->getCustomer()->getId();
+        self::assertNotNull(CustomerQuery::create()->findPk($id));
+
+        // This customer will be rolled back in tearDown().
+        // The next test should not see it.
+    }
+
+    public function testPreviousTestDataIsRolledBack(): void
+    {
+        $result = CustomerQuery::create()
+            ->filterByEmail('isolated@test.com')
+            ->findOne();
+
+        self::assertNull($result, 'Transaction rollback should have removed the customer from the previous test');
+    }
+}

--- a/tests/Functional/Action/ProductActionTest.php
+++ b/tests/Functional/Action/ProductActionTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Action;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Product\ProductCreateEvent;
+use Thelia\Core\Event\Product\ProductDeleteEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\ProductPriceQuery;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+final class ProductActionTest extends IntegrationTestCase
+{
+    private EventDispatcherInterface $dispatcher;
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dispatcher = $this->getService(EventDispatcherInterface::class);
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testCreateProductPersistsWithDefaultPSE(): void
+    {
+        $category = $this->factory->category();
+        $currency = $this->factory->currency();
+        $taxRule = $this->factory->taxRule();
+
+        $event = new ProductCreateEvent();
+        $event
+            ->setRef('TEST-PROD-1')
+            ->setTitle('Test Product')
+            ->setLocale('en_US')
+            ->setDefaultCategory($category->getId())
+            ->setVisible(true)
+            ->setVirtual(false)
+            ->setBasePrice(29.99)
+            ->setBaseWeight(0.5)
+            ->setCurrencyId($currency->getId())
+            ->setTaxRuleId($taxRule->getId())
+            ->setBaseQuantity(100);
+
+        $this->dispatcher->dispatch($event, TheliaEvents::PRODUCT_CREATE);
+
+        $product = $event->getProduct();
+        self::assertNotNull($product);
+        self::assertSame('TEST-PROD-1', $product->getRef());
+
+        // Default PSE must be created automatically
+        $defaultPse = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        self::assertNotNull($defaultPse, 'Default PSE must be created with the product');
+        self::assertEquals(100, $defaultPse->getQuantity());
+        self::assertEqualsWithDelta(0.5, $defaultPse->getWeight(), 0.001);
+
+        // Price must be set in the chosen currency
+        $price = ProductPriceQuery::create()
+            ->filterByProductSaleElementsId($defaultPse->getId())
+            ->filterByCurrencyId($currency->getId())
+            ->findOne();
+
+        self::assertNotNull($price, 'Price must exist for the default PSE');
+        self::assertEqualsWithDelta(29.99, (float) $price->getPrice(), 0.01);
+    }
+
+    public function testCreateProductAssignsDefaultCategory(): void
+    {
+        $category = $this->factory->category();
+        $currency = $this->factory->currency();
+        $taxRule = $this->factory->taxRule();
+
+        $event = new ProductCreateEvent();
+        $event
+            ->setRef('TEST-CAT-ASSIGN')
+            ->setTitle('Category Assignment Test')
+            ->setLocale('en_US')
+            ->setDefaultCategory($category->getId())
+            ->setBasePrice(10.0)
+            ->setCurrencyId($currency->getId())
+            ->setTaxRuleId($taxRule->getId());
+
+        $this->dispatcher->dispatch($event, TheliaEvents::PRODUCT_CREATE);
+
+        $product = $event->getProduct();
+        self::assertSame($category->getId(), $product->getDefaultCategoryId());
+    }
+
+    public function testCreateVirtualProduct(): void
+    {
+        $category = $this->factory->category();
+        $currency = $this->factory->currency();
+        $taxRule = $this->factory->taxRule();
+
+        $event = new ProductCreateEvent();
+        $event
+            ->setRef('VIRTUAL-1')
+            ->setTitle('Digital Download')
+            ->setLocale('en_US')
+            ->setDefaultCategory($category->getId())
+            ->setVisible(true)
+            ->setVirtual(true)
+            ->setBasePrice(5.0)
+            ->setCurrencyId($currency->getId())
+            ->setTaxRuleId($taxRule->getId());
+
+        $this->dispatcher->dispatch($event, TheliaEvents::PRODUCT_CREATE);
+
+        $product = $event->getProduct();
+        self::assertSame(1, $product->getVirtual());
+    }
+
+    public function testDeleteProductRemovesFromDatabase(): void
+    {
+        $this->useTransaction = false;
+
+        $category = $this->factory->category();
+        $currency = $this->factory->currency();
+        $taxRule = $this->factory->taxRule();
+
+        $createEvent = new ProductCreateEvent();
+        $createEvent
+            ->setRef('TO-DELETE')
+            ->setTitle('To Delete')
+            ->setLocale('en_US')
+            ->setDefaultCategory($category->getId())
+            ->setBasePrice(1.0)
+            ->setCurrencyId($currency->getId())
+            ->setTaxRuleId($taxRule->getId());
+
+        $this->dispatcher->dispatch($createEvent, TheliaEvents::PRODUCT_CREATE);
+        $productId = $createEvent->getProduct()->getId();
+
+        $deleteEvent = new ProductDeleteEvent($productId);
+        $this->dispatcher->dispatch($deleteEvent, TheliaEvents::PRODUCT_DELETE);
+
+        self::assertNull(ProductQuery::create()->findPk($productId));
+
+        // PSEs should be cascade-deleted
+        $remainingPse = ProductSaleElementsQuery::create()
+            ->filterByProductId($productId)
+            ->count();
+        self::assertSame(0, $remainingPse);
+    }
+}

--- a/tests/Functional/Test/FixtureFactoryTest.php
+++ b/tests/Functional/Test/FixtureFactoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Test;
+
+use Thelia\Model\AdminQuery;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+final class FixtureFactoryTest extends IntegrationTestCase
+{
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testReferenceEntitiesReturnExistingSeedData(): void
+    {
+        $lang1 = $this->factory->lang();
+        $lang2 = $this->factory->lang();
+
+        self::assertSame($lang1->getId(), $lang2->getId(), 'lang() must return the same seeded entity');
+
+        $currency1 = $this->factory->currency();
+        $currency2 = $this->factory->currency();
+
+        self::assertSame($currency1->getId(), $currency2->getId());
+    }
+
+    public function testCategoryCreation(): void
+    {
+        $category = $this->factory->category();
+
+        self::assertNotNull($category->getId());
+        self::assertSame(0, $category->getParent());
+        self::assertSame(1, $category->getVisible());
+    }
+
+    public function testProductCreationWithPSE(): void
+    {
+        $category = $this->factory->category();
+        $taxRule = $this->factory->taxRule();
+        $currency = $this->factory->currency();
+
+        $product = $this->factory->product($category, $taxRule, $currency);
+
+        self::assertNotNull($product->getId());
+        self::assertStringStartsWith('PROD-', $product->getRef());
+
+        $pse = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        self::assertNotNull($pse, 'Product must have a default PSE');
+    }
+
+    public function testCustomerCreationWithHashedPassword(): void
+    {
+        $title = $this->factory->customerTitle();
+        $customer = $this->factory->customer($title);
+
+        self::assertNotNull($customer->getId());
+        self::assertSame('PASSWORD_BCRYPT', $customer->getAlgo());
+        self::assertTrue(password_verify('password', $customer->getPassword()));
+    }
+
+    public function testAdminCreation(): void
+    {
+        $admin = $this->factory->admin();
+
+        self::assertNotNull($admin->getId());
+        self::assertStringStartsWith('admin-', $admin->getLogin());
+        self::assertSame('PASSWORD_BCRYPT', $admin->getAlgo());
+        self::assertTrue(password_verify('password', $admin->getPassword()));
+    }
+
+    public function testCounterEnsuresUniqueness(): void
+    {
+        $admin1 = $this->factory->admin();
+        $admin2 = $this->factory->admin();
+
+        self::assertNotSame($admin1->getLogin(), $admin2->getLogin());
+        self::assertNotSame($admin1->getEmail(), $admin2->getEmail());
+    }
+
+    public function testOverridesAreApplied(): void
+    {
+        $category = $this->factory->category(['visible' => 0, 'parent' => 0]);
+
+        self::assertSame(0, $category->getVisible());
+    }
+
+    public function testAllFixtureDataIsRolledBack(): void
+    {
+        $countBefore = AdminQuery::create()->count();
+
+        $this->factory->admin();
+        $this->factory->admin();
+        $this->factory->admin();
+
+        // These 3 admins exist within the transaction...
+        self::assertSame($countBefore + 3, AdminQuery::create()->count());
+
+        // ...but will be rolled back in tearDown().
+        // The next test can verify this.
+    }
+}


### PR DESCRIPTION
## Summary

Thelia 3 has no built-in way to run integration tests against a database. Each project reinvents its own bootstrap (~50-100 lines), modules can't have CI with database tests, and real bugs stay hidden until production.

This PR adds a complete, minimal test infrastructure:

- **`bin/test-prepare`** — standalone script that creates the test database, applies core schema + seed data, registers modules, and applies module schemas. Runs without booting the Symfony kernel, avoiding the chicken-and-egg problem of module activation.
- **`IntegrationTestCase`** — base class with kernel boot, Translator/URL singleton init, Request push for module listeners, and per-test transaction rollback.
- **`FixtureFactory`** — creates test entities (Lang, Currency, Category, Product, Customer, Admin…) with sensible defaults and a static counter for unique fields.
- **3 console commands** — `thelia:database:create`, `thelia:database:populate`, `module:schema:apply` for environments where the kernel is available.
- **22 functional tests / 63 assertions** covering Category CRUD, Customer lifecycle, Product creation with default PSE + pricing, Currency management, and FixtureFactory itself.

Also fixes three pre-existing bugs found during development:
- `Translator::$instance` and `URL::$instance` — typed static properties without default cause fatal errors outside HTTP context (now nullable)
- `#[Ignore]` on static methods in `PropelResourceInterface`, `ResourceAddonInterface`, `PaymentModule` — crashes Symfony Serializer's `AttributeLoader` during `cache:warmup` (removed; static methods are never serialized)