### PR TITLE
Add standalone install script and DatabaseSetup helper

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,15 +16,14 @@ declare(strict_types=1);
  *   ddev exec php bin/install
  *
  * Required env vars: DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD
- * Optional env vars: ACTIVE_FRONT_TEMPLATE, ACTIVE_ADMIN_TEMPLATE, ACTIVE_PDF_TEMPLATE, ACTIVE_EMAIL_TEMPLATE
  */
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Process\Process;
 use Thelia\Core\Install\CheckPermission;
-use Thelia\Core\Install\Database;
-use Thelia\Tools\TokenProvider;
+use Thelia\Install\Standalone\DatabaseSetup;
 
 (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 
@@ -49,6 +48,7 @@ $port     = $_SERVER['DATABASE_PORT'] ?? '3306';
 $user     = $_SERVER['DATABASE_USER'] ?? '';
 $password = $_SERVER['DATABASE_PASSWORD'] ?? '';
 $dbName   = $_SERVER['DATABASE_NAME'] ?? '';
+$errors   = 0;
 
 if ('' === $host || '' === $dbName) {
     fwrite(STDERR, "ERROR: DATABASE_HOST and DATABASE_NAME must be set.\n");
@@ -77,34 +77,22 @@ if (!$check->exec()) {
 
 echo "  OK\n";
 
-// ── Phase 2: Create database ─────────────────────────────────────────
+// ── Phase 2-4: Database, schema, secret ──────────────────────────────
 
-echo "Creating database \"{$dbName}\"...\n";
+try {
+    $setup = new DatabaseSetup($host, $port, $dbName, $user, $password);
 
-$pdo = new PDO("mysql:host={$host};port={$port}", $user, $password, [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-]);
-$pdo->exec("CREATE DATABASE IF NOT EXISTS `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    echo "Creating database \"{$dbName}\"...\n";
+    $setup->createDatabase();
 
-// ── Phase 3: Apply core schema + reference data ──────────────────────
-
-echo "Applying core schema...\n";
-
-$pdo = new PDO("mysql:host={$host};dbname={$dbName};port={$port}", $user, $password, [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-]);
-
-$database = new Database($pdo);
-$setupDir = THELIA_SETUP_DIRECTORY;
-
-$database->insertSql(null, [$setupDir.'thelia.sql']);
-$database->insertSql(null, [$setupDir.'insert.sql']);
-
-// ── Phase 4: Generate form secret ────────────────────────────────────
-
-$secret = TokenProvider::generateToken();
-$stmt = $pdo->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'form.secret'");
-$stmt->execute([$secret]);
+    echo "Applying core schema...\n";
+    $setup->connect();
+    $setup->applyCoreSchemAndSeed();
+    $setup->generateFormSecret();
+} catch (\PDOException $e) {
+    fwrite(STDERR, "ERROR: Database operation failed — {$e->getMessage()}\n");
+    exit(1);
+}
 
 // ── Phase 5: Write env file ──────────────────────────────────────────
 
@@ -115,14 +103,9 @@ echo "Writing {$envFile}...\n";
 
 $envContent = sprintf(
     "\n###> thelia/database-configuration ###\nDATABASE_HOST=%s\nDATABASE_PORT=%s\nDATABASE_NAME=%s\nDATABASE_USER=%s\nDATABASE_PASSWORD=%s\n###< thelia/database-configuration ###\n",
-    $host,
-    $port,
-    $dbName,
-    $user,
-    $password,
+    $host, $port, $dbName, $user, $password,
 );
 
-// Remove existing database block if present, then append
 if (file_exists($envFilePath)) {
     $existing = file_get_contents($envFilePath);
     $existing = preg_replace('/\n?###> thelia\/database-configuration ###.*?###< thelia\/database-configuration ###\n?/s', '', $existing);
@@ -131,101 +114,17 @@ if (file_exists($envFilePath)) {
     file_put_contents($envFilePath, $envContent);
 }
 
-// Publish env vars for the current process (subsequent phases read them)
-$_SERVER['DATABASE_HOST'] = $host;
-$_SERVER['DATABASE_PORT'] = $port;
-$_SERVER['DATABASE_NAME'] = $dbName;
-$_SERVER['DATABASE_USER'] = $user;
-$_SERVER['DATABASE_PASSWORD'] = $password;
-
-// ── Phase 6: Register and activate modules ───────────────────────────
+// ── Phase 6: Register modules ────────────────────────────────────────
 
 echo "Registering modules...\n";
+$count = $setup->registerAndApplyModules();
+echo "  {$count} module(s) registered\n";
 
-$moduleDirs = array_filter([THELIA_MODULE_DIR, THELIA_LOCAL_MODULE_DIR], 'is_dir');
-$position = 0;
-$ignorableCodes = [1050, 1060, 1061, 1068, 1826];
-
-$insertModule = $pdo->prepare(
-    'INSERT INTO `module` (`code`, `version`, `type`, `category`, `activate`, `position`, `full_namespace`, `mandatory`, `hidden`, `created_at`)
-     VALUES (:code, :version, 1, :category, 1, :position, :namespace, :mandatory, :hidden, NOW())
-     ON DUPLICATE KEY UPDATE `activate` = 1, `full_namespace` = VALUES(`full_namespace`), `version` = VALUES(`version`)'
-);
-
-foreach ($moduleDirs as $baseDir) {
-    foreach (new DirectoryIterator($baseDir) as $entry) {
-        if (!$entry->isDir() || $entry->isDot()) {
-            continue;
-        }
-
-        $moduleXml = $entry->getPathname().'/Config/module.xml';
-        if (!file_exists($moduleXml)) {
-            continue;
-        }
-
-        $xml = @simplexml_load_file($moduleXml);
-        if (false === $xml) {
-            continue;
-        }
-
-        $code = $entry->getFilename();
-        $namespace = (string) ($xml->fullnamespace ?? $code.'\\'.$code);
-        $version = (string) ($xml->version ?? '0.0.1');
-        $category = (string) ($xml->type ?? 'classic');
-        $mandatory = (int) ($xml->mandatory ?? 0);
-        $hidden = (int) ($xml->hidden ?? 0);
-
-        $insertModule->execute([
-            'code' => $code,
-            'version' => $version,
-            'category' => $category,
-            'position' => ++$position,
-            'namespace' => $namespace,
-            'mandatory' => $mandatory,
-            'hidden' => $hidden,
-        ]);
-
-        // Apply module schema if present
-        $mainSql = $entry->getPathname().'/Config/TheliaMain.sql';
-        if (!file_exists($mainSql)) {
-            continue;
-        }
-
-        $files = [$mainSql];
-        $updateDir = $entry->getPathname().'/Config/update';
-        if (is_dir($updateDir)) {
-            $updates = glob($updateDir.'/*.sql') ?: [];
-            usort($updates, static fn (string $a, string $b) => version_compare(basename($a, '.sql'), basename($b, '.sql')));
-            $files = array_merge($files, $updates);
-        }
-
-        foreach ($files as $file) {
-            $sql = file_get_contents($file);
-            foreach (array_filter(explode(";\n", $sql)) as $statement) {
-                $statement = trim($statement);
-                if ('' === $statement) {
-                    continue;
-                }
-                try {
-                    $pdo->exec($statement);
-                } catch (PDOException $e) {
-                    $code = (int) ($e->errorInfo[1] ?? 0);
-                    if (in_array($code, $ignorableCodes, true)) {
-                        continue;
-                    }
-                    if (1005 === $code && str_contains($e->getMessage(), 'errno: 121')) {
-                        continue;
-                    }
-                    fwrite(STDERR, "  WARN {$entry->getFilename()}/".basename($file).": {$e->getMessage()}\n");
-                }
-            }
-        }
-    }
+foreach ($setup->getWarnings() as $warning) {
+    fwrite(STDERR, "  WARN {$warning}\n");
 }
 
-echo "  {$position} module(s) registered\n";
-
-// ── Phase 7: Apply templates (kernel-dependent, subprocess) ──────────
+// ── Phase 7: Apply templates ─────────────────────────────────────────
 
 $themes = [
     'frontOffice' => $options['frontoffice_theme'] ?? $_SERVER['ACTIVE_FRONT_TEMPLATE'] ?? 'flexy',
@@ -234,8 +133,6 @@ $themes = [
     'email'       => $options['email_theme'] ?? $_SERVER['ACTIVE_EMAIL_TEMPLATE'] ?? 'default',
 ];
 
-// Pre-set template config in DB so the kernel doesn't try to load a
-// non-existent "default" template directory during boot.
 $configMap = [
     'frontOffice' => 'active-front-template',
     'backOffice'  => 'active-admin-template',
@@ -243,14 +140,12 @@ $configMap = [
     'email'       => 'active-mail-template',
 ];
 
-$updateConfig = $pdo->prepare("UPDATE `config` SET `value` = :value WHERE `name` = :name");
 foreach ($themes as $type => $name) {
     if (isset($configMap[$type]) && '' !== trim($name)) {
-        $updateConfig->execute(['value' => trim($name), 'name' => $configMap[$type]]);
+        $setup->setConfig($configMap[$type], trim($name));
     }
 }
 
-// Remove bundles for themes that are NOT selected (same logic as Install::handleThemesBundle)
 removeBundlesForNonSelectedThemes($themes);
 
 echo "Applying templates...\n";
@@ -262,9 +157,9 @@ foreach ($themes as $type => $name) {
     }
 
     echo "  template:set {$type} = {$name}\n";
-    $exitCode = runConsole(['template:set', $type, $name]);
-    if (0 !== $exitCode) {
-        fwrite(STDERR, "  WARNING: template:set returned non-zero for {$type}/{$name}\n");
+    if (0 !== runConsole(['template:set', $type, $name])) {
+        fwrite(STDERR, "  ERROR: template:set failed for {$type}/{$name}\n");
+        ++$errors;
     }
 }
 
@@ -272,23 +167,34 @@ foreach ($themes as $type => $name) {
 
 if (isset($options['with-demo'])) {
     echo "Importing demo data...\n";
-    runConsole(['thelia:demo:import', '--skip-images']);
+    if (0 !== runConsole(['thelia:demo:import', '--skip-images'])) {
+        fwrite(STDERR, "  ERROR: Demo import failed\n");
+        ++$errors;
+    }
 }
 
 // ── Phase 9: Optional admin creation ─────────────────────────────────
 
 if (isset($options['with-admin'])) {
-    $adminArgs = [
+    echo "Creating admin user...\n";
+    if (0 !== runConsole([
         'admin:create',
         '--login_name='.($options['admin_login'] ?? 'thelia'),
         '--first_name='.($options['admin_first_name'] ?? 'Admin'),
         '--last_name='.($options['admin_last_name'] ?? 'Thelia'),
         '--email='.($options['admin_email'] ?? 'admin@thelia.net'),
         '--password='.($options['admin_password'] ?? 'thelia'),
-    ];
+    ])) {
+        fwrite(STDERR, "  ERROR: Admin creation failed\n");
+        ++$errors;
+    }
+}
 
-    echo "Creating admin user...\n";
-    runConsole($adminArgs);
+// ── Result ───────────────────────────────────────────────────────────
+
+if ($errors > 0) {
+    echo "\nThelia installed with {$errors} error(s). Check messages above.\n";
+    exit(1);
 }
 
 echo "\nThelia installed successfully.\n";
@@ -297,8 +203,7 @@ echo "\nThelia installed successfully.\n";
 
 function runConsole(array $args): int
 {
-    $cmd = array_merge([PHP_BINARY, THELIA_ROOT.'bin/console'], $args);
-    $process = new Symfony\Component\Process\Process($cmd);
+    $process = new Process(array_merge([PHP_BINARY, THELIA_ROOT.'bin/console'], $args));
     $process->setTimeout(null);
     $process->run(static function (string $type, string $buffer): void {
         echo $buffer;
@@ -317,23 +222,16 @@ function removeBundlesForNonSelectedThemes(array $selectedThemes): void
     $helper = new Thelia\Domain\Module\Composer\ComposerHelper();
     $bundlesToRemove = [];
 
-    $templateTypes = ['frontOffice', 'backOffice', 'pdf', 'email'];
-
-    foreach ($templateTypes as $type) {
+    foreach (['frontOffice', 'backOffice', 'pdf', 'email'] as $type) {
         $selectedName = $selectedThemes[$type] ?? '';
-
-        // Scan all installed templates of this type and find bundles for non-selected ones
         $templateBaseDir = THELIA_TEMPLATE_DIR.$type.DS;
+
         if (!is_dir($templateBaseDir)) {
             continue;
         }
 
         foreach (new DirectoryIterator($templateBaseDir) as $entry) {
-            if (!$entry->isDir() || $entry->isDot()) {
-                continue;
-            }
-
-            if ($entry->getFilename() === $selectedName) {
+            if (!$entry->isDir() || $entry->isDot() || $entry->getFilename() === $selectedName) {
                 continue;
             }
 
@@ -342,10 +240,6 @@ function removeBundlesForNonSelectedThemes(array $selectedThemes): void
                 $bundlesToRemove[$bundleFqcn] = true;
             }
         }
-
-        // Also check vendor paths
-        $vendorPath = THELIA_VENDOR_ROOT.$selectedName;
-        // We don't remove selected — only non-selected
     }
 
     if ([] === $bundlesToRemove) {
@@ -359,19 +253,14 @@ function removeBundlesForNonSelectedThemes(array $selectedThemes): void
         if (isset($bundles[$fqcn])) {
             unset($bundles[$fqcn]);
             $changed = true;
-            echo "  Removed bundle {$fqcn} from bundles.php\n";
         }
     }
 
-    if ($changed) {
-        dumpBundlesPhp($bundles, $bundlesPath);
+    if (!$changed) {
+        return;
     }
-}
 
-function dumpBundlesPhp(array $bundles, string $bundlesPath): void
-{
     ksort($bundles);
-
     $lines = ["<?php\n", "\nreturn [\n"];
 
     foreach ($bundles as $fqcn => $envs) {
@@ -383,6 +272,5 @@ function dumpBundlesPhp(array $bundles, string $bundlesPath): void
     }
 
     $lines[] = "];\n";
-
     file_put_contents($bundlesPath, implode('', $lines));
 }

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,388 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Installs Thelia without booting the Symfony kernel.
+ *
+ * Phases 1-6 run standalone (PDO + filesystem only).
+ * Phase 7+ delegates to bin/console in subprocesses — by that point the
+ * database is populated, modules are registered, and the kernel can boot.
+ *
+ * Usage:
+ *   php bin/install                                       (reads env vars)
+ *   php bin/install --with-demo --with-admin              (non-interactive)
+ *   ddev exec php bin/install
+ *
+ * Required env vars: DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD
+ * Optional env vars: ACTIVE_FRONT_TEMPLATE, ACTIVE_ADMIN_TEMPLATE, ACTIVE_PDF_TEMPLATE, ACTIVE_EMAIL_TEMPLATE
+ */
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+use Thelia\Core\Install\CheckPermission;
+use Thelia\Core\Install\Database;
+use Thelia\Tools\TokenProvider;
+
+(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+$appEnv = $_SERVER['APP_ENV'] ?? 'dev';
+
+$options = getopt('', [
+    'frontoffice_theme:',
+    'backoffice_theme:',
+    'pdf_theme:',
+    'email_theme:',
+    'with-demo',
+    'with-admin',
+    'admin_login:',
+    'admin_password:',
+    'admin_first_name:',
+    'admin_last_name:',
+    'admin_email:',
+]);
+
+$host     = $_SERVER['DATABASE_HOST'] ?? '';
+$port     = $_SERVER['DATABASE_PORT'] ?? '3306';
+$user     = $_SERVER['DATABASE_USER'] ?? '';
+$password = $_SERVER['DATABASE_PASSWORD'] ?? '';
+$dbName   = $_SERVER['DATABASE_NAME'] ?? '';
+
+if ('' === $host || '' === $dbName) {
+    fwrite(STDERR, "ERROR: DATABASE_HOST and DATABASE_NAME must be set.\n");
+    exit(1);
+}
+
+if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
+    fwrite(STDERR, "ERROR: DATABASE_NAME contains invalid characters: {$dbName}\n");
+    exit(1);
+}
+
+// ── Phase 1: Check permissions ───────────────────────────────────────
+
+echo "Checking permissions...\n";
+
+$check = new CheckPermission(verifyInstall: false);
+if (!$check->exec()) {
+    foreach ($check->getValidationMessages() as $msg) {
+        if (!$msg['status']) {
+            fwrite(STDERR, "  FAIL: {$msg['text']} — {$msg['hint']}\n");
+        }
+    }
+    fwrite(STDERR, "ERROR: Permission checks failed.\n");
+    exit(1);
+}
+
+echo "  OK\n";
+
+// ── Phase 2: Create database ─────────────────────────────────────────
+
+echo "Creating database \"{$dbName}\"...\n";
+
+$pdo = new PDO("mysql:host={$host};port={$port}", $user, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+$pdo->exec("CREATE DATABASE IF NOT EXISTS `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+// ── Phase 3: Apply core schema + reference data ──────────────────────
+
+echo "Applying core schema...\n";
+
+$pdo = new PDO("mysql:host={$host};dbname={$dbName};port={$port}", $user, $password, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+
+$database = new Database($pdo);
+$setupDir = THELIA_SETUP_DIRECTORY;
+
+$database->insertSql(null, [$setupDir.'thelia.sql']);
+$database->insertSql(null, [$setupDir.'insert.sql']);
+
+// ── Phase 4: Generate form secret ────────────────────────────────────
+
+$secret = TokenProvider::generateToken();
+$stmt = $pdo->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'form.secret'");
+$stmt->execute([$secret]);
+
+// ── Phase 5: Write env file ──────────────────────────────────────────
+
+$envFile = 'test' === $appEnv ? '.env.test.local' : '.env.local';
+$envFilePath = THELIA_ROOT.$envFile;
+
+echo "Writing {$envFile}...\n";
+
+$envContent = sprintf(
+    "\n###> thelia/database-configuration ###\nDATABASE_HOST=%s\nDATABASE_PORT=%s\nDATABASE_NAME=%s\nDATABASE_USER=%s\nDATABASE_PASSWORD=%s\n###< thelia/database-configuration ###\n",
+    $host,
+    $port,
+    $dbName,
+    $user,
+    $password,
+);
+
+// Remove existing database block if present, then append
+if (file_exists($envFilePath)) {
+    $existing = file_get_contents($envFilePath);
+    $existing = preg_replace('/\n?###> thelia\/database-configuration ###.*?###< thelia\/database-configuration ###\n?/s', '', $existing);
+    file_put_contents($envFilePath, $existing.$envContent);
+} else {
+    file_put_contents($envFilePath, $envContent);
+}
+
+// Publish env vars for the current process (subsequent phases read them)
+$_SERVER['DATABASE_HOST'] = $host;
+$_SERVER['DATABASE_PORT'] = $port;
+$_SERVER['DATABASE_NAME'] = $dbName;
+$_SERVER['DATABASE_USER'] = $user;
+$_SERVER['DATABASE_PASSWORD'] = $password;
+
+// ── Phase 6: Register and activate modules ───────────────────────────
+
+echo "Registering modules...\n";
+
+$moduleDirs = array_filter([THELIA_MODULE_DIR, THELIA_LOCAL_MODULE_DIR], 'is_dir');
+$position = 0;
+$ignorableCodes = [1050, 1060, 1061, 1068, 1826];
+
+$insertModule = $pdo->prepare(
+    'INSERT INTO `module` (`code`, `version`, `type`, `category`, `activate`, `position`, `full_namespace`, `mandatory`, `hidden`, `created_at`)
+     VALUES (:code, :version, 1, :category, 1, :position, :namespace, :mandatory, :hidden, NOW())
+     ON DUPLICATE KEY UPDATE `activate` = 1, `full_namespace` = VALUES(`full_namespace`), `version` = VALUES(`version`)'
+);
+
+foreach ($moduleDirs as $baseDir) {
+    foreach (new DirectoryIterator($baseDir) as $entry) {
+        if (!$entry->isDir() || $entry->isDot()) {
+            continue;
+        }
+
+        $moduleXml = $entry->getPathname().'/Config/module.xml';
+        if (!file_exists($moduleXml)) {
+            continue;
+        }
+
+        $xml = @simplexml_load_file($moduleXml);
+        if (false === $xml) {
+            continue;
+        }
+
+        $code = $entry->getFilename();
+        $namespace = (string) ($xml->fullnamespace ?? $code.'\\'.$code);
+        $version = (string) ($xml->version ?? '0.0.1');
+        $category = (string) ($xml->type ?? 'classic');
+        $mandatory = (int) ($xml->mandatory ?? 0);
+        $hidden = (int) ($xml->hidden ?? 0);
+
+        $insertModule->execute([
+            'code' => $code,
+            'version' => $version,
+            'category' => $category,
+            'position' => ++$position,
+            'namespace' => $namespace,
+            'mandatory' => $mandatory,
+            'hidden' => $hidden,
+        ]);
+
+        // Apply module schema if present
+        $mainSql = $entry->getPathname().'/Config/TheliaMain.sql';
+        if (!file_exists($mainSql)) {
+            continue;
+        }
+
+        $files = [$mainSql];
+        $updateDir = $entry->getPathname().'/Config/update';
+        if (is_dir($updateDir)) {
+            $updates = glob($updateDir.'/*.sql') ?: [];
+            usort($updates, static fn (string $a, string $b) => version_compare(basename($a, '.sql'), basename($b, '.sql')));
+            $files = array_merge($files, $updates);
+        }
+
+        foreach ($files as $file) {
+            $sql = file_get_contents($file);
+            foreach (array_filter(explode(";\n", $sql)) as $statement) {
+                $statement = trim($statement);
+                if ('' === $statement) {
+                    continue;
+                }
+                try {
+                    $pdo->exec($statement);
+                } catch (PDOException $e) {
+                    $code = (int) ($e->errorInfo[1] ?? 0);
+                    if (in_array($code, $ignorableCodes, true)) {
+                        continue;
+                    }
+                    if (1005 === $code && str_contains($e->getMessage(), 'errno: 121')) {
+                        continue;
+                    }
+                    fwrite(STDERR, "  WARN {$entry->getFilename()}/".basename($file).": {$e->getMessage()}\n");
+                }
+            }
+        }
+    }
+}
+
+echo "  {$position} module(s) registered\n";
+
+// ── Phase 7: Apply templates (kernel-dependent, subprocess) ──────────
+
+$themes = [
+    'frontOffice' => $options['frontoffice_theme'] ?? $_SERVER['ACTIVE_FRONT_TEMPLATE'] ?? 'flexy',
+    'backOffice'  => $options['backoffice_theme'] ?? $_SERVER['ACTIVE_ADMIN_TEMPLATE'] ?? 'default',
+    'pdf'         => $options['pdf_theme'] ?? $_SERVER['ACTIVE_PDF_TEMPLATE'] ?? 'default',
+    'email'       => $options['email_theme'] ?? $_SERVER['ACTIVE_EMAIL_TEMPLATE'] ?? 'default',
+];
+
+// Pre-set template config in DB so the kernel doesn't try to load a
+// non-existent "default" template directory during boot.
+$configMap = [
+    'frontOffice' => 'active-front-template',
+    'backOffice'  => 'active-admin-template',
+    'pdf'         => 'active-pdf-template',
+    'email'       => 'active-mail-template',
+];
+
+$updateConfig = $pdo->prepare("UPDATE `config` SET `value` = :value WHERE `name` = :name");
+foreach ($themes as $type => $name) {
+    if (isset($configMap[$type]) && '' !== trim($name)) {
+        $updateConfig->execute(['value' => trim($name), 'name' => $configMap[$type]]);
+    }
+}
+
+// Remove bundles for themes that are NOT selected (same logic as Install::handleThemesBundle)
+removeBundlesForNonSelectedThemes($themes);
+
+echo "Applying templates...\n";
+
+foreach ($themes as $type => $name) {
+    $name = trim($name);
+    if ('' === $name) {
+        continue;
+    }
+
+    echo "  template:set {$type} = {$name}\n";
+    $exitCode = runConsole(['template:set', $type, $name]);
+    if (0 !== $exitCode) {
+        fwrite(STDERR, "  WARNING: template:set returned non-zero for {$type}/{$name}\n");
+    }
+}
+
+// ── Phase 8: Optional demo import ────────────────────────────────────
+
+if (isset($options['with-demo'])) {
+    echo "Importing demo data...\n";
+    runConsole(['thelia:demo:import', '--skip-images']);
+}
+
+// ── Phase 9: Optional admin creation ─────────────────────────────────
+
+if (isset($options['with-admin'])) {
+    $adminArgs = [
+        'admin:create',
+        '--login_name='.($options['admin_login'] ?? 'thelia'),
+        '--first_name='.($options['admin_first_name'] ?? 'Admin'),
+        '--last_name='.($options['admin_last_name'] ?? 'Thelia'),
+        '--email='.($options['admin_email'] ?? 'admin@thelia.net'),
+        '--password='.($options['admin_password'] ?? 'thelia'),
+    ];
+
+    echo "Creating admin user...\n";
+    runConsole($adminArgs);
+}
+
+echo "\nThelia installed successfully.\n";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function runConsole(array $args): int
+{
+    $cmd = array_merge([PHP_BINARY, THELIA_ROOT.'bin/console'], $args);
+    $process = new Symfony\Component\Process\Process($cmd);
+    $process->setTimeout(null);
+    $process->run(static function (string $type, string $buffer): void {
+        echo $buffer;
+    });
+
+    return $process->getExitCode() ?? 1;
+}
+
+function removeBundlesForNonSelectedThemes(array $selectedThemes): void
+{
+    $bundlesPath = THELIA_ROOT.'config'.DS.'bundles.php';
+    if (!file_exists($bundlesPath)) {
+        return;
+    }
+
+    $helper = new Thelia\Domain\Module\Composer\ComposerHelper();
+    $bundlesToRemove = [];
+
+    $templateTypes = ['frontOffice', 'backOffice', 'pdf', 'email'];
+
+    foreach ($templateTypes as $type) {
+        $selectedName = $selectedThemes[$type] ?? '';
+
+        // Scan all installed templates of this type and find bundles for non-selected ones
+        $templateBaseDir = THELIA_TEMPLATE_DIR.$type.DS;
+        if (!is_dir($templateBaseDir)) {
+            continue;
+        }
+
+        foreach (new DirectoryIterator($templateBaseDir) as $entry) {
+            if (!$entry->isDir() || $entry->isDot()) {
+                continue;
+            }
+
+            if ($entry->getFilename() === $selectedName) {
+                continue;
+            }
+
+            $bundleFqcn = $helper->findFirstClassBundle($entry->getPathname());
+            if (null !== $bundleFqcn) {
+                $bundlesToRemove[$bundleFqcn] = true;
+            }
+        }
+
+        // Also check vendor paths
+        $vendorPath = THELIA_VENDOR_ROOT.$selectedName;
+        // We don't remove selected — only non-selected
+    }
+
+    if ([] === $bundlesToRemove) {
+        return;
+    }
+
+    $bundles = require $bundlesPath;
+    $changed = false;
+
+    foreach (array_keys($bundlesToRemove) as $fqcn) {
+        if (isset($bundles[$fqcn])) {
+            unset($bundles[$fqcn]);
+            $changed = true;
+            echo "  Removed bundle {$fqcn} from bundles.php\n";
+        }
+    }
+
+    if ($changed) {
+        dumpBundlesPhp($bundles, $bundlesPath);
+    }
+}
+
+function dumpBundlesPhp(array $bundles, string $bundlesPath): void
+{
+    ksort($bundles);
+
+    $lines = ["<?php\n", "\nreturn [\n"];
+
+    foreach ($bundles as $fqcn => $envs) {
+        $envParts = [];
+        foreach ($envs as $env => $enabled) {
+            $envParts[] = sprintf("'%s' => %s", $env, $enabled ? 'true' : 'false');
+        }
+        $lines[] = sprintf("    %s::class => [%s],\n", $fqcn, implode(', ', $envParts));
+    }
+
+    $lines[] = "];\n";
+
+    file_put_contents($bundlesPath, implode('', $lines));
+}

--- a/bin/install
+++ b/bin/install
@@ -62,6 +62,12 @@ if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
 
 // ── Phase 1: Check permissions ───────────────────────────────────────
 
+// Ensure required directories exist (may be missing after a fresh clone)
+$fs = new Symfony\Component\Filesystem\Filesystem();
+foreach (['var', 'public', 'local/media', 'local/config'] as $dir) {
+    $fs->mkdir(THELIA_ROOT.$dir);
+}
+
 echo "Checking permissions...\n";
 
 $check = new CheckPermission(verifyInstall: false);
@@ -147,6 +153,42 @@ foreach ($themes as $type => $name) {
 }
 
 removeBundlesForNonSelectedThemes($themes);
+
+// Pre-copy templates from vendor to templates/ so the kernel can boot.
+// template:set does this too, but the kernel crashes if the active
+// template directory doesn't exist yet when it scans for UiComponents.
+$composerHelper = new Thelia\Domain\Module\Composer\ComposerHelper();
+$templateTypeToComposerType = [
+    'frontOffice' => 'thelia-frontoffice-template',
+    'backOffice'  => 'thelia-backoffice-template',
+    'pdf'         => 'thelia-pdf-template',
+    'email'       => 'thelia-email-template',
+];
+
+foreach ($themes as $type => $name) {
+    $name = trim($name);
+    if ('' === $name) {
+        continue;
+    }
+
+    $targetDir = THELIA_TEMPLATE_DIR.$type.DS.$name;
+    if (is_dir($targetDir)) {
+        continue;
+    }
+
+    $packageType = $templateTypeToComposerType[$type] ?? null;
+    if (null === $packageType) {
+        continue;
+    }
+
+    $vendorPath = $composerHelper->findInstalledPackagePathByTypeAndInstallerName($packageType, $name);
+    if (null === $vendorPath || !is_dir($vendorPath)) {
+        continue;
+    }
+
+    echo "  Copying {$name} → templates/{$type}/{$name}\n";
+    (new Symfony\Component\Filesystem\Filesystem())->mirror($vendorPath, $targetDir);
+}
 
 echo "Applying templates...\n";
 

--- a/bin/install
+++ b/bin/install
@@ -87,7 +87,7 @@ try {
 
     echo "Applying core schema...\n";
     $setup->connect();
-    $setup->applyCoreSchemAndSeed();
+    $setup->applyCoreSchemaAndSeed();
     $setup->generateFormSecret();
 } catch (\PDOException $e) {
     fwrite(STDERR, "ERROR: Database operation failed — {$e->getMessage()}\n");

--- a/bin/test-prepare
+++ b/bin/test-prepare
@@ -42,7 +42,7 @@ try {
 
     echo "Applying core schema...\n";
     $setup->connect();
-    $setup->applyCoreSchemAndSeed();
+    $setup->applyCoreSchemaAndSeed();
 
     echo "Registering modules...\n";
     $count = $setup->registerAndApplyModules();

--- a/bin/test-prepare
+++ b/bin/test-prepare
@@ -9,18 +9,12 @@ declare(strict_types=1);
  * Usage:
  *   php bin/test-prepare
  *   ddev exec php bin/test-prepare
- *
- * Steps:
- *   1. Create database (if not exists)
- *   2. Apply core schema (thelia.sql) + reference data (insert.sql)
- *   3. Register and activate all available modules
- *   4. Apply module schemas (TheliaMain.sql + update/*.sql)
  */
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
 use Symfony\Component\Dotenv\Dotenv;
-use Thelia\Core\Install\Database;
+use Thelia\Install\Standalone\DatabaseSetup;
 
 (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 
@@ -40,132 +34,26 @@ if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
     exit(1);
 }
 
-// ── Step 1: Create database ──────────────────────────────────────────
+try {
+    $setup = new DatabaseSetup($host, $port, $dbName, $user, $password);
 
-echo "Creating database \"{$dbName}\"...\n";
+    echo "Creating database \"{$dbName}\"...\n";
+    $setup->createDatabase();
 
-$pdo = new PDO("mysql:host={$host};port={$port}", $user, $password, [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-]);
-$pdo->exec("CREATE DATABASE IF NOT EXISTS `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    echo "Applying core schema...\n";
+    $setup->connect();
+    $setup->applyCoreSchemAndSeed();
 
-// ── Step 2: Core schema + reference data ─────────────────────────────
+    echo "Registering modules...\n";
+    $count = $setup->registerAndApplyModules();
+    echo "  {$count} module(s) registered\n";
 
-$pdo = new PDO("mysql:host={$host};dbname={$dbName};port={$port}", $user, $password, [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-]);
-
-$database = new Database($pdo);
-$setupDir = THELIA_SETUP_DIRECTORY;
-
-echo "Applying core schema...\n";
-$database->insertSql(null, [$setupDir.'thelia.sql']);
-$database->insertSql(null, [$setupDir.'insert.sql']);
-
-// ── Step 3: Register modules ─────────────────────────────────────────
-
-echo "Registering modules...\n";
-
-$moduleDirs = array_filter([THELIA_MODULE_DIR, THELIA_LOCAL_MODULE_DIR], 'is_dir');
-$position = 0;
-
-$insertModule = $pdo->prepare(
-    'INSERT INTO `module` (`code`, `version`, `type`, `category`, `activate`, `position`, `full_namespace`, `mandatory`, `hidden`, `created_at`)
-     VALUES (:code, :version, 1, :category, 1, :position, :namespace, :mandatory, :hidden, NOW())
-     ON DUPLICATE KEY UPDATE `activate` = 1, `full_namespace` = VALUES(`full_namespace`), `version` = VALUES(`version`)'
-);
-
-foreach ($moduleDirs as $baseDir) {
-    foreach (new DirectoryIterator($baseDir) as $entry) {
-        if (!$entry->isDir() || $entry->isDot()) {
-            continue;
-        }
-
-        $moduleXml = $entry->getPathname().'/Config/module.xml';
-        if (!file_exists($moduleXml)) {
-            continue;
-        }
-
-        $xml = @simplexml_load_file($moduleXml);
-        if (false === $xml) {
-            continue;
-        }
-
-        $code = $entry->getFilename();
-        $namespace = (string) ($xml->fullnamespace ?? $code.'\\'.$code);
-        $version = (string) ($xml->version ?? '0.0.1');
-        $category = (string) ($xml->type ?? 'classic');
-        $mandatory = (int) ($xml->mandatory ?? 0);
-        $hidden = (int) ($xml->hidden ?? 0);
-
-        $insertModule->execute([
-            'code' => $code,
-            'version' => $version,
-            'category' => $category,
-            'position' => ++$position,
-            'namespace' => $namespace,
-            'mandatory' => $mandatory,
-            'hidden' => $hidden,
-        ]);
+    foreach ($setup->getWarnings() as $warning) {
+        fwrite(STDERR, "  WARN {$warning}\n");
     }
+
+    echo "\nDone: database \"{$dbName}\" is ready.\n";
+} catch (\PDOException $e) {
+    fwrite(STDERR, "ERROR: Database connection failed — {$e->getMessage()}\n");
+    exit(1);
 }
-
-echo "  {$position} module(s) registered\n";
-
-// ── Step 4: Apply module schemas ─────────────────────────────────────
-
-echo "Applying module schemas...\n";
-
-$ignorableCodes = [1050, 1060, 1061, 1068, 1826];
-$moduleCount = 0;
-
-foreach ($moduleDirs as $baseDir) {
-    foreach (new DirectoryIterator($baseDir) as $entry) {
-        if (!$entry->isDir() || $entry->isDot()) {
-            continue;
-        }
-
-        $mainSql = $entry->getPathname().'/Config/TheliaMain.sql';
-        if (!file_exists($mainSql)) {
-            continue;
-        }
-
-        $moduleName = $entry->getFilename();
-        $files = [$mainSql];
-
-        $updateDir = $entry->getPathname().'/Config/update';
-        if (is_dir($updateDir)) {
-            $updates = glob($updateDir.'/*.sql') ?: [];
-            usort($updates, static fn (string $a, string $b) => version_compare(basename($a, '.sql'), basename($b, '.sql')));
-            $files = array_merge($files, $updates);
-        }
-
-        foreach ($files as $file) {
-            $sql = file_get_contents($file);
-            foreach (array_filter(explode(";\n", $sql)) as $statement) {
-                $statement = trim($statement);
-                if ('' === $statement) {
-                    continue;
-                }
-                try {
-                    $pdo->exec($statement);
-                } catch (PDOException $e) {
-                    $code = (int) ($e->errorInfo[1] ?? 0);
-                    if (in_array($code, $ignorableCodes, true)) {
-                        continue;
-                    }
-                    if (1005 === $code && str_contains($e->getMessage(), 'errno: 121')) {
-                        continue;
-                    }
-                    // Non-fatal: log and continue to next statement
-                    fwrite(STDERR, "  WARN {$moduleName}/".basename($file).": {$e->getMessage()}\n");
-                }
-            }
-        }
-
-        ++$moduleCount;
-    }
-}
-
-echo "  {$moduleCount} module schema(s) applied\n";
-echo "\nDone: database \"{$dbName}\" is ready.\n";

--- a/composer.json
+++ b/composer.json
@@ -54,12 +54,11 @@
         ],
         "thelia-install": [
             "rm -f .env.test.local",
-            "@phpc Thelia thelia:install -n --database_host=db --database_username=db --database_password=db --database_name=test --database_port=3306 --frontoffice_theme=flexy --backoffice_theme=default --pdf_theme=default --email_theme=default"
+            "@phpc bin/install --frontoffice_theme=flexy --backoffice_theme=default --pdf_theme=default --email_theme=default"
         ],
         "demo-database": [
-            "@thelia-install",
-            "@phpc Thelia thelia:demo:import --skip-images",
-            "@phpc Thelia admin:create --login_name thelia --password thelia --last_name thelia --first_name thelia --email thelia@example.com"
+            "rm -f .env.test.local",
+            "@phpc bin/install --frontoffice_theme=flexy --backoffice_theme=default --pdf_theme=default --email_theme=default --with-demo --with-admin --admin_login=thelia --admin_password=thelia --admin_first_name=thelia --admin_last_name=thelia --admin_email=thelia@example.com"
         ],
         "cs-diff": [
             "@phpc ./vendor/bin/php-cs-fixer fix --dry-run --stop-on-violation --diff"

--- a/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
+++ b/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
@@ -38,6 +38,9 @@ final class DatabaseSetup
         private readonly string $user,
         private readonly string $password,
     ) {
+        if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $this->dbName)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid database name: "%s"', $this->dbName));
+        }
     }
 
     public function createDatabase(): void
@@ -58,7 +61,7 @@ final class DatabaseSetup
         );
     }
 
-    public function applyCoreSchemAndSeed(): void
+    public function applyCoreSchemaAndSeed(): void
     {
         $database = new Database($this->pdo);
         $database->insertSql(null, [THELIA_SETUP_DIRECTORY.'thelia.sql']);

--- a/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
+++ b/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Install\Standalone;
+
+use Thelia\Core\Install\Database;
+
+final class DatabaseSetup
+{
+    private const IGNORABLE_MYSQL_CODES = [1050, 1060, 1061, 1068, 1826];
+
+    private const MODULE_TYPE_MAP = [
+        'classic' => 1,
+        'payment' => 3,
+        'delivery' => 2,
+    ];
+
+    private \PDO $pdo;
+
+    /** @var string[] */
+    private array $warnings = [];
+
+    public function __construct(
+        private readonly string $host,
+        private readonly string $port,
+        private readonly string $dbName,
+        private readonly string $user,
+        private readonly string $password,
+    ) {
+    }
+
+    public function createDatabase(): void
+    {
+        $pdo = new \PDO("mysql:host={$this->host};port={$this->port}", $this->user, $this->password, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+        $pdo->exec("CREATE DATABASE IF NOT EXISTS `{$this->dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+
+    public function connect(): void
+    {
+        $this->pdo = new \PDO(
+            "mysql:host={$this->host};dbname={$this->dbName};port={$this->port}",
+            $this->user,
+            $this->password,
+            [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION],
+        );
+    }
+
+    public function applyCoreSchemAndSeed(): void
+    {
+        $database = new Database($this->pdo);
+        $database->insertSql(null, [THELIA_SETUP_DIRECTORY.'thelia.sql']);
+        $database->insertSql(null, [THELIA_SETUP_DIRECTORY.'insert.sql']);
+    }
+
+    public function generateFormSecret(): void
+    {
+        $secret = \Thelia\Tools\TokenProvider::generateToken();
+        $this->pdo->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'form.secret'")->execute([$secret]);
+    }
+
+    public function setConfig(string $name, string $value): void
+    {
+        $this->pdo->prepare('UPDATE `config` SET `value` = :value WHERE `name` = :name')->execute([
+            'value' => $value,
+            'name' => $name,
+        ]);
+    }
+
+    public function registerAndApplyModules(): int
+    {
+        $moduleDirs = array_filter([THELIA_MODULE_DIR, THELIA_LOCAL_MODULE_DIR], 'is_dir');
+        $position = 0;
+
+        $insertModule = $this->pdo->prepare(
+            'INSERT INTO `module` (`code`, `version`, `type`, `category`, `activate`, `position`, `full_namespace`, `mandatory`, `hidden`, `created_at`)
+             VALUES (:code, :version, :type, :category, 1, :position, :namespace, :mandatory, :hidden, NOW())
+             ON DUPLICATE KEY UPDATE `full_namespace` = VALUES(`full_namespace`), `version` = VALUES(`version`)'
+        );
+
+        foreach ($moduleDirs as $baseDir) {
+            foreach (new \DirectoryIterator($baseDir) as $entry) {
+                if (!$entry->isDir() || $entry->isDot()) {
+                    continue;
+                }
+
+                $moduleXml = $entry->getPathname().'/Config/module.xml';
+                if (!file_exists($moduleXml)) {
+                    continue;
+                }
+
+                $xml = @simplexml_load_file($moduleXml);
+                if (false === $xml) {
+                    continue;
+                }
+
+                $code = $entry->getFilename();
+                $xmlType = (string) ($xml->type ?? 'classic');
+
+                $insertModule->execute([
+                    'code' => $code,
+                    'version' => (string) ($xml->version ?? '0.0.1'),
+                    'type' => self::MODULE_TYPE_MAP[$xmlType] ?? 1,
+                    'category' => $xmlType,
+                    'position' => ++$position,
+                    'namespace' => (string) ($xml->fullnamespace ?? $code.'\\'.$code),
+                    'mandatory' => (int) ($xml->mandatory ?? 0),
+                    'hidden' => (int) ($xml->hidden ?? 0),
+                ]);
+
+                $this->applyModuleSchema($entry->getPathname(), $code);
+            }
+        }
+
+        return $position;
+    }
+
+    /** @return string[] */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
+    }
+
+    public function getPdo(): \PDO
+    {
+        return $this->pdo;
+    }
+
+    private function applyModuleSchema(string $modulePath, string $moduleName): void
+    {
+        $mainSql = $modulePath.'/Config/TheliaMain.sql';
+        if (!file_exists($mainSql)) {
+            return;
+        }
+
+        $files = [$mainSql];
+
+        $updateDir = $modulePath.'/Config/update';
+        if (is_dir($updateDir)) {
+            $updates = glob($updateDir.'/*.sql') ?: [];
+            usort($updates, static fn (string $a, string $b) => version_compare(basename($a, '.sql'), basename($b, '.sql')));
+            $files = array_merge($files, $updates);
+        }
+
+        foreach ($files as $file) {
+            $sql = file_get_contents($file);
+            if (false === $sql) {
+                continue;
+            }
+
+            foreach (array_filter(explode(";\n", $sql)) as $statement) {
+                $statement = trim($statement);
+                if ('' === $statement) {
+                    continue;
+                }
+
+                try {
+                    $this->pdo->exec($statement);
+                } catch (\PDOException $e) {
+                    $code = (int) ($e->errorInfo[1] ?? 0);
+
+                    if (\in_array($code, self::IGNORABLE_MYSQL_CODES, true)) {
+                        continue;
+                    }
+                    if (1005 === $code && str_contains($e->getMessage(), 'errno: 121')) {
+                        continue;
+                    }
+
+                    $this->warnings[] = "{$moduleName}/".basename($file).": {$e->getMessage()}";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- `bin/install` — installs Thelia without booting the Symfony kernel (phases 1-6: DB creation, schema, seed, secret, env file, module registration). Delegates to `bin/console` subprocesses for kernel-dependent steps (template:set, demo import, admin creation).
- `DatabaseSetup` helper in `core/lib/Thelia/Install/Standalone/` — shared between `bin/install` and `bin/test-prepare`, handles DB creation, schema application, module registration with correct type mapping (classic/payment/delivery).
- Fixes the chicken-and-egg problem: modules must be registered before the kernel boots, but `thelia:install` tried to boot the kernel before registering modules.
- Pre-sets template config in DB before kernel boot, preventing the "UiComponents directory not found" crash.
- Composer scripts `thelia-install` and `demo-database` now use `bin/install`.