### PR TITLE
Security and observability hardening on core API surface

### DIFF
--- a/.env
+++ b/.env
@@ -47,6 +47,9 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=461285fccfe02fd95c388a69b23961086bbf488272f50cd7a47925a4eaa9943e
+# Access token TTL in seconds. Lower in production (e.g. 900 = 15 min)
+# and rely on the refresh token endpoint for sliding sessions.
+JWT_TOKEN_TTL=3600
 ###< lexik/jwt-authentication-bundle ###
 
 ###> symfony/routing ###

--- a/core/lib/Thelia/Api/Resource/Customer.php
+++ b/core/lib/Thelia/Api/Resource/Customer.php
@@ -71,10 +71,12 @@ use Thelia\Model\Map\CustomerTableMap;
             uriTemplate: '/front/customers',
         ),
         new Get(
-            uriTemplate: '/front/account/customers/{id}'
+            uriTemplate: '/front/account/customers/{id}',
+            security: 'is_granted("ROLE_CUSTOMER") and object.getId() == user.getId()',
         ),
         new Put(
-            uriTemplate: '/front/account/customers/{id}'
+            uriTemplate: '/front/account/customers/{id}',
+            security: 'is_granted("ROLE_CUSTOMER") and object.getId() == user.getId()',
         ),
     ],
     normalizationContext: ['groups' => [self::GROUP_FRONT_READ_SINGLE]],

--- a/core/lib/Thelia/Core/Template/Element/BaseLoop.php
+++ b/core/lib/Thelia/Core/Template/Element/BaseLoop.php
@@ -51,7 +51,9 @@ use Thelia\Type\TypeCollection;
  * @method ModelCriteria buildModelCriteria()
  * @method array         buildArray()
  *
- * @deprecated prefer to use the the resources from API
+ * BaseLoop is the canonical extension point for `{loop type="..."}` in the
+ * Smarty back-office templates. Front-office (Twig/Flexy) code should
+ * prefer the API resources exposed by `DataAccessService::resources()`.
  */
 abstract class BaseLoop implements LoopInterface
 {

--- a/tests/Api/Front/CustomerApiTest.php
+++ b/tests/Api/Front/CustomerApiTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Ownership coverage for /api/front/account/customers/{id}.
+ *
+ * Guards against the IDOR regression: any authenticated customer
+ * could previously read or update another customer's account by
+ * passing an arbitrary id on Get / Put.
+ */
+final class CustomerApiTest extends ApiTestCase
+{
+    public function testCustomerCanReadOwnAccount(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/customers/'.$customer->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+        self::assertSame($customer->getId(), $data['id']);
+    }
+
+    public function testCustomerCannotReadAnotherCustomersAccount(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $other = $factory->customer($factory->customerTitle());
+        $attacker = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+
+        $token = $this->authenticateAsCustomer($attacker);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/customers/'.$other->getId(), token: $token);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testCustomerCannotUpdateAnotherCustomersAccount(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $other = $factory->customer($factory->customerTitle());
+        $attacker = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+
+        $token = $this->authenticateAsCustomer($attacker);
+
+        $response = $this->jsonRequest(
+            'PUT',
+            '/api/front/account/customers/'.$other->getId(),
+            payload: ['firstname' => 'Hijacked'],
+            token: $token,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testUnauthenticatedReadIsRejected(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+
+        $response = $this->jsonRequest('GET', '/api/front/account/customers/'.$customer->getId());
+
+        self::assertContains($response->getStatusCode(), [401, 403]);
+    }
+}

--- a/tests/Integration/Api/DataAccessServiceTest.php
+++ b/tests/Integration/Api/DataAccessServiceTest.php
@@ -16,6 +16,7 @@ namespace Thelia\Tests\Integration\Api;
 
 use Thelia\Api\Service\DataAccess\DataAccessService;
 use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsAdmin;
 
 /**
  * Guard-rail for {@see DataAccessService::resources()}, which calls
@@ -29,6 +30,8 @@ use Thelia\Test\IntegrationTestCase;
  */
 final class DataAccessServiceTest extends IntegrationTestCase
 {
+    use LogsInAsAdmin;
+
     private DataAccessService $dataAccess;
 
     protected function setUp(): void
@@ -44,8 +47,17 @@ final class DataAccessServiceTest extends IntegrationTestCase
         self::assertIsArray($result);
     }
 
+    public function testFrontCategoriesCollectionResolvesWithoutError(): void
+    {
+        $result = $this->dataAccess->resources('/api/front/categories');
+
+        self::assertIsArray($result);
+    }
+
     public function testAdminCategoriesCollectionResolvesWithoutError(): void
     {
+        $this->loginAsAdminInSession();
+
         $result = $this->dataAccess->resources('/api/admin/categories');
 
         self::assertIsArray($result);
@@ -53,14 +65,9 @@ final class DataAccessServiceTest extends IntegrationTestCase
 
     public function testAdminProductsCollectionResolvesWithoutError(): void
     {
+        $this->loginAsAdminInSession();
+
         $result = $this->dataAccess->resources('/api/admin/products');
-
-        self::assertIsArray($result);
-    }
-
-    public function testFrontCategoriesCollectionResolvesWithoutError(): void
-    {
-        $result = $this->dataAccess->resources('/api/front/categories');
 
         self::assertIsArray($result);
     }

--- a/tests/Integration/Api/DataAccessServiceTest.php
+++ b/tests/Integration/Api/DataAccessServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\DataAccessService;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Guard-rail for {@see DataAccessService::resources()}, which calls
+ * `api_platform.state_provider.locator` (CallableProvider) directly to
+ * bypass the HTTP stack. If a future API Platform release renames or
+ * restructures that locator, the front (Flexy) goes silent in prod.
+ *
+ * This test exercises the full pipeline (route match → operation
+ * resolution → state provider invocation → normalization) on stable
+ * native resources so the breakage surfaces in CI before deploy.
+ */
+final class DataAccessServiceTest extends IntegrationTestCase
+{
+    private DataAccessService $dataAccess;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dataAccess = static::getContainer()->get(DataAccessService::class);
+    }
+
+    public function testFrontProductsCollectionResolvesWithoutError(): void
+    {
+        $result = $this->dataAccess->resources('/api/front/products');
+
+        self::assertIsArray($result);
+    }
+
+    public function testAdminCategoriesCollectionResolvesWithoutError(): void
+    {
+        $result = $this->dataAccess->resources('/api/admin/categories');
+
+        self::assertIsArray($result);
+    }
+
+    public function testAdminProductsCollectionResolvesWithoutError(): void
+    {
+        $result = $this->dataAccess->resources('/api/admin/products');
+
+        self::assertIsArray($result);
+    }
+
+    public function testFrontCategoriesCollectionResolvesWithoutError(): void
+    {
+        $result = $this->dataAccess->resources('/api/front/categories');
+
+        self::assertIsArray($result);
+    }
+}

--- a/tests/Integration/Core/Security/AccessControlRulesTest.php
+++ b/tests/Integration/Core/Security/AccessControlRulesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\AccessMapInterface;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Guard-rail for the path-based access_control rules injected via
+ * Reflection in {@see \Thelia\Core\TheliaKernel::processSecurity()}.
+ *
+ * If a future Symfony bump silently changes the SecurityBundle config
+ * shape, the Reflection injection will no-op and these assertions
+ * will catch it before production deploy.
+ */
+final class AccessControlRulesTest extends IntegrationTestCase
+{
+    private AccessMapInterface $accessMap;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->accessMap = static::getContainer()->get('security.access_map');
+    }
+
+    public function testAdminApiRequiresRoleAdmin(): void
+    {
+        [$roles] = $this->accessMap->getPatterns(Request::create('/api/admin/customers'));
+
+        self::assertNotNull($roles, 'No access_control rule matched /api/admin/customers');
+        self::assertContains('ROLE_ADMIN', $roles);
+    }
+
+    public function testFrontAccountApiRequiresRoleCustomer(): void
+    {
+        [$roles] = $this->accessMap->getPatterns(Request::create('/api/front/account/customers/1'));
+
+        self::assertNotNull($roles, 'No access_control rule matched /api/front/account/*');
+        self::assertContains('ROLE_CUSTOMER', $roles);
+    }
+
+    public function testLoginEndpointsArePublic(): void
+    {
+        [$adminLoginRoles] = $this->accessMap->getPatterns(Request::create('/api/admin/login'));
+        [$frontLoginRoles] = $this->accessMap->getPatterns(Request::create('/api/front/login'));
+
+        self::assertNotNull($adminLoginRoles);
+        self::assertContains('PUBLIC_ACCESS', $adminLoginRoles);
+        self::assertNotNull($frontLoginRoles);
+        self::assertContains('PUBLIC_ACCESS', $frontLoginRoles);
+    }
+
+    public function testApiDocsIsPublic(): void
+    {
+        [$roles] = $this->accessMap->getPatterns(Request::create('/api/docs'));
+
+        self::assertNotNull($roles);
+        self::assertContains('PUBLIC_ACCESS', $roles);
+    }
+}


### PR DESCRIPTION
- Restrict `/front/account/customers/{id}` `Get` and `Put` to the  authenticated owner. Adds an ownership expression matching the  existing Cart/Order pattern.
- Expose `JWT_TOKEN_TTL` env variable so deployments can tune access   token lifetime without patching configuration.
- Clarify `BaseLoop` status: it remains the canonical extension point  for `{loop type=...}` in the Smarty back-office. The misleading  `@deprecated` tag is replaced with explicit guidance.
- Add integration coverage for the path-based `access_control` rules  injected at boot, so a future Symfony bump can no longer silently  drop them.
- Smoke-cover `DataAccessService::resources()` against  `api_platform.state_provider.locator`, the internal entry point used
 by the Twig front for native resources.

