### PR TITLE
Fix OrderFilter raising TypeError when DateFilter (or any array filter) is used

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/OrderFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/OrderFilter.php
@@ -24,8 +24,6 @@ class OrderFilter extends AbstractFilter
     public function apply(ModelCriteria $query, string $resourceClass, Operation $operation = null, array $context = []): void
     {
         if (!isset($context['filters']['order']) || !\is_array($context['filters']['order'])) {
-            parent::apply($query, $resourceClass, $operation, $context);
-
             return;
         }
 


### PR DESCRIPTION
Hit this trying to query orders with `?createdAt[after]=…` — got a 500 with `strtoupper(): Argument #1 ($string) must be of type string, array given`.

`OrderFilter::apply()` falls back to `AbstractFilter::apply()` when there's no `order[...]` param. That parent then iterates every filter in the request and pipes it back into `OrderFilter::filterProperty()` → `normalizeValue()` → `strtoupper()`. As soon as the value happens to be an array (DateFilter, RangeFilter, anything bracket-style) on a property declared on the same resource for OrderFilter, it blows up.

OrderFilter is a sort filter — if no sort is requested, it should just bail.

Repro:

```
GET /api/admin/orders?createdAt[after]=2026-05-05T00:00:00&orderStatus.code=paid
```

Workaround in the meantime: add `&order[createdAt]=desc` to dodge the buggy fallback.