### PR TITLE
Fix OrderFilter iterating non-sort filters when no order param is given

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/OrderFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/OrderFilter.php
@@ -25,8 +25,6 @@ class OrderFilter extends AbstractFilter
     public function apply(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         if (!isset($context['filters']['order']) || !\is_array($context['filters']['order'])) {
-            parent::apply($query, $resourceClass, $operation, $context);
-
             return;
         }
 


### PR DESCRIPTION
Same root cause as #3421 (which targets `main`), opening separately for `twig` since the file diverged.

`OrderFilter::apply()` falls back to `AbstractFilter::apply()` when there's no `order[...]` param, which iterates every filter in the request and pipes it through `OrderFilter::filterProperty()`. If a property is registered on the resource for OrderFilter (e.g. `createdAt` on Order) and the request uses bracket syntax (`?createdAt[after]=…`), `normalizeValue()` ends up calling `strtoupper((string) $value)` on an array.

Here the explicit `(string)` cast prevents the hard `TypeError`, but it still emits an "Array to string conversion" notice and triggers a useless `orderBy` evaluation on every dual-purpose filter.

OrderFilter is a sort filter — when no sort is requested, just bail.