### PR TITLE
chore: require default-twig back-office template ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": ">= 8.3",
         "thelia/core": "dev-twig",
         "thelia/backoffice-default-template": "^0.1",
-        "thelia/backoffice-default-twig-template": "^0.1",
+        "thelia/backoffice-default-twig-template": "^0.2",
         "thelia/email-default-template": "dev-twig",
         "thelia/pdf-default-template": "dev-twig",
         "symfony/flex": "^2.4",


### PR DESCRIPTION
Bumps the `thelia/backoffice-default-twig-template` constraint from `^0.1` to `^0.2` so the freshly released `0.2.0` is the one resolved.

`0.2.0` (301 commits since `0.1.0`) brings the Twig back-office to functional parity with the legacy Smarty back-office. While the constraint stayed at `^0.1`, a plain `composer install` resolved to the stale `0.1.0` tag instead of the reliability release.

- Verified on Packagist: `0.2.0` and `0.1.0` are available; `^0.2` resolves to `0.2.0`.
- No `composer.lock` is tracked, so nothing else to regenerate.
- `composer validate` passes (only the pre-existing empty-namespace psr-4 warning, unrelated).

Release: https://github.com/thelia-templates/default-twig/releases/tag/0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
