### PR TITLE
fix bo template catalog-breadcrumb

### DIFF
--- a/templates/backOffice/default/includes/catalog-breadcrumb.html
+++ b/templates/backOffice/default/includes/catalog-breadcrumb.html
@@ -15,7 +15,7 @@
 			        {/if}
 				</li>
 			{else}
-			   <li><a href="{url path='/admin/categories' category_id=" $ID" action='browse'}">{$TITLE}</a></li>
+			   <li><a href="{url path='/admin/categories' category_id="$ID" action='browse'}">{$TITLE}</a></li>
 			{/if}
 	   {/loop}
 	{/ifloop}


### PR DESCRIPTION
- fix link /admin/categories?category_id=+1 to /admin/categories?category_id=1 in templates/backOffice/default/includes/catalog-breadcrumb.html

The link /admin/categories?category_id=+1 triggers a 403 Forbidden error on certain environments. 
The + sign in the URL is interpreted as a space.