### PR TITLE
Feat/api updated at rewriting filters

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/NullableSearchFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/NullableSearchFilter.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Filter;
+
+use ApiPlatform\Metadata\Operation;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+
+/**
+ * Exact-match filter that also accepts the literal value "null" to match SQL NULL.
+ *
+ * e.g. ?redirected=5 -> redirected = 5 ; ?redirected=null -> redirected IS NULL.
+ */
+class NullableSearchFilter extends AbstractFilter
+{
+    public const NULL_VALUE = 'null';
+
+    protected function filterProperty(string $property, $value, ModelCriteria $query, string $resourceClass, Operation $operation = null, array $context = []): void
+    {
+        if (null === $value || !$this->isPropertyEnabled($property, $resourceClass)) {
+            return;
+        }
+
+        if (!property_exists($resourceClass, $property)) {
+            throw new \RuntimeException(sprintf('Property "%s" does not exist in class "%s".', $property, $resourceClass));
+        }
+
+        $column = ucfirst($property);
+
+        if (self::NULL_VALUE === $value || '' === $value) {
+            $query->filterBy($column, null, Criteria::ISNULL);
+
+            return;
+        }
+
+        if (\is_array($value)) {
+            $query->filterBy($column, $value, Criteria::IN);
+
+            return;
+        }
+
+        $query->filterBy($column, $value, Criteria::EQUAL);
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        $description = [];
+
+        $filterProperties = $this->getProperties();
+        if (null === $filterProperties) {
+            return [];
+        }
+
+        foreach ($filterProperties as $property => $propertyOptions) {
+            $propertyName = $this->normalizePropertyName($property);
+            $description[$propertyName] = [
+                'property' => $propertyName,
+                'type' => 'string',
+                'required' => false,
+                'description' => sprintf('Filter "%s" by exact value, or use "null" to match entries with no value.', $propertyName),
+            ];
+        }
+
+        return $description;
+    }
+}

--- a/core/lib/Thelia/Api/Bridge/Propel/State/RewritingUrlProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/RewritingUrlProcessor.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Api\Resource\RewritingUrl;
+use Thelia\Model\RewritingUrlQuery;
+
+/**
+ * Persists a RewritingUrl and, when a new active URL is created for an object
+ * (same view/viewId/viewLocale), flags the previously active URL(s) as redirected
+ * to the new one, mirroring UrlRewritingTrait::setRewrittenUrl().
+ */
+readonly class RewritingUrlProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private PropelPersistProcessor $persistProcessor,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        $isCreation = !isset($uriVariables['id']);
+
+        $result = $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+
+        if ($isCreation && $result instanceof RewritingUrl) {
+            $this->redirectPreviousUrls($result);
+        }
+
+        return $result;
+    }
+
+    private function redirectPreviousUrls(RewritingUrl $rewritingUrl): void
+    {
+        $id = $rewritingUrl->getId();
+        $view = $rewritingUrl->view ?? null;
+        $viewId = $rewritingUrl->viewId ?? null;
+        $viewLocale = $rewritingUrl->viewLocale ?? null;
+        $redirected = $rewritingUrl->redirected ?? null;
+
+        // Only a newly created active URL bound to an object triggers the redirection.
+        if (null === $id || null === $view || null === $viewId || null === $viewLocale || null !== $redirected) {
+            return;
+        }
+
+        RewritingUrlQuery::create()
+            ->filterByView($view)
+            ->filterByViewId($viewId)
+            ->filterByViewLocale($viewLocale)
+            ->filterById($id, Criteria::NOT_EQUAL)
+            ->filterByRedirected(null, Criteria::ISNULL)
+            ->update(['Redirected' => $id]);
+    }
+}

--- a/core/lib/Thelia/Api/Resource/Brand.php
+++ b/core/lib/Thelia/Api/Resource/Brand.php
@@ -12,6 +12,7 @@
 
 namespace Thelia\Api\Resource;
 
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
@@ -22,6 +23,8 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Filter\DateFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
 use Thelia\Model\Map\BrandTableMap;
 
 #[ApiResource(
@@ -61,6 +64,18 @@ use Thelia\Model\Map\BrandTableMap;
     ],
     normalizationContext: ['groups' => [self::GROUP_FRONT_READ]]
 )]
+#[ApiFilter(
+    filterClass: DateFilter::class,
+    properties: [
+        'updatedAt' => 'include_null_before_and_after',
+    ]
+)]
+#[ApiFilter(
+    filterClass: OrderFilter::class,
+    properties: [
+        'updatedAt',
+    ]
+)]
 class Brand extends AbstractTranslatableResource
 {
     public const GROUP_ADMIN_READ = 'admin:brand:read';
@@ -92,6 +107,12 @@ class Brand extends AbstractTranslatableResource
         Product::GROUP_FRONT_READ_SINGLE,
     ])]
     public ?int $position = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?\DateTime $createdAt;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?\DateTime $updatedAt;
 
     #[ApiProperty(
         types: 'object'
@@ -135,6 +156,30 @@ class Brand extends AbstractTranslatableResource
     public function setPosition(?int $position): self
     {
         $this->position = $position;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTime $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
 
         return $this;
     }

--- a/core/lib/Thelia/Api/Resource/Category.php
+++ b/core/lib/Thelia/Api/Resource/Category.php
@@ -22,7 +22,9 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Filter\DateFilter;
 use Thelia\Api\Bridge\Propel\Filter\NotInFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
 use Thelia\Model\Map\CategoryTableMap;
 
 #[ApiResource(
@@ -66,6 +68,18 @@ use Thelia\Model\Map\CategoryTableMap;
     filterClass: NotInFilter::class,
     properties: [
         'id',
+    ]
+)]
+#[ApiFilter(
+    filterClass: DateFilter::class,
+    properties: [
+        'updatedAt' => 'include_null_before_and_after',
+    ]
+)]
+#[ApiFilter(
+    filterClass: OrderFilter::class,
+    properties: [
+        'updatedAt',
     ]
 )]
 class Category extends AbstractTranslatableResource

--- a/core/lib/Thelia/Api/Resource/Content.php
+++ b/core/lib/Thelia/Api/Resource/Content.php
@@ -12,6 +12,7 @@
 
 namespace Thelia\Api\Resource;
 
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -22,6 +23,8 @@ use ApiPlatform\Metadata\Put;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
+use Thelia\Api\Bridge\Propel\Filter\DateFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
 use Thelia\Model\Map\ContentTableMap;
 
 #[ApiResource(
@@ -60,6 +63,18 @@ use Thelia\Model\Map\ContentTableMap;
         ),
     ],
     normalizationContext: ['groups' => [self::GROUP_FRONT_READ]],
+)]
+#[ApiFilter(
+    filterClass: DateFilter::class,
+    properties: [
+        'updatedAt' => 'include_null_before_and_after',
+    ]
+)]
+#[ApiFilter(
+    filterClass: OrderFilter::class,
+    properties: [
+        'updatedAt',
+    ]
 )]
 class Content extends AbstractTranslatableResource
 {

--- a/core/lib/Thelia/Api/Resource/Folder.php
+++ b/core/lib/Thelia/Api/Resource/Folder.php
@@ -12,6 +12,7 @@
 
 namespace Thelia\Api\Resource;
 
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -21,6 +22,8 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Filter\DateFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
 use Thelia\Model\Map\FolderTableMap;
 
 #[ApiResource(
@@ -47,6 +50,18 @@ use Thelia\Model\Map\FolderTableMap;
     ],
     normalizationContext: ['groups' => [self::GROUP_ADMIN_READ]],
     denormalizationContext: ['groups' => [self::GROUP_ADMIN_WRITE]]
+)]
+#[ApiFilter(
+    filterClass: DateFilter::class,
+    properties: [
+        'updatedAt' => 'include_null_before_and_after',
+    ]
+)]
+#[ApiFilter(
+    filterClass: OrderFilter::class,
+    properties: [
+        'updatedAt',
+    ]
 )]
 class Folder extends AbstractTranslatableResource
 {

--- a/core/lib/Thelia/Api/Resource/Product.php
+++ b/core/lib/Thelia/Api/Resource/Product.php
@@ -97,6 +97,7 @@ use Thelia\Model\ProductQuery;
     properties: [
         'ref',
         'productCategories.position',
+        'updatedAt',
     ]
 )]
 #[ApiFilter(

--- a/core/lib/Thelia/Api/Resource/RewritingUrl.php
+++ b/core/lib/Thelia/Api/Resource/RewritingUrl.php
@@ -80,7 +80,7 @@ class RewritingUrl implements PropelResourceInterface
     public ?string $viewLocale;
 
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE])]
-    public ?string $redirected;
+    public ?int $redirected;
 
     public function getId(): ?int
     {
@@ -142,12 +142,12 @@ class RewritingUrl implements PropelResourceInterface
         return $this;
     }
 
-    public function getRedirected(): ?string
+    public function getRedirected(): ?int
     {
         return $this->redirected;
     }
 
-    public function setRedirected(?string $redirected): self
+    public function setRedirected(?int $redirected): self
     {
         $this->redirected = $redirected;
 

--- a/core/lib/Thelia/Api/Resource/RewritingUrl.php
+++ b/core/lib/Thelia/Api/Resource/RewritingUrl.php
@@ -21,12 +21,14 @@ use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Thelia\Api\Bridge\Propel\Filter\NullableSearchFilter;
 use Thelia\Api\Bridge\Propel\Filter\SearchFilter;
+use Thelia\Api\Bridge\Propel\State\RewritingUrlProcessor;
 use Thelia\Model\Map\RewritingUrlTableMap;
 
 #[ApiResource(
     operations: [
         new Post(
-            uriTemplate: '/admin/rewriting_url'
+            uriTemplate: '/admin/rewriting_url',
+            processor: RewritingUrlProcessor::class
         ),
         new GetCollection(
             uriTemplate: '/admin/rewriting_url'

--- a/core/lib/Thelia/Api/Resource/RewritingUrl.php
+++ b/core/lib/Thelia/Api/Resource/RewritingUrl.php
@@ -19,6 +19,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Filter\NullableSearchFilter;
 use Thelia\Api\Bridge\Propel\Filter\SearchFilter;
 use Thelia\Model\Map\RewritingUrlTableMap;
 
@@ -45,6 +46,11 @@ use Thelia\Model\Map\RewritingUrlTableMap;
         'view',
         'viewId',
         'viewLocale',
+    ]
+)]
+#[ApiFilter(
+    filterClass: NullableSearchFilter::class,
+    properties: [
         'redirected',
     ]
 )]


### PR DESCRIPTION
## API: updated_at filtering/sorting + RewritingUrl improvements

- Expose `updated_at` on GET routes for products, categories, folders, contents and brands (added `created_at`/`updated_at` to Brand; now also present on Product/Category collections).
- Add `updated_at` filtering (`before`/`after`/`strictly_before`/`strictly_after`) and sorting (`order[updatedAt]`) on those resources.
- RewritingUrl: new `NullableSearchFilter` on `redirected` — `?redirected=<id>` or `?redirected=null`.                                                                                                                                 
- RewritingUrl: type `redirected` as `int`.
- RewritingUrl POST: flag the object's previous active URL as `redirected` to the newly created one (mirrors `UrlRewritingTrait::setRewrittenUrl()`).