### PR TITLE
fix(api): guard attribute access against a zero default folder or category id

### DIFF
--- a/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
@@ -85,7 +85,9 @@ class AttributeAccessService
             if ($productId !== null) {
                 $product = ProductQuery::create()->findPk($productId);
                 if ($product !== null) {
-                    $categoryId = $product->getDefaultCategoryId();
+                    // getDefaultCategoryId() returns 0, not null, when the product has no default category.
+                    $defaultCategoryId = $product->getDefaultCategoryId();
+                    $categoryId = $defaultCategoryId === 0 ? null : $defaultCategoryId;
                 }
             }
         }
@@ -126,7 +128,9 @@ class AttributeAccessService
             if ($contentId !== null) {
                 $content = ContentQuery::create()->findPk($contentId);
                 if ($content !== null) {
-                    $folderId = $content->getDefaultFolderId();
+                    // getDefaultFolderId() returns 0, not null, when the content has no default folder.
+                    $defaultFolderId = $content->getDefaultFolderId();
+                    $folderId = $defaultFolderId === 0 ? null : $defaultFolderId;
                 }
             }
         }

--- a/tests/Integration/Api/AttributeAccessServiceTest.php
+++ b/tests/Integration/Api/AttributeAccessServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\AttributeAccessService;
+use Thelia\Model\Content;
+use Thelia\Model\Product;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Content::getDefaultFolderId() and Product::getDefaultCategoryId() return 0,
+ * not null, when no default link exists. The attribute accessors must treat
+ * that 0 as "no parent" and return an empty string, like every other guard in
+ * the service, instead of querying folder/category 0 and ending up in the
+ * NotFoundHttpException of dataAccessWithI18n().
+ */
+final class AttributeAccessServiceTest extends IntegrationTestCase
+{
+    private AttributeAccessService $attributeAccess;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->attributeAccess = static::getContainer()->get(AttributeAccessService::class);
+    }
+
+    public function testFolderAttributeIsEmptyForContentWithoutDefaultFolder(): void
+    {
+        $content = new Content();
+        $content->setVisible(1);
+        $content->setLocale('en_US');
+        $content->setTitle('Content without folder');
+        $content->save($this->getPropelConnection());
+
+        self::assertSame(0, $content->getDefaultFolderId());
+
+        $this->setRequestParam('content_id', $content->getId());
+
+        self::assertSame('', $this->attributeAccess->attributeFolder('TITLE'));
+    }
+
+    public function testCategoryAttributeIsEmptyForProductWithoutDefaultCategory(): void
+    {
+        $factory = $this->createFixtureFactory();
+
+        $product = new Product();
+        $product->setRef('PROD-WITHOUT-CATEGORY');
+        $product->setVisible(1);
+        $product->setPosition(1);
+        $product->setTaxRuleId($factory->taxRule()->getId());
+        $product->setLocale('en_US');
+        $product->setTitle('Product without category');
+        $product->save($this->getPropelConnection());
+
+        self::assertSame(0, $product->getDefaultCategoryId());
+
+        $this->setRequestParam('product_id', $product->getId());
+
+        self::assertSame('', $this->attributeAccess->attributeCategory('TITLE'));
+    }
+
+    private function setRequestParam(string $key, mixed $value): void
+    {
+        static::getContainer()->get('request_stack')->getCurrentRequest()->attributes->set($key, $value);
+    }
+}


### PR DESCRIPTION
## Problem

Reading a data-access attribute for the parent of a content or a product raises a `NotFoundHttpException` when that parent does not exist:

- `attr('folder', ...)` on a content that has no default folder
- `attr('category', ...)` on a product that has no default category

Every other guard in `AttributeAccessService` returns an empty string when the target cannot be resolved, so a template has no way to tell "no parent" from a genuine 404 other than guarding the call itself.

## Root cause

`Content::getDefaultFolderId()` and `Product::getDefaultCategoryId()` are typed `: int` and return `0`, not `null`, when no default link row exists:

```php
// core/lib/Thelia/Model/Content.php:63
return null === $default_folder ? 0 : $default_folder->getFolderId();
```

`AttributeAccessService::attributeFolder()` and `attributeCategory()` only check for `null`:

```php
// core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php:134
if ($folderId === null) {
    return '';
}
```

`0` passes that guard, so `FolderQuery::filterByPrimaryKey(0)` runs, finds nothing, and `dataAccessWithI18n()` ends on `throw new NotFoundHttpException()`.

Note that `attributeBrand()`, right below, cannot hit this: `Product::getBrandId()` is a nullable foreign key and does return `null`. The failure comes purely from the type asymmetry between a nullable FK getter and these two computed `int` getters.

## Is the 404 intentional?

For an id that comes from the request, yes — `attributeContent()` with a `content_id` that does not exist should return 404, and this change leaves that path untouched. It only normalises the `0` returned by a model getter, never an explicitly requested id.

For a derived parent id, the rest of the core says no:

- `getBaseBreadcrumb()` (`CatalogBreadcrumbTrait.php:44`, `FolderBreadcrumbTrait.php:29`) is handed the very same `getDefaultFolderId()` / `getDefaultCategoryId()` value for the very same purpose — resolving the parent chain for display. It calls `filterById($currentId)->findOne()` and guards with `if (null !== $category)`, so a `0` simply ends the loop and yields the root breadcrumb. No exception.
- `Loop\Content` (line 300) and `Loop\Product` (line 1212) expose the raw `0` to templates as `DEFAULT_FOLDER` / `DEFAULT_CATEGORY`, as an ordinary value.

So a content with no default folder renders a working breadcrumb in the back-office while the same content makes a front-office template 404. That reads as an oversight rather than a rule.

## Why this change is needed

A content with no default folder, or a product with no default category, is a reachable state and not a data-integrity error:

- `ContentsImporter::import()` calls `?->setDefaultFolder()`, which is silently skipped when no folder matches (`core/lib/Thelia/Command/Import/Importer/ContentsImporter.php:49`).
- Deleting the folder or category link leaves the content/product in place.

A template cannot work around it cleanly. The accessor is reached through `attr('folder', 'TITLE')`, so the caller has no return value to test — the exception is thrown inside the accessor, and the only workaround is to duplicate the parent lookup in the template before every call, which is exactly what the accessor exists to avoid. The result is a 404 on a page whose content renders fine.

Making the model getters return `?int` would be the other option, but they are public API used well beyond this service, so widening their return type is a breaking change for a bug that is local to these two guards.

## Fix

Normalise the `0` returned by both getters to `null` where it is read, so the existing "no parent" guard a few lines below handles it. Behaviour for an explicitly requested `folder_id` / `category_id` is unchanged.

## How to reproduce

The added integration test covers both accessors. Without the fix both fail with `NotFoundHttpException`:

```
vendor/bin/phpunit --testsuite integration --filter AttributeAccessServiceTest
```

The test deliberately covers only the no-parent path. Asserting the nominal path would go through `dataAccessWithI18n()`, which populates the `self::$dataAccessCache` static keyed on the object label alone, leaking state into other tests in the same process.

## Compatibility

No BC break. Both methods keep their signature, and the empty string returned for the no-parent case is what the rest of the class already returns when a target cannot be resolved.
