### PR TITLE
fix(api): localize the brand filter group label

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
@@ -18,6 +18,7 @@ use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\BrandFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\CategoryFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaChoiceFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
@@ -400,6 +401,9 @@ readonly class FilterService
         }
         if ($filter instanceof CategoryFilter) {
             $mainTitle = $this->translator->trans(id: 'Category', locale: $locale);
+        }
+        if ($filter instanceof BrandFilter) {
+            $mainTitle = $this->translator->trans(id: 'Brand', locale: $locale);
         }
         $position = null;
         $isVisible = true;

--- a/tests/Integration/Api/BrandFilterTitleTest.php
+++ b/tests/Integration/Api/BrandFilterTitleTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Api\Resource\Filter;
+use Thelia\Model\ChoiceFilter;
+use Thelia\Model\ChoiceFilterOther;
+use Thelia\Model\Template;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The brand filter carries no parent entity to take its group label from, so
+ * FilterService::hydrateFilterDto() falls back to a static label. That fallback
+ * must be localized, like the one already hardcoded for the category filter,
+ * instead of exposing the raw technical filter name.
+ */
+final class BrandFilterTitleTest extends IntegrationTestCase
+{
+    private FilterService $filterService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->filterService = static::getContainer()->get(FilterService::class);
+    }
+
+    public function testBrandFilterTitleIsLocalized(): void
+    {
+        $categoryId = $this->createCategoryWithABrandedProduct();
+
+        $brandFilter = $this->findBrandFilter($categoryId, 'fr_FR');
+
+        self::assertInstanceOf(Filter::class, $brandFilter);
+        self::assertSame('Marque', $brandFilter->getTitle());
+    }
+
+    public function testBrandFilterTitleFallsBackToEnglishLabel(): void
+    {
+        $categoryId = $this->createCategoryWithABrandedProduct();
+
+        $brandFilter = $this->findBrandFilter($categoryId, 'en_US');
+
+        self::assertInstanceOf(Filter::class, $brandFilter);
+        self::assertSame('Brand', $brandFilter->getTitle());
+    }
+
+    private function createCategoryWithABrandedProduct(): int
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $template = new Template();
+        $template->setLocale('en_US');
+        $template->setName('Template with a brand filter');
+        $template->save($connection);
+
+        $category = $factory->category();
+        $category->setDefaultTemplateId($template->getId());
+        $category->save($connection);
+
+        $brand = $factory->brand();
+        // BrandFilter::getValue() reads the brand title in the requested locale,
+        // so both tested locales need a translation row.
+        $brand->setLocale('fr_FR')->setTitle('Marque de test');
+        $brand->save($connection);
+
+        $product = $factory->product($category, $factory->taxRule(), $factory->currency());
+        $product->setBrandId($brand->getId());
+        $product->setTemplateId($template->getId());
+        $product->save($connection);
+
+        // A visible choice filter is what makes the category expose filters at all.
+        $other = new ChoiceFilterOther();
+        $other->setType('brand');
+        $other->setVisible(true);
+        $other->setLocale('en_US');
+        $other->setTitle('Brand');
+        $other->save($connection);
+
+        $choiceFilter = new ChoiceFilter();
+        $choiceFilter->setCategoryId($category->getId());
+        $choiceFilter->setTemplateId($template->getId());
+        $choiceFilter->setOtherId($other->getId());
+        $choiceFilter->setPosition(1);
+        $choiceFilter->setVisible(true);
+        $choiceFilter->setType('checkbox');
+        $choiceFilter->save($connection);
+
+        return $category->getId();
+    }
+
+    private function findBrandFilter(int $categoryId, string $locale): ?Filter
+    {
+        $filters = $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    // tfilters values are nested one level deeper than the filter name.
+                    'tfilters' => ['category' => [['eq' => $categoryId]]],
+                    'locale' => $locale,
+                ],
+            ],
+            'products',
+        );
+
+        foreach ($filters as $filter) {
+            if ($filter->getType() === 'brand') {
+                return $filter;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Problem

In a filter list built by `FilterService`, the brand filter is labelled with the raw technical filter name `brand`, in every locale. Attribute, feature and category filters all get a proper, localized group label.

A front-office template receiving the `Filter` DTO has no way to recover a display label from it: `getTitle()` returns `brand`, and translating it on the theme side means shipping a `brand` key per locale in the theme catalog to paper over a core value.

## Root cause

`FilterService::hydrateFilterDto()` derives the group label from the first `FilterValue`, then falls back to the technical name:

```php
if (!$mainTitle) {
    $mainTitle = $filter::getFilterName()[0];
}
if ($filter instanceof CategoryFilter) {
    $mainTitle = $this->translator->trans(id: 'Category', locale: $locale);
}
```

`AttributeAvFilter`, `FeatureAvFilter` and `CategoryFilter` all call `setMainTitle()` with a title read from the parent entity in the requested locale, so `$mainTitle` is set and localized. `BrandFilter::getValue()` sets only `setId()` and `setTitle()` — the brand *is* the value, there is no parent entity to take a group label from — so the fallback applies and yields `brand`.

The category filter has the same shape (no meaningful parent title) and the core already solved it there, with a hardcoded translated label. The brand filter was simply never given the same treatment.

## Why this change is needed

The group label is what a shop displays above the list of checkboxes ("Brand", "Marque"). Every other filter provides it, so a theme can render the whole filter list generically. Brand is the one case that forces the theme to special-case a core value, and it is not fixable outside the core in a way that survives: the fallback string comes from `getFilterName()`, which is also the key used in the `tfilters` query parameter, so it cannot be renamed to something human-readable without changing the filter API.

Adding `setMainTitle()` inside `BrandFilter` is the other option, but it would mean injecting a translator into a filter class that currently has no constructor (none of the shipped filters do), for a value that is a static label rather than data — while `hydrateFilterDto()` already holds the translator and already applies exactly this pattern for `CategoryFilter`.

## Fix

Translate the group label of `BrandFilter` in `hydrateFilterDto()`, mirroring the existing `CategoryFilter` case. The `Brand` key already exists in the core catalogs (`core/lib/Thelia/Config/I18n/fr_FR.php` maps it to `Marque`), so no new translation entry is needed.

## How to reproduce

The added integration test builds a category with a branded product and a visible brand choice filter, then reads the resulting filter list in `fr_FR` and in `en_US`. Without the fix both assertions get `brand`:

```
vendor/bin/phpunit --testsuite integration --filter BrandFilterTitleTest
```

## Compatibility

`Filter::getType()` still returns `brand`, so anything keyed on the filter type is unaffected. Only `getTitle()` changes, from the technical name to the localized label — which is what the other filters already return.
