### PR TITLE
fix(api): guard filter value titles against missing translations

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
@@ -24,6 +24,8 @@ use Thelia\Model\Attribute;
 
 class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface
 {
+    use LocalizedTitleTrait;
+
     public function getResourceType(): array
     {
         return ['products'];
@@ -88,10 +90,10 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
             foreach ($productSaleElements->getAttributeCombinationsJoinAttributeAv() as $attributeAv) {
                 $value[] =
                     (new FilterValue())
-                        ->setMainTitle($attributeAv->getAttribute()->setLocale($locale)->getTitle())
+                        ->setMainTitle($this->localizedTitle($attributeAv->getAttribute(), $locale))
                         ->setMainId($attributeAv->getAttribute()->getId())
                         ->setId($attributeAv->getAttributeAvId())
-                        ->setTitle($attributeAv->getAttributeAv()->setLocale($locale)->getTitle());
+                        ->setTitle($this->localizedTitle($attributeAv->getAttributeAv(), $locale));
             }
         }
 

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
@@ -22,6 +22,8 @@ use Thelia\Model\Brand;
 
 class BrandFilter implements TheliaFilterInterface
 {
+    use LocalizedTitleTrait;
+
     public function getResourceType(): array
     {
         return ['products'];
@@ -52,7 +54,7 @@ class BrandFilter implements TheliaFilterInterface
         return [
             (new FilterValue())
                 ->setId($brand->getId())
-                ->setTitle($brand->setLocale($locale)->getTitle()),
+                ->setTitle($this->localizedTitle($brand, $locale)),
         ];
     }
 }

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
@@ -23,6 +23,8 @@ use Thelia\Model\CategoryQuery;
 
 class CategoryFilter implements TheliaFilterInterface
 {
+    use LocalizedTitleTrait;
+
     public const CATEGORY_DEPTH_NAME = 'category_depth';
 
     public function __construct(private readonly FilterService $filterService)
@@ -91,11 +93,11 @@ class CategoryFilter implements TheliaFilterInterface
                 foreach ($categories as $category) {
                     $value[] =
                         (new FilterValue())
-                            ->setMainTitle($mainCategory->setLocale($locale)->getTitle())
+                            ->setMainTitle($this->localizedTitle($mainCategory, $locale))
                             ->setMainId($mainCategory->getId())
                             ->setId($category->getId())
                             ->setDepth($depthIndex)
-                            ->setTitle($category->setLocale($locale)->getTitle());
+                            ->setTitle($this->localizedTitle($category, $locale));
                 }
             }
         }

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
@@ -26,6 +26,8 @@ use Thelia\Model\Map\FeatureProductTableMap;
 
 class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface
 {
+    use LocalizedTitleTrait;
+
     public function getResourceType(): array
     {
         return ['products'];
@@ -90,10 +92,10 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
 
             $value[] =
                 (new FilterValue())
-                ->setMainTitle($featureProduct->getFeature()->setLocale($locale)->getTitle())
+                ->setMainTitle($this->localizedTitle($featureProduct->getFeature(), $locale))
                 ->setMainId($featureProduct->getFeature()->getId())
                 ->setId($featureProduct->getFeatureAv()->getId())
-                ->setTitle($featureProduct->getFeatureAv()->setLocale($locale)->getTitle());
+                ->setTitle($this->localizedTitle($featureProduct->getFeatureAv(), $locale));
         }
 
         return $value;

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/LocalizedTitleTrait.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/LocalizedTitleTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
+
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+
+trait LocalizedTitleTrait
+{
+    /**
+     * FilterValue::setTitle() takes a string, so an entity left untranslated in the
+     * requested locale would otherwise fail the whole filter list rather than that
+     * single facet.
+     *
+     * Falling back to the default language mirrors ResourceService::formatI18ns():
+     * the back office "If a translation is missing or incomplete" setting decides.
+     * Filters are exposed on the front only (GET /front/tfilters/{resource}), so the
+     * admin exclusion that applies there has no equivalent here.
+     */
+    protected function localizedTitle(ActiveRecordInterface $record, string $locale): string
+    {
+        $title = $record->setLocale($locale)->getTitle();
+
+        // Explicit emptiness test rather than ?: — "0" is a legitimate attribute
+        // value title (a size, for instance) and must not count as missing.
+        if (null !== $title && '' !== $title) {
+            return $title;
+        }
+
+        $fallbackLocale = $this->fallbackLocale($locale);
+
+        if (null !== $fallbackLocale) {
+            $title = $record->setLocale($fallbackLocale)->getTitle();
+        }
+
+        return $title ?? '';
+    }
+
+    private function fallbackLocale(string $currentLocale): ?string
+    {
+        if (Lang::REPLACE_BY_DEFAULT_LANGUAGE !== (int) ConfigQuery::getDefaultLangWhenNoTranslationAvailable()) {
+            return null;
+        }
+
+        $defaultLocale = Lang::getDefaultLanguage()->getLocale();
+
+        return $defaultLocale === $currentLocale ? null : $defaultLocale;
+    }
+}

--- a/tests/Integration/Api/FilterValueTitleFallbackTest.php
+++ b/tests/Integration/Api/FilterValueTitleFallbackTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Api\Resource\Filter;
+use Thelia\Api\Resource\FilterValue;
+use Thelia\Model\ChoiceFilter;
+use Thelia\Model\ChoiceFilterOther;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\Template;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A brand name is a proper noun, so a shop routinely leaves it untranslated in
+ * secondary locales. Reading such a title in the requested locale yields null,
+ * which FilterValue::setTitle() rejects — and because FilterService builds the
+ * whole list in one pass, a single untranslated entity used to fail every filter
+ * of the page, not just its own facet.
+ *
+ * Whether the title then falls back to the default language is governed by the
+ * back office "If a translation is missing or incomplete" setting, as it is in
+ * ResourceService::formatI18ns().
+ */
+final class FilterValueTitleFallbackTest extends IntegrationTestCase
+{
+    private const BRAND_TITLE = 'Untranslated Brand';
+
+    private FilterService $filterService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->filterService = static::getContainer()->get(FilterService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // The config cache is static: left as-is it would outlive the transaction
+        // rollback and leak this test's setting into the rest of the suite.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testUntranslatedTitleFallsBackWhenTheSettingAllowsIt(): void
+    {
+        $this->setTranslationFallback(Lang::REPLACE_BY_DEFAULT_LANGUAGE);
+
+        $categoryId = $this->createCategoryWithAnUntranslatedBrandedProduct();
+
+        $brandFilter = $this->findBrandFilter($categoryId, 'fr_FR');
+
+        self::assertInstanceOf(Filter::class, $brandFilter);
+
+        $values = $brandFilter->getValues();
+        self::assertCount(1, $values);
+        self::assertInstanceOf(FilterValue::class, $values[0]);
+        self::assertSame(self::BRAND_TITLE, $values[0]->getTitle());
+    }
+
+    /**
+     * Strict mode keeps the facet unlabelled rather than borrowing another
+     * language — but it must still not take the filter list down with it.
+     */
+    public function testUntranslatedTitleStaysEmptyWhenTheSettingIsStrict(): void
+    {
+        $this->setTranslationFallback(Lang::STRICTLY_USE_REQUESTED_LANGUAGE);
+
+        $categoryId = $this->createCategoryWithAnUntranslatedBrandedProduct();
+
+        $brandFilter = $this->findBrandFilter($categoryId, 'fr_FR');
+
+        self::assertInstanceOf(Filter::class, $brandFilter);
+
+        $values = $brandFilter->getValues();
+        self::assertCount(1, $values);
+        self::assertSame('', $values[0]->getTitle());
+    }
+
+    public function testUntranslatedBrandKeepsItsTitleInTheDefaultLocale(): void
+    {
+        $categoryId = $this->createCategoryWithAnUntranslatedBrandedProduct();
+
+        $brandFilter = $this->findBrandFilter($categoryId, 'en_US');
+
+        self::assertInstanceOf(Filter::class, $brandFilter);
+        self::assertSame(self::BRAND_TITLE, $brandFilter->getValues()[0]->getTitle());
+    }
+
+    /**
+     * ConfigQuery::read() only honours a stored value through the cache the kernel
+     * primes at boot; on a cold read a stored "0" is falsy and collapses back to the
+     * default. Priming the cache the way ConfigCacheService does is what makes the
+     * strict setting observable here at all.
+     */
+    private function setTranslationFallback(int $mode): void
+    {
+        ConfigQuery::write('default_lang_without_translation', (string) $mode);
+
+        $configs = [];
+        foreach (ConfigQuery::create()->find() as $config) {
+            $configs[$config->getName()] = $config->getValue();
+        }
+
+        ConfigQuery::initCache($configs);
+    }
+
+    private function createCategoryWithAnUntranslatedBrandedProduct(): int
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $template = new Template();
+        $template->setLocale('en_US');
+        $template->setName('Template with a brand filter');
+        $template->save($connection);
+
+        $category = $factory->category();
+        $category->setDefaultTemplateId($template->getId());
+        $category->save($connection);
+
+        // Translated in the default language only: this is what triggers the bug.
+        $brand = $factory->brand(['locale' => 'en_US', 'title' => self::BRAND_TITLE]);
+
+        $product = $factory->product($category, $factory->taxRule(), $factory->currency());
+        $product->setBrandId($brand->getId());
+        $product->setTemplateId($template->getId());
+        $product->save($connection);
+
+        // A visible choice filter is what makes the category expose filters at all.
+        $other = new ChoiceFilterOther();
+        $other->setType('brand');
+        $other->setVisible(true);
+        $other->setLocale('en_US');
+        $other->setTitle('Brand');
+        $other->save($connection);
+
+        $choiceFilter = new ChoiceFilter();
+        $choiceFilter->setCategoryId($category->getId());
+        $choiceFilter->setTemplateId($template->getId());
+        $choiceFilter->setOtherId($other->getId());
+        $choiceFilter->setPosition(1);
+        $choiceFilter->setVisible(true);
+        $choiceFilter->setType('checkbox');
+        $choiceFilter->save($connection);
+
+        return $category->getId();
+    }
+
+    private function findBrandFilter(int $categoryId, string $locale): ?Filter
+    {
+        $filters = $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    // tfilters values are nested one level deeper than the filter name.
+                    'tfilters' => ['category' => [['eq' => $categoryId]]],
+                    'locale' => $locale,
+                ],
+            ],
+            'products',
+        );
+
+        foreach ($filters as $filter) {
+            if ($filter->getType() === 'brand') {
+                return $filter;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Problem

On a shop with more than one active language, opening a category listing returns a 500 for the entire filter list as soon as a single filtered entity — a brand, a category, an attribute value or a feature value — has no translation in the requested locale. It is not that one facet degrades: no filter is returned at all.

## Root cause

`FilterValue::setTitle()` takes a `string` (`core/lib/Thelia/Api/Resource/FilterValue.php:89`), while the four custom filters pass `$entity->setLocale($locale)->getTitle()`, which is `null` when the entity has no i18n row for that locale — `BrandFilter.php:55`, `CategoryFilter.php:94` and `:98`, `AttributeAvFilter.php:91` and `:94`, `FeatureAvFilter.php:93` and `:96`.

`FilterService` builds the whole list in one pass, so a single untranslated record raises a `TypeError` that takes every filter of the page down with it.

## Why this change is needed

Callers cannot work around it. The list is produced entirely inside the API bridge and exposed through one read-only operation (`GET /front/tfilters/{resource}`); a theme has no hook between reading the title and handing it to `FilterValue`.

Any shop that activates a second language is exposed as soon as a proper noun — a brand name, typically — is left untranslated, which is ordinary editorial practice rather than a misconfiguration.

## Fix

A shared `LocalizedTitleTrait` used by the four filters, separating two concerns:

- the value handed to `setTitle()` is always a string, unconditionally — a type requirement, not a policy decision;
- whether a missing translation falls back to the default language follows the existing back office setting "If a translation is missing or incomplete" (`ConfigQuery::getDefaultLangWhenNoTranslationAvailable()`), mirroring what `ResourceService::formatI18ns()` has done since 867be081. Under `STRICTLY_USE_REQUESTED_LANGUAGE` the facet renders with an empty label rather than borrowing another language.

The admin exclusion `formatI18ns()` applies has no equivalent here: the `Filter` resource declares a single front operation.

Emptiness is tested explicitly rather than with `?:`, so a title of `"0"` — a legitimate attribute value, a size for instance — is not treated as missing.

Widening `FilterValue::setTitle()` to `?string` was considered and rejected: it moves the problem to consumers, which then have to render a label-less facet, and changes a public signature.

## How to reproduce

`tests/Integration/Api/FilterValueTitleFallbackTest.php` covers the three cases. Without the patch the first two error with:

```
TypeError: Thelia\Api\Resource\FilterValue::setTitle(): Argument #1 ($title) must be of type
string, null given, called in .../CustomFilters/Filters/BrandFilter.php on line 55
```

## Compatibility

No BC break, no signature change. The only behaviour change is that filter titles now honour the missing-translation setting — previously they could not be produced at all in that situation.
