### PR TITLE
fix(api): read PSE attribute titles in the requested locale

### DIFF
--- a/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
@@ -14,15 +14,18 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Service\DataAccess;
 
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Attribute\AttributeAvProductEvent;
 use Thelia\Core\Event\ProductSaleElement\PseByProductEvent;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Security\SecurityContext;
+use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 use Thelia\Model\AttributeAvQuery;
 use Thelia\Model\AttributeQuery;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductSaleElementsQuery;
@@ -36,6 +39,7 @@ class ProductSaleElementsAccessService
         private readonly TaxEngine $taxEngine,
         private readonly SecurityContext $securityContext,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly LangService $langService,
     ) {
         $this->request = $requestStack->getMainRequest();
     }
@@ -92,7 +96,7 @@ class ProductSaleElementsAccessService
 
     public function attrAvByProduct($product_id)
     {
-        $locale = Lang::getDefaultLanguage()->getLocale();
+        $locale = $this->langService->getLocale() ?? Lang::getDefaultLanguage()->getLocale();
         $attributes = [];
         $attributesId = [];
         $attributeAvailabilitiesId = [];
@@ -105,24 +109,59 @@ class ProductSaleElementsAccessService
         }
 
         foreach (array_unique($attributesId) as $atributeId) {
-            $attribute = AttributeQuery::create()->joinWithI18n($locale)->findOneById($atributeId);
+            $attribute = AttributeQuery::create()->findOneById($atributeId);
 
             $attributes[$atributeId] = [
-                'label' => $attribute->getTitle(),
+                'label' => $this->localizedTitle($attribute, $locale),
                 'id' => $attribute->getId(),
             ];
         }
 
         foreach (array_unique($attributeAvailabilitiesId) as $attributeAvId) {
-            $attributeAv = AttributeAvQuery::create()->joinWithI18n($locale)->findOneById($attributeAvId);
+            $attributeAv = AttributeAvQuery::create()->findOneById($attributeAvId);
             $attributes[$attributeAv->getAttributeId()]['values'][] = [
                 'id' => $attributeAv->getId(),
-                'label' => $attributeAv->getTitle(),
+                'label' => $this->localizedTitle($attributeAv, $locale),
             ];
         }
 
         $event = $this->eventDispatcher->dispatch(new AttributeAvProductEvent($attributes));
 
         return $event->getAttributes();
+    }
+
+    /**
+     * Falling back to the default language mirrors ResourceService::formatI18ns(): the back office
+     * "If a translation is missing or incomplete" setting decides. This data access is exposed on
+     * the front only, so the admin exclusion that applies there has no equivalent here.
+     */
+    private function localizedTitle(ActiveRecordInterface $record, string $locale): string
+    {
+        $title = $record->setLocale($locale)->getTitle();
+
+        // Explicit emptiness test rather than ?: — "0" is a legitimate attribute value title
+        // (a size, for instance) and must not count as missing.
+        if (null !== $title && '' !== $title) {
+            return $title;
+        }
+
+        $fallbackLocale = $this->fallbackLocale($locale);
+
+        if (null !== $fallbackLocale) {
+            $title = $record->setLocale($fallbackLocale)->getTitle();
+        }
+
+        return $title ?? '';
+    }
+
+    private function fallbackLocale(string $currentLocale): ?string
+    {
+        if (Lang::REPLACE_BY_DEFAULT_LANGUAGE !== (int) ConfigQuery::getDefaultLangWhenNoTranslationAvailable()) {
+            return null;
+        }
+
+        $defaultLocale = Lang::getDefaultLanguage()->getLocale();
+
+        return $defaultLocale === $currentLocale ? null : $defaultLocale;
     }
 }

--- a/tests/Integration/Api/PseAttributeTitleLocaleTest.php
+++ b/tests/Integration/Api/PseAttributeTitleLocaleTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\ProductSaleElementsAccessService;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Model\Attribute;
+use Thelia\Model\AttributeAv;
+use Thelia\Model\AttributeCombination;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * attrAvByProduct() feeds the variant selector of a product page: the attribute
+ * names ("Size", "Colour") and their values. It used to read them in the shop's
+ * default language whatever the language of the request, so a storefront browsed
+ * in a secondary locale showed a fully translated page with untranslated variant
+ * labels.
+ *
+ * Whether an attribute left untranslated in the requested locale then falls back
+ * to the default language is governed by the back office "If a translation is
+ * missing or incomplete" setting, as it is in ResourceService::formatI18ns().
+ */
+final class PseAttributeTitleLocaleTest extends IntegrationTestCase
+{
+    private ProductSaleElementsAccessService $pseAccess;
+    private LangService $langService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pseAccess = static::getContainer()->get(ProductSaleElementsAccessService::class);
+        $this->langService = static::getContainer()->get(LangService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // The config cache is static: left as-is it would outlive the transaction
+        // rollback and leak this test's setting into the rest of the suite.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testTitlesAreReadInTheRequestedLocale(): void
+    {
+        $productId = $this->createProductWithOneVariant(
+            ['en_US' => 'Colour', 'fr_FR' => 'Couleur'],
+            ['en_US' => 'Blue', 'fr_FR' => 'Bleu'],
+        );
+
+        $this->useLocale('fr_FR');
+
+        $attributes = $this->pseAccess->attrAvByProduct($productId);
+
+        self::assertCount(1, $attributes);
+
+        $attribute = reset($attributes);
+        self::assertSame('Couleur', $attribute['label']);
+        self::assertSame('Bleu', $attribute['values'][0]['label']);
+    }
+
+    public function testUntranslatedTitlesFallBackWhenTheSettingAllowsIt(): void
+    {
+        $this->setTranslationFallback(Lang::REPLACE_BY_DEFAULT_LANGUAGE);
+
+        // Translated in the default language only: this is what the fallback is for.
+        $productId = $this->createProductWithOneVariant(
+            ['en_US' => 'Colour'],
+            ['en_US' => 'Blue'],
+        );
+
+        $this->useLocale('fr_FR');
+
+        $attributes = $this->pseAccess->attrAvByProduct($productId);
+
+        $attribute = reset($attributes);
+        self::assertSame('Colour', $attribute['label']);
+        self::assertSame('Blue', $attribute['values'][0]['label']);
+    }
+
+    /**
+     * Strict mode leaves the label empty rather than borrowing another language —
+     * it must not fall back, and it must not fail either.
+     */
+    public function testUntranslatedTitlesStayEmptyWhenTheSettingIsStrict(): void
+    {
+        $this->setTranslationFallback(Lang::STRICTLY_USE_REQUESTED_LANGUAGE);
+
+        $productId = $this->createProductWithOneVariant(
+            ['en_US' => 'Colour'],
+            ['en_US' => 'Blue'],
+        );
+
+        $this->useLocale('fr_FR');
+
+        $attributes = $this->pseAccess->attrAvByProduct($productId);
+
+        $attribute = reset($attributes);
+        self::assertSame('', $attribute['label']);
+        self::assertSame('', $attribute['values'][0]['label']);
+    }
+
+    /**
+     * @param array<string, string> $attributeTitles locale => title
+     * @param array<string, string> $valueTitles     locale => title
+     */
+    private function createProductWithOneVariant(array $attributeTitles, array $valueTitles): int
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+        $pse = $factory->productSaleElement($product, ['isDefault' => true]);
+
+        $attribute = new Attribute();
+        $this->translate($attribute, $attributeTitles);
+        $attribute->save($connection);
+
+        $attributeAv = new AttributeAv();
+        $attributeAv->setAttributeId($attribute->getId());
+        $this->translate($attributeAv, $valueTitles);
+        $attributeAv->save($connection);
+
+        $combination = new AttributeCombination();
+        $combination->setProductSaleElementsId($pse->getId());
+        $combination->setAttributeId($attribute->getId());
+        $combination->setAttributeAvId($attributeAv->getId());
+        $combination->save($connection);
+
+        return $product->getId();
+    }
+
+    /**
+     * @param array<string, string> $titles locale => title
+     */
+    private function translate(Attribute|AttributeAv $record, array $titles): void
+    {
+        foreach ($titles as $locale => $title) {
+            $record->setLocale($locale)->setTitle($title);
+        }
+    }
+
+    private function useLocale(string $locale): void
+    {
+        $lang = LangQuery::create()->findOneByLocale($locale, $this->getPropelConnection());
+
+        if (null === $lang) {
+            $lang = $this->createFixtureFactory()->lang([
+                'locale' => $locale,
+                'code' => explode('_', $locale)[0],
+                'title' => $locale,
+            ]);
+        }
+
+        $this->langService->setLang($lang);
+    }
+
+    /**
+     * ConfigQuery::read() only honours a stored value through the cache the kernel
+     * primes at boot; on a cold read a stored "0" is falsy and collapses back to the
+     * default. Priming the cache the way ConfigCacheService does is what makes the
+     * strict setting observable here at all.
+     */
+    private function setTranslationFallback(int $mode): void
+    {
+        ConfigQuery::write('default_lang_without_translation', (string) $mode);
+
+        $configs = [];
+        foreach (ConfigQuery::create()->find() as $config) {
+            $configs[$config->getName()] = $config->getValue();
+        }
+
+        ConfigQuery::initCache($configs);
+    }
+}


### PR DESCRIPTION
## Problem

On a storefront browsed in a secondary language, the variant selector of a product page shows its
attribute names and values in the shop's **default** language, while the rest of the page is
correctly translated. A shop whose default language is English and whose customer browses in French
gets a fully French product page with a selector reading `Colour` / `Blue` instead of
`Couleur` / `Bleu`.

## Root cause

`Thelia\Api\Service\DataAccess\ProductSaleElementsAccessService::attrAvByProduct()` opens with:

```php
$locale = Lang::getDefaultLanguage()->getLocale();
```

and uses that locale for the two `joinWithI18n()` calls that load the `Attribute` and `AttributeAv`
titles. The locale of the request is never consulted — neither through the session lang, nor through
a parameter. The method takes only a product id, so a caller has no way to ask for another language.

## Why this change is needed

`attrAvByProduct()` is the only data access exposing attribute and attribute value labels for a
product's variants, and it is consumed by front-office templates. There is no way to work around the
problem from the calling side: the method exposes no locale parameter, and re-reading every title
from the caller would mean duplicating the whole `attribute_combination` traversal it exists to
encapsulate.

Every other read path in the API layer already honours the requested locale — `ResourceService`
resolves it through `LocaleService` and applies the documented translation fallback in
`formatI18ns()`, and `FilterService` resolves it through `LangService`. This service is the outlier,
so any multilingual shop displaying variants is affected regardless of the theme in use.

## Fix

Resolve the locale through `Thelia\Domain\Localization\Service\LangService`, the same dependency
`FilterService` already uses in this layer. It reads the session lang and falls back to the default
language when no lang can be resolved, so contexts without a request (CLI, workers) keep the current
behaviour.

Switching to the requested locale alone would trade one bug for another: `joinWithI18n()` is a
LEFT JOIN, so an attribute left untranslated in the requested locale would come back with an **empty**
title where it previously showed the default language. The two title reads therefore go through a
small helper that falls back to the default language, gated on
`ConfigQuery::getDefaultLangWhenNoTranslationAvailable()` — the same back office setting
("If a translation is missing or incomplete") that governs `ResourceService::formatI18ns()`. In
strict mode the label stays empty, which is the documented intent of that setting.

The helper reads the title through `setLocale()` instead of `joinWithI18n()` because the join cannot
express a per-record fallback. Adapting the query-level mechanism (`ModelCriteriaTools::getFrontEndI18n()`)
would have meant rewriting both queries for the same result.

## How to reproduce

`tests/Integration/Api/PseAttributeTitleLocaleTest::testTitlesAreReadInTheRequestedLocale` builds a
product with one variant whose attribute and value are translated in both `en_US` and `fr_FR`, sets
the session lang to `fr_FR`, and asserts the French titles. It fails without this patch, returning
the `en_US` titles.

The two other tests cover the fallback setting in both modes;
`testUntranslatedTitlesStayEmptyWhenTheSettingIsStrict` also fails without the patch.

## Compatibility

Behaviour change, intentional and limited to `attrAvByProduct()`: labels now follow the requested
locale instead of always being the default language's. A shop that is not multilingual, or whose
requested locale is the default one, sees no difference.

`ProductSaleElementsAccessService::__construct()` takes one more argument. The service is registered
with autowiring, so no configuration change is required; only code instantiating it manually would
need updating.
