### PR TITLE
fix: restore the persistent cart cookie broken by strict config comparison

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -638,7 +638,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
         $this->getSession()->setSessionCart($cart);
 
-        if (1 === ConfigQuery::read('cart.use_persistent_cookie', 1)) {
+        if (1 === (int) ConfigQuery::read('cart.use_persistent_cookie', 1)) {
             // set cart_use_cookie to "" to remove the cart cookie
             // see Thelia\Core\EventListener\ResponseListener
             $this->getSession()->set('cart_use_cookie', '');
@@ -673,7 +673,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
     {
         $id = null;
 
-        if (1 === ConfigQuery::read('cart.use_persistent_cookie', 1)) {
+        if (1 === (int) ConfigQuery::read('cart.use_persistent_cookie', 1)) {
             $id = $this->tokenProvider->getToken();
             $this->getSession()->set('cart_use_cookie', $id);
         }

--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -32,7 +32,7 @@ class Cart extends BaseCart
      * @throws PropelException
      */
     public function duplicate(
-        string $token,
+        ?string $token,
         ?Customer $customer = null,
         ?Currency $currency = null,
         ?EventDispatcherInterface $dispatcher = null,

--- a/tests/Integration/Action/CartActionTest.php
+++ b/tests/Integration/Action/CartActionTest.php
@@ -14,12 +14,17 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Action;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Cart\CartCreateEvent;
 use Thelia\Core\Event\Cart\CartEvent;
+use Thelia\Core\Event\Cart\CartRestoreEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\Cart;
 use Thelia\Model\CartItemQuery;
 use Thelia\Model\CartQuery;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Test\ActionIntegrationTestCase;
 
@@ -143,6 +148,66 @@ final class CartActionTest extends ActionIntegrationTestCase
         $this->dispatch($clear, TheliaEvents::CART_CLEAR);
 
         self::assertNull(CartQuery::create()->findPk($cartId));
+    }
+
+    public function testCreateEmptyCartAsksForTheCartCookieRemoval(): void
+    {
+        self::assertSame(1, (int) ConfigQuery::read('cart.use_persistent_cookie', 1));
+
+        $this->dispatch(new CartCreateEvent(), TheliaEvents::CART_CREATE_NEW);
+
+        // An empty string is the signal ResponseListener reads to clear the cart cookie.
+        self::assertSame('', $this->mainRequest()->getSession()->get('cart_use_cookie'));
+    }
+
+    public function testRestoreCurrentCartDuplicatesACartOwnedByAnotherCustomer(): void
+    {
+        $owner = $this->factory->customer($this->factory->customerTitle());
+        $cart = $this->factory->cart($owner);
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+            ['baseQuantity' => 100],
+        );
+        $this->dispatchAddItem($cart, $product->getId(), $this->defaultPseFor($product->getId())->getId(), 1);
+
+        $this->mainRequest()->cookies->set(
+            ConfigQuery::read('cart.cookie_name', 'thelia_cart'),
+            $cart->getToken(),
+        );
+
+        $event = new CartRestoreEvent();
+        $this->dispatch($event, TheliaEvents::CART_RESTORE_CURRENT);
+
+        $restored = $event->getCart();
+        self::assertInstanceOf(Cart::class, $restored);
+        self::assertNotSame($cart->getId(), $restored->getId());
+        self::assertNull($restored->getCustomerId());
+        // The duplicate carries a fresh token, which is also what ends up in the cookie.
+        self::assertNotNull($restored->getToken());
+        self::assertNotSame($cart->getToken(), $restored->getToken());
+    }
+
+    public function testDuplicateAcceptsANullTokenWhenTheCartCookieIsDisabled(): void
+    {
+        $cart = $this->newEmptyCart();
+        $cart->save();
+
+        $duplicate = $cart->duplicate(
+            null,
+            null,
+            $this->factory->currency(),
+            $this->getService(EventDispatcherInterface::class),
+        );
+
+        self::assertInstanceOf(Cart::class, $duplicate);
+        self::assertNull($duplicate->getToken());
+    }
+
+    private function mainRequest(): Request
+    {
+        return $this->getService(RequestStack::class)->getMainRequest();
     }
 
     private function newEmptyCart(): Cart


### PR DESCRIPTION
## Problem

The persistent cart cookie no longer works on the `twig` branch.

Two symptoms, both silent:

1. **The `thelia_cart` cookie is never sent to the browser**, so a cart never survives the end of a session. Every cart created by the application is also stored with `token = NULL`, since `persistCart()` fills the token from the same helper.
2. **When a cart *does* have to be duplicated, the request fails with a 500.** `Cart::duplicate()` is called with `null`, which its signature rejects:

   ```
   TypeError: Thelia\Model\Cart::duplicate(): Argument #1 ($token) must be of type string, null given,
     called in core/lib/Thelia/Action/Cart.php on line 655
     Action/Cart.php:655 duplicateCart()
     Action/Cart.php:554 manageCartDuplicationAtCustomerLogin()
     Action/Cart.php:518 managePersistentCart()
     Action/Cart.php:447 restoreCurrentCart()
   ```

   This path is reached whenever a visitor presents a cart cookie pointing at a cart owned by someone else, and whenever a customer with a discount logs in while holding a non-empty anonymous cart.

The two defects mask each other: because symptom 1 stops the cookie from ever being issued, `managePersistentCart()` rarely finds a cart to restore, so symptom 2 stays mostly dormant on a running site.

On a store I checked, 23 of 23 carts created by the application carried `token = NULL`; the only rows with a token came from the demo SQL seed.

## Root cause

`ConfigQuery::read()` returns the `config.value` column, a `VARCHAR`, so `cart.use_persistent_cookie` reads back as the **string** `'1'`. Two call sites compare it with `===` against the **integer** `1`:

- `core/lib/Thelia/Action/Cart.php:641` in `createEmptyCart()`
- `core/lib/Thelia/Action/Cart.php:676` in `generateCartCookieIdentifier()`

`1 === '1'` is `false`, so:

- `generateCartCookieIdentifier()` always returns `null` and never sets the `cart_use_cookie` session key that `ResponseListener` reads to issue the cookie;
- `createEmptyCart()` never asks for the cookie to be cleared either.

A third call site, `Action/Cart.php:441` in `restoreCurrentCart()`, already casts with `(int)` and is correct — which is why the persistent branch is still entered while the two others are not.

This is a regression from the 2.x port. On `main` the same code reads:

```php
if (ConfigQuery::read('cart.use_persistent_cookie', 1) == 1) {   // loose, works
public function duplicate($token, ...)                            // untyped, accepts null
```

Adding strict comparison and strict typing broke both halves of the same feature in the same move.

## Why this change is needed

The persistent cart cookie is a documented, back-office-configurable feature (`cart.use_persistent_cookie`, `cart.cookie_name`, `cart.cookie_lifetime`), and there is no way for calling code to work around it: the comparison and the cookie emission both live inside `Thelia\Action\Cart`, and the token that ends up on the `cart` row is written there too. A project cannot restore the behaviour without replacing the whole cart action listener.

The `duplicate()` signature matters independently of the comparison. `generateCartCookieIdentifier()` is declared `?string` — returning `null` is its documented behaviour when `cart.use_persistent_cookie` is disabled — and it is the only value ever passed to `duplicate()`. As it stands, the declared contract of the caller cannot be satisfied by the callee. The `cart.token` column is nullable and not constrained on `NULL`, and `Cart::setToken()` already accepts `?string`, so `null` is a valid value at every layer except this one signature.

## Fix

- Cast to `int` before comparing, at the two remaining call sites — same style as the already-correct `restoreCurrentCart()` a few lines above.
- Widen `Cart::duplicate()`'s first parameter to `?string`, restoring what 2.x accepted and matching both `setToken(?string)` and the nullable column.

## How to reproduce

The three integration tests added in `tests/Integration/Action/CartActionTest.php` all fail on `twig` without the patch and pass with it:

| Test | Failure without the patch |
|---|---|
| `testCreateEmptyCartAsksForTheCartCookieRemoval` | `Failed asserting that null is identical to ''` |
| `testRestoreCurrentCartDuplicatesACartOwnedByAnotherCustomer` | `TypeError` through the production path shown above |
| `testDuplicateAcceptsANullTokenWhenTheCartCookieIsDisabled` | `TypeError` on the model call directly |

Manually, on a store with the default configuration: browse the front, add something to the cart, and check that no `thelia_cart` cookie is set and that the new `cart` row has `token = NULL`.

## Compatibility

No behavioural change for calling code beyond restoring the intended feature.

One caveat worth stating: widening `Cart::duplicate()`'s parameter to `?string` is safe for every caller, but a subclass that overrides `duplicate()` with the narrower `string $token` would become incompatible with its parent under PHP's contravariance rule. I found no such override in the core; a module doing it would need the same one-character change.

## Out of scope, but related

While instrumenting this I found that `ConfigQuery::read()` applies its default with `?:` rather than `??`:

```php
$value = $model->getValue() ?: $default;
```

A stored `'0'` is falsy, so it is replaced by the default. For `cart.use_persistent_cookie` this means that after the fix above, the *enabled* path is correct but the *disabled* path is still unreachable from the back office — and the same holds for `default_lang_without_translation`, `form_firewall_active` and `process_assets`. That change touches every configuration read in the core, so it is deliberately not part of this PR; happy to open a separate one or an issue if you want it addressed.
