### PR TITLE
fix(mailer): restore the session language when email rendering fails

### DIFF
--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -188,15 +188,22 @@ class MailerFactory
             $session->setLang($requiredLang);
         }
 
-        $email = (new Email());
+        try {
+            $email = (new Email());
 
-        $this->setupMessageHeaders($email, $from, $to, $cc, $bcc, $replyTo);
+            $this->setupMessageHeaders($email, $from, $to, $cc, $bcc, $replyTo);
 
-        $message->buildMessage($parser, $email);
+            $message->buildMessage($parser, $email);
 
-        $session->setLang($currentLang);
-
-        return $email;
+            return $email;
+        } finally {
+            // Restore on every path: sendEmailMessage() deliberately swallows a rendering
+            // failure so the request survives it, which would otherwise leave the visitor's
+            // session in the language of an email they never received.
+            if (null !== $currentLang) {
+                $session->setLang($currentLang);
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Mailer/MailerFactoryTest.php
+++ b/tests/Integration/Mailer/MailerFactoryTest.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Mailer;
 
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\MailerInterface;
 use Thelia\Core\Template\Parser\ParserResolver;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Mailer\MailerFactory;
+use Thelia\Model\LangQuery;
+use Thelia\Model\Message;
 use Thelia\Test\IntegrationTestCase;
 
 final class MailerFactoryTest extends IntegrationTestCase
@@ -79,6 +82,38 @@ final class MailerFactoryTest extends IntegrationTestCase
 
         self::assertCount(1, $email->getReplyTo());
         self::assertSame('reply@test.com', $email->getReplyTo()[0]->getAddress());
+    }
+
+    public function testCreateEmailMessageRestoresTheSessionLangWhenRenderingFails(): void
+    {
+        $session = $this->getService(RequestStack::class)->getMainRequest()->getSession();
+
+        $french = LangQuery::create()->findOneByLocale('fr_FR');
+        self::assertNotNull($french);
+        $session->setLang($french);
+
+        // No body and no template file: buildMessage() throws once the required language has
+        // already been written into the session.
+        $message = new Message();
+        $message->setName('test_unrenderable_message');
+        $message->setLocale('en_US');
+        $message->setSubject('Subject');
+        $message->save();
+
+        try {
+            $this->mailerFactory->createEmailMessage(
+                'test_unrenderable_message',
+                ['sender@example.com' => 'Sender'],
+                ['recipient@example.com' => 'Recipient'],
+                [],
+                'en_US',
+            );
+            self::fail('Rendering was expected to fail.');
+        } catch (\Exception) {
+            // The failure is the point: sendEmailMessage() swallows it in production.
+        }
+
+        self::assertSame('fr_FR', $session->getLang()->getLocale());
     }
 
     public function testSendDoesNotThrowWithNullTransport(): void


### PR DESCRIPTION
## Problem

A visitor browsing the front office in a non-default language is silently switched to the shop's default language as soon as an email fails to render during their request.

Observed on a demo install, browsing in French: every page up to and including `/checkout/payment` renders with `<html lang="fr">`. Right after placing the order, `/checkout/pay` and every subsequent page render with `<html lang="en">` — the shop's default. The order itself is correct (`order.lang_id` = French); only the visitor's session is wrong, and it stays wrong for the rest of the session.

Nothing surfaces in the Symfony log, because the failure is swallowed into `Tlog`:

```
ERROR [MailerFactory.php:sendEmailMessage()] Error while sending email message order_confirmation: Unable to find template "…"
ERROR [MailerFactory.php:sendEmailMessage()] Error while sending email message order_notification: Email "" does not comply with addr-spec of RFC 2822.
```

## Root cause

`MailerFactory::createEmailMessage()` writes the email's language into the **visitor's session** and restores it only on the success path:

```php
$currentLang = $session->getLang();

if (null !== $requiredLang = LangQuery::create()->findOneByLocale($locale)) {
    $session->setLang($requiredLang);   // the visitor's session
}

$message->buildMessage($parser, $email);   // throws here → the next line never runs

$session->setLang($currentLang);
```

There is no `try`/`finally`, and the caller deliberately swallows the exception so the request survives a broken email:

```php
try {
    $instance = $this->createEmailMessage(...);
    $this->send($instance);
} catch (\Exception $ex) {
    Tlog::getInstance()->addError('Error while sending email message '.$messageCode.': '.$ex->getMessage());
}
```

The two halves contradict each other: the comment above the swap says the change is temporary, and `sendEmailMessage()` is written so a failing email is a non-event — yet a failing email permanently changes what the visitor sees.

Placing an order sends two messages, so the session is walked twice:

| Message | Locale | Session before → after | Outcome |
|---|---|---|---|
| `order_confirmation` | customer's | `fr` → customer's | throws, restore skipped |
| `order_notification` | `null` → shop default | customer's → **default** | throws, restore skipped |

## Why this change is needed

The trigger ships enabled. `setup/insert.sql` creates `store_notification_emails` empty:

```sql
(41, 'store_notification_emails','', 0, 1, NOW(), NOW()),
```

so `sendEmailToShopManagers('order_notification')` fails with `Email "" does not comply with addr-spec` on a fresh install, before anyone has misconfigured anything. On a multilingual shop that means every customer browsing in a non-default language is switched to the default right after paying — on the order confirmation page, silently, with no way for them or the merchant to understand why.

Calling code cannot work around this. The mutation and the missing restore are both inside `MailerFactory`, and the exception that skips the restore is caught by `MailerFactory` itself, so a project has no seam to intervene at.

Independently of exceptions: an email addressed to the **shop managers** has no business changing a **customer's** UI language. That side effect is out of scope for the notification path even when everything succeeds.

## Fix

Wrap the build in `try`/`finally` so the language is restored on every path. The `null` guard keeps `setLang(Lang $lang)` type-safe should `getLang()` ever return `null`.

## How to reproduce

`tests/Integration/Mailer/MailerFactoryTest::testCreateEmailMessageRestoresTheSessionLangWhenRenderingFails` fails on `twig` without the patch and passes with it:

```
Failed asserting that two strings are identical.
-'fr_FR'
+'en_US'
```

It sets the session to `fr_FR`, asks for an email in `en_US` whose message has neither body nor template file — `buildMessage()` throws once the language has already been swapped — and asserts the session language afterwards.

Manually: on a multilingual shop, empty `store_notification_emails` (its shipped default), browse the front in a non-default language, place an order, and watch the language change on the confirmation page.

## Compatibility

No signature or behavioural change on the success path: the same restore happens, at the same point. The only difference is that it now also happens when rendering throws.

## A caveat worth stating

This makes the existing contract hold, but it does not remove the underlying design problem: `MailerFactory` has to borrow the visitor's session because the parser reads its language from there. Passing the locale explicitly to the parser would remove the shared mutable state altogether and make the whole dance unnecessary. That is a larger change than this fix, and it touches the parser interface, so I kept this PR to restoring the invariant that the current code already claims. Happy to follow it with the larger change if you would rather fix it at the root — say the word and I will close this one.
