### PR TITLE
fix: raise lexik/jwt-authentication-bundle minimum to ^2.20 in thelia/core

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -75,7 +75,7 @@
         "phpstan/phpdoc-parser": "^1.4",
         "symfony/property-info": "6.4.*",
         "symfony/runtime": "6.4.*",
-        "lexik/jwt-authentication-bundle": "^2.16",
+        "lexik/jwt-authentication-bundle": "^2.20",
         "symfony/monolog-bundle": "^3.10"
     },
     "require-dev": {


### PR DESCRIPTION
## Problem

A fresh install fails during container compilation:

```
composer create-project thelia/thelia-project thelia 2.6.0
php Thelia thelia:install
```

```
Unrecognized option "enabled" under "lexik_jwt_authentication.api_platform".
Available options are "check_path", "password_path", "username_path".
```

The same error is raised by every console command, including `php Thelia admin:create`, so the install cannot be completed.

## Cause

`api-platform/core` prepends the option unconditionally as soon as the Lexik bundle is registered (`ApiPlatformExtension::prepend()`, present since 3.2.0):

```php
if (isset($container->getExtensions()['lexik_jwt_authentication'])) {
    $container->prependExtensionConfig('lexik_jwt_authentication', [
        'api_platform' => ['enabled' => true],
    ]);
}
```

The `enabled` key was added to the `api_platform` node in `lexik/jwt-authentication-bundle` v2.19.0 (`->canBeEnabled()`). In v2.18.1 and below the node only accepts `check_path`, `username_path` and `password_path`.

`core/composer.json` declares `"lexik/jwt-authentication-bundle": "^2.16"`, so Composer is free to resolve 2.16, 2.17 or 2.18 and produce a broken install. It happens in practice when `ext-sodium` is missing, since `lcobucci/jwt` 4 and 5 require it, and the resolver backtracks to an older Lexik release.

The root `composer.json` already requires `^2.20`, so the two files disagree and only the split `thelia/core` package is used by real project installs.

## Fix

Raise the constraint in `core/composer.json` to `^2.20` to match the root `composer.json`. The technical minimum is `^2.19`, but aligning both files avoids the divergence coming back.

## Test

With `ext-sodium` disabled, `composer create-project thelia/thelia-project` resolves Lexik to 2.18.1 and `php Thelia thelia:install` fails with the message above. With the bumped constraint, Composer refuses the 2.18 resolution instead of producing an install that cannot boot.

Reported on the Thelia Discord.
