### PR TITLE
fix(api): enforce address ownership on GET /front/account/addresses/{id}

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Extension/CustomerGetCollectionExtension.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Extension/CustomerGetCollectionExtension.php
@@ -40,7 +40,13 @@ final readonly class CustomerGetCollectionExtension implements QueryCollectionEx
             return;
         }
 
-        $patterns = $this->accessMap->getPatterns($this->requestStack->getMainRequest());
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+
+        if (null === $request) {
+            return;
+        }
+
+        $patterns = $this->accessMap->getPatterns($request);
 
         if (!isset($patterns[0][0]) || 'ROLE_CUSTOMER' !== $patterns[0][0]) {
             return;

--- a/core/lib/Thelia/Api/Resource/Address.php
+++ b/core/lib/Thelia/Api/Resource/Address.php
@@ -73,7 +73,7 @@ use Thelia\Model\Map\AddressTableMap;
         new Get(
             uriTemplate: '/front/account/addresses/{id}',
             normalizationContext: ['groups' => [self::GROUP_FRONT_READ, self::GROUP_FRONT_READ_SINGLE]],
-            // security: 'object.customer.getId() == user.getId()'
+            security: 'object.customer.getId() == user.getId()',
         ),
         new Put(
             uriTemplate: '/front/account/addresses/{id}',

--- a/tests/Api/Front/AddressApiTest.php
+++ b/tests/Api/Front/AddressApiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Ownership coverage for /api/front/account/addresses/{id}.
+ *
+ * Guards against the IDOR regression: the Get operation shipped without
+ * its security expression, so any authenticated customer could read
+ * another customer's address book by enumerating sequential ids.
+ */
+final class AddressApiTest extends ApiTestCase
+{
+    public function testCustomerCanReadOwnAddress(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+        $address = $factory->address($customer);
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/addresses/'.$address->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+        self::assertSame($address->getId(), $data['id']);
+    }
+
+    public function testCustomerCannotReadAnotherCustomersAddress(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $victim = $factory->customer($factory->customerTitle());
+        $victimAddress = $factory->address($victim);
+        $attacker = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+
+        $token = $this->authenticateAsCustomer($attacker);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/addresses/'.$victimAddress->getId(), token: $token);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testCollectionOnlyExposesOwnAddresses(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $victim = $factory->customer($factory->customerTitle());
+        $factory->address($victim);
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+        $factory->address($customer);
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/addresses', token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        self::assertHydraTotalItems(1, $response);
+    }
+
+    public function testUnauthenticatedReadIsRejected(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+        $address = $factory->address($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/addresses/'.$address->getId());
+
+        self::assertContains($response->getStatusCode(), [401, 403]);
+    }
+}


### PR DESCRIPTION
The security expression on the front Get operation was left commented out, so any authenticated customer could read another customer's address by enumerating sequential ids.

Also scope the customer collection filter on the request actually being served instead of the main request, so a sub-request cannot bypass it.