### PR TITLE
fix: InputBag scalar-default error on admin logs page

### DIFF
--- a/core/lib/Thelia/Controller/Admin/AdminLogsController.php
+++ b/core/lib/Thelia/Controller/Admin/AdminLogsController.php
@@ -35,10 +35,10 @@ class AdminLogsController extends BaseAdminController
 
         /** @var AdminLog $entry */
         foreach (AdminLogQuery::getEntries(
-            $this->getRequest()->request->get('admins', []),
+            $this->getRequest()->request->all('admins'),
             $this->getRequest()->request->get('fromDate', null),
             $this->getRequest()->request->get('toDate', null),
-            array_merge($this->getRequest()->request->get('resources', []), $this->getRequest()->request->get('modules', [])),
+            array_merge($this->getRequest()->request->all('resources'), $this->getRequest()->request->all('modules')),
             null
         ) as $entry) {
             $entries[] = [


### PR DESCRIPTION
## Problem

`/admin/configuration/adminLogs/logger` crashes with:

```
Expected a scalar value as a 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()", "array" given.
```

`AdminLogsController::loadLoggerAjaxAction()` calls `InputBag::get('admins', [])` (and similarly for `resources`/`modules`), passing an empty array as the default. Since symfony/http-foundation 6.x, `InputBag::get()` rejects any non-scalar default (and any non-scalar value), which this code has always relied on to retrieve the array of selected admins/resources/modules from the log filter form.

## Fix

Use `InputBag::all('admins')` / `all('resources')` / `all('modules')` instead, which is the API intended for array request parameters and returns an empty array when the key is absent — preserving the original behavior without triggering the scalar-only check.

## Scope

Checked the codebase for the same anti-pattern (`->request->get()` / `->query->get()` on an `InputBag` with a non-scalar default). `AdminLogsController` was the only offender; other `->get('key', [])` calls found in the codebase go through `Request::get()` (via `$this->getRequest()->get(...)`), a different method with no such restriction.

Fixes #3210