### PR TITLE
fix: persist visible=0 instead of NULL when unchecking visibility

### DIFF
--- a/core/lib/Thelia/Action/Brand.php
+++ b/core/lib/Thelia/Action/Brand.php
@@ -38,7 +38,7 @@ class Brand extends BaseAction implements EventSubscriberInterface
         $brand = new BrandModel();
 
         $brand
-            ->setVisible($event->getVisible())
+            ->setVisible($event->getVisible() ? 1 : 0)
             ->setLocale($event->getLocale())
             ->setTitle($event->getTitle())
             ->save()
@@ -54,7 +54,7 @@ class Brand extends BaseAction implements EventSubscriberInterface
     {
         if (null !== $brand = BrandQuery::create()->findPk($event->getBrandId())) {
             $brand
-                ->setVisible($event->getVisible())
+                ->setVisible($event->getVisible() ? 1 : 0)
                 ->setLogoImageId((int) $event->getLogoImageId() == 0 ? null : $event->getLogoImageId())
                 ->setLocale($event->getLocale())
                 ->setTitle($event->getTitle())

--- a/core/lib/Thelia/Action/Category.php
+++ b/core/lib/Thelia/Action/Category.php
@@ -47,7 +47,7 @@ class Category extends BaseAction implements EventSubscriberInterface
         $category
             ->setLocale($event->getLocale())
             ->setParent($event->getParent())
-            ->setVisible($event->getVisible())
+            ->setVisible($event->getVisible() ? 1 : 0)
             ->setTitle($event->getTitle())
 
             ->save()
@@ -71,7 +71,7 @@ class Category extends BaseAction implements EventSubscriberInterface
                 ->setPostscriptum($event->getPostscriptum())
 
                 ->setParent($event->getParent())
-                ->setVisible($event->getVisible())
+                ->setVisible($event->getVisible() ? 1 : 0)
 
                 ->save();
 

--- a/core/lib/Thelia/Action/Content.php
+++ b/core/lib/Thelia/Action/Content.php
@@ -47,7 +47,7 @@ class Content extends BaseAction implements EventSubscriberInterface
     {
         $content = (new ContentModel())
 
-            ->setVisible($event->getVisible())
+            ->setVisible($event->getVisible() ? 1 : 0)
             ->setLocale($event->getLocale())
             ->setTitle($event->getTitle())
             ->create($event->getDefaultFolder())
@@ -69,7 +69,7 @@ class Content extends BaseAction implements EventSubscriberInterface
             $con->beginTransaction();
             try {
                 $content
-                    ->setVisible($event->getVisible())
+                    ->setVisible($event->getVisible() ? 1 : 0)
                     ->setLocale($event->getLocale())
                     ->setTitle($event->getTitle())
                     ->setDescription($event->getDescription())

--- a/core/lib/Thelia/Action/Country.php
+++ b/core/lib/Thelia/Action/Country.php
@@ -35,7 +35,7 @@ class Country extends BaseAction implements EventSubscriberInterface
         $country = new CountryModel();
 
         $country
-            ->setVisible($event->isVisible())
+            ->setVisible($event->isVisible() ? 1 : 0)
             ->setIsocode($event->getIsocode())
             ->setIsoalpha2($event->getIsoAlpha2())
             ->setIsoalpha3($event->getIsoAlpha3())
@@ -51,7 +51,7 @@ class Country extends BaseAction implements EventSubscriberInterface
     {
         if (null !== $country = CountryQuery::create()->findPk($event->getCountryId())) {
             $country
-                ->setVisible($event->isVisible())
+                ->setVisible($event->isVisible() ? 1 : 0)
                 ->setIsocode($event->getIsocode())
                 ->setIsoalpha2($event->getIsoAlpha2())
                 ->setIsoalpha3($event->getIsoAlpha3())

--- a/core/lib/Thelia/Action/Folder.php
+++ b/core/lib/Thelia/Action/Folder.php
@@ -43,7 +43,7 @@ class Folder extends BaseAction implements EventSubscriberInterface
         if (null !== $folder = FolderQuery::create()->findPk($event->getFolderId())) {
             $folder
                 ->setParent($event->getParent())
-                ->setVisible($event->getVisible())
+                ->setVisible($event->getVisible() ? 1 : 0)
                 ->setLocale($event->getLocale())
                 ->setTitle($event->getTitle())
                 ->setDescription($event->getDescription())
@@ -111,7 +111,7 @@ class Folder extends BaseAction implements EventSubscriberInterface
 
         $folder
             ->setParent($event->getParent())
-            ->setVisible($event->getVisible())
+            ->setVisible($event->getVisible() ? 1 : 0)
             ->setLocale($event->getLocale())
             ->setTitle($event->getTitle())
             ->save();

--- a/core/lib/Thelia/Action/State.php
+++ b/core/lib/Thelia/Action/State.php
@@ -34,7 +34,7 @@ class State extends BaseAction implements EventSubscriberInterface
         $state = new StateModel();
 
         $state
-            ->setVisible($event->isVisible())
+            ->setVisible($event->isVisible() ? 1 : 0)
             ->setCountryId($event->getCountry())
             ->setIsocode($event->getIsocode())
             ->setLocale($event->getLocale())
@@ -49,7 +49,7 @@ class State extends BaseAction implements EventSubscriberInterface
     {
         if (null !== $state = StateQuery::create()->findPk($event->getStateId())) {
             $state
-                ->setVisible($event->isVisible())
+                ->setVisible($event->isVisible() ? 1 : 0)
                 ->setCountryId($event->getCountry())
                 ->setIsocode($event->getIsocode())
                 ->setLocale($event->getLocale())


### PR DESCRIPTION
## Problem

On the back-office admin forms for categories, folders, contents, brands, countries (and states), unchecking the "visible" checkbox stores `NULL` in database instead of `0`. This breaks the `visible="no"` loop filter, since it only matches rows with `visible = 0`, not `NULL`.

Root cause: the `visible` checkbox is submitted as an `IntegerType` field that is absent from the POST body when unchecked, so `$formData['visible']` is `null`. That `null` flows unchanged from the admin controllers through the `*CreateEvent`/`*UpdateEvent` objects into `Action\Category`, `Action\Folder`, `Action\Content`, `Action\Brand`, `Action\Country` and `Action\State`, which call `->setVisible($event->getVisible())` with no cast, so Propel persists `NULL`.

`Product` already avoids this: `Action\Product::create()`/`update()` cast with `$event->getVisible() ? 1 : 0` (added in 2014). That cast was never extended to the other entities sharing the same "visible" concept.

## Prior attempt: #3190

@Elyos59 opened #3190, changing `setup/thelia.sql` to add `DEFAULT 0` (and `NOT NULL` for `folder`/`content`/`brand`) to the `visible` columns. It was closed unmerged in 2024.

That change only affects the schema used for fresh installs; it doesn't fix the code that produces the `NULL` value in the first place. Applied on its own, it would also have made things worse for `folder`/`content`/`brand`: since Propel emits `visible = NULL` explicitly whenever `setVisible(null)` is called, adding a `NOT NULL` constraint without also fixing the calling code would turn a silently wrong value into a hard SQL error on save.

## Fix

This PR completes #3190's intent by fixing the code that produces the bad value, applying the same `? 1 : 0` cast `Product` already uses, to `Category`, `Folder`, `Content`, `Brand`, `Country`, and `State` (state shares the same pattern as country and was included for consistency, matching parity with the fix already present for country/state in the rewritten 3.x branch).

The database schema itself is intentionally left untouched in this PR: changing existing nullable columns to `NOT NULL DEFAULT 0` requires a proper `setup/update/sql/*.sql` migration plus cleanup of rows that already contain `NULL`, which is a separate, larger change from this bug fix.

## Files changed

- `core/lib/Thelia/Action/Category.php`
- `core/lib/Thelia/Action/Folder.php`
- `core/lib/Thelia/Action/Content.php`
- `core/lib/Thelia/Action/Brand.php`
- `core/lib/Thelia/Action/Country.php`
- `core/lib/Thelia/Action/State.php`

Fixes #3181
