### PR TITLE
fix: restore Taiwan country_i18n titles and area link

### DIFF
--- a/setup/I18n/de_DE.php
+++ b/setup/I18n/de_DE.php
@@ -919,6 +919,7 @@ return [
     'Tab document - top' => 'Dokument Tab - oben',
     'Tab image - bottom' => 'Bild Tab - unten',
     'Tab image - top' => 'Bild Tab - oben',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tadschikistan',
     'Tanzania' => 'Tansania',
     'Tax - Edit JavaScript' => 'Taxe - JavaScript Änderung',

--- a/setup/I18n/en_US.php
+++ b/setup/I18n/en_US.php
@@ -1288,6 +1288,7 @@ return [
     'Tab image - bottom' => 'Tab image - bottom',
     'Tab image - top' => 'Tab image - top',
     'Tabasco' => 'Tabasco',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tajikistan',
     'Tamaulipas' => 'Tamaulipas',
     'Tanzania' => 'Tanzania',

--- a/setup/I18n/es_ES.php
+++ b/setup/I18n/es_ES.php
@@ -942,6 +942,7 @@ return [
     'Tab document - top' => 'Ficha de documento - arriba',
     'Tab image - bottom' => 'Pestaña de imagen - abajo',
     'Tab image - top' => 'Pestaña de imagen - arriba',
+    'Taïwan' => 'Taiwán',
     'Tajikistan' => 'Tayikistán',
     'Tanzania' => 'Tanzanía',
     'Tax - Edit JavaScript' => 'Editar JavaScript',

--- a/setup/I18n/fr_FR.php
+++ b/setup/I18n/fr_FR.php
@@ -1268,6 +1268,7 @@ return [
     'Tab image - bottom' => 'Onglet image - en bas',
     'Tab image - top' => 'Onglet image - en haut',
     'Tabasco' => 'Tabasco',
+    'Taïwan' => 'Taïwan',
     'Tajikistan' => 'Tadjikistan',
     'Tamaulipas' => 'Tamaulipas',
     'Tanzania' => 'Tanzanie',

--- a/setup/I18n/it_IT.php
+++ b/setup/I18n/it_IT.php
@@ -324,6 +324,7 @@ return [
     'Sweden' => 'Svezia',
     'Switzerland' => 'Svizzera',
     'Syria' => 'Siria',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tagikistan',
     'Tanzania' => 'Tanzania',
     'Taranto' => 'Taranto',

--- a/setup/I18n/ru_RU.php
+++ b/setup/I18n/ru_RU.php
@@ -1265,6 +1265,7 @@ return [
     'Tab image - bottom' => 'Вкладка изображений - внизу',
     'Tab image - top' => 'Вкладка изображений - вверху',
     'Tabasco' => 'Табаско',
+    'Taïwan' => 'Тайвань',
     'Tajikistan' => 'Таджикистан',
     'Tamaulipas' => 'Тамаулипас',
     'Tanzania' => 'Танзания',

--- a/setup/insert.sql
+++ b/setup/insert.sql
@@ -1662,6 +1662,7 @@ INSERT INTO `country_area` (`country_id`, `area_id`, `created_at`, `updated_at`)
 (270, 5, NOW(), NOW()),
 (271, 5, NOW(), NOW()),
 (272, 6, NOW(), NOW()),
+(273, 4, NOW(), NOW()),
 (1, 9, NOW(), NOW()),
 (2, 10, NOW(), NOW()),
 (3, 13, NOW(), NOW()),
@@ -8438,7 +8439,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'de_DE', 'Saint-Barthélemy', NULL, NULL, NULL),
     (271, 'de_DE', 'Saint-Martin (franz. Teil)', NULL, NULL, NULL),
     (272, 'de_DE', 'Französische Süd- und Antarktisgebiete', NULL, NULL, NULL),
-    (273, 'de_DE', NULL, NULL, NULL, NULL),
+    (273, 'de_DE', 'Taiwan', NULL, NULL, NULL),
     (1, 'en_US', 'Afghanistan', NULL, NULL, NULL),
     (2, 'en_US', 'South Africa', NULL, NULL, NULL),
     (3, 'en_US', 'Albania', NULL, NULL, NULL),
@@ -8644,7 +8645,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'en_US', 'Saint Barthélemy', NULL, NULL, NULL),
     (271, 'en_US', 'Saint Martin (French part)', NULL, NULL, NULL),
     (272, 'en_US', 'French Southern Territories', NULL, NULL, NULL),
-    (273, 'en_US', NULL, NULL, NULL, NULL),
+    (273, 'en_US', 'Taiwan', NULL, NULL, NULL),
     (1, 'es_ES', 'Afganistán', NULL, NULL, NULL),
     (2, 'es_ES', 'Sudáfrica', NULL, NULL, NULL),
     (3, 'es_ES', 'Albania', NULL, NULL, NULL),
@@ -8850,7 +8851,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'es_ES', 'San Bartolomé', NULL, NULL, NULL),
     (271, 'es_ES', 'San Martín (parte francesa)', NULL, NULL, NULL),
     (272, 'es_ES', 'Tierras Australes y Antárticas Francesas', NULL, NULL, NULL),
-    (273, 'es_ES', NULL, NULL, NULL, NULL),
+    (273, 'es_ES', 'Taiwán', NULL, NULL, NULL),
     (1, 'fr_FR', 'Afghanistan', NULL, NULL, NULL),
     (2, 'fr_FR', 'Afrique du Sud', NULL, NULL, NULL),
     (3, 'fr_FR', 'Albanie', NULL, NULL, NULL),
@@ -9056,7 +9057,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'fr_FR', 'Saint-Barthélemy', NULL, NULL, NULL),
     (271, 'fr_FR', 'Saint-Martin (Antilles françaises)', NULL, NULL, NULL),
     (272, 'fr_FR', 'Terres australes et antarctiques françaises', NULL, NULL, NULL),
-    (273, 'fr_FR', NULL, NULL, NULL, NULL),
+    (273, 'fr_FR', 'Taïwan', NULL, NULL, NULL),
     (1, 'it_IT', 'Afghanistan', NULL, NULL, NULL),
     (2, 'it_IT', 'Sudafrica', NULL, NULL, NULL),
     (3, 'it_IT', 'Albania', NULL, NULL, NULL),
@@ -9262,7 +9263,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'it_IT', 'Saint-Barthélemy', NULL, NULL, NULL),
     (271, 'it_IT', 'Saint-Martin', NULL, NULL, NULL),
     (272, 'it_IT', 'Terre australi e antartiche francesi', NULL, NULL, NULL),
-    (273, 'it_IT', NULL, NULL, NULL, NULL),
+    (273, 'it_IT', 'Taiwan', NULL, NULL, NULL),
     (1, 'ru_RU', 'Афганистан', NULL, NULL, NULL),
     (2, 'ru_RU', 'Южная Африка', NULL, NULL, NULL),
     (3, 'ru_RU', 'Албания', NULL, NULL, NULL),
@@ -9468,7 +9469,7 @@ INSERT INTO `country_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `po
     (270, 'ru_RU', 'Сен-Бартельми', NULL, NULL, NULL),
     (271, 'ru_RU', 'Сен-Мартен (французская часть)', NULL, NULL, NULL),
     (272, 'ru_RU', 'Французские Южные Территории', NULL, NULL, NULL),
-    (273, 'ru_RU', NULL, NULL, NULL, NULL)
+    (273, 'ru_RU', 'Тайвань', NULL, NULL, NULL)
 ;
 
 INSERT INTO `state_i18n` (`id`, `locale`, `title`) VALUES

--- a/setup/insert.sql.tpl
+++ b/setup/insert.sql.tpl
@@ -1662,6 +1662,7 @@ INSERT INTO `country_area` (`country_id`, `area_id`, `created_at`, `updated_at`)
 (270, 5, NOW(), NOW()),
 (271, 5, NOW(), NOW()),
 (272, 6, NOW(), NOW()),
+(273, 4, NOW(), NOW()),
 (1, 9, NOW(), NOW()),
 (2, 10, NOW(), NOW()),
 (3, 13, NOW(), NOW()),


### PR DESCRIPTION
### Problem

Taiwan (`country` id 273, ISO `TW`) exists in `setup/insert.sql` but:
- all 7 of its `country_i18n` rows (one per installed locale) have `title = NULL`
- its `country_area` link (row `(273, 4, ...)`) is missing entirely

So on a fresh install, Taiwan shows up in the countries list with no translated name and no zone/area attached.

### Root cause

This was actually fixed once, in #3154 (Feb 2024), which patched `setup/insert.sql` directly with the correct titles and the `country_area` row. That patch never touched `setup/insert.sql.tpl` (the Smarty template `insert.sql` is generated from via `generate:sql`) for those two parts:
- the template's `country_area` block never had the `(273, 4, ...)` row
- the template's `country_i18n` block already referenced Taiwan via `{intl l='Taïwan' locale=$locale}`, but no `setup/I18n/*.php` translation catalog ever defined a `'Taïwan'` key, so that lookup always resolves to `NULL` (see `GenerateSQLCommand::translate()`)

When `setup/insert.sql` was regenerated from the template in #3326 (Oct 2025, unrelated delivery-module fix), the hand patch was silently wiped out, since the template itself never carried the data.

### Fix

- `setup/insert.sql.tpl`: added the missing `(273, 4, NOW(), NOW())` row to the `country_area` insert.
- `setup/I18n/{de_DE,en_US,es_ES,fr_FR,it_IT,ru_RU}.php`: added the `'Taïwan'` translation key used by the existing `{intl l='Taïwan' ...}` template line, using the same wording already restored in `setup/insert.sql` by #3154 (`cs_CZ` has no country translations at all and is left untouched, same as before).
- `setup/insert.sql`: re-applied the corresponding correct values (7 `country_i18n` titles + the `country_area` link) so the fix is effective immediately, without waiting for a regeneration.

This also fixes the template/catalog, not just the generated file, so a future `generate:sql` run will reproduce this data instead of dropping it again.

Fixes #3161
