### PR TITLE
fix: add missing Taïwan country_area and I18n entries to setup template

### DIFF
--- a/setup/I18n/de_DE.php
+++ b/setup/I18n/de_DE.php
@@ -921,6 +921,7 @@ return [
     'Tab document - top' => 'Dokument Tab - oben',
     'Tab image - bottom' => 'Bild Tab - unten',
     'Tab image - top' => 'Bild Tab - oben',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tadschikistan',
     'Tanzania' => 'Tansania',
     'Tax - Edit JavaScript' => 'Taxe - JavaScript Änderung',

--- a/setup/I18n/en_US.php
+++ b/setup/I18n/en_US.php
@@ -1290,6 +1290,7 @@ return [
     'Tab image - bottom' => 'Tab image - bottom',
     'Tab image - top' => 'Tab image - top',
     'Tabasco' => 'Tabasco',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tajikistan',
     'Tamaulipas' => 'Tamaulipas',
     'Tanzania' => 'Tanzania',

--- a/setup/I18n/es_ES.php
+++ b/setup/I18n/es_ES.php
@@ -944,6 +944,7 @@ return [
     'Tab document - top' => 'Ficha de documento - arriba',
     'Tab image - bottom' => 'Pestaña de imagen - abajo',
     'Tab image - top' => 'Pestaña de imagen - arriba',
+    'Taïwan' => 'Taiwán',
     'Tajikistan' => 'Tayikistán',
     'Tanzania' => 'Tanzanía',
     'Tax - Edit JavaScript' => 'Editar JavaScript',

--- a/setup/I18n/fr_FR.php
+++ b/setup/I18n/fr_FR.php
@@ -1270,6 +1270,7 @@ return [
     'Tab image - bottom' => 'Onglet image - en bas',
     'Tab image - top' => 'Onglet image - en haut',
     'Tabasco' => 'Tabasco',
+    'Taïwan' => 'Taïwan',
     'Tajikistan' => 'Tadjikistan',
     'Tamaulipas' => 'Tamaulipas',
     'Tanzania' => 'Tanzanie',

--- a/setup/I18n/it_IT.php
+++ b/setup/I18n/it_IT.php
@@ -326,6 +326,7 @@ return [
     'Sweden' => 'Svezia',
     'Switzerland' => 'Svizzera',
     'Syria' => 'Siria',
+    'Taïwan' => 'Taiwan',
     'Tajikistan' => 'Tagikistan',
     'Tanzania' => 'Tanzania',
     'Taranto' => 'Taranto',

--- a/setup/I18n/ru_RU.php
+++ b/setup/I18n/ru_RU.php
@@ -1267,6 +1267,7 @@ return [
     'Tab image - bottom' => 'Вкладка изображений - внизу',
     'Tab image - top' => 'Вкладка изображений - вверху',
     'Tabasco' => 'Табаско',
+    'Taïwan' => 'Тайвань',
     'Tajikistan' => 'Таджикистан',
     'Tamaulipas' => 'Тамаулипас',
     'Tanzania' => 'Танзания',

--- a/setup/insert.sql.tpl
+++ b/setup/insert.sql.tpl
@@ -1641,6 +1641,7 @@ INSERT INTO `country_area` (`country_id`, `area_id`, `created_at`, `updated_at`)
 (270, 5, NOW(), NOW()),
 (271, 5, NOW(), NOW()),
 (272, 6, NOW(), NOW()),
+(273, 4, NOW(), NOW()),
 (1, 9, NOW(), NOW()),
 (2, 10, NOW(), NOW()),
 (3, 13, NOW(), NOW()),


### PR DESCRIPTION
## Context

This is a **preventive fix** for the `main` branch (Thelia 3.0.0-beta1).

The generated `setup/insert.sql` file currently contains correct data for Taïwan (country id 273): translated titles in all 6 install locales and a `country_area` row linking it to zone 4.

However, the **template** `setup/insert.sql.tpl` that `insert.sql` is regenerated from is incomplete:

- it has no `country_area` row for country id 273
- its `country_i18n` block calls `{intl l='Taïwan' locale=$locale}`, but the `Taïwan` key does not exist in any of the 6 `setup/I18n/*.php` catalogs used to generate the file

As a result, the next time `insert.sql` is regenerated from the template (`php Thelia generate:sql`), Taïwan would silently lose its translated titles (falling back to `NULL`) and its zone attachment (`country_area`) — the exact regression that hit the 2.6 branch, where fix #3154 was later overwritten by a regeneration (#3326).

## Changes

- Added the `Taïwan` translation key, in alphabetical order, to the 6 `setup/I18n/*.php` catalogs used by the generator (`de_DE`, `en_US`, `es_ES`, `fr_FR`, `it_IT`, `ru_RU`).
- Added the missing `(273, 4, NOW(), NOW())` row to the `country_area` INSERT block in `setup/insert.sql.tpl`, at the same position country id 273 already occupies in the generated `insert.sql`.
- `setup/insert.sql` itself needed no change: it already contains the correct data.

## Verification

Since composer dependencies aren't installed in this environment, the Smarty `{intl}` resolution used by `generate:sql` was reproduced by directly loading the 6 updated I18n catalogs and reading the `Taïwan` key for each locale. The result matches exactly what's already committed in `setup/insert.sql`:

| locale | resolved translation | matches insert.sql |
|---|---|---|
| de_DE | Taiwan | yes |
| en_US | Taiwan | yes |
| es_ES | Taiwán | yes |
| fr_FR | Taïwan | yes |
| it_IT | Taiwan | yes |
| ru_RU | Тайвань | yes |

The added `country_area` template line `(273, 4, NOW(), NOW()),` is inserted in the same position (right after country id 272) as the existing row in the generated `insert.sql`, so a regeneration produces byte-identical output for this data.

Same fix already applied on the 2.6 branch: #3453.

Refs #3161
