### PR TITLE
Deny admin session when the admin account was deleted

### DIFF
--- a/core/lib/Thelia/Core/Security/SecurityContext.php
+++ b/core/lib/Thelia/Core/Security/SecurityContext.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\User\UserInterface;
+use Thelia\Model\Admin;
+use Thelia\Model\AdminQuery;
 use Thelia\Model\Customer;
 
 /**
@@ -27,6 +29,9 @@ class SecurityContext
 {
     /** @var RequestStack */
     private $requestStack;
+
+    /** @var \WeakReference<Admin>|null the session admin already checked against the database */
+    private ?\WeakReference $revalidatedAdminUser = null;
 
     public function __construct(RequestStack $requestStack)
     {
@@ -54,7 +59,38 @@ class SecurityContext
      */
     public function getAdminUser()
     {
-        return $this->getSession()->getAdminUser();
+        $user = $this->getSession()->getAdminUser();
+
+        if ($user instanceof Admin && $this->revalidatedAdminUser?->get() !== $user) {
+            return $this->revalidateAdminUser($user);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Reload the session admin from the database, once per request, so that a
+     * deleted admin (or one whose profile was changed) does not keep a
+     * privileged session built from stale serialized data.
+     *
+     * @return Admin|null the freshly loaded admin, or null if it no longer exists
+     */
+    private function revalidateAdminUser(Admin $sessionAdminUser)
+    {
+        $freshAdminUser = AdminQuery::create()->findPk($sessionAdminUser->getId());
+
+        if (null === $freshAdminUser) {
+            $this->clearAdminUser();
+
+            return null;
+        }
+
+        $freshAdminUser->eraseCredentials();
+
+        $this->getSession()->setAdminUser($freshAdminUser);
+        $this->revalidatedAdminUser = \WeakReference::create($freshAdminUser);
+
+        return $freshAdminUser;
     }
 
     /**
@@ -64,7 +100,7 @@ class SecurityContext
      */
     public function hasAdminUser()
     {
-        return $this->getSession()->getAdminUser() !== null;
+        return $this->getAdminUser() !== null;
     }
 
     /**
@@ -257,6 +293,8 @@ class SecurityContext
      */
     public function clearAdminUser(): void
     {
+        $this->revalidatedAdminUser = null;
+
         $this->getSession()->clearAdminUser();
     }
 }

--- a/tests/Legacy/Core/Security/SecurityContextTest.php
+++ b/tests/Legacy/Core/Security/SecurityContextTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Core\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Model\Admin;
+use Thelia\Model\LangQuery;
+
+class SecurityContextTest extends TestCase
+{
+    /** @var Session */
+    protected $session;
+
+    /** @var SecurityContext */
+    protected $securityContext;
+
+    protected function setUp(): void
+    {
+        $this->session = new Session(new MockArraySessionStorage());
+
+        $request = new Request();
+        $request->setSession($this->session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $this->securityContext = new SecurityContext($requestStack);
+    }
+
+    public function testDeletedAdminNoLongerHasAValidSession(): void
+    {
+        $admin = new Admin();
+        $admin
+            ->setFirstname('thelia')
+            ->setLastname('thelia')
+            ->setLogin(uniqid('security_context_test'))
+            ->setEmail(uniqid('security_context_test').'@example.com')
+            ->setPassword('azerty')
+            ->setLocale(LangQuery::create()->findOne()->getLocale())
+        ;
+        $admin->save();
+
+        $this->securityContext->setAdminUser($admin);
+
+        $this->assertTrue($this->securityContext->hasAdminUser());
+
+        $admin->delete();
+
+        // Simulate the next request: the session admin is unserialized afresh,
+        // exactly as the session storage does between two requests.
+        $staleAdmin = unserialize(serialize($this->session->getAdminUser()));
+        $this->assertInstanceOf(Admin::class, $staleAdmin);
+        $this->session->setAdminUser($staleAdmin);
+
+        $this->assertNull($this->securityContext->getAdminUser());
+        $this->assertFalse($this->securityContext->hasAdminUser());
+    }
+}


### PR DESCRIPTION
An admin session stores a serialized copy of the `Admin` object at login time, and `SecurityContext::getAdminUser()` returned it as-is on every subsequent request. `Action/Administrator::delete()` only removes the database row, so a deleted admin kept a fully privileged back-office session until it naturally expired. The stale serialized object also kept its original `profile_id`, so demoting an admin did not affect already open sessions either.

### Fix

`SecurityContext::getAdminUser()` now revalidates the session admin against the database:

- the admin is reloaded by primary key; if the row no longer exists, the admin is removed from the session and `null` is returned (`hasAdminUser()` follows, so `checkAuth()` and the admin firewall deny access);
- if it still exists, the freshly loaded object replaces the stale one in the session, so profile changes take effect on the next request as well.

Revalidating on read was chosen over invalidating sessions in `Administrator::delete()` because the latter cannot reach sessions stored outside the current process (files of other users, alternative session handlers) and does not cover permission revocation. Every admin entry point already funnels through `SecurityContext`, so the check cannot be bypassed.

### Performance

The check is memoized per revalidated instance, so it costs a single primary-key `SELECT` per request, and only for requests whose session actually contains an admin user. Anonymous and customer front-office requests are unaffected.

A test covering "session of a deleted admin → access denied" is added to the Legacy suite.

Fixes #2087