### PR TITLE
Deny admin session when the admin account was deleted

### DIFF
--- a/core/lib/Thelia/Core/Security/SecurityContext.php
+++ b/core/lib/Thelia/Core/Security/SecurityContext.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\User\UserInterface;
+use Thelia\Model\Admin;
+use Thelia\Model\AdminQuery;
 use Thelia\Model\Customer;
 
 /**
@@ -27,6 +29,9 @@ use Thelia\Model\Customer;
  */
 class SecurityContext
 {
+    /** @var \WeakReference<Admin>|null the session admin already checked against the database */
+    private ?\WeakReference $revalidatedAdminUser = null;
+
     public function __construct(private readonly RequestStack $requestStack)
     {
     }
@@ -45,7 +50,36 @@ class SecurityContext
      */
     public function getAdminUser(): mixed
     {
-        return $this->getSession()?->getAdminUser();
+        $user = $this->getSession()?->getAdminUser();
+
+        if ($user instanceof Admin && $this->revalidatedAdminUser?->get() !== $user) {
+            return $this->revalidateAdminUser($user);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Reload the session admin from the database, once per request, so that a
+     * deleted admin (or one whose profile was changed) does not keep a
+     * privileged session built from stale serialized data.
+     */
+    private function revalidateAdminUser(Admin $sessionAdminUser): ?Admin
+    {
+        $freshAdminUser = AdminQuery::create()->findPk($sessionAdminUser->getId());
+
+        if (null === $freshAdminUser) {
+            $this->clearAdminUser();
+
+            return null;
+        }
+
+        $freshAdminUser->eraseCredentials();
+
+        $this->getSession()?->setAdminUser($freshAdminUser);
+        $this->revalidatedAdminUser = \WeakReference::create($freshAdminUser);
+
+        return $freshAdminUser;
     }
 
     /**
@@ -55,7 +89,7 @@ class SecurityContext
      */
     public function hasAdminUser(): bool
     {
-        return null !== $this->getSession()?->getAdminUser();
+        return null !== $this->getAdminUser();
     }
 
     /**
@@ -244,6 +278,8 @@ class SecurityContext
      */
     public function clearAdminUser(): void
     {
+        $this->revalidatedAdminUser = null;
+
         $this->getSession()?->clearAdminUser();
     }
 }

--- a/tests/Integration/Core/Security/SecurityContextTest.php
+++ b/tests/Integration/Core/Security/SecurityContextTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Core\Security;
 
+use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Core\Security\SecurityContext;
@@ -89,6 +90,61 @@ final class SecurityContextTest extends IntegrationTestCase
         $this->securityContext->clearAdminUser();
         $notFound = $this->securityContext->checkRole(['ADMIN']);
         self::assertNull($notFound);
+    }
+
+    public function testDeletedAdminNoLongerHasAValidSession(): void
+    {
+        $admin = $this->createFixtureFactory()->admin();
+        $this->securityContext->setAdminUser($admin);
+
+        self::assertTrue($this->securityContext->hasAdminUser());
+
+        $admin->delete();
+
+        // Simulate the next request: the session admin is unserialized afresh,
+        // exactly as the session storage does between two requests.
+        $this->reloadSessionAdminUser();
+
+        self::assertNull($this->securityContext->getAdminUser());
+        self::assertFalse($this->securityContext->hasAdminUser());
+    }
+
+    public function testSessionAdminProfileIsRefreshedFromTheDatabase(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $profile = $factory->profile();
+        $admin = $factory->admin();
+        $this->securityContext->setAdminUser($admin);
+
+        // Demote the admin (superadministrator -> restricted profile) while
+        // the session still holds the old serialized object.
+        $staleSerializedAdmin = serialize($admin);
+        $admin->setProfileId($profile->getId());
+        $admin->save();
+
+        $this->getSession()->setAdminUser(unserialize($staleSerializedAdmin));
+
+        $freshAdmin = $this->securityContext->getAdminUser();
+
+        self::assertInstanceOf(Admin::class, $freshAdmin);
+        self::assertSame($profile->getId(), $freshAdmin->getProfileId());
+    }
+
+    private function getSession(): Session
+    {
+        $session = self::getContainer()->get('request_stack')->getMainRequest()->getSession();
+        self::assertInstanceOf(Session::class, $session);
+
+        return $session;
+    }
+
+    private function reloadSessionAdminUser(): void
+    {
+        $session = $this->getSession();
+        $staleAdmin = unserialize(serialize($session->getAdminUser()));
+        self::assertInstanceOf(Admin::class, $staleAdmin);
+
+        $session->setAdminUser($staleAdmin);
     }
 
     public function testGetPermissionsSkipsOrphanPermissionRows(): void


### PR DESCRIPTION
Same flaw as on 2.6 (see #3455): the session stores a serialized copy of the `Admin` object at login time and `SecurityContext::getAdminUser()` returned it as-is, so a deleted admin kept a fully privileged back-office session until natural expiration, and a demoted admin kept its old `profile_id`.

### Fix

`SecurityContext::getAdminUser()` now revalidates the session admin against the database:

- the admin is reloaded by primary key; if the row no longer exists, the admin is removed from the session and `null` is returned (`hasAdminUser()` follows, so `ControllerListener::adminFirewall()` denies access);
- if it still exists, the freshly loaded object replaces the stale one in the session, so profile changes take effect on the next request as well.

Revalidating on read was chosen over invalidating sessions in `Administrator::delete()` because the latter cannot reach sessions stored outside the current process and does not cover permission revocation. Every admin entry point funnels through `SecurityContext`, so the check cannot be bypassed.

### Performance

The check is memoized per revalidated instance: a single primary-key `SELECT` per request, and only for requests whose session actually contains an admin user. Anonymous and customer front-office requests are unaffected.

Two integration tests are added: session of a deleted admin is denied, and a stale session picks up a profile change.

Refs #2087