### PR TITLE
fix: set og:image to main product image on product page

### DIFF
--- a/templates/frontOffice/modern/product.html
+++ b/templates/frontOffice/modern/product.html
@@ -28,6 +28,15 @@
   {loop name="product.seo.meta" type="product" id=$product_id limit="1" with_prev_next_info="1"}
   {include file="includes/meta-seo.html"}
   {/loop}
+
+  {* Share meta *}
+  {loop name="image.product.meta" type="image" limit="1" product=$product_id width="600" height="600" resize_mode="crop"}
+    <meta property="og:image" content="{$IMAGE_URL nofilter}" />
+    <meta property="og:image:secure_url" content="{$IMAGE_URL nofilter}" />
+    <meta property="og:image:width" content="600" />
+    <meta property="og:image:height" content="600" />
+    <meta name="twitter:image" content="{$IMAGE_URL nofilter}" />
+  {/loop}
 {/block}
 
 {* Breadcrumb *}


### PR DESCRIPTION
https://github.com/thelia/thelia/issues/3216

The modern front theme sets og:image on content and folder pages using the item's first image, but product.html never had the equivalent block, so it fell back to the generic default-social-thumbnail.webp on every product page.

Add the same "Share meta" image loop used by content.html and folder.html to product.html, sourced from the product's main image.