### PR TITLE
fix: count direct children of the category, not the site total

### DIFF
--- a/templates/backOffice/default/categories.html
+++ b/templates/backOffice/default/categories.html
@@ -122,7 +122,7 @@
                                             {$TITLE}
                                           </a>
                                           ( {count type="product" visible="*" backend_context="1" visible="*" category={$ID} } {intl l="Products" d='hookadminhome.bo.default'} - 
-                                          {count type="category" visible="*" backend_context="1" visible="*" category={$ID} } {intl l="Categories" d='hookadminhome.bo.default'} )
+                                          {count type="category" visible="*" backend_context="1" visible="*" parent={$ID} } {intl l="Categories" d='hookadminhome.bo.default'} )
                                      </td>
 
                                      {hook name="categories.row" location="category_list_row" category_id={$ID} }


### PR DESCRIPTION
The category listing in the back office catalog (`{count type="category" ... category={$ID}}`) passed a `category` argument to the `category` loop, but that loop only defines a `parent` argument, not `category`. Unknown loop arguments are silently ignored (no error), so the filter never applied and the count query ran unfiltered, always returning the total number of categories on the site instead of the number of direct children of the row's category.

Fix: pass `parent={$ID}` instead of `category={$ID}` to the categories count, matching the argument the `category` loop actually declares.

https://github.com/thelia/thelia/issues/3374