### PR TITLE
docs: clarify Node.js/Yarn PATH errors in modern-init.sh

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,7 @@ Requirements
     * upload\_max\_filesize 2M
     * date.timezone must be defined
 * Web Server Apache 2 or Nginx
+* [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/), only if you build the `modern` front-office template assets (see `setup/modern-init.sh`)
 
 
 ### MySQL 5.6

--- a/setup/modern-init.sh
+++ b/setup/modern-init.sh
@@ -20,6 +20,7 @@ then
     echo "${green}Node: OK${reset}"
 else
     echo "${red}Node is not installed nor in your PATH${reset}"
+    echo "${yellow}If you just installed Node.js, close and reopen your terminal so your PATH is refreshed.${reset}"
     exit 1
 fi
 
@@ -29,6 +30,7 @@ then
     echo "${green}Yarn: OK${reset}"
 else
     echo "${red}Yarn is not installed or nor in your PATH${reset}"
+    echo "${yellow}If you just installed Yarn, close and reopen your terminal so your PATH is refreshed.${reset}"
     exit 1
 fi
 
@@ -39,6 +41,7 @@ if command -v composer > /dev/null 2>&1
     echo "${green}Composer: OK${reset}"
   else
     echo "${red}Composer is not installed nor in your PATH${reset}"
+    echo "${yellow}If you just installed Composer, close and reopen your terminal so your PATH is refreshed.${reset}"
     exit 1
 fi
 


### PR DESCRIPTION
Fixes the confusion reported in https://github.com/thelia/thelia/issues/3204: users can hit "Node.js is not installed or not in your PATH" from `setup/modern-init.sh` even after installing Node.js, most commonly because their terminal still has the old PATH cached.

The script's `command -v` checks were correct, but the error messages gave no next step. This adds a hint to restart the terminal for the Node/Yarn/Composer checks, and documents the Node.js/Yarn prerequisite in the main README, which previously never mentioned `setup/modern-init.sh` or its dependencies at all.