### PR TITLE
fix: PAYMENT_MODULE empty in order-payment-gateway javascript hook

### DIFF
--- a/templates/frontOffice/default/order-payment-gateway.html
+++ b/templates/frontOffice/default/order-payment-gateway.html
@@ -26,6 +26,8 @@
             {include file="misc/checkout-progress.tpl"  step="last"}
 
             {loop type="order" name="placed-order" id=$order_id}
+            {* PAYMENT_MODULE is reset once this loop ends, but is still needed in the javascript-initialization block below *}
+            {assign var="orderPaymentModuleId" value=$PAYMENT_MODULE}
             {ifhook rel="order-payment-gateway.body"}
                 {hook name="order-payment-gateway.body" module="$PAYMENT_MODULE"}
             {/ifhook}
@@ -65,7 +67,7 @@
 
 {block name="javascript-initialization"}
 {ifhook rel="order-payment-gateway.javascript"}
-   {hook name="order-payment-gateway.javascript" module="$PAYMENT_MODULE"}
+   {hook name="order-payment-gateway.javascript" module="$orderPaymentModuleId"}
 {/ifhook}
 {elsehook rel="order-payment-gateway.javascript"}
     <script type="text/javascript">

--- a/templates/frontOffice/modern/order-payment-gateway.html
+++ b/templates/frontOffice/modern/order-payment-gateway.html
@@ -22,6 +22,8 @@
     {include file="components/smarty/Title/Title.html" title={intl l="Secure payment"} }
 
     {loop type="order" name="placed-order" id=$order_id}
+    {* PAYMENT_MODULE is reset once this loop ends, but is still needed in the javascript-initialization block below *}
+    {assign var="orderPaymentModuleId" value=$PAYMENT_MODULE}
     {ifhook rel="order-payment-gateway.body"}
         {hook name="order-payment-gateway.body" module="$PAYMENT_MODULE"}
     {/ifhook}
@@ -60,7 +62,7 @@
 
 {block name="javascript-initialization"}
   {ifhook rel="order-payment-gateway.javascript"}
-    {hook name="order-payment-gateway.javascript" module="$PAYMENT_MODULE"}
+    {hook name="order-payment-gateway.javascript" module="$orderPaymentModuleId"}
   {/ifhook}
   {elsehook rel="order-payment-gateway.javascript"}
       {strip}


### PR DESCRIPTION
In `order-payment-gateway.html` (default and modern themes), the `order` loop sets `$PAYMENT_MODULE`, but the loop plugin restores previous variable values once the loop closes (`TheliaLoop::theliaLoop`, varstack restore). The `order-payment-gateway.javascript` hook lives in a separate `javascript-initialization` block, rendered after the loop has already reset `$PAYMENT_MODULE`, so `{hook ... module="$PAYMENT_MODULE"}` receives an empty value and the module-specific hook event is never dispatched.

Fix: assign the payment module id to a dedicated variable inside the loop and use that variable in the javascript-initialization block, so it survives past the loop's scope.

https://github.com/thelia/thelia/issues/3215