### PR TITLE
fix: sync visibility switch state to form before product save

### DIFF
--- a/templates/backOffice/default/product-edit.html
+++ b/templates/backOffice/default/product-edit.html
@@ -839,7 +839,7 @@ $(function() {
                     action : 'visibilityToggle'
                 },
                 success: function() {
-                    $('#visible_field').prop('checked', $that.find('input').prop('checked'))
+                    $('#visible_field').prop('checked', data.value)
                 }
             });
         });


### PR DESCRIPTION
The top toolbar visibility switch on the product edit page (`product-edit.html`) is a separate control from the actual hidden form checkbox (`#visible_field`) submitted by the Save button. A JS handler was meant to sync the two after the switch's AJAX toggle call, but referenced an undefined variable `$that`, so the sync silently failed (JS ReferenceError).

As a result, toggling the switch persisted the new state immediately via AJAX, but the hidden form field kept the page-load state. Clicking Save then resubmitted that stale state, overwriting the just-toggled value back.

Fix: use `data.value`, the boolean already provided by the bootstrap-switch `switch-change` event, instead of the undefined variable.

See https://github.com/thelia/thelia/issues/3262