### PR TITLE
fix: allow null user from remember-me token providers

### DIFF
--- a/core/lib/Thelia/Core/Security/UserProvider/AdminTokenUserProvider.php
+++ b/core/lib/Thelia/Core/Security/UserProvider/AdminTokenUserProvider.php
@@ -18,7 +18,7 @@ use Thelia\Model\AdminQuery;
 
 class AdminTokenUserProvider extends TokenUserProvider
 {
-    public function getUser(array $dataArray): UserInterface
+    public function getUser(array $dataArray): ?UserInterface
     {
         return AdminQuery::create()
             ->filterByLogin($dataArray['username'], Criteria::EQUAL)

--- a/core/lib/Thelia/Core/Security/UserProvider/CustomerTokenUserProvider.php
+++ b/core/lib/Thelia/Core/Security/UserProvider/CustomerTokenUserProvider.php
@@ -18,7 +18,7 @@ use Thelia\Model\CustomerQuery;
 
 class CustomerTokenUserProvider extends TokenUserProvider
 {
-    public function getUser(array $dataArray): UserInterface
+    public function getUser(array $dataArray): ?UserInterface
     {
         return CustomerQuery::create()
             ->filterByEmail($dataArray['username'], Criteria::EQUAL)

--- a/core/lib/Thelia/Core/Security/UserProvider/TokenUserProvider.php
+++ b/core/lib/Thelia/Core/Security/UserProvider/TokenUserProvider.php
@@ -17,5 +17,5 @@ use Thelia\Core\Security\User\UserInterface;
 
 abstract class TokenUserProvider extends TokenProvider implements TokenUserProviderInterface
 {
-    abstract public function getUser(array $key): UserInterface;
+    abstract public function getUser(array $key): ?UserInterface;
 }

--- a/core/lib/Thelia/Core/Security/UserProvider/TokenUserProviderInterface.php
+++ b/core/lib/Thelia/Core/Security/UserProvider/TokenUserProviderInterface.php
@@ -16,5 +16,5 @@ use Thelia\Core\Security\User\UserInterface;
 
 interface TokenUserProviderInterface
 {
-    public function getUser(array $key): UserInterface;
+    public function getUser(array $key): ?UserInterface;
 }


### PR DESCRIPTION
When a remember-me cookie references a token that no longer exists in the database, `TokenUserProvider::getUser()` returns null from Propel's `findOne()`, but the return type is declared as non-nullable `UserInterface`. This raises a `TypeError` (HTTP 500) instead of the intended graceful degradation: `TokenAuthenticator::getAuthentifiedUser()` already checks for a null user and throws `TokenAuthenticationException`, which `RequestListener` catches to clear the cookie and fall back to an anonymous session.

Makes `getUser()` return `?UserInterface` in `TokenUserProviderInterface`, `TokenUserProvider`, `AdminTokenUserProvider` and `CustomerTokenUserProvider`, matching the existing null-handling logic.

Related: https://github.com/thelia/thelia/issues/3403 and #3457 (same fix, but opened against `main`, which is Thelia 3 - a different branch where this code path already guards against null differently and doesn't reproduce the bug).