### PR TITLE
fix: drop leading backslash on non-native calls in SsrfGuardTest

### DIFF
--- a/tests/Unit/Tinymce/SsrfGuardTest.php
+++ b/tests/Unit/Tinymce/SsrfGuardTest.php
@@ -29,7 +29,7 @@ final class SsrfGuardTest extends TestCase
      */
     public function testInternalAddressesAreBlocked(string $ip): void
     {
-        self::assertTrue(\thelia_ip_is_blocked($ip));
+        self::assertTrue(thelia_ip_is_blocked($ip));
     }
 
     /**
@@ -50,7 +50,7 @@ final class SsrfGuardTest extends TestCase
 
     public function testPublicAddressIsAllowed(): void
     {
-        self::assertFalse(\thelia_ip_is_blocked('8.8.8.8'));
+        self::assertFalse(thelia_ip_is_blocked('8.8.8.8'));
     }
 
     /**
@@ -58,8 +58,8 @@ final class SsrfGuardTest extends TestCase
      */
     public function testDangerousUrlsAreRejected(string $url): void
     {
-        self::assertNull(\thelia_remote_url_target($url));
-        self::assertFalse(\thelia_fetch_remote_file($url));
+        self::assertNull(thelia_remote_url_target($url));
+        self::assertFalse(thelia_fetch_remote_file($url));
     }
 
     /**
@@ -78,7 +78,7 @@ final class SsrfGuardTest extends TestCase
 
     public function testPublicHttpUrlIsAccepted(): void
     {
-        $target = \thelia_remote_url_target('http://8.8.8.8/robots.txt');
+        $target = thelia_remote_url_target('http://8.8.8.8/robots.txt');
 
         self::assertIsArray($target);
         self::assertSame('8.8.8.8', $target['ip']);


### PR DESCRIPTION
The `test` workflow has been red on `2.6` since ff10d64d (#3452). The failing step is `composer ci`, which runs `php-cs-fixer --dry-run --stop-on-violation`: the new `tests/Unit/Tinymce/SsrfGuardTest.php` calls the guard helpers as `\thelia_ip_is_blocked()` etc., and the `native_function_invocation` rule (strict mode, @Symfony:risky) only allows a leading backslash on compiler-optimized native functions.

This removes the backslash on the five `thelia_*` calls. `php-cs-fixer --dry-run` now reports 0 of 1952 files to fix. No behaviour change: the helpers are declared in the global namespace and resolve identically.