### PR TITLE
fix: correct inverted add/remove event string values for attribute and feature templates

### DIFF
--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -511,8 +511,8 @@ final class TheliaEvents
     public const ATTRIBUTE_DELETE = 'action.deleteAttribute';
     public const ATTRIBUTE_UPDATE_POSITION = 'action.updateAttributePosition';
 
-    public const ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES = 'action.addAttributeToAllTemplate';
-    public const ATTRIBUTE_ADD_TO_ALL_TEMPLATES = 'action.removeAttributeFromAllTemplate';
+    public const ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES = 'action.removeAttributeFromAllTemplate';
+    public const ATTRIBUTE_ADD_TO_ALL_TEMPLATES = 'action.addAttributeToAllTemplate';
 
     // -- Features management ---------------------------------------------
 
@@ -521,8 +521,8 @@ final class TheliaEvents
     public const FEATURE_DELETE = 'action.deleteFeature';
     public const FEATURE_UPDATE_POSITION = 'action.updateFeaturePosition';
 
-    public const FEATURE_REMOVE_FROM_ALL_TEMPLATES = 'action.addFeatureToAllTemplate';
-    public const FEATURE_ADD_TO_ALL_TEMPLATES = 'action.removeFeatureFromAllTemplate';
+    public const FEATURE_REMOVE_FROM_ALL_TEMPLATES = 'action.removeFeatureFromAllTemplate';
+    public const FEATURE_ADD_TO_ALL_TEMPLATES = 'action.addFeatureToAllTemplate';
 
     // -- Attributes values management ----------------------------------------
 


### PR DESCRIPTION
The event constants for adding/removing an attribute or feature from all product templates have their string values swapped: `ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES` was set to `action.addAttributeToAllTemplate` and vice versa, same for the `FEATURE_*` pair (core/lib/Thelia/Core/Event/TheliaEvents.php:514-515 and :524-525).

The constant names already match their real usage in `AttributeController`/`FeatureController` and `Action\Attribute`/`Action\Feature`, so this only swaps the misleading string values back to match the constant names; no listener or dispatcher references the raw literal, so behavior is unchanged.

Same inversion exists identically on the Thelia 3 line, fixed in companion PR https://github.com/thelia/thelia/pull/3466.

See https://github.com/thelia/thelia/issues/3203