### PR TITLE
fix: correct inverted add/remove event string values for attribute and feature templates

### DIFF
--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -434,8 +434,8 @@ final class TheliaEvents
     public const ATTRIBUTE_UPDATE = 'action.updateAttribute';
     public const ATTRIBUTE_DELETE = 'action.deleteAttribute';
     public const ATTRIBUTE_UPDATE_POSITION = 'action.updateAttributePosition';
-    public const ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES = 'action.addAttributeToAllTemplate';
-    public const ATTRIBUTE_ADD_TO_ALL_TEMPLATES = 'action.removeAttributeFromAllTemplate';
+    public const ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES = 'action.removeAttributeFromAllTemplate';
+    public const ATTRIBUTE_ADD_TO_ALL_TEMPLATES = 'action.addAttributeToAllTemplate';
 
     // -- Features management ---------------------------------------------
 
@@ -443,8 +443,8 @@ final class TheliaEvents
     public const FEATURE_UPDATE = 'action.updateFeature';
     public const FEATURE_DELETE = 'action.deleteFeature';
     public const FEATURE_UPDATE_POSITION = 'action.updateFeaturePosition';
-    public const FEATURE_REMOVE_FROM_ALL_TEMPLATES = 'action.addFeatureToAllTemplate';
-    public const FEATURE_ADD_TO_ALL_TEMPLATES = 'action.removeFeatureFromAllTemplate';
+    public const FEATURE_REMOVE_FROM_ALL_TEMPLATES = 'action.removeFeatureFromAllTemplate';
+    public const FEATURE_ADD_TO_ALL_TEMPLATES = 'action.addFeatureToAllTemplate';
 
     // -- Attributes values management ----------------------------------------
 


### PR DESCRIPTION
Same bug as the 2.6 line: the event constants for adding/removing an attribute or feature from all product templates have their string values swapped: `ATTRIBUTE_REMOVE_FROM_ALL_TEMPLATES` was set to `action.addAttributeToAllTemplate` and vice versa, same for the `FEATURE_*` pair (core/lib/Thelia/Core/Event/TheliaEvents.php:437-438 and :446-447).

The constant names already match their real usage in the admin controllers and `Action\Attribute`/`Action\Feature` listeners, so this only swaps the misleading string values back to match the constant names; no listener or dispatcher references the raw literal, so behavior is unchanged.

Companion PR on 2.6: https://github.com/thelia/thelia/pull/3465

See https://github.com/thelia/thelia/issues/3203