### PR TITLE
fix: use consistent Title wording for the config variable field

### DIFF
--- a/core/lib/Thelia/Form/ConfigCreationForm.php
+++ b/core/lib/Thelia/Form/ConfigCreationForm.php
@@ -38,7 +38,7 @@ class ConfigCreationForm extends BaseForm
                 'constraints' => [
                     new Constraints\NotBlank(),
                 ],
-                'label' => Translator::getInstance()->trans('Purpose *'),
+                'label' => Translator::getInstance()->trans('Title *'),
                 'label_attr' => [
                     'for' => 'purpose',
                 ],

--- a/templates/backOffice/default/variables.html
+++ b/templates/backOffice/default/variables.html
@@ -70,7 +70,7 @@
                                     order='title'
                                     reverse_order='title_reverse'
                                     path={url path='/admin/configuration/variables'}
-                                    label={intl l='Purpose'}
+                                    label={intl l='Title'}
                                  }
   	                           </th>
 


### PR DESCRIPTION
The system variables screens use two different labels for the same
underlying `title` column: the list column header and the creation form
both translate the key `Purpose` (fr_FR "Objet"), while the modification
form (`StandardDescriptionFieldsTrait`) translates `Title` (fr_FR "Titre").
Users see "Objet" when listing/creating a variable and "Titre" when
editing it, which is confusing.

This aligns the list header (`templates/backOffice/default/variables.html`)
and the creation form (`core/lib/Thelia/Form/ConfigCreationForm.php`) on
the `Title` translation key already used by the modification form, so the
same field is labeled consistently everywhere.

https://github.com/thelia/thelia/issues/3050