### PR TITLE
fix: stop storing Tinymce custom CSS as a file in the module directory

### DIFF
--- a/local/modules/Tinymce/Config/module.xml
+++ b/local/modules/Tinymce/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>Editeur visuel TinyMCE</title>
     </descriptive>
-    <version>2.6.1</version>
+    <version>2.6.2</version>
     <author>
         <name>Manuel Raynaud</name>
         <email>manu@raynaud.io</email>

--- a/local/modules/Tinymce/Controller/ConfigureController.php
+++ b/local/modules/Tinymce/Controller/ConfigureController.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Thelia\Controller\Admin\BaseAdminController;
 use Thelia\Core\Security\AccessManager;
 use Thelia\Core\Security\Resource\AdminResources;
-use Thelia\Exception\TheliaProcessException;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Tools\URL;
 use Tinymce\Form\ConfigurationForm;
@@ -66,19 +65,10 @@ class ConfigureController extends BaseAdminController
             Tinymce::setConfigValue('show_menu_bar', $data['show_menu_bar']);
             Tinymce::setConfigValue('force_pasting_as_text', $data['force_pasting_as_text']);
             Tinymce::setConfigValue('editor_height', $data['editor_height']);
+            // The custom CSS is stored as module configuration only: it used to be written to a
+            // file inside the module's own template tree, which composer can wipe on update and
+            // which does not exist on a fresh install, flooding the logs with asset warnings.
             Tinymce::setConfigValue('custom_css', $data['custom_css']);
-
-            // Save Custom CSS in default assets
-            $customCss = __DIR__.DS.'..'.DS.'templates'.DS.'backOffice'.DS.'default'.DS.'assets'.DS.'css'.DS.'custom-css.less';
-
-            if (false === file_put_contents($customCss, $data['custom_css'])) {
-                throw new TheliaProcessException(
-                    $this->getTranslator()->trans(
-                        'Failed to update custom CSS file "%file". Please check this file or parent folder write permissions.',
-                        ['%file' => $customCss]
-                    )
-                );
-            }
 
             // Log configuration modification
             $this->adminLogAppend(

--- a/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
+++ b/local/modules/Tinymce/templates/backOffice/default/tinymce_init.tpl
@@ -100,16 +100,18 @@
         {$css = $asset_url}
         {/stylesheets}
 
-        {stylesheets file='assets/css/custom-css.less' failsafe=true filters='less' source='Tinymce' template='default'}
-            {if $asset_url != ''}
-                {$css = "`$css`,`$asset_url`"}
-            {/if}
-        {/stylesheets}
-
         {if $css != ''}
             content_css: "{$css}",
             importcss_append: true,
         {/if}
+
+        // Custom CSS is stored as module configuration, not as a file in the module directory
+        // (a file there would be lost on composer update and missing on a fresh install).
+        {loop type="module-config" name="dummy" module="tinymce" variable="custom_css" default_value=""}
+            {if $VALUE != ''}
+                content_style: `{$VALUE}`,
+            {/if}
+        {/loop}
 
         convert_urls: false,
         relative_urls : false,


### PR DESCRIPTION
Custom CSS entered in the Tinymce module configuration was written to `local/modules/Tinymce/templates/backOffice/default/assets/css/custom-css.less`, inside the module's own template tree. That file is not part of the module's tracked assets, so it is missing on a fresh install and can be wiped when the module package is reinstalled/updated. When absent, the Smarty asset resolver logs a warning on every admin page rendering the editor, which floods the logs (see https://github.com/thelia/thelia/issues/2620).

The custom CSS was already persisted as module configuration (`Tinymce::setConfigValue('custom_css', ...)`), so the file was redundant. The fix drops the file write/read entirely and injects the stored value directly into TinyMCE via the native `content_style` option, which the bundled TinyMCE 4.3 already supports.

Note: the custom CSS box was previously run through the LESS compiler (like `editor.less`); it is now injected as raw CSS text, so LESS-specific syntax in that field is no longer processed. Plain CSS, which is what the field's label suggests, is unaffected.