### PR TITLE
refactor: move setupFormErrorContext() to BaseController

### DIFF
--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -25,7 +25,6 @@ use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\Exception\AuthorizationException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
-use Thelia\Form\BaseForm;
 use Thelia\Log\Tlog;
 use Thelia\Model\AdminLog;
 use Thelia\Model\ConfigQuery;
@@ -137,32 +136,6 @@ class BaseAdminController extends BaseController
                 '%error' => $exception->getMessage(),
             ],
         );
-    }
-
-    protected function setupFormErrorContext(string $action, string $error_message, ?BaseForm $form = null, ?\Exception $exception = null): void
-    {
-        // Log the error message
-        Tlog::getInstance()->error(
-            $this->translator->trans(
-                'Error during %action process : %error. Exception was %exc',
-                [
-                    '%action' => $action,
-                    '%error' => $error_message,
-                    '%exc' => $exception instanceof \Exception ? $exception->getMessage() : 'no exception',
-                ],
-            ),
-        );
-
-        if ($form instanceof BaseForm) {
-            // Mark the form as errored
-            $form->setErrorMessage($error_message);
-
-            // Pass it to the parser context
-            $this->getParserContext()->addForm($form);
-        }
-
-        // Pass the error message to the parser.
-        $this->getParserContext()->setGeneralError($error_message);
     }
 
     /**

--- a/core/lib/Thelia/Controller/BaseController.php
+++ b/core/lib/Thelia/Controller/BaseController.php
@@ -207,6 +207,32 @@ abstract class BaseController implements ControllerInterface
         return $this->theliaFormValidator;
     }
 
+    protected function setupFormErrorContext(string $action, string $error_message, ?BaseForm $form = null, ?\Exception $exception = null): void
+    {
+        // Log the error message
+        Tlog::getInstance()->error(
+            $this->translator->trans(
+                'Error during %action process : %error. Exception was %exc',
+                [
+                    '%action' => $action,
+                    '%error' => $error_message,
+                    '%exc' => $exception instanceof \Exception ? $exception->getMessage() : 'no exception',
+                ],
+            ),
+        );
+
+        if ($form instanceof BaseForm) {
+            // Mark the form as errored
+            $form->setErrorMessage($error_message);
+
+            // Pass it to the parser context
+            $this->getParserContext()->addForm($form);
+        }
+
+        // Pass the error message to the parser.
+        $this->getParserContext()->setGeneralError($error_message);
+    }
+
     protected function generateOrderPdf(
         EventDispatcherInterface $eventDispatcher,
         int $order_id,


### PR DESCRIPTION
https://github.com/thelia/thelia/issues/2654

setupFormErrorContext() lived only in BaseAdminController, so front controllers (which also extend BaseController) had no access to it despite needing the same error-context setup.

Moved the method as-is to BaseController, where the translator, Tlog and getParserContext() dependencies it uses were already available. BaseAdminController keeps inheriting it unchanged, so admin controllers see no behavior change.