### PR TITLE
fix: make the update process resume correctly and create the missing CDN variables

### DIFF
--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -150,7 +150,45 @@ class Update
         }
         $lastEntry = end($this->version);
 
-        return $lastEntry == $version;
+        return version_compare($lastEntry, $version, '<=');
+    }
+
+    /**
+     * Find the position of the current version in the update script list.
+     *
+     * Some releases ship without an update script (2.2.5, 2.3.6, 2.4.5, ...), so the current
+     * version is not always part of that list. In that case the update resumes from the closest
+     * known version below the current one, instead of replaying every script from the beginning.
+     *
+     * @param string $currentVersion
+     *
+     * @throws UpdateException when no known version precedes the current one
+     *
+     * @return int
+     */
+    protected function getStartIndex($currentVersion)
+    {
+        $index = array_search($currentVersion, $this->version, true);
+
+        if (false !== $index) {
+            return $index;
+        }
+
+        $closestIndex = null;
+
+        foreach ($this->version as $position => $knownVersion) {
+            if (version_compare($knownVersion, $currentVersion, '<=')) {
+                $closestIndex = $position;
+            }
+        }
+
+        if (null === $closestIndex) {
+            throw new UpdateException(
+                sprintf('Unknown installed version "%s", unable to find where to start the update.', $currentVersion)
+            );
+        }
+
+        return $closestIndex;
     }
 
     public function process()
@@ -165,7 +203,7 @@ class Update
             throw new UpToDateException('You already have the latest version. No update available');
         }
 
-        $index = array_search($currentVersion, $this->version);
+        $index = $this->getStartIndex($currentVersion);
 
         $this->connection->beginTransaction();
 
@@ -175,7 +213,7 @@ class Update
         try {
             $size = \count($this->version);
 
-            for ($i = ++$index; $i < $size; ++$i) {
+            for ($i = $index + 1; $i < $size; ++$i) {
                 $version = $this->version[$i];
                 $this->updateToVersion($version, $database);
                 $this->updatedVersions[] = $version;

--- a/setup/update/sql/2.5.5.sql
+++ b/setup/update/sql/2.5.5.sql
@@ -19,5 +19,6 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
         (@max_id + 1, 'es_ES', NULL, NULL, NULL, NULL),
         (@max_id + 1, 'fr_FR', NULL, NULL, NULL, NULL),
         (@max_id + 1, 'it_IT', NULL, NULL, NULL, NULL),
-        (@max_id + 1, 'ru_RU', NULL, NULL, NULL, NULL)
+        (@max_id + 1, 'ru_RU', NULL, NULL, NULL, NULL);
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/sql/2.6.2.sql
+++ b/setup/update/sql/2.6.2.sql
@@ -1,0 +1,27 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+UPDATE `config` SET `value`='2.6.2' WHERE `name`='thelia_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_major_version';
+UPDATE `config` SET `value`='6' WHERE `name`='thelia_minus_version';
+UPDATE `config` SET `value`='2' WHERE `name`='thelia_release_version';
+UPDATE `config` SET `value`='' WHERE `name`='thelia_extra_version';
+
+SELECT @configIdMax := IFNULL(MAX(`id`),0) FROM `config`;
+
+-- add the CDN config variables if they don't exist : they are created on a fresh install since 2.4,
+-- but no update script ever created them.
+INSERT IGNORE INTO `config` (`id`, `name`, `value`, `secured`, `hidden`, `created_at`, `updated_at`) VALUES
+(@configIdMax+1, 'cdn.documents-base-url', '', 0, 0, NOW(), NOW()),
+(@configIdMax+2, 'cdn.assets-base-url', '', 0, 0, NOW(), NOW())
+
+;
+
+-- add the missing translation rows of these variables, for every locale of the shop
+INSERT IGNORE INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `postscriptum`)
+SELECT `config`.`id`, `lang`.`locale`, NULL, NULL, NULL, NULL
+FROM `config`, `lang`
+WHERE `config`.`name` IN ('cdn.documents-base-url', 'cdn.assets-base-url')
+
+;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/setup/update/tpl/2.5.5.sql.tpl
+++ b/setup/update/tpl/2.5.5.sql.tpl
@@ -17,5 +17,6 @@ INSERT INTO `config_i18n` (`id`, `locale`, `title`, `chapo`, `description`, `pos
     (@max_id + 1, '{$locale}', {intl l='Rounding mode for calculating the order total (1: sums of roundings, 2: rounding of sums).' locale=$locale}, NULL, NULL, NULL){if ! $locale@last},
     {/if}
 {/foreach}
+;
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Three defects of the update chain, all reachable on 2.6.

**https://github.com/thelia/thelia/issues/2743** — `Update::process()` located the installed version with `array_search()`. A few releases ship without an update script (2.2.5, 2.3.6, 2.4.5), so the search returned `false`, `++$index` left it at `false` (PHP does not increment booleans, and warns about it since 8.1), and the loop replayed every script starting from 2.0.0-beta2. The update now resumes from the closest known version below the installed one, and aborts with an explicit message when there is none. `isLatestVersion()` compares versions instead of strings, so a shop running a version newer than the last script is reported up to date.

**https://github.com/thelia/thelia/issues/2802** — `cdn.documents-base-url` and `cdn.assets-base-url` are created by `setup/insert.sql` since 2.4 but no update script ever created them, so updated shops cannot configure a CDN. They are added by a new `setup/update/sql/2.6.2.sql`, with `INSERT IGNORE` so a shop that created them by hand keeps its value, and translation rows built from the shop's own `lang` table.

**Found while validating the chain** — `setup/update/sql/2.5.5.sql` misses the `;` before `SET FOREIGN_KEY_CHECKS = 1`. The statement splitter therefore builds a single invalid statement and every update crossing 2.5.5 stops on a 1064 error. Reproduced and fixed against MariaDB 10.11, along with the template it is generated from.

https://github.com/thelia/thelia/issues/2362 needs nothing: `setup/update/php/2.4.0.php` already adds `ignored_module_hook.created_at` and `updated_at` when they are missing.
