### PR TITLE
fix: search_in with search_mode=any_word in Product loop

### DIFF
--- a/core/lib/Thelia/Core/Template/Element/BaseI18nLoop.php
+++ b/core/lib/Thelia/Core/Template/Element/BaseI18nLoop.php
@@ -72,29 +72,54 @@ abstract class BaseI18nLoop extends BaseLoop
     }
 
     /**
+     * Build the SQL placeholder(s) and PDO binding type for a search term. When $searchTerm is a list of values
+     * (search_mode=any_word uses Criteria::IN with several words), a single "?" cannot be bound to it: one
+     * placeholder per value is required instead, and Propel must be left to auto-detect the binding type.
+     *
+     * @param string|array $searchTerm
+     *
+     * @return array{0: string|array, 1: string, 2: int|null} the (possibly normalized) search term, the SQL
+     *                                                        placeholder, and the PDO binding type to use
+     */
+    protected function buildSearchTermPlaceholder($searchTerm): array
+    {
+        if (\is_array($searchTerm) && 1 === \count($searchTerm)) {
+            $searchTerm = reset($searchTerm);
+        }
+
+        if (\is_array($searchTerm)) {
+            return [$searchTerm, '('.implode(', ', array_fill(0, \count($searchTerm), '?')).')', null];
+        }
+
+        return [$searchTerm, '?', \PDO::PARAM_STR];
+    }
+
+    /**
      * Add the search clause for an I18N column, taking care of the back/front context, as default_locale_i18n is
      * not defined in the backEnd I18N context.
      *
-     * @param string $columnName     the column to search into, such as TITLE
-     * @param string $searchCriteria the search criteria, such as Criterial::LIKE, Criteria::EQUAL, etc
-     * @param string $searchTerm     the searched term
+     * @param string       $columnName     the column to search into, such as TITLE
+     * @param string       $searchCriteria the search criteria, such as Criterial::LIKE, Criteria::EQUAL, etc
+     * @param string|array $searchTerm     the searched term, or a list of terms when $searchCriteria is Criteria::IN
      */
-    public function addSearchInI18nColumn(ModelCriteria $search, string $columnName, string $searchCriteria, string $searchTerm): void
+    public function addSearchInI18nColumn(ModelCriteria $search, string $columnName, string $searchCriteria, $searchTerm): void
     {
+        [$searchTerm, $placeholder, $bindingType] = $this->buildSearchTermPlaceholder($searchTerm);
+
         if (!$this->getBackendContext()) {
             $search->where(
                 "CASE WHEN NOT ISNULL(`requested_locale_i18n`.ID)
                         THEN `requested_locale_i18n`.`$columnName`
                         ELSE `default_locale_i18n`.`$columnName`
-                        END ".$searchCriteria.' ?',
+                        END ".$searchCriteria.' '.$placeholder,
                 $searchTerm,
-                \PDO::PARAM_STR
+                $bindingType
             );
         } else {
             $search->where(
-                "`requested_locale_i18n`.`$columnName` $searchCriteria ?",
+                "`requested_locale_i18n`.`$columnName` $searchCriteria $placeholder",
                 $searchTerm,
-                \PDO::PARAM_STR
+                $bindingType
             );
         }
     }

--- a/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
+++ b/core/lib/Thelia/Core/Template/Element/StandardI18nFieldsSearchTrait.php
@@ -29,9 +29,10 @@ trait StandardI18nFieldsSearchTrait
     }
 
     /**
-     * @param string[] $searchIn
+     * @param string|array $searchTerm the searched term, or a list of terms when $searchCriteria is Criteria::IN
+     * @param string[]     $searchIn
      */
-    protected function addStandardI18nSearch(ModelCriteria $search, string $searchTerm, string $searchCriteria, array $searchIn = ['title', 'chapo', 'description', 'postscriptum']): void
+    protected function addStandardI18nSearch(ModelCriteria $search, $searchTerm, string $searchCriteria, array $searchIn = ['title', 'chapo', 'description', 'postscriptum']): void
     {
         $firstSearch = true;
         foreach (self::$standardI18nSearchFields as $searchInElement) {

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -204,10 +204,12 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     $search->filterByRef($searchTerm, $searchCriteria);
                     break;
                 case 'id':
+                    [$idSearchTerm, $placeholder, $bindingType] = $this->buildSearchTermPlaceholder($searchTerm);
+
                     $search->where(
-                        "`product`.`id` $searchCriteria ?",
-                        $searchTerm,
-                        \PDO::PARAM_STR
+                        "`product`.`id` $searchCriteria $placeholder",
+                        $idSearchTerm,
+                        $bindingType
                     );
                     break;
             }


### PR DESCRIPTION
Fixes the exception reported in https://github.com/thelia/thelia/issues/2340.

`search_mode="any_word"` explodes the search term into an array of words and uses `Criteria::IN`, but the raw SQL clauses used for i18n columns (title, chapo, description, postscriptum) and the `id` field build a single `?` placeholder and bind it with an explicit `PDO::PARAM_STR`. This forces Propel into `RawModelCriterion`, which only accepts a single scalar value, so the whole word array ends up bound to one placeholder (PDO stringifies it to the literal `Array`, matching the reported SQL error).

The fix builds one `?` placeholder per word (wrapped in `(...)`) and leaves the PDO binding type to `null` when several values are involved, so Propel picks `SeveralModelCriterion` and binds each word to its own parameter. Single-word and non-IN searches (sentence/strict_sentence) are unaffected.

Same root cause exists in Thelia 3 (`main`); a matching fix is proposed separately.