### PR TITLE
fix: respect edition locale in mail message preview

### DIFF
--- a/core/lib/Thelia/Controller/Admin/MessageController.php
+++ b/core/lib/Thelia/Controller/Admin/MessageController.php
@@ -262,18 +262,31 @@ class MessageController extends AbstractCrudController
             $parser->assign($key, $value);
         }
 
+        $editionLang = $this->getCurrentEditionLang();
+
+        // The parser derives the "locale" template variable and the translator locale from the
+        // admin language stored in session, not from the message's edition locale. Temporarily
+        // switch it so the preview (and any {intl} tag in the template) uses the expected locale.
+        $session = $this->getSession();
+        $previousAdminLang = $session->getAdminLang();
+        $session->setAdminLang($editionLang);
+
         try {
-            if ($html) {
-                $content = $message->setLocale($this->getCurrentEditionLocale())->getHtmlMessageBody($parser);
-            } else {
-                $content = $message->setLocale($this->getCurrentEditionLocale())->getTextMessageBody($parser);
+            try {
+                if ($html) {
+                    $content = $message->setLocale($editionLang->getLocale())->getHtmlMessageBody($parser);
+                } else {
+                    $content = $message->setLocale($editionLang->getLocale())->getTextMessageBody($parser);
+                }
+            } catch (\InvalidArgumentException|\ErrorException $exception) {
+                return new Response($this->getTranslator()->trans('You probably didn\'t inject the missing variable to preview the HTML. Error is : %err',
+                    ['%err' => $exception->getMessage()]), 200);
+            } catch (\Exception $exception) {
+                return new Response($this->getTranslator()->trans('Something goes wrong, error is : %err',
+                    ['%err' => $exception->getMessage()]), 200);
             }
-        } catch (\InvalidArgumentException|\ErrorException $exception) {
-            return new Response($this->getTranslator()->trans('You probably didn\'t inject the missing variable to preview the HTML. Error is : %err',
-                ['%err' => $exception->getMessage()]), 200);
-        } catch (\Exception $exception) {
-            return new Response($this->getTranslator()->trans('Something goes wrong, error is : %err',
-                ['%err' => $exception->getMessage()]), 200);
+        } finally {
+            $session->setAdminLang($previousAdminLang);
         }
 
         return new Response($content);


### PR DESCRIPTION
The mail template preview in the back office (`/admin/configuration/messages/update`) never matched the selected locale: `{intl}` tags without an explicit `locale` param, and the `$locale`/`$lang_code` template variables, are all resolved from the admin's session language (see `TheliaSmarty`'s `SmartyParser::internalRenderer()`), which `MessageController::previewAction()` never touched. It only called `$message->setLocale()`, which affects the message's own i18n fields (subject, body) but not the parser/translator context — hence translations only worked when a `locale` variable was manually added to 'Variables to inject'.

The fix temporarily switches the admin language in session to the current edition locale before rendering the preview (mirroring the swap already done in `MailerFactory::createEmailMessage()` for real sends), and restores it afterward.

https://github.com/thelia/thelia/issues/2307