### PR TITLE
fix: align module schema charset with core utf8 default

### DIFF
--- a/core/lib/Thelia/Command/Skeleton/Module/schema.xml
+++ b/core/lib/Thelia/Command/Skeleton/Module/schema.xml
@@ -2,6 +2,10 @@
 <database defaultIdMethod="native" name="TheliaMain"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="%%XSD_LOCATION%%" >
+    <vendor type="mysql">
+        <parameter name="Engine" value="InnoDB"/>
+        <parameter name="Charset" value="utf8"/>
+    </vendor>
     <!--
     See propel documentation on http://propelorm.org for all information about schema file
 

--- a/local/modules/Carousel/Config/TheliaMain.sql
+++ b/local/modules/Carousel/Config/TheliaMain.sql
@@ -23,7 +23,7 @@ CREATE TABLE `carousel`
     `created_at` DATETIME,
     `updated_at` DATETIME,
     PRIMARY KEY (`id`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARACTER SET='utf8';
 
 -- ---------------------------------------------------------------------
 -- carousel_i18n
@@ -45,7 +45,7 @@ CREATE TABLE `carousel_i18n`
         FOREIGN KEY (`id`)
         REFERENCES `carousel` (`id`)
         ON DELETE CASCADE
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARACTER SET='utf8';
 
 # This restores the fkey checks, after having unset them earlier
 SET FOREIGN_KEY_CHECKS = 1;

--- a/local/modules/Carousel/Config/module.xml
+++ b/local/modules/Carousel/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.6.1</version>
+    <version>2.6.2</version>
     <author>
         <name>Manuel Raynaud, Franck Allimant</name>
         <email>manu@raynaud.io, franck@cqfdev.fr</email>

--- a/local/modules/Carousel/Config/schema.xml
+++ b/local/modules/Carousel/Config/schema.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <database defaultIdMethod="native" name="TheliaMain" namespace="Carousel\Model">
+    <vendor type="mysql">
+        <parameter name="Engine" value="InnoDB"/>
+        <parameter name="Charset" value="utf8"/>
+    </vendor>
     <!--
     See propel documentation on http://propelorm.org for all information about schema file
     -->


### PR DESCRIPTION
Core's `local/config/schema.xml` explicitly sets `utf8` as the vendor charset, but module schemas do not, so their tables end up with whatever the MySQL server's default charset is instead of matching core.

Within this repository, that concretely affects the bundled Carousel module: `Config/TheliaMain.sql` creates `carousel` and `carousel_i18n` without `CHARACTER SET`, and `Config/schema.xml` has no `<vendor>` block to regenerate it correctly. Both are now aligned with core's utf8.

The module skeleton used by `module:generate` (`core/lib/Thelia/Command/Skeleton/Module/schema.xml`) is also updated so new modules scaffolded going forward default to the same charset as core, instead of silently inheriting the server default.

This only affects table creation on fresh installs / new module activations, no migration of already-installed databases.

https://github.com/thelia/thelia/issues/2843