### PR TITLE
feat: add base64 conversion option to local_media smarty block

### DIFF
--- a/local/modules/TheliaSmarty/Config/module.xml
+++ b/local/modules/TheliaSmarty/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.6.1</version>
+    <version>2.6.2</version>
     <authors>
         <author>
             <name>Manuel Raynaud</name>

--- a/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/DataAccessFunctions.php
@@ -927,6 +927,10 @@ class DataAccessFunctions extends AbstractSmartyPlugin
             try {
                 $this->dispatcher->dispatch($event, TheliaEvents::IMAGE_PROCESS);
                 $template->assign('MEDIA_URL', $event->getFileUrl());
+
+                if ($this->getParam($params, 'base64', false)) {
+                    $template->assign('MEDIA_BASE64', $this->toBase64($event->getCacheFilepath()));
+                }
             } catch (\Exception $ex) {
                 Tlog::getInstance()->error($ex->getMessage());
                 $template->assign('MEDIA_URL', '');
@@ -938,6 +942,20 @@ class DataAccessFunctions extends AbstractSmartyPlugin
         }
 
         return null;
+    }
+
+    /**
+     * Convert a local file into a base64-encoded data URI.
+     *
+     * @param string $path the absolute path of the file to convert
+     *
+     * @return string the data URI (e.g. "data: image/png;base64,...")
+     */
+    private function toBase64($path)
+    {
+        $imgData = base64_encode(file_get_contents($path));
+
+        return 'data: '.mime_content_type($path).';base64,'.$imgData;
     }
 
     public function getPluginDescriptors()


### PR DESCRIPTION
Adds an optional `base64` parameter to the `local_media` Smarty block (used for the store logo, favicon and banner). When set, the block also assigns a `MEDIA_BASE64` template variable with a data URI of the processed image, in addition to the existing `MEDIA_URL`.

This follows the same convention already used by the `image` loop (`base64` argument producing `IMAGE_BASE64`), and is useful for emails and PDFs, where embedding images as data URIs avoids relying on the source being reachable over HTTP.

Reference: https://github.com/thelia/thelia/issues/3163