### PR TITLE
fix: remove invalid coupon codes from cart session

### DIFF
--- a/core/lib/Thelia/Coupon/CouponManager.php
+++ b/core/lib/Thelia/Coupon/CouponManager.php
@@ -15,6 +15,9 @@ namespace Thelia\Coupon;
 use Thelia\Condition\Implementation\ConditionInterface;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Coupon\Type\CouponInterface;
+use Thelia\Exception\CouponExpiredException;
+use Thelia\Exception\CouponNoUsageLeftException;
+use Thelia\Exception\InactiveCouponException;
 use Thelia\Exception\UnmatchableConditionException;
 use Thelia\Log\Tlog;
 use Thelia\Model\AddressQuery;
@@ -97,13 +100,15 @@ class CouponManager
      */
     public function getCurrentCoupons()
     {
-        $couponCodes = $this->facade->getRequest()?->getSession()?->getConsumedCoupons();
+        $session = $this->facade->getRequest()?->getSession();
+        $couponCodes = $session?->getConsumedCoupons();
 
         if (null === $couponCodes) {
             return [];
         }
 
         $coupons = [];
+        $codesToRemove = [];
 
         foreach ($couponCodes as $couponCode) {
             // Only valid coupons are returned
@@ -111,12 +116,24 @@ class CouponManager
                 if (false !== $couponInterface = $this->couponFactory->buildCouponFromCode($couponCode)) {
                     $coupons[] = $couponInterface;
                 }
+            } catch (CouponExpiredException|InactiveCouponException|CouponNoUsageLeftException $ex) {
+                // The coupon can no longer become valid again in this session: remove it from the cart
+                // instead of leaving it there silently ignored on every calculation.
+                $codesToRemove[] = $couponCode;
+
+                Tlog::getInstance()->warning(
+                    sprintf('Coupon %s removed from cart, exception occurred: %s', $couponCode, $ex->getMessage())
+                );
             } catch (\Exception $ex) {
                 // Just ignore the coupon and log the problem, just in case someone realize it.
                 Tlog::getInstance()->warning(
                     sprintf('Coupon %s ignored, exception occurred: %s', $couponCode, $ex->getMessage())
                 );
             }
+        }
+
+        if ([] !== $codesToRemove) {
+            $session?->setConsumedCoupons(array_values(array_diff($couponCodes, $codesToRemove)));
         }
 
         return $coupons;


### PR DESCRIPTION
When a coupon code applied to the cart later becomes invalid (expired, disabled by an admin, or out of usage), `CouponManager::getCurrentCoupons()` silently skips it on every discount computation, but never removes it from the session's consumed coupons list — the code stays stuck in the cart indefinitely with no way for the customer to remove it other than clearing all coupons.

This changes `getCurrentCoupons()` to also remove the coupon code from the session when the underlying build fails with `CouponExpiredException`, `InactiveCouponException` or `CouponNoUsageLeftException` (states that cannot resolve themselves later in the same cart). Codes affected by `CouponNotReleaseException` (not yet started) or requiring a customer login are left untouched, since they can still become valid.

https://github.com/thelia/thelia/issues/3166