### PR TITLE
fix: keep every selected attribute value on sale when a product has several

### DIFF
--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -117,7 +117,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
         $sale = $event->getSale();
 
         // Get all selected product sale elements for this sale
-        if (null !== $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()) {
+        if (null !== $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()->find()) {
             $saleOffsetByCurrency = $sale->getPriceOffsets();
 
             $offsetType = $sale->getPriceOffsetType();
@@ -127,14 +127,26 @@ class Sale extends BaseAction implements EventSubscriberInterface
             $con->beginTransaction();
 
             try {
+                // A product is present once per selected attribute value, so the sale status of its PSE has to be
+                // reset once and for all before processing the selection. Doing it in the loop below would discard
+                // the promo status set by the previously processed attribute values of the same product.
+                $saleProductIds = [];
+
                 /** @var SaleProduct $saleProduct */
                 foreach ($saleProducts as $saleProduct) {
-                    // Reset all sale status on product's PSE
+                    $saleProductIds[$saleProduct->getProductId()] = $saleProduct->getProductId();
+                }
+
+                if (!empty($saleProductIds)) {
+                    // Reset all sale status on the PSE of the sale's products
                     ProductSaleElementsQuery::create()
-                        ->filterByProductId($saleProduct->getProductId())
+                        ->filterByProductId($saleProductIds, Criteria::IN)
                         ->update(['Promo' => false], $con)
                     ;
+                }
 
+                /** @var SaleProduct $saleProduct */
+                foreach ($saleProducts as $saleProduct) {
                     $taxCalculator->load(
                         $saleProduct->getProduct($con),
                         CountryModel::getShopLocation()


### PR DESCRIPTION
In a sale, a product selected with several attribute values is stored as one `sale_product` row per attribute value. `Sale::updateProductsSaleStatus()` reset the promo flag of every PSE of the product **inside** the loop over these rows, so each iteration discarded the promo status set by the previous ones: only the last selected attribute value ended up on sale.

The reset is now done once, for all the products of the sale, before the selection is applied.

https://github.com/thelia/thelia/issues/2462