### PR TITLE
fix: report invalid coupon condition parameters instead of a 500

### DIFF
--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -398,6 +398,7 @@ return [
     'Phone' => 'Phone',
     'Placed order' => 'Placed order',
     'Please accept the Terms and conditions in order to register.' => 'Please accept the Terms and conditions in order to register.',
+    'Please check the parameters of this condition: some of them are missing or invalid.' => 'Please check the parameters of this condition: some of them are missing or invalid.',
     'Please check your input: %error' => 'Please check your input: %error',
     'Please enter a valid email address' => 'Please enter a valid email address',
     'Please enter your email address' => 'Please enter your email address',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -399,6 +399,7 @@ return [
     'Phone' => 'Téléphone',
     'Placed order' => 'Commande terminée',
     'Please accept the Terms and conditions in order to register.' => 'Veuillez accepter les termes et conditions pour vous inscrire.',
+    'Please check the parameters of this condition: some of them are missing or invalid.' => 'Merci de vérifier les paramètres de cette condition : certains sont manquants ou invalides.',
     'Please check your input: %error' => 'Merci de vérifier votre saisie: %error',
     'Please enter a valid email address' => 'Veuillez saisir une adresse e-mail valide',
     'Please enter your email address' => 'Renseignez votre adresse e-mail',

--- a/core/lib/Thelia/Controller/Admin/CouponController.php
+++ b/core/lib/Thelia/Controller/Admin/CouponController.php
@@ -29,6 +29,8 @@ use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Coupon\CouponFactory;
 use Thelia\Coupon\CouponManager;
 use Thelia\Coupon\Type\CouponInterface;
+use Thelia\Exception\InvalidConditionOperatorException;
+use Thelia\Exception\InvalidConditionValueException;
 use Thelia\Form\Definition\AdminForm;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\Log\Tlog;
@@ -390,7 +392,21 @@ class CouponController extends BaseAdminController
             return $this->pageNotFound();
         }
 
-        $conditionToSave = $this->buildConditionFromRequest();
+        try {
+            $conditionToSave = $this->buildConditionFromRequest();
+        } catch (InvalidConditionOperatorException|InvalidConditionValueException) {
+            // The exception constructor already logged the detailed error.
+            return new Response(
+                $this->getTranslator()->trans(
+                    'Please check the parameters of this condition: some of them are missing or invalid.'
+                ),
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
+        if (!$conditionToSave instanceof ConditionInterface) {
+            return $this->pageNotFound();
+        }
 
         /** @var CouponFactory $couponFactory */
         $couponFactory = $this->container->get('thelia.coupon.factory');
@@ -743,13 +759,16 @@ class CouponController extends BaseAdminController
     /**
      * Build ConditionInterface from request.
      *
-     * @return ConditionInterface
+     * @throws InvalidConditionOperatorException if an operator submitted for this condition is not allowed
+     * @throws InvalidConditionValueException    if a value submitted for this condition is missing or invalid
+     *
+     * @return ConditionInterface|false the condition, or false if the submitted condition service does not exist
      */
     protected function buildConditionFromRequest()
     {
         $request = $this->getRequest();
         $post = $request->request->getIterator();
-        $serviceId = $request->request->get('categoryCondition');
+        $serviceId = (string) $request->request->get('categoryCondition');
         $operators = [];
         $values = [];
         foreach ($post as $key => $input) {

--- a/templates/backOffice/default/assets/js/coupon.js
+++ b/templates/backOffice/default/assets/js/coupon.js
@@ -86,26 +86,29 @@ $(function($){
         var $form = $("#condition-form");
         var data = $form.serialize();
         var url = $form.attr('action');
+        var $errors = $('#condition-form-errors');
         url = url.replace('8888888', $.couponManager.conditionToUpdateIndex);
-        $('#condition-add-operators-values').html('<div class="loading" ></div>');
+        $errors.hide().empty();
 
         $.post(
             url,
             data
         ).done(function() {
-            $.couponManager.displayConditionsSummary();
             $('#condition-add-operators-values').html('');
             $('#condition-add-type').find('.typeToolTip').html('');
             // Set the condition selector to default
             $("#category-condition option").filter(function() {
                 return $(this).val() == '';
             }).prop('selected', true);
-        }).fail(function() {
-            $('#condition-add-operators-values').html(
-                $.couponManager.intlPleaseRetry
-            );
-        }).always(function() {
             $('#condition-save-btn').hide();
+        }).fail(function(jqXHR) {
+            // Keep the submitted inputs untouched, so that the user can fix them and retry.
+            $errors.text(
+                jqXHR.status === 400 && jqXHR.responseText
+                    ? jqXHR.responseText
+                    : $.couponManager.intlPleaseRetry
+            ).show();
+        }).always(function() {
             // Reload condition summaries ajax
             $.couponManager.displayConditionsSummary();
         });

--- a/templates/backOffice/default/coupon/form.html
+++ b/templates/backOffice/default/coupon/form.html
@@ -284,6 +284,8 @@
 
                         </div>
 
+                        <div id="condition-form-errors" class="alert alert-danger" style="display: none;"></div>
+
                         <a id="condition-save-btn" title="{intl l='Save this condition'}" class="btn btn-primary pull-right" data-toggle="confirm" data-script="">
                             <span class="glyphicon glyphicon-plus-sign"></span> {intl l='Save this condition'}
                         </a>


### PR DESCRIPTION
Saving a coupon condition in the back-office calls `ConditionFactory::build()`, which delegates to `ConditionInterface::setValidatorsFromForm()`. That method throws `InvalidConditionOperatorException` or `InvalidConditionValueException` on a missing or invalid parameter, and `CouponController::saveConditionsAction()` never caught them: any invalid entry ended up as a 500, and the admin only got a generic "please retry" message with the condition inputs wiped out.

The controller now catches both exceptions and answers 400 with a translated message, which the back-office displays above the save button while leaving the entered values in place so they can be corrected. `ConditionFactory::build()` also returns `false` when the submitted service id is unknown; that value used to be pushed into the condition collection and crashed on serialization, it is now a 404.

https://github.com/thelia/thelia/issues/396