### PR TITLE
ci: add stale workflow for inactive issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: '30 1 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues only, PRs are never touched
+          days-before-issue-stale: 365
+          days-before-issue-close: 60
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          stale-issue-label: stale
+          exempt-issue-labels: security,needs-decision,regression,pinned
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has had
+            no activity for 365 days. It will be closed in 60 days if no further
+            activity occurs. If this issue is still relevant, please leave a
+            comment to keep it open — that alone removes the stale label.
+            Thank you for your contributions.
+
+          close-issue-message: >
+            This issue has been closed due to inactivity. Feel free to reopen it
+            or open a new one if it is still relevant.
+
+          operations-per-run: 30
+          remove-stale-when-updated: true


### PR DESCRIPTION
Adds an `actions/stale` workflow scoped to issues only (PRs are excluded via `days-before-pr-stale: -1`).

Policy: issues are marked stale after 365 days of inactivity and closed 60 days later if untouched; any comment removes the `stale` label. Exempt labels: `security`, `needs-decision`, `regression`, `pinned`. Runs weekly (Monday), capped at 30 operations per run.

Follows up on the recent backlog cleanup (~80 → ~25 issues) to keep it from silently reaccumulating.

These thresholds and exempt labels are a starting point — open to discussion/adjustment before merging.