### PR TITLE
fix: keep the back office breadcrumb usable for untitled categories and folders

### DIFF
--- a/templates/backOffice/default/I18n/en_US.php
+++ b/templates/backOffice/default/I18n/en_US.php
@@ -1220,6 +1220,8 @@ return [
     'Unspecified' => 'Unspecified',
     'Unsupported field type \'%type\' in form-field.html' => 'Unsupported field type \'%type\' in form-field.html',
     'Untaxed total' => 'Untaxed total',
+    'Untitled category' => 'Untitled category',
+    'Untitled folder' => 'Untitled folder',
     'Update' => 'Update',
     'Update URL' => 'Update URL',
     'Update an administrator' => 'Update an administrator',

--- a/templates/backOffice/default/I18n/fr_FR.php
+++ b/templates/backOffice/default/I18n/fr_FR.php
@@ -1228,6 +1228,8 @@ return [
     'Unspecified' => 'Non mentionné',
     'Unsupported field type \'%type\' in form-field.html' => 'Le type de champ \'%type\' n\'est pas supporté par form-field.html ',
     'Untaxed total' => 'Total HT',
+    'Untitled category' => 'Catégorie sans titre',
+    'Untitled folder' => 'Dossier sans titre',
     'Update' => 'Mettre à jour',
     'Update URL' => 'URL de mise à jour',
     'Update an administrator' => 'Mettre à jour cet administrateur',

--- a/templates/backOffice/default/includes/catalog-breadcrumb.html
+++ b/templates/backOffice/default/includes/catalog-breadcrumb.html
@@ -5,17 +5,21 @@
 	<li><a href="{url path='admin/catalog'}">{intl l="Catalog"}</a></li>
 
 	{ifloop rel="category_path"}
-		{loop name="category_path" type="category-path" visible="*" category=$category_id}
+		{loop name="category_path" type="category-path" visible="*" backend_context="1" category=$category_id}
+			{assign var="category_title" value=$TITLE}
+			{if $category_title == ''}
+				{assign var="category_title" value={intl l='Untitled category'}}
+			{/if}
 			{if $ID == $category_id && $editing_product|default:false == false}
 				<li class="active">
 				   {if $editing_category|default:false == true}
-                       {intl l='Editing %cat' cat="{$TITLE}"} <a href="{url path='/admin/categories' category_id=$ID}" title="{intl l='Browse this category'}">{intl l="(browse)"}</a>
+                       {intl l='Editing %cat' cat="{$category_title}"} <a href="{url path='/admin/categories' category_id=$ID}" title="{intl l='Browse this category'}">{intl l="(browse)"}</a>
 				   {else}
-                       {$TITLE} <a href="{url path='/admin/categories/update' category_id=$ID}" title="{intl l='Edit this category'}">{intl l="(edit)"}</a>
+                       {$category_title} <a href="{url path='/admin/categories/update' category_id=$ID}" title="{intl l='Edit this category'}">{intl l="(edit)"}</a>
 			        {/if}
 				</li>
 			{else}
-			   <li><a href="{url path='/admin/categories' category_id="$ID" action='browse'}">{$TITLE}</a></li>
+			   <li><a href="{url path='/admin/categories' category_id="$ID" action='browse'}">{$category_title}</a></li>
 			{/if}
 	   {/loop}
 	{/ifloop}

--- a/templates/backOffice/default/includes/folder-breadcrumb.html
+++ b/templates/backOffice/default/includes/folder-breadcrumb.html
@@ -5,17 +5,21 @@
 	<li><a href="{url path='admin/folders'}">{intl l="Folders"}</a></li>
 
 	{ifloop rel="folder_path"}
-		{loop name="folder_path" type="folder-path" visible="*" folder=$folder_id}
+		{loop name="folder_path" type="folder-path" visible="*" backend_context="1" folder=$folder_id}
+			{assign var="folder_title" value=$TITLE}
+			{if $folder_title == ''}
+				{assign var="folder_title" value={intl l='Untitled folder'}}
+			{/if}
 			{if $ID == $parent|default:null}
 				<li class="active">
 				   {if $editing_folder|default:false == true}
-                       {intl l='Editing %fold' fold="{$TITLE}"}
+                       {intl l='Editing %fold' fold="{$folder_title}"}
 				   {else}
-                       {$TITLE} <a href="{url path="/admin/folders/update/%id" id=$ID}" title="{intl l='Edit this folder'}">{intl l="(edit)"}</a>
+                       {$folder_title} <a href="{url path="/admin/folders/update/%id" id=$ID}" title="{intl l='Edit this folder'}">{intl l="(edit)"}</a>
 			        {/if}
 				</li>
 			{else}
-			   <li><a href="{url path='/admin/folders' parent="$ID" }">{$TITLE}</a></li>
+			   <li><a href="{url path='/admin/folders' parent="$ID" }">{$folder_title}</a></li>
 			{/if}
 	   {/loop}
 	{/ifloop}


### PR DESCRIPTION
https://github.com/thelia/thelia/issues/3184

The catalog and folder breadcrumbs run the `category-path` / `folder-path` loops without `backend_context`, so they apply the front-office translation rule: a category with no title in the requested locale (and none in the default locale) is dropped from the result. The breadcrumb then renders empty and the `(edit)` link — the only way to reach the edit form from that page — disappears. Ancestors are affected too: the path walk stops at the first untitled category, truncating everything above it.

Both loops now run with `backend_context="1"`, which keeps untranslated rows, and the breadcrumb falls back to "Untitled category" / "Untitled folder" when the title is empty.

Reproduced on a 2.6 install with demo data: a visible category whose only `category_i18n` row is `fr_FR` while the back office runs in `en_US` (the default language) produced a breadcrumb with no entry at all; with the patch it shows "Untitled category (edit)". Same check done for folders and for a titled child of an untitled parent.