### PR TITLE
fix: render the delivery step again when its form fails validation

### DIFF
--- a/local/modules/Front/Controller/OrderController.php
+++ b/local/modules/Front/Controller/OrderController.php
@@ -229,6 +229,8 @@ class OrderController extends BaseFrontController
                 ->setGeneralError($message)
             ;
         }
+
+        return $this->render('order-delivery');
     }
 
     /**


### PR DESCRIPTION
https://github.com/thelia/thelia/issues/3317

`Front\Controller\OrderController::deliver()` returns nothing when `thelia_order_delivery` fails validation. The right template is only shown because the route that points to it carries a `_view` default (local/modules/Front/Config/front.xml:175). A module that declares its own route on `POST /order/delivery` shadows that route and its `_view` default; `ViewListener::findView()` then falls back to `index` and the shop home page is rendered in place of the delivery step, losing the form and its error message. This is what the PayPal module does with `#[Route('/order/delivery', methods: ['POST'])]` on `PayPalResponseController::executeExpressCheckoutAction()`, which returns `parent::deliver()` as-is.

`deliver()` now returns the `order-delivery` render explicitly on the error path, so the response no longer depends on the matched route. The success path still returns the redirect to `order.invoice`.

Reproduced on a 2.6 install: with a module route shadowing `POST /order/delivery`, an invalid delivery form rendered `<body class="page-home">` with no delivery form; with the patch it renders `<body class="page-order-delivery">` and shows "Please check your input: ...". The stock route was checked before and after and is unchanged.

Note that `invoice()` in the same controller ends the same way and would behave identically if a module shadowed `POST /order/invoice`; left alone here to keep the change to the reported case.