### PR TITLE
fix: reset PSE promo status once before the attribute loop in Sale

### DIFF
--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -119,7 +119,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
         $sale = $event->getSale();
 
         // Get all selected product sale elements for this sale
-        if (null === $sale || null === $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()) {
+        if (null === $sale || null === $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()->find()) {
             return;
         }
         $saleOffsetByCurrency = $sale->getPriceOffsets();
@@ -131,13 +131,25 @@ class Sale extends BaseAction implements EventSubscriberInterface
         $con->beginTransaction();
 
         try {
+            // A product is present once per selected attribute value, so the sale status of its PSE has to be
+            // reset once and for all before processing the selection. Doing it in the loop below would discard
+            // the promo status set by the previously processed attribute values of the same product.
+            $saleProductIds = [];
+
             /** @var SaleProduct $saleProduct */
             foreach ($saleProducts as $saleProduct) {
-                // Reset all sale status on product's PSE
-                ProductSaleElementsQuery::create()
-                    ->filterByProductId($saleProduct->getProductId())
-                    ->update(['Promo' => 0], $con);
+                $saleProductIds[$saleProduct->getProductId()] = $saleProduct->getProductId();
+            }
 
+            if ([] !== $saleProductIds) {
+                // Reset all sale status on the PSE of the sale's products
+                ProductSaleElementsQuery::create()
+                    ->filterByProductId($saleProductIds, Criteria::IN)
+                    ->update(['Promo' => 0], $con);
+            }
+
+            /** @var SaleProduct $saleProduct */
+            foreach ($saleProducts as $saleProduct) {
                 $taxCalculator->load(
                     $saleProduct->getProduct($con),
                     CountryModel::getShopLocation(),


### PR DESCRIPTION
Fixes https://github.com/thelia/thelia/issues/3491

Ports the fix from #3482 (branch 2.6): in `Sale::updateProductsSaleStatus()`, the PSE promo flag reset ran inside the loop over selected attribute values, so only the last processed attribute value of a product stayed on sale. The reset now runs once before the loop, as a single bulk update over the distinct product ids, and the sale products query is materialized with `->find()` so it can be iterated twice.