### PR TITLE
fix: remove invalid coupon codes from cart session

### DIFF
--- a/core/lib/Thelia/Domain/Promotion/Coupon/Service/CouponManager.php
+++ b/core/lib/Thelia/Domain/Promotion/Coupon/Service/CouponManager.php
@@ -17,6 +17,9 @@ namespace Thelia\Domain\Promotion\Coupon\Service;
 use Thelia\Condition\Exception\UnmatchableConditionException;
 use Thelia\Condition\Implementation\ConditionInterface;
 use Thelia\Domain\Promotion\Coupon\CouponFactory;
+use Thelia\Domain\Promotion\Coupon\Exception\CouponExpiredException;
+use Thelia\Domain\Promotion\Coupon\Exception\CouponNoUsageLeftException;
+use Thelia\Domain\Promotion\Coupon\Exception\InactiveCouponException;
 use Thelia\Domain\Promotion\Coupon\FacadeInterface;
 use Thelia\Domain\Promotion\Coupon\Type\CouponInterface;
 use Thelia\Log\Tlog;
@@ -81,13 +84,15 @@ class CouponManager
      */
     public function getCurrentCoupons(): array
     {
-        $couponCodes = $this->facade->getRequest()->getSession()->getConsumedCoupons();
+        $session = $this->facade->getRequest()->getSession();
+        $couponCodes = $session->getConsumedCoupons();
 
         if (null === $couponCodes) {
             return [];
         }
 
         $coupons = [];
+        $codesToRemove = [];
 
         foreach ($couponCodes as $couponCode) {
             // Only valid coupons are returned
@@ -95,12 +100,24 @@ class CouponManager
                 if (false !== $couponInterface = $this->couponFactory->buildCouponFromCode($couponCode)) {
                     $coupons[] = $couponInterface;
                 }
+            } catch (CouponExpiredException|InactiveCouponException|CouponNoUsageLeftException $ex) {
+                // The coupon can no longer become valid again in this session: remove it from the cart
+                // instead of leaving it there silently ignored on every calculation.
+                $codesToRemove[] = $couponCode;
+
+                Tlog::getInstance()->warning(
+                    \sprintf('Coupon %s removed from cart, exception occurred: %s', $couponCode, $ex->getMessage()),
+                );
             } catch (\Exception $ex) {
                 // Just ignore the coupon and log the problem, just in case someone realize it.
                 Tlog::getInstance()->warning(
                     \sprintf('Coupon %s ignored, exception occurred: %s', $couponCode, $ex->getMessage()),
                 );
             }
+        }
+
+        if ([] !== $codesToRemove) {
+            $session->setConsumedCoupons(array_values(array_diff($couponCodes, $codesToRemove)));
         }
 
         return $coupons;


### PR DESCRIPTION
When a coupon code applied to the cart later becomes definitively invalid (expired, disabled, or out of usages), `CouponManager::getCurrentCoupons()` silently ignored it on every recalculation instead of clearing it from the session. This ports the fix from 2.6 (thelia/thelia#3480) to the T3 `Domain/Promotion/Coupon` architecture: only the definitively-invalid states (`CouponExpiredException`, `InactiveCouponException`, `CouponNoUsageLeftException`) remove the code from session; recoverable states (future start date via `CouponNotReleaseException`, unmet condition such as login required via `UnmatchableConditionException`) are left untouched.

Fixes https://github.com/thelia/thelia/issues/3490