### PR TITLE
fix: resume update chain from the closest known version

### DIFF
--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -133,7 +133,41 @@ class Update
 
         $lastEntry = end($this->version);
 
-        return $lastEntry === $version;
+        return version_compare($lastEntry, $version, '<=');
+    }
+
+    /**
+     * Find the position of the current version in the update script list.
+     *
+     * Some releases ship without an update script, so the current version is not always part of
+     * that list. In that case, the update resumes from the closest known version below the
+     * current one instead of replaying every script from the beginning.
+     *
+     * @throws UpdateException when no known version precedes the current one
+     */
+    protected function getStartIndex(string $currentVersion): int
+    {
+        $index = array_search($currentVersion, $this->version, true);
+
+        if (false !== $index) {
+            return $index;
+        }
+
+        $closestIndex = null;
+
+        foreach ($this->version as $position => $knownVersion) {
+            if (version_compare($knownVersion, $currentVersion, '<=')) {
+                $closestIndex = $position;
+            }
+        }
+
+        if (null === $closestIndex) {
+            throw new UpdateException(
+                \sprintf('Unknown installed version "%s", unable to find where to start the update.', $currentVersion)
+            );
+        }
+
+        return $closestIndex;
     }
 
     public function process(): array
@@ -149,7 +183,7 @@ class Update
             throw new UpToDateException('You already have the latest version. No update available');
         }
 
-        $index = array_search($currentVersion, $this->version, true);
+        $index = $this->getStartIndex($currentVersion);
 
         $this->connection->beginTransaction();
 
@@ -159,7 +193,7 @@ class Update
         try {
             $size = \count($this->version);
 
-            for ($i = ++$index; $i < $size; ++$i) {
+            for ($i = $index + 1; $i < $size; ++$i) {
                 $version = $this->version[$i];
                 $this->updateToVersion($version, $database);
                 $this->updatedVersions[] = $version;

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -162,9 +162,7 @@ class Update
         }
 
         if (null === $closestIndex) {
-            throw new UpdateException(
-                \sprintf('Unknown installed version "%s", unable to find where to start the update.', $currentVersion)
-            );
+            throw new UpdateException(\sprintf('Unknown installed version "%s", unable to find where to start the update.', $currentVersion));
         }
 
         return $closestIndex;


### PR DESCRIPTION
Fixes #3485

Ports the resume-version fix from https://github.com/thelia/thelia/pull/3471 (branch `2.6`).

`Update::process()` located the installed version with `array_search()`. Releases that ship without their own update script are absent from that list, so the search returned `false`; `++$index` left it at `false` (PHP does not increment booleans, and warns about it since 8.1), and the loop replayed every script from `2.0.0-beta2`. The update now resumes from the closest known version below the installed one, via a new `getStartIndex()`, and throws an explicit `UpdateException` when there is none. `isLatestVersion()` now compares versions instead of strings, so a shop on a version newer than the last known script is correctly reported as up to date.

The `cdn.documents-base-url` / `cdn.assets-base-url` variable creation from the same 2.6 PR is not ported here: it needs a new `setup/update/sql/<next-version>.sql` script, and no T3 release number can be derived cleanly right now (`3.0.0-beta1` already shipped without an update script of its own — see report). Left for a follow-up once the next version number is decided.
