### PR TITLE
fix: purge old export cache files before each export

### DIFF
--- a/core/lib/Thelia/Domain/DataTransfer/EventListener/PurgeExportCacheListener.php
+++ b/core/lib/Thelia/Domain/DataTransfer/EventListener/PurgeExportCacheListener.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thelia\Domain\DataTransfer\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Thelia\Core\Event\Maintenance\MaintenancePurgeEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\DataTransfer\Service\ExportCachePurger;
+
+readonly class PurgeExportCacheListener
+{
+    public function __construct(private ExportCachePurger $exportCachePurger)
+    {
+    }
+
+    #[AsEventListener(event: TheliaEvents::MAINTENANCE_PURGE)]
+    public function onMaintenancePurge(MaintenancePurgeEvent $event): void
+    {
+        $deletedCount = $this->exportCachePurger->purgeOldExportFiles(THELIA_CACHE_DIR.'export'.DS);
+
+        $event->addResult(\sprintf(
+            '<comment>Export cache files:</comment> <info>%d deleted</info>',
+            $deletedCount
+        ));
+    }
+}

--- a/core/lib/Thelia/Domain/DataTransfer/EventListener/PurgeExportCacheListener.php
+++ b/core/lib/Thelia/Domain/DataTransfer/EventListener/PurgeExportCacheListener.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Domain\DataTransfer\EventListener;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;

--- a/core/lib/Thelia/Domain/DataTransfer/ExportHandler.php
+++ b/core/lib/Thelia/Domain/DataTransfer/ExportHandler.php
@@ -22,6 +22,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Serializer\SerializerInterface;
 use Thelia\Core\Translation\Translator;
 use Thelia\Domain\DataTransfer\Export\AbstractExport;
+use Thelia\Domain\DataTransfer\Service\ExportCachePurger;
 use Thelia\Model\Export;
 use Thelia\Model\ExportCategory;
 use Thelia\Model\ExportCategoryQuery;
@@ -35,8 +36,10 @@ use Thelia\Model\Lang;
  */
 class ExportHandler
 {
-    public function __construct(protected EventDispatcherInterface $eventDispatcher)
-    {
+    public function __construct(
+        protected EventDispatcherInterface $eventDispatcher,
+        protected ExportCachePurger $exportCachePurger,
+    ) {
     }
 
     public function getExport(int $exportId, bool $dispatchException = false): ?Export
@@ -178,6 +181,8 @@ class ExportHandler
 
         $fileSystem = new Filesystem();
         $fileSystem->mkdir(\dirname($filePath));
+
+        $this->exportCachePurger->purgeOldExportFiles(\dirname($filePath));
 
         $file = new \SplFileObject($filePath, 'w+b');
 

--- a/core/lib/Thelia/Domain/DataTransfer/Service/ExportCachePurger.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Service/ExportCachePurger.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Thelia\Domain\DataTransfer\Service;
 
 use Symfony\Component\Filesystem\Filesystem;

--- a/core/lib/Thelia/Domain/DataTransfer/Service/ExportCachePurger.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Service/ExportCachePurger.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thelia\Domain\DataTransfer\Service;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class ExportCachePurger
+{
+    private const EXPORT_CACHE_MAX_AGE_DAYS = 1;
+
+    public function purgeOldExportFiles(string $directory): int
+    {
+        if (!is_dir($directory)) {
+            return 0;
+        }
+
+        $finder = new Finder();
+        $finder->files()->in($directory)->date('before '.self::EXPORT_CACHE_MAX_AGE_DAYS.' days ago');
+
+        $fileSystem = new Filesystem();
+        $deletedCount = 0;
+
+        foreach ($finder as $oldExportFile) {
+            $fileSystem->remove($oldExportFile->getRealPath());
+            ++$deletedCount;
+        }
+
+        return $deletedCount;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/thelia/thelia/issues/3487

Ports the fix from thelia/thelia#3475 (2.6) to `main`: `ExportHandler::processExport()` now purges export cache files older than 1 day before writing a new export, so `cache/export/` no longer grows unbounded.

Adapted to T3 architecture: the purge logic lives in a new `Thelia\Domain\DataTransfer\Service\ExportCachePurger`, reused by an `#[AsEventListener]` on `TheliaEvents::MAINTENANCE_PURGE` (`PurgeExportCacheListener`) so the export cache is also cleaned up by `bin/console maintenance:purge`, alongside the existing cart/admin-log purges.