### PR TITLE
fix: align module:generate schema skeleton charset with core utf8mb4

### DIFF
--- a/core/lib/Thelia/Command/Skeleton/Module/schema.xml
+++ b/core/lib/Thelia/Command/Skeleton/Module/schema.xml
@@ -2,6 +2,12 @@
 <database defaultIdMethod="native" name="TheliaMain"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="%%XSD_LOCATION%%" >
+    <vendor type="mysql">
+        <parameter name="Engine" value="InnoDB"/>
+        <parameter name="Charset" value="utf8mb4"/>
+        <parameter name="Collate" value="utf8mb4_general_ci"/>
+        <parameter name="RowFormat" value="DYNAMIC"/>
+    </vendor>
     <!--
     See propel documentation on http://propelorm.org for all information about schema file
 


### PR DESCRIPTION
The `module:generate` skeleton schema (`core/lib/Thelia/Command/Skeleton/Module/schema.xml`) had no `<vendor>` charset block, so newly scaffolded modules inherited the MySQL server's default charset instead of Thelia's.

Core's own `local/config/schema.xml` now declares `utf8mb4`/`utf8mb4_general_ci`/`DYNAMIC` (#3445), so the skeleton is aligned on that instead of the plain `utf8` used for the equivalent Thelia 2.6 fix (thelia/thelia#3478).

Fixes https://github.com/thelia/thelia/issues/2843