### PR TITLE
fix: fall back to same-host check when multi-domain lang.url has no match

### DIFF
--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -251,7 +251,9 @@ class RequestListener implements EventSubscriberInterface
                         ->filterByUrl(sprintf('%s://%s', $components['scheme'], $components['host']), ModelCriteria::LIKE)
                         ->findOne();
 
-                    if (null !== $lang) {
+                    // Fall back to a same-host comparison when no lang.url matches the referrer
+                    // (e.g. lang URLs left empty), instead of silently dropping the previous URL.
+                    if (null !== $lang || str_contains($referrer, $request->getSchemeAndHttpHost())) {
                         $session->setReturnToUrl($referrer);
 
                         if (\in_array($view, $catalogViews)) {


### PR DESCRIPTION
With `one_domain_foreach_lang=1`, `RequestListener::registerPreviousUrl()` only recorded the referrer as the previous URL when a `lang` row's `url` matched the referrer's scheme and host. If `lang.url` values are left empty, no lang ever matches, so the previous URL is silently never recorded and every 'return to previous page' feature (`{navigate to=\"previous\"}`, login redirects) permanently falls back to the index page.

This now falls back to the same-host comparison used in single-domain mode when no `lang.url` matches, instead of dropping the referrer. Behavior is unchanged when a lang does match.

See https://github.com/thelia/thelia/issues/3497

Thelia 3 port: https://github.com/thelia/thelia/pull/3504