### PR TITLE
fix: fall back to same-host check when multi-domain lang.url has no match

### DIFF
--- a/core/lib/Thelia/Core/EventListener/RequestListener.php
+++ b/core/lib/Thelia/Core/EventListener/RequestListener.php
@@ -202,7 +202,9 @@ class RequestListener
                 ->filterByUrl(\sprintf('%s://%s', $components['scheme'], $components['host']), Criteria::LIKE)
                 ->findOne();
 
-            if (null === $lang) {
+            // Fall back to a same-host comparison when no lang.url matches the referrer
+            // (e.g. lang URLs left empty), instead of silently dropping the previous URL.
+            if (null === $lang && !str_contains($referrer, $request->getSchemeAndHttpHost())) {
                 return;
             }
 


### PR DESCRIPTION
With `one_domain_foreach_lang=1`, `RequestListener::registerPreviousUrl()` only recorded the referrer as the previous URL when a `lang` row's `url` matched the referrer's scheme and host. If `lang.url` values are left empty, no lang ever matches, so the previous URL is silently never recorded and every 'return to previous page' feature permanently falls back to the index page.

This now falls back to the same-host comparison used in single-domain mode when no `lang.url` matches, instead of returning early. Behavior is unchanged when a lang does match.

Port of #3503. Fixes #3497