### PR TITLE
fix: keep the current page when switching to another language domain

### DIFF
--- a/core/lib/Thelia/Domain/Localization/Service/LangService.php
+++ b/core/lib/Thelia/Domain/Localization/Service/LangService.php
@@ -21,10 +21,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\Routing\Rewriting\Exception\UrlRewritingException;
+use Thelia\Core\Routing\Rewriting\RewritingResolver;
 use Thelia\Model\Admin;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\LangQuery;
+use Thelia\Model\RewritingUrlQuery;
 
 readonly class LangService
 {
@@ -187,11 +190,54 @@ readonly class LangService
             return Lang::getDefaultLanguage();
         }
 
+        // If the language domain differs from the current one, redirect to it, keeping the
+        // current page when a translation of it exists for the target language.
         if (rtrim($domainUrl, '/') !== $request->getSchemeAndHttpHost()) {
-            return new RedirectResponse($domainUrl, Response::HTTP_MOVED_PERMANENTLY);
+            return new RedirectResponse(
+                $this->getTranslatedDomainUrl($request, $domainUrl, $lang),
+                Response::HTTP_MOVED_PERMANENTLY,
+            );
         }
 
         return $lang;
+    }
+
+    /**
+     * Resolve the current rewritten URL to its translation in the target language, so that
+     * switching domain keeps the visitor on the same page. Falls back to the bare domain URL
+     * when rewriting is disabled, when the current page has no rewritten URL, or when it has
+     * no translation in the target language.
+     */
+    private function getTranslatedDomainUrl(Request $request, string $domainUrl, Lang $lang): string
+    {
+        if (!ConfigQuery::isRewritingEnable()) {
+            return $domainUrl;
+        }
+
+        $currentPath = ltrim($request->getRealPathInfo(), '/');
+
+        if ('' === $currentPath) {
+            return $domainUrl;
+        }
+
+        try {
+            $currentUrl = new RewritingResolver($currentPath);
+        } catch (UrlRewritingException) {
+            return $domainUrl;
+        }
+
+        $translatedUrl = RewritingUrlQuery::create()
+            ->filterByView($currentUrl->view)
+            ->filterByViewId($currentUrl->viewId)
+            ->filterByViewLocale($lang->getLocale())
+            ->filterByRedirected(null, Criteria::ISNULL)
+            ->findOne();
+
+        if (null === $translatedUrl) {
+            return $domainUrl;
+        }
+
+        return rtrim($domainUrl, '/').'/'.$translatedUrl->getUrl();
     }
 
     private function getLanguageByDomain(Request $request): ?Lang

--- a/tests/Integration/Domain/Localization/LangServiceMultiDomainTest.php
+++ b/tests/Integration/Domain/Localization/LangServiceMultiDomainTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Localization;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Model\Category;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * With one_domain_foreach_lang enabled, switching language must keep the visitor on the
+ * page they were reading whenever that page has a translation on the target domain.
+ */
+final class LangServiceMultiDomainTest extends IntegrationTestCase
+{
+    private const CURRENT_DOMAIN = 'http://en.example.com';
+    private const TARGET_DOMAIN = 'http://fr.example.com';
+
+    private LangService $langService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->langService = new LangService(new RequestStack(), new NullLogger());
+
+        ConfigQuery::write('rewriting_enable', '1');
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+    }
+
+    protected function tearDown(): void
+    {
+        // ConfigQuery memoizes values in a static cache that would outlive the
+        // transaction rollback and leak into the next test.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testRedirectKeepsCurrentPageWhenATranslationExists(): void
+    {
+        $this->frenchLangOnTargetDomain();
+
+        $category = $this->createFixtureFactory()->category();
+        $englishUrl = $this->rewrittenUrl($category, 'en_US', 'Multi domain category');
+        $frenchUrl = $this->rewrittenUrl($category, 'fr_FR', 'Categorie multi domaine');
+
+        $response = $this->switchToFrench('/'.$englishUrl);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(self::TARGET_DOMAIN.'/'.$frenchUrl, $response->getTargetUrl());
+    }
+
+    public function testRedirectFallsBackToDomainRootWhenThePageHasNoTranslation(): void
+    {
+        $this->frenchLangOnTargetDomain();
+
+        $category = $this->createFixtureFactory()->category();
+        $englishUrl = $this->rewrittenUrl($category, 'en_US', 'Untranslated category');
+
+        self::assertNull($category->getRewrittenUrl('fr_FR'));
+
+        $response = $this->switchToFrench('/'.$englishUrl);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(self::TARGET_DOMAIN, $response->getTargetUrl());
+    }
+
+    public function testRedirectFallsBackToDomainRootWhenTheCurrentUrlIsUnknown(): void
+    {
+        $this->frenchLangOnTargetDomain();
+
+        $response = $this->switchToFrench('/no-such-page.html');
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(self::TARGET_DOMAIN, $response->getTargetUrl());
+    }
+
+    public function testRedirectFallsBackToDomainRootWhenRewritingIsDisabled(): void
+    {
+        ConfigQuery::write('rewriting_enable', '0');
+
+        $this->frenchLangOnTargetDomain();
+
+        $category = $this->createFixtureFactory()->category();
+        $englishUrl = $this->rewrittenUrl($category, 'en_US', 'Rewriting disabled category');
+        $this->rewrittenUrl($category, 'fr_FR', 'Categorie sans reecriture');
+
+        $response = $this->switchToFrench('/'.$englishUrl);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(self::TARGET_DOMAIN, $response->getTargetUrl());
+    }
+
+    private function switchToFrench(string $path): Lang|Response
+    {
+        return $this->langService->resolveFrontLanguageFromRequest(
+            Request::create(self::CURRENT_DOMAIN.$path.'?lang=fr'),
+        );
+    }
+
+    private function frenchLangOnTargetDomain(): Lang
+    {
+        $lang = LangQuery::create()->findOneByLocale('fr_FR')
+            ?? $this->createFixtureFactory()->lang(['title' => 'Français', 'code' => 'fr', 'locale' => 'fr_FR']);
+
+        $lang->setActive(true)->setUrl(self::TARGET_DOMAIN)->save();
+
+        return $lang;
+    }
+
+    private function rewrittenUrl(Category $category, string $locale, string $title): string
+    {
+        $category->setLocale($locale)->setTitle($title)->save();
+
+        return $category->getRewrittenUrl($locale)
+            ?? $category->generateRewrittenUrl($locale, $this->getPropelConnection());
+    }
+}


### PR DESCRIPTION
With `one_domain_foreach_lang` enabled, `LangService` redirected to the bare root of the target language's domain, dropping the page the visitor was reading. It now resolves the current rewritten URL and redirects to its translation on the target domain, falling back to the domain root when rewriting is disabled, when the current path has no rewritten URL, or when no translation exists for the target language.

Port of the 2.6 fix https://github.com/thelia/thelia/pull/3477 to the `Domain/Localization` service layer, plus an integration test covering the four cases.

The Flexy `LangSelect` half of the issue is not addressed here: `templates/frontOffice/flexy` is not tracked on `main` (gitignored), its canonical home is `thelia-templates/flexy`.

Fixes https://github.com/thelia/thelia/issues/3489
