### PR TITLE
fix: sanitize rewritten URLs in RewritingUrl::preInsert

### DIFF
--- a/core/lib/Thelia/Model/RewritingUrl.php
+++ b/core/lib/Thelia/Model/RewritingUrl.php
@@ -20,6 +20,9 @@ use Thelia\Model\Base\RewritingUrl as BaseRewritingUrl;
 
 class RewritingUrl extends BaseRewritingUrl
 {
+    public const REMOVE_HTML_CONFIG_KEY = 'admin.url.sanitizer.remove.html';
+    public const SPECIAL_CHARS_REGEXP_CONFIG_KEY = 'admin.url.sanitizer.special.chars.regexp.config.key';
+
     public function postInsert(?ConnectionInterface $con = null): void
     {
         parent::postInsert($con);
@@ -35,5 +38,186 @@ class RewritingUrl extends BaseRewritingUrl
                     'Redirected' => $this->getId(),
                 ]);
         }
+    }
+
+    public function preInsert(?ConnectionInterface $con = null): bool
+    {
+        parent::preInsert($con);
+
+        $sanitizedUrl = $this->unifyUrl($this->sanitizeUrl($this->getUrl() ?? ''));
+
+        $this->setUrl($sanitizedUrl);
+
+        return true;
+    }
+
+    protected function sanitizeUrl(string $url): string
+    {
+        // Unlike 2.6, T3's own URL generation (UrlRewritingTrait::generateRewrittenUrl())
+        // builds and resolves ".html"-suffixed candidates to detect slug collisions, so the
+        // default here keeps the extension untouched. Set the config key to enable stripping.
+        if (ConfigQuery::read(self::REMOVE_HTML_CONFIG_KEY, false)) {
+            $url = $this->removeHtmlExtension($url);
+        }
+
+        $sanitizedUrl = filter_var(
+            $this->replaceMultipleHyphens(
+                $this->replaceSpecialCharacter(
+                    $this->replaceSpace(
+                        $this->convertAccents($url)
+                    )
+                )
+            ),
+            \FILTER_SANITIZE_URL
+        );
+
+        return strtolower(\is_string($sanitizedUrl) ? $sanitizedUrl : $url);
+    }
+
+    protected function unifyUrl(string $cleanedUrl): string
+    {
+        $urlExist = RewritingUrlQuery::create()
+            ->filterByUrl($cleanedUrl)
+            ->filterById($this->getId(), Criteria::NOT_EQUAL)
+            ->findOne();
+
+        if (null === $urlExist) {
+            return $cleanedUrl;
+        }
+
+        return $this->unifyUrl($this->getViewId().'-'.$cleanedUrl);
+    }
+
+    protected function replaceSpace(string $string, string $replacement = '-'): string
+    {
+        return preg_replace('/\s+/', $replacement, $string) ?? $string;
+    }
+
+    protected function replaceMultipleHyphens(string $string, string $replacement = '-'): string
+    {
+        return preg_replace('/-+/', $replacement, $string) ?? $string;
+    }
+
+    protected function replaceSpecialCharacter(string $string, string $replacement = ''): string
+    {
+        return preg_replace(
+            '/'.ConfigQuery::read(
+                self::SPECIAL_CHARS_REGEXP_CONFIG_KEY,
+                '[^a-zA-Z0-9-\.]'
+            ).'/',
+            $replacement,
+            $string
+        ) ?? $string;
+    }
+
+    protected function removeHtmlExtension(string $string, string $replacement = ''): string
+    {
+        return str_ireplace('.html', $replacement, $string);
+    }
+
+    protected function convertAccents(string $string): string
+    {
+        if (!preg_match('/[\x80-\xff]/', $string)) {
+            return $string;
+        }
+
+        $chars = [
+            // Decompositions for Latin-1 Supplement
+            \chr(195).\chr(128) => 'A', \chr(195).\chr(129) => 'A',
+            \chr(195).\chr(130) => 'A', \chr(195).\chr(131) => 'A',
+            \chr(195).\chr(132) => 'A', \chr(195).\chr(133) => 'A',
+            \chr(195).\chr(135) => 'C', \chr(195).\chr(136) => 'E',
+            \chr(195).\chr(137) => 'E', \chr(195).\chr(138) => 'E',
+            \chr(195).\chr(139) => 'E', \chr(195).\chr(140) => 'I',
+            \chr(195).\chr(141) => 'I', \chr(195).\chr(142) => 'I',
+            \chr(195).\chr(143) => 'I', \chr(195).\chr(145) => 'N',
+            \chr(195).\chr(146) => 'O', \chr(195).\chr(147) => 'O',
+            \chr(195).\chr(148) => 'O', \chr(195).\chr(149) => 'O',
+            \chr(195).\chr(150) => 'O', \chr(195).\chr(153) => 'U',
+            \chr(195).\chr(154) => 'U', \chr(195).\chr(155) => 'U',
+            \chr(195).\chr(156) => 'U', \chr(195).\chr(157) => 'Y',
+            \chr(195).\chr(159) => 's', \chr(195).\chr(160) => 'a',
+            \chr(195).\chr(161) => 'a', \chr(195).\chr(162) => 'a',
+            \chr(195).\chr(163) => 'a', \chr(195).\chr(164) => 'a',
+            \chr(195).\chr(165) => 'a', \chr(195).\chr(167) => 'c',
+            \chr(195).\chr(168) => 'e', \chr(195).\chr(169) => 'e',
+            \chr(195).\chr(170) => 'e', \chr(195).\chr(171) => 'e',
+            \chr(195).\chr(172) => 'i', \chr(195).\chr(173) => 'i',
+            \chr(195).\chr(174) => 'i', \chr(195).\chr(175) => 'i',
+            \chr(195).\chr(177) => 'n', \chr(195).\chr(178) => 'o',
+            \chr(195).\chr(179) => 'o', \chr(195).\chr(180) => 'o',
+            \chr(195).\chr(181) => 'o', \chr(195).\chr(182) => 'o',
+            \chr(195).\chr(182) => 'o', \chr(195).\chr(185) => 'u',
+            \chr(195).\chr(186) => 'u', \chr(195).\chr(187) => 'u',
+            \chr(195).\chr(188) => 'u', \chr(195).\chr(189) => 'y',
+            \chr(195).\chr(191) => 'y',
+            // Decompositions for Latin Extended-A
+            \chr(196).\chr(128) => 'A', \chr(196).\chr(129) => 'a',
+            \chr(196).\chr(130) => 'A', \chr(196).\chr(131) => 'a',
+            \chr(196).\chr(132) => 'A', \chr(196).\chr(133) => 'a',
+            \chr(196).\chr(134) => 'C', \chr(196).\chr(135) => 'c',
+            \chr(196).\chr(136) => 'C', \chr(196).\chr(137) => 'c',
+            \chr(196).\chr(138) => 'C', \chr(196).\chr(139) => 'c',
+            \chr(196).\chr(140) => 'C', \chr(196).\chr(141) => 'c',
+            \chr(196).\chr(142) => 'D', \chr(196).\chr(143) => 'd',
+            \chr(196).\chr(144) => 'D', \chr(196).\chr(145) => 'd',
+            \chr(196).\chr(146) => 'E', \chr(196).\chr(147) => 'e',
+            \chr(196).\chr(148) => 'E', \chr(196).\chr(149) => 'e',
+            \chr(196).\chr(150) => 'E', \chr(196).\chr(151) => 'e',
+            \chr(196).\chr(152) => 'E', \chr(196).\chr(153) => 'e',
+            \chr(196).\chr(154) => 'E', \chr(196).\chr(155) => 'e',
+            \chr(196).\chr(156) => 'G', \chr(196).\chr(157) => 'g',
+            \chr(196).\chr(158) => 'G', \chr(196).\chr(159) => 'g',
+            \chr(196).\chr(160) => 'G', \chr(196).\chr(161) => 'g',
+            \chr(196).\chr(162) => 'G', \chr(196).\chr(163) => 'g',
+            \chr(196).\chr(164) => 'H', \chr(196).\chr(165) => 'h',
+            \chr(196).\chr(166) => 'H', \chr(196).\chr(167) => 'h',
+            \chr(196).\chr(168) => 'I', \chr(196).\chr(169) => 'i',
+            \chr(196).\chr(170) => 'I', \chr(196).\chr(171) => 'i',
+            \chr(196).\chr(172) => 'I', \chr(196).\chr(173) => 'i',
+            \chr(196).\chr(174) => 'I', \chr(196).\chr(175) => 'i',
+            \chr(196).\chr(176) => 'I', \chr(196).\chr(177) => 'i',
+            \chr(196).\chr(178) => 'IJ', \chr(196).\chr(179) => 'ij',
+            \chr(196).\chr(180) => 'J', \chr(196).\chr(181) => 'j',
+            \chr(196).\chr(182) => 'K', \chr(196).\chr(183) => 'k',
+            \chr(196).\chr(184) => 'k', \chr(196).\chr(185) => 'L',
+            \chr(196).\chr(186) => 'l', \chr(196).\chr(187) => 'L',
+            \chr(196).\chr(188) => 'l', \chr(196).\chr(189) => 'L',
+            \chr(196).\chr(190) => 'l', \chr(196).\chr(191) => 'L',
+            \chr(197).\chr(128) => 'l', \chr(197).\chr(129) => 'L',
+            \chr(197).\chr(130) => 'l', \chr(197).\chr(131) => 'N',
+            \chr(197).\chr(132) => 'n', \chr(197).\chr(133) => 'N',
+            \chr(197).\chr(134) => 'n', \chr(197).\chr(135) => 'N',
+            \chr(197).\chr(136) => 'n', \chr(197).\chr(137) => 'N',
+            \chr(197).\chr(138) => 'n', \chr(197).\chr(139) => 'N',
+            \chr(197).\chr(140) => 'O', \chr(197).\chr(141) => 'o',
+            \chr(197).\chr(142) => 'O', \chr(197).\chr(143) => 'o',
+            \chr(197).\chr(144) => 'O', \chr(197).\chr(145) => 'o',
+            \chr(197).\chr(146) => 'OE', \chr(197).\chr(147) => 'oe',
+            \chr(197).\chr(148) => 'R', \chr(197).\chr(149) => 'r',
+            \chr(197).\chr(150) => 'R', \chr(197).\chr(151) => 'r',
+            \chr(197).\chr(152) => 'R', \chr(197).\chr(153) => 'r',
+            \chr(197).\chr(154) => 'S', \chr(197).\chr(155) => 's',
+            \chr(197).\chr(156) => 'S', \chr(197).\chr(157) => 's',
+            \chr(197).\chr(158) => 'S', \chr(197).\chr(159) => 's',
+            \chr(197).\chr(160) => 'S', \chr(197).\chr(161) => 's',
+            \chr(197).\chr(162) => 'T', \chr(197).\chr(163) => 't',
+            \chr(197).\chr(164) => 'T', \chr(197).\chr(165) => 't',
+            \chr(197).\chr(166) => 'T', \chr(197).\chr(167) => 't',
+            \chr(197).\chr(168) => 'U', \chr(197).\chr(169) => 'u',
+            \chr(197).\chr(170) => 'U', \chr(197).\chr(171) => 'u',
+            \chr(197).\chr(172) => 'U', \chr(197).\chr(173) => 'u',
+            \chr(197).\chr(174) => 'U', \chr(197).\chr(175) => 'u',
+            \chr(197).\chr(176) => 'U', \chr(197).\chr(177) => 'u',
+            \chr(197).\chr(178) => 'U', \chr(197).\chr(179) => 'u',
+            \chr(197).\chr(180) => 'W', \chr(197).\chr(181) => 'w',
+            \chr(197).\chr(182) => 'Y', \chr(197).\chr(183) => 'y',
+            \chr(197).\chr(184) => 'Y', \chr(197).\chr(185) => 'Z',
+            \chr(197).\chr(186) => 'z', \chr(197).\chr(187) => 'Z',
+            \chr(197).\chr(188) => 'z', \chr(197).\chr(189) => 'Z',
+            \chr(197).\chr(190) => 'z', \chr(197).\chr(191) => 's',
+        ];
+
+        return strtr($string, $chars);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/thelia/thelia/issues/2344

Ports the native URL sanitization that `2.6` has since #3377: `RewritingUrl::preInsert()` now strips `%` and any character outside `[a-zA-Z0-9.-]` from every rewritten URL before insert, plus accent folding, hyphen/space normalization, and a duplicate-URL safety net (view-id prefix on collision).

Adaptation for `main`: the ported `.html`-extension-removal toggle defaults to **disabled** here (2.6 defaults it to enabled). T3's own `UrlRewritingTrait::generateRewrittenUrl()` builds and resolves `.html`-suffixed candidates to detect slug collisions, so forcing the extension off by default would silently break that mechanism (verified against the existing `testGenerateRewrittenUrlHandlesCollisions` integration test). The special-character stripping — the actual fix for the reported issue — is unaffected and matches 2.6 exactly.

Verified idempotent alongside the optional `UrlSanitizer` module (same algorithm, separate config keys): running both sanitizers back to back on an already-clean URL is a no-op.