### PR TITLE
fix: keep the template translation domain when a hook is rendered

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Hook.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Hook.php
@@ -42,6 +42,9 @@ class Hook extends AbstractSmartyPlugin
     /** @var Module */
     protected $smartyPluginModule;
 
+    /** @var Translation|null */
+    protected $smartyPluginTranslation;
+
     /** @var array */
     protected $hookResults = [];
 
@@ -55,12 +58,14 @@ class Hook extends AbstractSmartyPlugin
         $kernelDebug,
         EventDispatcherInterface $dispatcher,
         TranslatorInterface $translator,
-        Module $smartyPluginModule
+        Module $smartyPluginModule,
+        Translation $smartyPluginTranslation = null
     ) {
         $this->debug = $kernelDebug;
         $this->dispatcher = $dispatcher;
         $this->translator = $translator;
         $this->smartyPluginModule = $smartyPluginModule;
+        $this->smartyPluginTranslation = $smartyPluginTranslation;
         $this->hookResults = [];
     }
 
@@ -108,23 +113,31 @@ class Hook extends AbstractSmartyPlugin
             $eventName .= '.'.$module;
         }
 
-        $this->getDispatcher()->dispatch($event, $eventName);
+        // The templates rendered by the modules that listen to this hook may change the default
+        // translation domain and locale: this must not affect the template we are rendering.
+        $this->smartyPluginTranslation?->saveDefaults();
 
-        $content = trim($event->dump());
+        try {
+            $this->getDispatcher()->dispatch($event, $eventName);
 
-        if ($this->debug && $smarty->getRequest()->get('SHOW_HOOK')) {
-            $content = self::showHook(
-                $hookName,
-                $params,
-                $smarty->getTemplateVars()
-            ).$content;
-        }
+            $content = trim($event->dump());
 
-        $this->hookResults[$hookName] = $content;
+            if ($this->debug && $smarty->getRequest()->get('SHOW_HOOK')) {
+                $content = self::showHook(
+                    $hookName,
+                    $params,
+                    $smarty->getTemplateVars()
+                ).$content;
+            }
 
-        // support for compatibility with module_include
-        if ($type === TemplateDefinition::BACK_OFFICE) {
-            $content .= $this->moduleIncludeCompat($params, $smarty);
+            $this->hookResults[$hookName] = $content;
+
+            // support for compatibility with module_include
+            if ($type === TemplateDefinition::BACK_OFFICE) {
+                $content .= $this->moduleIncludeCompat($params, $smarty);
+            }
+        } finally {
+            $this->smartyPluginTranslation?->restoreDefaults();
         }
 
         return $content;
@@ -247,7 +260,14 @@ HTML;
             $eventName .= '.'.$module;
         }
 
-        $this->getDispatcher()->dispatch($event, $eventName);
+        // See processHookFunction() : the fragments are rendered by the modules during the dispatch.
+        $this->smartyPluginTranslation?->saveDefaults();
+
+        try {
+            $this->getDispatcher()->dispatch($event, $eventName);
+        } finally {
+            $this->smartyPluginTranslation?->restoreDefaults();
+        }
 
         // save results so we can use it in forHook block
         $this->hookResults[$hookName] = $event->get();

--- a/local/modules/TheliaSmarty/Template/Plugins/Translation.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Translation.php
@@ -25,6 +25,9 @@ class Translation extends AbstractSmartyPlugin
     protected $defaultTranslationDomain = '';
     protected $defaultLocale;
 
+    /** @var array saved default domain and locale, see saveDefaults() */
+    protected $savedDefaults = [];
+
     protected $protectedParams = [
         'l',
         'd',
@@ -53,6 +56,27 @@ class Translation extends AbstractSmartyPlugin
     public function setDefaultLocale(array $params): void
     {
         $this->defaultLocale = $this->getParam($params, 'locale');
+    }
+
+    /**
+     * Save the current default translation domain and locale, so that a template rendered
+     * in the meantime cannot change them for the rest of the current template.
+     */
+    public function saveDefaults(): void
+    {
+        $this->savedDefaults[] = [$this->defaultTranslationDomain, $this->defaultLocale];
+    }
+
+    /**
+     * Restore the default translation domain and locale saved by saveDefaults().
+     */
+    public function restoreDefaults(): void
+    {
+        if ([] === $this->savedDefaults) {
+            return;
+        }
+
+        [$this->defaultTranslationDomain, $this->defaultLocale] = array_pop($this->savedDefaults);
     }
 
     /**


### PR DESCRIPTION
A module template rendered by a hook can call `{default_translation_domain}`, which sets the domain globally on the `Translation` Smarty plugin: the rest of the page is then translated in the module domain, and the untranslated strings fall back to their source text.

The `hook` and `hookblock` plugins now save the default translation domain and locale before dispatching the hook event, and restore them once the modules have rendered their fragments. The save is stacked, so nested hooks behave the same.

`{include}` of a template that sets its own domain is unaffected by this change and still leaks; scoping the domain lexically is a larger change, discussed in https://github.com/thelia/thelia/issues/2065