### PR TITLE
fix: restore template definition even if mail rendering fails

### DIFF
--- a/core/lib/Thelia/Model/Message.php
+++ b/core/lib/Thelia/Model/Message.php
@@ -119,16 +119,21 @@ class Message extends BaseMessage
             $useFallbackTemplate
         );
 
-        $subject = $parser->renderString($this->getSubject());
-        $htmlMessage = $this->getHtmlMessageBody($parser);
-        $textMessage = $this->getTextMessageBody($parser);
+        try {
+            $subject = $parser->renderString($this->getSubject());
+            $htmlMessage = $this->getHtmlMessageBody($parser);
+            $textMessage = $this->getTextMessageBody($parser);
 
-        $messageInstance->subject($subject);
-        $messageInstance->text($textMessage);
-        $messageInstance->html($htmlMessage);
-
-        // Restore previous template
-        $parser->popTemplateDefinition();
+            $messageInstance->subject($subject);
+            $messageInstance->text($textMessage);
+            $messageInstance->html($htmlMessage);
+        } finally {
+            // Restore previous template, even if rendering failed: MailerFactory::sendEmailMessage()
+            // catches rendering exceptions so the request can go on, which would otherwise leave the
+            // parser stuck on the mail template definition for the rest of the request (e.g. a payment
+            // module rendering its own template right after order notification emails are sent).
+            $parser->popTemplateDefinition();
+        }
 
         return $messageInstance;
     }


### PR DESCRIPTION
Fixes https://github.com/thelia/thelia/issues/2751.

`Message::buildMessage()` calls `pushTemplateDefinition()` before rendering the subject/body/layout, then `popTemplateDefinition()` after. But `MailerFactory::sendEmailMessage()` wraps the whole rendering in a broad `catch (\Exception)` so a failed order-confirmation email doesn't stop the checkout. If rendering throws (bad Smarty syntax in a custom subject/message, a missing layout file, etc.), the pop never runs and the parser stays stuck on the mail template definition for the rest of the request.

In practice this hits right after checkout: notification emails are sent first, and the payment module that runs next can no longer find its own template, because the parser is still pointed at the mail template's directories.

Wraps the render calls in try/finally so popTemplateDefinition() always runs, whatever happens during rendering.