### PR TITLE
fix: bind full form data to customer create/update events

### DIFF
--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -155,6 +155,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerCreation, 'post');
 
                 $customerCreateEvent = $this->createEventInstance($form->getData());
+                $customerCreateEvent->bindForm($form->getForm());
 
                 $eventDispatcher->dispatch($customerCreateEvent, TheliaEvents::CUSTOMER_CREATEACCOUNT);
 
@@ -272,6 +273,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerPasswordUpdateForm, 'post');
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
+                $customerChangeEvent->bindForm($form->getForm());
                 $customerChangeEvent->setCustomer($customer);
                 $eventDispatcher->dispatch($customerChangeEvent, TheliaEvents::CUSTOMER_UPDATEPROFILE);
 
@@ -328,6 +330,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerProfileUpdateForm, 'post');
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
+                $customerChangeEvent->bindForm($form->getForm());
                 $customerChangeEvent->setCustomer($customer);
 
                 $customerChangeEvent->setEmailUpdateAllowed(


### PR DESCRIPTION
Front CustomerController::createEventInstance() builds CustomerCreateOrUpdateEvent from an explicit whitelist of `$form->getData()` keys, so a field added by a module listening on `FORM_BEFORE_BUILD . ".thelia_customer_create"` (or the profile update forms) never reaches the event — a listener on CUSTOMER_CREATEACCOUNT / CUSTOMER_UPDATEPROFILE has no way to read it.

ActionEvent already exposes a generic `bindForm(Form $form)` that copies every submitted field into the event, either through a matching setter or, for unknown fields, through a magic `__set`/`__get` bag — the same mechanism AbstractCrudController and CartController already rely on for this exact purpose.

This adds the missing `$event->bindForm($form->getForm())` call at the three CustomerController call sites (create, password update, profile update), so any extra field survives into the dispatched event and can be read back as `$event->myField`.

https://github.com/thelia/thelia/issues/2280