### PR TITLE
fix: prevent fatal TypeError when a hook is attached with the wrong event kind

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Hook.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Hook.php
@@ -118,7 +118,11 @@ class Hook extends AbstractSmartyPlugin
         $this->smartyPluginTranslation?->saveDefaults();
 
         try {
-            $this->getDispatcher()->dispatch($event, $eventName);
+            try {
+                $this->getDispatcher()->dispatch($event, $eventName);
+            } catch (\TypeError $exception) {
+                $this->logHookTypeMismatch($hookName, $eventName, $exception);
+            }
 
             $content = trim($event->dump());
 
@@ -264,13 +268,41 @@ HTML;
         $this->smartyPluginTranslation?->saveDefaults();
 
         try {
-            $this->getDispatcher()->dispatch($event, $eventName);
+            try {
+                $this->getDispatcher()->dispatch($event, $eventName);
+            } catch (\TypeError $exception) {
+                $this->logHookTypeMismatch($hookName, $eventName, $exception);
+            }
         } finally {
             $this->smartyPluginTranslation?->restoreDefaults();
         }
 
         // save results so we can use it in forHook block
         $this->hookResults[$hookName] = $event->get();
+    }
+
+    /**
+     * A module method can be attached to a hook of the wrong kind through the back-office
+     * hook management screens: a "simple" method (expecting a HookRenderEvent) attached to
+     * a "block" hook, or the reverse. Since HookRenderEvent and HookRenderBlockEvent are
+     * unrelated sibling classes, the dispatcher then calls the listener with the wrong event
+     * type, which PHP reports as a TypeError. Log it clearly and degrade instead of letting
+     * the whole page fail; in debug mode, re-throw so the misconfiguration stays visible.
+     *
+     * @throws \TypeError
+     */
+    protected function logHookTypeMismatch($hookName, $eventName, \TypeError $exception): void
+    {
+        Tlog::getInstance()->error(sprintf(
+            'Hook "%s" (event "%s") could not be rendered: a module method is attached to it with an incompatible event type (a "simple" method attached to a "block" hook, or vice-versa). %s',
+            $hookName,
+            $eventName,
+            $exception->getMessage()
+        ));
+
+        if ($this->debug) {
+            throw $exception;
+        }
     }
 
     /**


### PR DESCRIPTION
A hook code is rendered either as a "simple" hook (Smarty `{hook}`, dispatches `HookRenderEvent`) or a "block" hook (`{hookblock}`, dispatches `HookRenderBlockEvent`). These two event classes are unrelated siblings. The back-office "add module hook" screens let an admin attach any module method to any hook with no check that the method's event type matches the hook's kind, so a mismatched pairing can end up wired into the dispatcher and blow up with an uncaught TypeError as soon as the hook renders, taking down the whole page (BO and FO).

`TheliaSmarty\Template\Plugins\Hook` now catches that specific TypeError around the dispatch call in both `processHookFunction()` and `processHookBlock()`, logs a clear message identifying the offending hook, and degrades to an empty result instead of a fatal page. In debug mode it still re-throws, matching the existing error-handling convention already used a few lines below in the same class (`checkEmptyHook()`).

https://github.com/thelia/thelia/issues/2699