### PR TITLE
fix: consume coupons when the payment is confirmed, not when the order is created

### DIFF
--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -293,12 +293,10 @@ class Coupon extends BaseAction implements EventSubscriberInterface
                     $couponModel = $couponQuery->findOneByCode($couponCode->getCode());
                     $couponModel->setLocale($this->getSession()->getLang()->getLocale());
 
-                    /* decrease coupon quantity */
-                    $this->couponManager->decrementQuantity($couponModel, $event->getOrder()->getCustomerId());
-
-                    /* memorize coupon */
+                    /* memorize coupon. Its usage is not counted yet: this is done when the order is paid. */
                     $orderCoupon = new OrderCoupon();
                     $orderCoupon->setOrder($event->getOrder())
+                        ->setUsageCanceled(true)
                         ->setCode($couponModel->getCode())
                         ->setType($couponModel->getType())
                         ->setAmount($couponCode->exec())
@@ -356,8 +354,10 @@ class Coupon extends BaseAction implements EventSubscriberInterface
     }
 
     /**
-     * Cancels order coupons usage when order is canceled or refunded,
-     * or use canceled coupons again if the order is no longer canceled or refunded.
+     * Counts the usage of the coupons of an order as soon as the order is paid, and gives it back to
+     * the coupons when the order is no longer paid: canceled, refunded, or back to the "not paid" status.
+     *
+     * Any other status, a custom one for example, leaves the coupon usage count unchanged.
      *
      * @param string $eventName
      *
@@ -366,14 +366,16 @@ class Coupon extends BaseAction implements EventSubscriberInterface
      */
     public function orderStatusChange(OrderEvent $event, $eventName, EventDispatcherInterface $dispatcher): void
     {
-        // The order has been canceled or refunded ?
-        if ($event->getOrder()->isCancelled() || $event->getOrder()->isRefunded()) {
+        $order = $event->getOrder();
+
+        // The order is no longer paid ?
+        if ($order->isNotPaid() || $order->isCancelled() || $order->isRefunded()) {
             // Cancel usage of all coupons for this order
             $usedCoupons = OrderCouponQuery::create()
                 ->filterByUsageCanceled(false)
-                ->findByOrderId($event->getOrder()->getId());
+                ->findByOrderId($order->getId());
 
-            $customerId = $event->getOrder()->getCustomerId();
+            $customerId = $order->getCustomerId();
 
             /** @var OrderCoupon $usedCoupon */
             foreach ($usedCoupons as $usedCoupon) {
@@ -385,13 +387,13 @@ class Coupon extends BaseAction implements EventSubscriberInterface
                 // Mark coupon usage as canceled in the OrderCoupon table
                 $usedCoupon->setUsageCanceled(true)->save();
             }
-        } else {
-            // Mark canceled coupons for this order as used again
+        } elseif ($order->isPaid(false)) {
+            // Count the usage of the coupons which are not counted yet
             $usedCoupons = OrderCouponQuery::create()
                 ->filterByUsageCanceled(true)
-                ->findByOrderId($event->getOrder()->getId());
+                ->findByOrderId($order->getId());
 
-            $customerId = $event->getOrder()->getCustomerId();
+            $customerId = $order->getCustomerId();
 
             /** @var OrderCoupon $usedCoupon */
             foreach ($usedCoupons as $usedCoupon) {


### PR DESCRIPTION
`Action\Coupon::afterOrder()` is subscribed to `ORDER_BEFORE_PAYMENT`, which is dispatched by
`Action\Order::create()` right after the order row is written and before the payment module runs.
The coupon usage count was therefore decremented at order creation: a customer who gives up on the
payment page, or whose payment fails, loses the coupon for good, because an order left in the
`not_paid` status never triggers the compensation done in `orderStatusChange()`.

The usage count is now handled entirely by `orderStatusChange()`:

- `afterOrder()` only memorizes the coupon in `order_coupon`, with `usage_canceled = true` — the
  coupon is recorded on the order but its usage is not counted yet.
- the usage is counted when the order becomes paid (`paid`, `processing` or `sent`), and given back
  when the order is no longer paid: `canceled`, `refunded`, or back to `not_paid` (which is what
  `BasePaymentModuleController::cancelPayment()` does). Any other status, a custom one for example,
  leaves the count unchanged.

Payment modules need no change: they already report the payment through `ORDER_UPDATE_STATUS`.
Existing rows need no migration, as the `usage_canceled` flag they carry already reflects whether
their usage is counted.

Note that between order creation and payment confirmation, the coupon keeps its remaining usages,
so a single-use coupon can be applied to two orders started in that window. This is the expected
consequence of counting a usage only once the money is in.


The `usage_canceled` column is business logic, no shipped template reads it, but it is exposed as the
`IS_USAGE_CANCELED` output field of the `order-coupon` loop and as `usageCanceled` on the API
resource: code reading either will now see `true` for the coupons of an order still awaiting payment,
meaning "this usage is not counted", not "the merchant canceled it".

https://github.com/thelia/thelia/issues/2195