### PR TITLE
fix: refresh cart item prices and special offer status when a cart is restored

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -181,6 +181,19 @@ class Cart extends BaseAction implements EventSubscriberInterface
      */
     public function updateCartPrices(CartModel $cart, CurrencyModel $currency): void
     {
+        $this->refreshCartItemPrices($cart, $currency);
+
+        // update the currency cart
+        $cart->setCurrencyId($currency->getId());
+        $cart->save();
+    }
+
+    /**
+     * Update the price, the promo price and the special offer status of the items of a cart, so that
+     * they always reflect the current catalog prices, in the given currency.
+     */
+    protected function refreshCartItemPrices(CartModel $cart, CurrencyModel $currency): void
+    {
         $customer = $cart->getCustomer();
         $discount = 0;
 
@@ -192,18 +205,25 @@ class Cart extends BaseAction implements EventSubscriberInterface
         foreach ($cart->getCartItems() as $cartItem) {
             $productSaleElements = $cartItem->getProductSaleElements();
 
+            if (null === $productSaleElements) {
+                continue;
+            }
+
             $productPrice = $productSaleElements->getPricesByCurrency($currency, $discount);
+
+            // Nothing changed in the catalog, leave this item alone.
+            if ((float) $cartItem->getPrice() === (float) $productPrice->getPrice()
+                && (float) $cartItem->getPromoPrice() === (float) $productPrice->getPromoPrice()
+                && (int) $cartItem->getPromo() === (int) $productSaleElements->getPromo()) {
+                continue;
+            }
 
             $cartItem
                 ->setPrice($productPrice->getPrice())
-                ->setPromoPrice($productPrice->getPromoPrice());
-
-            $cartItem->save();
+                ->setPromoPrice($productPrice->getPromoPrice())
+                ->setPromo($productSaleElements->getPromo())
+                ->save();
         }
-
-        // update the currency cart
-        $cart->setCurrencyId($currency->getId());
-        $cart->save();
     }
 
     /**
@@ -320,6 +340,13 @@ class Cart extends BaseAction implements EventSubscriberInterface
         if ($cart->getCurrency()) {
             $this->getSession()->setCurrency($cart->getCurrency());
         }
+
+        // A restored cart may have been created a long time ago: bring the price and the special offer
+        // status of its items back in line with the current catalog.
+        if (!$cart->isNew()) {
+            $this->refreshCartItemPrices($cart, $cart->getCurrency() ?: $this->getSession()->getCurrency(true));
+        }
+
         $cartRestoreEvent->setCart($cart);
     }
 


### PR DESCRIPTION
`cart_item` stores the price, the promo price and the promo flag of a product at the moment it is
added to the cart, and nothing refreshed them for a returning visitor: the cart cookie lives for a
year, `updateCartPrices()` only ran on a currency change, and `Cart::duplicate()` only runs when a
customer logs in. A visitor coming back after the catalog changed was therefore charged the price of
a special offer that had ended, or paid full price for a product now on offer, since
`Action\Order::createOrder()` copies those columns into `order_product`.

`Action\Cart::restoreCurrentCart()` now refreshes the items of a restored cart from the catalog,
through the new `refreshCartItemPrices()` extracted from `updateCartPrices()`. Items whose price and
offer status still match the catalog are left untouched, so no write happens when nothing changed.

`updateCartPrices()` also refreshes the promo flag now: on a currency change it used to update both
prices while keeping a stale flag, which billed the promo price of a product no longer on offer.

Returning visitors will see the cart total follow the catalog, which is the point of the fix, and is
already what happens today when a customer with a discount logs in.

https://github.com/thelia/thelia/issues/1719
