### PR TITLE
fix: consume coupons when the payment is confirmed, not when the order is created

### DIFF
--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -283,12 +283,10 @@ class Coupon extends BaseAction implements EventSubscriberInterface
                 $couponModel = $couponQuery->findOneByCode($couponCode->getCode());
                 $couponModel->setLocale($this->getSession()?->getLang()?->getLocale());
 
-                /* decrease coupon quantity */
-                $this->couponManager->decrementQuantity($couponModel, $event->getOrder()?->getCustomerId());
-
-                /* memorize coupon */
+                /* memorize coupon. Its usage is not counted yet: this is done when the order is paid. */
                 $orderCoupon = new OrderCoupon();
                 $orderCoupon->setOrder($event->getOrder())
+                    ->setUsageCanceled(1)
                     ->setCode($couponModel->getCode())
                     ->setType($couponModel->getType())
                     ->setAmount((string) $couponCode->exec())
@@ -342,22 +340,26 @@ class Coupon extends BaseAction implements EventSubscriberInterface
     }
 
     /**
-     * Cancels order coupons usage when order is canceled or refunded,
-     * or use canceled coupons again if the order is no longer canceled or refunded.
+     * Counts the usage of the coupons of an order as soon as the order is paid, and gives it back to
+     * the coupons when the order is no longer paid: canceled, refunded, or back to the "not paid" status.
+     *
+     * Any other status, a custom one for example, leaves the coupon usage count unchanged.
      *
      * @throws \Exception
      * @throws PropelException
      */
     public function orderStatusChange(OrderEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
     {
-        // The order has been canceled or refunded ?
-        if ($event->getOrder()->isCancelled() || $event->getOrder()->isRefunded()) {
+        $order = $event->getOrder();
+
+        // The order is no longer paid ?
+        if ($order->isNotPaid() || $order->isCancelled() || $order->isRefunded()) {
             // Cancel usage of all coupons for this order
             $usedCoupons = OrderCouponQuery::create()
                 ->filterByUsageCanceled(false)
-                ->findByOrderId($event->getOrder()->getId());
+                ->findByOrderId($order->getId());
 
-            $customerId = $event->getOrder()->getCustomerId();
+            $customerId = $order->getCustomerId();
 
             /** @var OrderCoupon $usedCoupon */
             foreach ($usedCoupons as $usedCoupon) {
@@ -369,13 +371,13 @@ class Coupon extends BaseAction implements EventSubscriberInterface
                 // Mark coupon usage as canceled in the OrderCoupon table
                 $usedCoupon->setUsageCanceled(1)->save();
             }
-        } else {
-            // Mark canceled coupons for this order as used again
+        } elseif ($order->isPaid(false)) {
+            // Count the usage of the coupons which are not counted yet
             $usedCoupons = OrderCouponQuery::create()
                 ->filterByUsageCanceled(true)
-                ->findByOrderId($event->getOrder()->getId());
+                ->findByOrderId($order->getId());
 
-            $customerId = $event->getOrder()->getCustomerId();
+            $customerId = $order->getCustomerId();
 
             /** @var OrderCoupon $usedCoupon */
             foreach ($usedCoupons as $usedCoupon) {

--- a/tests/Integration/Action/CouponActionTest.php
+++ b/tests/Integration/Action/CouponActionTest.php
@@ -16,9 +16,15 @@ namespace Thelia\Tests\Integration\Action;
 
 use Thelia\Core\Event\Coupon\CouponCreateOrUpdateEvent;
 use Thelia\Core\Event\Coupon\CouponDeleteEvent;
+use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\Coupon;
 use Thelia\Model\CouponQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderCoupon;
+use Thelia\Model\OrderCouponQuery;
+use Thelia\Model\OrderStatus;
+use Thelia\Model\OrderStatusQuery;
 use Thelia\Test\ActionIntegrationTestCase;
 
 final class CouponActionTest extends ActionIntegrationTestCase
@@ -56,6 +62,83 @@ final class CouponActionTest extends ActionIntegrationTestCase
         $this->dispatch($event, TheliaEvents::COUPON_DELETE);
 
         self::assertNull(CouponQuery::create()->findPk($couponId));
+    }
+
+    public function testUsageIsCountedWhenTheOrderIsPaid(): void
+    {
+        $coupon = $this->factory->coupon(['code' => 'PAID-CPN', 'maxUsage' => 1]);
+        $order = $this->factory->order();
+        $orderCoupon = $this->rememberCouponOnOrder($order, $coupon);
+
+        $this->moveOrderTo($order, OrderStatus::CODE_PAID);
+
+        self::assertSame(0, CouponQuery::create()->findPk($coupon->getId())->getMaxUsage());
+        self::assertFalse((bool) OrderCouponQuery::create()->findPk($orderCoupon->getId())->getUsageCanceled());
+    }
+
+    public function testUsageIsNotCountedWhenThePaymentIsAbandoned(): void
+    {
+        $coupon = $this->factory->coupon(['code' => 'UNPAID-CPN', 'maxUsage' => 1]);
+        $order = $this->factory->order();
+        $orderCoupon = $this->rememberCouponOnOrder($order, $coupon);
+
+        // What BasePaymentModuleController::cancelPayment() does when the payment fails.
+        $this->moveOrderTo($order, OrderStatus::CODE_NOT_PAID);
+
+        self::assertSame(1, CouponQuery::create()->findPk($coupon->getId())->getMaxUsage());
+        self::assertTrue((bool) OrderCouponQuery::create()->findPk($orderCoupon->getId())->getUsageCanceled());
+    }
+
+    public function testUsageIsGivenBackWhenAPaidOrderIsCanceled(): void
+    {
+        $coupon = $this->factory->coupon(['code' => 'CANCEL-CPN', 'maxUsage' => 1]);
+        $order = $this->factory->order();
+        $orderCoupon = $this->rememberCouponOnOrder($order, $coupon);
+
+        $this->moveOrderTo($order, OrderStatus::CODE_PAID);
+        $this->moveOrderTo($order, OrderStatus::CODE_CANCELED);
+
+        self::assertSame(1, CouponQuery::create()->findPk($coupon->getId())->getMaxUsage());
+        self::assertTrue((bool) OrderCouponQuery::create()->findPk($orderCoupon->getId())->getUsageCanceled());
+    }
+
+    /**
+     * Records a coupon on an order the way Action\Coupon::afterOrder() does on ORDER_BEFORE_PAYMENT:
+     * the coupon is remembered, but its usage is not counted yet.
+     */
+    private function rememberCouponOnOrder(Order $order, Coupon $coupon): OrderCoupon
+    {
+        $orderCoupon = new OrderCoupon();
+        $orderCoupon
+            ->setOrder($order)
+            ->setUsageCanceled(1)
+            ->setCode($coupon->getCode())
+            ->setType($coupon->getType())
+            ->setAmount('5')
+            ->setTitle($coupon->getTitle())
+            ->setShortDescription($coupon->getShortDescription())
+            ->setDescription($coupon->getDescription())
+            ->setStartDate($coupon->getStartDate())
+            ->setExpirationDate($coupon->getExpirationDate())
+            ->setIsCumulative($coupon->getIsCumulative())
+            ->setIsRemovingPostage($coupon->getIsRemovingPostage())
+            ->setIsAvailableOnSpecialOffers($coupon->getIsAvailableOnSpecialOffers())
+            ->setSerializedConditions($coupon->getSerializedConditions())
+            ->setPerCustomerUsageCount($coupon->getPerCustomerUsageCount())
+            ->save();
+
+        return $orderCoupon;
+    }
+
+    private function moveOrderTo(Order $order, string $statusCode): void
+    {
+        $status = OrderStatusQuery::create()->findOneByCode($statusCode);
+        self::assertNotNull($status, "Seeded order status '$statusCode' is missing.");
+
+        $event = new OrderEvent($order);
+        $event->setStatus($status->getId());
+
+        $this->dispatch($event, TheliaEvents::ORDER_UPDATE_STATUS);
     }
 
     /**


### PR DESCRIPTION
Port of https://github.com/thelia/thelia/pull/3522 to Thelia 3, where `Action\Coupon` has the same
wiring: `afterOrder()` on `ORDER_BEFORE_PAYMENT` decremented the coupon usage count at order
creation, so a customer who gave up on the payment page, or whose payment failed, lost the coupon —
an order left in the `not_paid` status never reaches the compensation done in `orderStatusChange()`.

The usage count is now handled entirely by `orderStatusChange()`: `afterOrder()` only records the
coupon in `order_coupon` with `usage_canceled = 1`, the usage is counted when the order becomes paid
(`paid`, `processing`, `sent`) and given back when it is `canceled`, `refunded` or back to
`not_paid`. Any other status leaves the count unchanged. Payment modules need no change, and existing
rows need no migration.

Three integration tests in `CouponActionTest` cover the paid, abandoned-payment and cancel-after-paid
transitions.


The `usage_canceled` column is business logic, no shipped template reads it, but it is exposed as the
`IS_USAGE_CANCELED` output field of the `order-coupon` loop and as `usageCanceled` on the API
resource: code reading either will now see `1` for the coupons of an order still awaiting payment,
meaning "this usage is not counted", not "the merchant canceled it".

https://github.com/thelia/thelia/issues/2195