### PR TITLE
fix: refresh cart item prices and special offer status when a cart is restored

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -328,6 +328,19 @@ class Cart extends BaseAction implements EventSubscriberInterface
      */
     public function updateCartPrices(CartModel $cart, CurrencyModel $currency): void
     {
+        $this->refreshCartItemPrices($cart, $currency);
+
+        // update the currency cart
+        $cart->setCurrencyId($currency->getId());
+        $cart->save();
+    }
+
+    /**
+     * Update the price, the promo price and the special offer status of the items of a cart, so that
+     * they always reflect the current catalog prices, in the given currency.
+     */
+    protected function refreshCartItemPrices(CartModel $cart, CurrencyModel $currency): void
+    {
         $customer = $cart->getCustomer();
         $discount = 0;
 
@@ -339,18 +352,25 @@ class Cart extends BaseAction implements EventSubscriberInterface
         foreach ($cart->getCartItems() as $cartItem) {
             $productSaleElements = $cartItem->getProductSaleElements();
 
+            if (null === $productSaleElements) {
+                continue;
+            }
+
             $productPrice = $productSaleElements->getPricesByCurrency($currency, $discount);
+
+            // Nothing changed in the catalog, leave this item alone.
+            if ((float) $cartItem->getPrice() === (float) $productPrice->getPrice()
+                && (float) $cartItem->getPromoPrice() === (float) $productPrice->getPromoPrice()
+                && (int) $cartItem->getPromo() === (int) $productSaleElements->getPromo()) {
+                continue;
+            }
 
             $cartItem
                 ->setPrice((string) $productPrice->getPrice())
-                ->setPromoPrice((string) $productPrice->getPromoPrice());
-
-            $cartItem->save();
+                ->setPromoPrice((string) $productPrice->getPromoPrice())
+                ->setPromo($productSaleElements->getPromo())
+                ->save();
         }
-
-        // update the currency cart
-        $cart->setCurrencyId($currency->getId());
-        $cart->save();
     }
 
     /**
@@ -456,6 +476,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
         if ($cart->getCurrency()) {
             $this->getSession()->setCurrency($cart->getCurrency());
+        }
+
+        // A restored cart may have been created a long time ago: bring the price and the special offer
+        // status of its items back in line with the current catalog.
+        if (!$cart->isNew()) {
+            $this->refreshCartItemPrices($cart, $cart->getCurrency() ?: $this->getSession()->getCurrency(true));
         }
 
         $cartRestoreEvent->setCart($cart);

--- a/tests/Integration/Action/CartActionTest.php
+++ b/tests/Integration/Action/CartActionTest.php
@@ -189,6 +189,38 @@ final class CartActionTest extends ActionIntegrationTestCase
         self::assertNotSame($cart->getToken(), $restored->getToken());
     }
 
+    public function testRestoreCurrentCartRealignsItemPricesWithTheCatalog(): void
+    {
+        $cart = $this->factory->cart();
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+            ['baseQuantity' => 100],
+        );
+        $pse = $this->defaultPseFor($product->getId());
+        $this->dispatchAddItem($cart, $product->getId(), $pse->getId(), 1);
+
+        // The item was added while the product was on a special offer, which has since ended.
+        $item = CartItemQuery::create()->filterByCartId($cart->getId())->findOne();
+        $item->setPromo(1)->setPromoPrice('4.44')->save();
+        self::assertSame(4.44, $item->getRealPrice());
+
+        $this->mainRequest()->cookies->set(
+            ConfigQuery::read('cart.cookie_name', 'thelia_cart'),
+            $cart->getToken(),
+        );
+
+        $this->dispatch(new CartRestoreEvent(), TheliaEvents::CART_RESTORE_CURRENT);
+
+        $catalogPrice = $pse->getPricesByCurrency($cart->getCurrency(), 0);
+        $item->reload();
+
+        self::assertSame(0, (int) $item->getPromo());
+        self::assertSame((float) $catalogPrice->getPromoPrice(), (float) $item->getPromoPrice());
+        self::assertSame((float) $catalogPrice->getPrice(), $item->getRealPrice());
+    }
+
     public function testDuplicateAcceptsANullTokenWhenTheCartCookieIsDisabled(): void
     {
         $cart = $this->newEmptyCart();


### PR DESCRIPTION
Port of https://github.com/thelia/thelia/pull/3523 to Thelia 3, where `Action\Cart` has the same
behaviour: the price, promo price and promo flag snapshotted in `cart_item` were never refreshed for
a returning visitor, so the order created from that cart billed a special offer that had ended, or
full price for a product now on offer.

`restoreCurrentCart()` now realigns the items of a restored cart with the catalog, through the new
`refreshCartItemPrices()` extracted from `updateCartPrices()`. Items that still match the catalog are
left untouched, so no write happens when nothing changed. `updateCartPrices()` also refreshes the
promo flag now: on a currency change it used to update both prices while keeping a stale flag.

Covered by a new integration test in `CartActionTest`.

https://github.com/thelia/thelia/issues/1719
