### PR TITLE
fix: look up the session on each token access so cart item updates work

### DIFF
--- a/core/lib/Thelia/Tools/TokenProvider.php
+++ b/core/lib/Thelia/Tools/TokenProvider.php
@@ -34,14 +34,14 @@ class TokenProvider
         protected TranslatorInterface $translator,
         string $tokenName = null
     ) {
-        $this->setSessionFromRequest();
         $this->tokenName = $tokenName;
-
-        if (null !== $this->session && null !== $this->tokenName) {
-            $this->token = $this->session->get($this->tokenName);
-        }
+        $this->token = $this->getStoredToken();
     }
 
+    /**
+     * The session is not necessarily available when this service is instantiated, so it has
+     * to be looked up again on each access.
+     */
     private function setSessionFromRequest(): void
     {
         $currentRequest = $this->requestStack?->getCurrentRequest();
@@ -53,19 +53,38 @@ class TokenProvider
         }
     }
 
+    private function getStoredToken(): ?string
+    {
+        $this->setSessionFromRequest();
+
+        if (null === $this->session || null === $this->tokenName) {
+            return null;
+        }
+
+        return $this->session->get($this->tokenName);
+    }
+
+    private function storeToken(string $token): void
+    {
+        $this->setSessionFromRequest();
+
+        $this->token = $token;
+
+        if (null !== $this->tokenName) {
+            $this->session?->set($this->tokenName, $token);
+        }
+    }
+
     /**
      * @throws RandomException
      */
     public function assignToken(): ?string
     {
-        if (null !== $this->token) {
-            return $this->token;
+        if (null !== $storedToken = $this->getStoredToken()) {
+            return $this->token = $storedToken;
         }
 
-        $this->token = $this->getToken();
-        if (null !== $this->tokenName) {
-            $this->session?->set($this->tokenName, $this->token);
-        }
+        $this->storeToken($this->token ?? $this->getToken());
 
         return $this->token;
     }
@@ -75,6 +94,8 @@ class TokenProvider
      */
     public function checkToken(?string $entryValue): bool
     {
+        $this->token = $this->getStoredToken() ?? $this->token;
+
         if (null === $this->token) {
             throw new TokenAuthenticationException(
                 'Tried to check a token without assigning it before'
@@ -89,10 +110,12 @@ class TokenProvider
         return true;
     }
 
+    /**
+     * @throws RandomException
+     */
     protected function refreshToken(): void
     {
-        $this->token = null;
-        $this->assignToken();
+        $this->storeToken($this->getToken());
     }
 
     /**

--- a/tests/Unit/Tools/TokenProviderTest.php
+++ b/tests/Unit/Tools/TokenProviderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Tools;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Thelia\Core\Security\Exception\TokenAuthenticationException;
+use Thelia\Tools\TokenProvider;
+
+final class TokenProviderTest extends TestCase
+{
+    private const TOKEN_NAME = 'thelia.token_provider';
+
+    public function testTokenIsStoredInASessionThatAppearsAfterInstantiation(): void
+    {
+        // The service is often built before the session is started, e.g. while the
+        // kernel.request listeners are being instantiated.
+        $requestStack = new RequestStack();
+        $tokenProvider = $this->createTokenProvider($requestStack);
+
+        $session = $this->pushRequestWithSession($requestStack);
+
+        $token = $tokenProvider->assignToken();
+
+        self::assertSame($token, $session->get(self::TOKEN_NAME));
+    }
+
+    public function testTokenAssignedOnAPreviousRequestIsAccepted(): void
+    {
+        $requestStack = new RequestStack();
+        $tokenProvider = $this->createTokenProvider($requestStack);
+
+        $session = $this->pushRequestWithSession($requestStack);
+        $session->set(self::TOKEN_NAME, 'a-token-assigned-before');
+
+        self::assertTrue($tokenProvider->checkToken('a-token-assigned-before'));
+    }
+
+    public function testAnInvalidTokenIsRejected(): void
+    {
+        $requestStack = new RequestStack();
+        $tokenProvider = $this->createTokenProvider($requestStack);
+
+        $session = $this->pushRequestWithSession($requestStack);
+        $session->set(self::TOKEN_NAME, 'a-token-assigned-before');
+
+        $this->expectException(TokenAuthenticationException::class);
+
+        $tokenProvider->checkToken('another-token');
+    }
+
+    public function testAMissingTokenIsRejected(): void
+    {
+        $requestStack = new RequestStack();
+        $tokenProvider = $this->createTokenProvider($requestStack);
+
+        $this->pushRequestWithSession($requestStack);
+
+        $this->expectException(TokenAuthenticationException::class);
+
+        $tokenProvider->checkToken('any-token');
+    }
+
+    private function createTokenProvider(RequestStack $requestStack): TokenProvider
+    {
+        return new TokenProvider(
+            $requestStack,
+            $this->createMock(TranslatorInterface::class),
+            self::TOKEN_NAME
+        );
+    }
+
+    private function pushRequestWithSession(RequestStack $requestStack): Session
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+
+        $request = new Request();
+        $request->setSession($session);
+
+        $requestStack->push($request);
+
+        return $session;
+    }
+}


### PR DESCRIPTION
Updating or removing a cart item does nothing and logs `Tried to check a token without assigning it before` (https://github.com/thelia/thelia/issues/3376).

`Thelia\Tools\TokenProvider` captured the session once, in its constructor, and kept it for the whole request. When the service is built before `KernelListener::sessionInit()` has attached and started the session, `$this->session` stays `null`: `assignToken()` then generates a token for `{token_url}` but the nullsafe write silently drops it, so `checkToken()` on the next request finds nothing. Whether this happens depends only on when the container first builds the service, which differs between environments — in `dev` it is built during `kernel.request`, before the session exists.

The session is now resolved on each read and write instead of being cached at construction, and `checkToken()` re-reads the stored token before comparing. The `isStarted()` guard is kept, so API routes still do not get a session.

Removing the exception, as suggested in the issue, would make `checkToken()` accept any value and drop the protection on the routes that rely on it.

Added unit tests covering a token assigned after the service was built, a token assigned on a previous request, an invalid token and a missing token.
