### PR TITLE
feat: expose full ISO 3166-2 code as a computed field on states

### DIFF
--- a/core/lib/Thelia/Api/Resource/State.php
+++ b/core/lib/Thelia/Api/Resource/State.php
@@ -89,6 +89,9 @@ class State extends AbstractTranslatableResource
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, OrderAddress::GROUP_ADMIN_READ])]
     public ?string $isocode;
 
+    #[Groups([self::GROUP_ADMIN_READ])]
+    public ?string $isoCode3166_2 = null;
+
     #[Relation(targetResource: Country::class)]
     #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, Order::GROUP_ADMIN_READ_SINGLE])]
     public Country $country;
@@ -134,6 +137,18 @@ class State extends AbstractTranslatableResource
     public function setIsocode(?string $isocode): self
     {
         $this->isocode = $isocode;
+
+        return $this;
+    }
+
+    public function getIsoCode3166_2(): ?string
+    {
+        return $this->isoCode3166_2;
+    }
+
+    public function setIsoCode3166_2(?string $isoCode3166_2): self
+    {
+        $this->isoCode3166_2 = $isoCode3166_2;
 
         return $this;
     }

--- a/core/lib/Thelia/Core/Template/Loop/State.php
+++ b/core/lib/Thelia/Core/Template/Loop/State.php
@@ -144,6 +144,7 @@ class State extends BaseI18nLoop implements PropelSearchLoopInterface
                 ->set('LOCALE', $this->locale)
                 ->set('TITLE', $state->getVirtualColumn('i18n_TITLE'))
                 ->set('ISOCODE', $state->getIsocode())
+                ->set('ISOCODE_3166_2', $state->getIsoCode3166_2())
             ;
 
             $this->addOutputFields($loopResultRow, $state);

--- a/core/lib/Thelia/Model/State.php
+++ b/core/lib/Thelia/Model/State.php
@@ -16,4 +16,21 @@ use Thelia\Model\Base\State as BaseState;
 
 class State extends BaseState
 {
+    /**
+     * Get the full ISO 3166-2 code of this state (e.g. "US-CA"), built from
+     * the country ISO alpha-2 code and the state ISO code.
+     *
+     * @return string|null the full ISO 3166-2 code, or null if the country or the state ISO code is not defined
+     */
+    public function getIsoCode3166_2(): ?string
+    {
+        $country = $this->getCountry();
+        $isocode = $this->getIsocode();
+
+        if (null === $country || null === $isocode) {
+            return null;
+        }
+
+        return $country->getIsoalpha2().'-'.$isocode;
+    }
 }


### PR DESCRIPTION
Addresses the literal ask in https://github.com/thelia/thelia/issues/3168: a single field giving the full ISO 3166-2 subdivision code (e.g. `US-CA`) instead of combining `country.isoalpha2` and `state.isocode` manually.

`state.isocode` already stores the bare subdivision suffix and stays untouched — no schema change, no data migration, no risk to the existing `/admin/states/iso/{countryIso3}/{stateIso}` route or the seeded rows.

Adds `State::getIsoCode3166_2()` (null when country or isocode is missing), exposed as `ISOCODE_3166_2` in the state loop and as a read-only field on `Api\Resource\State`.

Companion Thelia 3 port: https://github.com/thelia/thelia/pull/3531.