### PR TITLE
feat: expose full ISO 3166-2 code as a computed field on states

### DIFF
--- a/core/lib/Thelia/Api/Resource/State.php
+++ b/core/lib/Thelia/Api/Resource/State.php
@@ -100,6 +100,9 @@ class State extends AbstractTranslatableResource
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, OrderAddress::GROUP_ADMIN_READ, Order::GROUP_FRONT_READ_SINGLE])]
     public ?string $isocode = null;
 
+    #[Groups([self::GROUP_ADMIN_READ, Order::GROUP_FRONT_READ_SINGLE])]
+    public ?string $isoCode3166_2 = null;
+
     #[Relation(targetResource: Country::class)]
     #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, Order::GROUP_ADMIN_READ_SINGLE, Order::GROUP_FRONT_READ_SINGLE])]
     public Country $country;
@@ -145,6 +148,18 @@ class State extends AbstractTranslatableResource
     public function setIsocode(?string $isocode): self
     {
         $this->isocode = $isocode;
+
+        return $this;
+    }
+
+    public function getIsoCode3166_2(): ?string
+    {
+        return $this->isoCode3166_2;
+    }
+
+    public function setIsoCode3166_2(?string $isoCode3166_2): self
+    {
+        $this->isoCode3166_2 = $isoCode3166_2;
 
         return $this;
     }

--- a/core/lib/Thelia/Core/Template/Loop/State.php
+++ b/core/lib/Thelia/Core/Template/Loop/State.php
@@ -147,7 +147,8 @@ class State extends BaseI18nLoop implements PropelSearchLoopInterface
                 ->set('IS_TRANSLATED', $state->getVirtualColumn('IS_TRANSLATED'))
                 ->set('LOCALE', $this->locale)
                 ->set('TITLE', $state->getVirtualColumn('i18n_TITLE'))
-                ->set('ISOCODE', $state->getIsocode());
+                ->set('ISOCODE', $state->getIsocode())
+                ->set('ISOCODE_3166_2', $state->getIsoCode3166_2());
 
             $this->addOutputFields($loopResultRow, $state);
 

--- a/core/lib/Thelia/Model/State.php
+++ b/core/lib/Thelia/Model/State.php
@@ -18,4 +18,21 @@ use Thelia\Model\Base\State as BaseState;
 
 class State extends BaseState
 {
+    /**
+     * Get the full ISO 3166-2 code of this state (e.g. "US-CA"), built from
+     * the country ISO alpha-2 code and the state ISO code.
+     *
+     * @return string|null the full ISO 3166-2 code, or null if the country or the state ISO code is not defined
+     */
+    public function getIsoCode3166_2(): ?string
+    {
+        $country = $this->getCountry();
+        $isocode = $this->getIsocode();
+
+        if (null === $country || null === $isocode) {
+            return null;
+        }
+
+        return $country->getIsoalpha2().'-'.$isocode;
+    }
 }


### PR DESCRIPTION
Thelia 3 port of #3530, itself addressing the literal ask in https://github.com/thelia/thelia/issues/3168: a single field giving the full ISO 3166-2 subdivision code (e.g. `US-CA`) instead of combining `country.isoalpha2` and `state.isocode` manually. The issue stays open for the separate, larger worldwide-seed question (option C in the triage), so no closing keyword here.

Same computed accessor as the 2.6 fix, adapted to T3: `State::getIsoCode3166_2()` (null when country or isocode is missing), exposed as `ISOCODE_3166_2` in the state loop and as a read-only field on `Api\Resource\State` — added `Order::GROUP_FRONT_READ_SINGLE` to its serialization groups alongside `isocode`/`country` for consistency with the front checkout read context that doesn't exist on the 2.6 branch.