### PR TITLE
feat(order-status): let a custom status declare the canonical status it stands for

### DIFF
--- a/core/lib/Thelia/Action/OrderStatus.php
+++ b/core/lib/Thelia/Action/OrderStatus.php
@@ -80,6 +80,7 @@ class OrderStatus extends BaseAction implements EventSubscriberInterface
     {
         $orderStatus
             ->setCode($orderStatus->getProtectedStatus() ? $orderStatus->getCode() : $event->getCode())
+            ->setEquivalentCode($this->resolveEquivalentCode($event, $orderStatus))
             ->setColor($event->getColor())
             // i18n
             ->setLocale($event->getLocale())
@@ -98,6 +99,29 @@ class OrderStatus extends BaseAction implements EventSubscriberInterface
         $orderStatus->save();
 
         $event->setOrderStatus($orderStatus);
+    }
+
+    /**
+     * A protected (native) status stands for itself and never carries an equivalence. A custom one
+     * may only stand for a canonical code.
+     */
+    protected function resolveEquivalentCode(OrderStatusEvent $event, OrderStatusModel $orderStatus): ?string
+    {
+        if ($orderStatus->getProtectedStatus()) {
+            return null;
+        }
+
+        $equivalentCode = $event->getEquivalentCode();
+
+        if (null === $equivalentCode || '' === $equivalentCode) {
+            return null;
+        }
+
+        if (!\in_array($equivalentCode, OrderStatusModel::CANONICAL_CODES, true)) {
+            throw new \InvalidArgumentException(Translator::getInstance()->trans('%code is not a canonical order status code.', ['%code' => $equivalentCode]));
+        }
+
+        return $equivalentCode;
     }
 
     /**

--- a/core/lib/Thelia/Api/Resource/OrderStatus.php
+++ b/core/lib/Thelia/Api/Resource/OrderStatus.php
@@ -114,6 +114,17 @@ class OrderStatus extends AbstractTranslatableResource
     ])]
     public string $code;
 
+    /**
+     * The canonical code this status stands for, one of \Thelia\Model\OrderStatus::CANONICAL_CODES,
+     * or null when the status stands for itself.
+     */
+    #[Groups([
+        self::GROUP_ADMIN_READ,
+        self::GROUP_ADMIN_WRITE,
+        self::GROUP_FRONT_READ,
+    ])]
+    public ?string $equivalentCode = null;
+
     #[Groups([
         self::GROUP_ADMIN_READ,
         self::GROUP_ADMIN_WRITE,
@@ -166,6 +177,18 @@ class OrderStatus extends AbstractTranslatableResource
     public function setCode(string $code): self
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    public function getEquivalentCode(): ?string
+    {
+        return $this->equivalentCode;
+    }
+
+    public function setEquivalentCode(?string $equivalentCode): self
+    {
+        $this->equivalentCode = $equivalentCode;
 
         return $this;
     }

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -18,6 +18,7 @@ return [
     '"%param" parameter cannot be empty in loop type: %type, name: %name' => '"%param" parameter cannot be empty in loop type: %type, name: %name',
     '"%param" parameter is missing in loop type: %type, name: %name' => '"%param" parameter is missing in loop type: %type, name: %name',
     '#000000' => '#000000',
+    '%code is not a canonical order status code.' => '%code is not a canonical order status code.',
     '%module (version: %version)' => '%module (version: %version)',
     '%n for number, %c for the currency code, %s for the currency symbol' => '%n for number, %c for the currency code, %s for the currency symbol',
     '%obj SEO modification' => '%obj SEO modification',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -18,6 +18,7 @@ return [
     '"%param" parameter cannot be empty in loop type: %type, name: %name' => 'Le paramètre "%param" ne peut être vide dans la boucle type: %type, nom: %name ',
     '"%param" parameter is missing in loop type: %type, name: %name' => 'Le paramètre "%param" est absent dans la boucle type: %type, nom: %name ',
     '#000000' => '#000000',
+    '%code is not a canonical order status code.' => '%code n\'est pas un code de statut de commande canonique.',
     '%module (version: %version)' => '%module (version: %version)',
     '%n for number, %c for the currency code, %s for the currency symbol' => '%n pour le nombre, %c pour le code de devise, %s pour le symbole monétaire',
     '%obj SEO modification' => 'Modification SEO de %obj',

--- a/core/lib/Thelia/Core/Event/OrderStatus/OrderStatusEvent.php
+++ b/core/lib/Thelia/Core/Event/OrderStatus/OrderStatusEvent.php
@@ -25,6 +25,7 @@ use Thelia\Model\OrderStatus;
 class OrderStatusEvent extends ActionEvent
 {
     protected string $code;
+    protected ?string $equivalentCode = null;
     protected string $title;
     protected ?string $description = null;
     protected ?string $chapo = null;
@@ -83,6 +84,22 @@ class OrderStatusEvent extends ActionEvent
     public function setCode(string $code): static
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * The canonical status code this status stands for, one of OrderStatus::CANONICAL_CODES,
+     * or null when the status stands for itself.
+     */
+    public function getEquivalentCode(): ?string
+    {
+        return $this->equivalentCode;
+    }
+
+    public function setEquivalentCode(?string $equivalentCode): static
+    {
+        $this->equivalentCode = $equivalentCode;
 
         return $this;
     }

--- a/core/lib/Thelia/Model/OrderStatus.php
+++ b/core/lib/Thelia/Model/OrderStatus.php
@@ -29,6 +29,18 @@ class OrderStatus extends BaseOrderStatus
     public const CODE_REFUNDED = 'refunded';
 
     /**
+     * The canonical status codes, the only values a custom status may declare as its equivalence.
+     */
+    public const CANONICAL_CODES = [
+        self::CODE_NOT_PAID,
+        self::CODE_PAID,
+        self::CODE_PROCESSING,
+        self::CODE_SENT,
+        self::CODE_CANCELED,
+        self::CODE_REFUNDED,
+    ];
+
+    /**
      * Check if the current status is NOT PAID.
      *
      * @param bool $exact if true, the method will check if the current status is exactly OrderStatus::CODE_NOT_PAID.
@@ -116,8 +128,24 @@ class OrderStatus extends BaseOrderStatus
     }
 
     /**
+     * The canonical code this status stands for.
+     *
+     * A protected (native) status always stands for its own code. A custom status stands for the
+     * canonical code it declares as its equivalence, or for its own code when it declares none.
+     */
+    public function getEffectiveCode(): string
+    {
+        if ($this->getProtectedStatus()) {
+            return $this->getCode();
+        }
+
+        return $this->getEquivalentCode() ?: $this->getCode();
+    }
+
+    /**
      * Check if the current status is $statusCode or, if $statusCode is an array, if the current
-     * status is in the $statusCode array.
+     * status is in the $statusCode array. The comparison is made on the effective code, so a
+     * custom status declaring an equivalence answers for the canonical code it stands for.
      *
      * @param string|array $statusCode the status code, one of OrderStatus::CODE_xxx constants
      *
@@ -125,10 +153,12 @@ class OrderStatus extends BaseOrderStatus
      */
     public function hasStatusHelper(string|array $statusCode): bool
     {
+        $effectiveCode = $this->getEffectiveCode();
+
         if (\is_array($statusCode)) {
-            return \in_array($this->getCode(), $statusCode, true);
+            return \in_array($effectiveCode, $statusCode, true);
         }
 
-        return $this->getCode() === $statusCode;
+        return $effectiveCode === $statusCode;
     }
 }

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -386,6 +386,7 @@ final class FixtureFactory
 
         $status = new OrderStatus();
         $status->setCode($overrides['code'] ?? 'status-'.$n);
+        $status->setEquivalentCode($overrides['equivalentCode'] ?? null);
         $status->setColor($overrides['color'] ?? '#cccccc');
         $status->setLocale($overrides['locale'] ?? 'en_US');
         $status->setTitle($overrides['title'] ?? 'Status '.$n);

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -778,6 +778,7 @@
   <table name="order_status" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="code" required="true" size="45" type="VARCHAR" />
+    <column name="equivalent_code" size="45" type="VARCHAR" />
     <column name="color" size="7" type="CHAR" />
     <column name="position" type="INTEGER" />
     <column defaultValue="0" name="protected_status" type="BOOLEAN" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -905,6 +905,7 @@ CREATE TABLE `order_status`
 (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `code` VARCHAR(45) NOT NULL,
+    `equivalent_code` VARCHAR(45),
     `color` CHAR(7),
     `position` INTEGER,
     `protected_status` TINYINT(1) DEFAULT 0,

--- a/tests/Integration/Action/OrderStatusActionTest.php
+++ b/tests/Integration/Action/OrderStatusActionTest.php
@@ -18,6 +18,7 @@ use Thelia\Core\Event\OrderStatus\OrderStatusCreateEvent;
 use Thelia\Core\Event\OrderStatus\OrderStatusDeleteEvent;
 use Thelia\Core\Event\OrderStatus\OrderStatusUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\OrderStatus;
 use Thelia\Model\OrderStatusQuery;
 use Thelia\Test\ActionIntegrationTestCase;
 
@@ -58,6 +59,42 @@ final class OrderStatusActionTest extends ActionIntegrationTestCase
         $reloaded = OrderStatusQuery::create()->findPk($status->getId());
         self::assertSame('#ff0000', $reloaded->getColor());
         self::assertSame('Updated', $reloaded->setLocale('en_US')->getTitle());
+    }
+
+    public function testUpdatePersistsEquivalentCode(): void
+    {
+        $status = $this->factory->orderStatus(['code' => 'paid_on_delivery', 'title' => 'Paid on delivery']);
+
+        $event = new OrderStatusUpdateEvent($status->getId());
+        $event
+            ->setCode('paid_on_delivery')
+            ->setEquivalentCode(OrderStatus::CODE_PAID)
+            ->setColor('#00ff00')
+            ->setLocale('en_US')
+            ->setTitle('Paid on delivery');
+
+        $this->dispatch($event, TheliaEvents::ORDER_STATUS_UPDATE);
+
+        $reloaded = OrderStatusQuery::create()->findPk($status->getId());
+        self::assertSame(OrderStatus::CODE_PAID, $reloaded->getEquivalentCode());
+        self::assertTrue($reloaded->isPaid());
+    }
+
+    public function testUpdateRejectsNonCanonicalEquivalentCode(): void
+    {
+        $status = $this->factory->orderStatus(['code' => 'bad_equivalence']);
+
+        $event = new OrderStatusUpdateEvent($status->getId());
+        $event
+            ->setCode('bad_equivalence')
+            ->setEquivalentCode('not_a_canonical_code')
+            ->setColor('#00ff00')
+            ->setLocale('en_US')
+            ->setTitle('Bad equivalence');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->dispatch($event, TheliaEvents::ORDER_STATUS_UPDATE);
     }
 
     public function testDeleteRemovesNonProtectedOrderStatus(): void

--- a/tests/Integration/Model/OrderStatusEquivalenceTest.php
+++ b/tests/Integration/Model/OrderStatusEquivalenceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Model\OrderStatus;
+use Thelia\Model\OrderStatusQuery;
+use Thelia\Test\IntegrationTestCase;
+
+final class OrderStatusEquivalenceTest extends IntegrationTestCase
+{
+    public function testCustomStatusEquivalentToPaidIsPaid(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $status = $factory->orderStatus([
+            'code' => 'paid_on_delivery_test',
+            'equivalentCode' => OrderStatus::CODE_PAID,
+        ]);
+
+        self::assertSame(OrderStatus::CODE_PAID, $status->getEffectiveCode());
+        self::assertTrue($status->isPaid());
+        self::assertTrue($status->isPaid(false));
+        self::assertFalse($status->isNotPaid());
+
+        $order = $factory->order(null, ['statusCode' => 'paid_on_delivery_test']);
+
+        self::assertTrue($order->isPaid());
+        self::assertFalse($order->isNotPaid());
+    }
+
+    public function testCustomStatusWithoutEquivalenceKeepsItsOwnCode(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $status = $factory->orderStatus(['code' => 'awaiting_stock_test']);
+
+        self::assertNull($status->getEquivalentCode());
+        self::assertSame('awaiting_stock_test', $status->getEffectiveCode());
+        self::assertFalse($status->isPaid());
+        self::assertFalse($status->isPaid(false));
+        self::assertTrue($status->isNotPaid(false));
+
+        $order = $factory->order(null, ['statusCode' => 'awaiting_stock_test']);
+
+        self::assertFalse($order->isPaid());
+    }
+
+    public function testCustomStatusEquivalentToSentIsSentAndDerivedPaid(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $status = $factory->orderStatus([
+            'code' => 'handed_to_carrier_test',
+            'equivalentCode' => OrderStatus::CODE_SENT,
+        ]);
+
+        self::assertTrue($status->isSent());
+        self::assertTrue($status->isPaid(false));
+        self::assertFalse($status->isPaid());
+    }
+
+    public function testProtectedStatusIgnoresEquivalence(): void
+    {
+        $paid = OrderStatusQuery::create()->findOneByCode(OrderStatus::CODE_PAID);
+
+        self::assertNotNull($paid, 'Seeded order status "paid" is missing — run bin/test-prepare.');
+        self::assertTrue($paid->getProtectedStatus());
+
+        $paid->setEquivalentCode(OrderStatus::CODE_REFUNDED);
+
+        self::assertSame(OrderStatus::CODE_PAID, $paid->getEffectiveCode());
+        self::assertTrue($paid->isPaid());
+        self::assertFalse($paid->isRefunded());
+    }
+}


### PR DESCRIPTION
A custom order status can now declare which of the six canonical statuses it stands for, through a
nullable `order_status.equivalent_code`. `OrderStatus::getEffectiveCode()` resolves it (a protected
status always stands for itself) and `hasStatusHelper()` compares on it, so `Order::isPaid()`,
`isSent()`, ... answer true for a custom "Paid on delivery" status equivalent to `paid`.
Statuses without an equivalence behave exactly as before.

The event and the action carry the new field, the admin API exposes it, and an integration test
covers both the equivalence and the unchanged case.

Fresh installs get the column from `setup/thelia.sql`. Existing installs need
`ALTER TABLE order_status ADD COLUMN equivalent_code VARCHAR(45) NULL AFTER code;` — to be folded
into the update script of the next release.

CI note: `local/config/schema.xml` is also shipped by the `thelia/config` package, which Composer
installs over `local/config`, so the Propel models are generated from the published schema. PHPStan
and the test suites will keep reporting `OrderStatus::getEquivalentCode()` as undefined until
`thelia/config` ships the new column.

Back-office side (the "Equivalent to" select): https://github.com/thelia-templates/default-twig/pull/11

Fixes #2562