### PR TITLE
chore: let PHPStan scale its worker count to the machine

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,6 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    parallel:
-        maximumNumberOfProcesses: 2
     level: 1
     tmpDir: var/cache-ci/phpstan
     paths:


### PR DESCRIPTION
`phpstan.neon` capped the analysis at two worker processes. The cap slows the run down on any machine with more cores, and PHPStan already picks a sensible worker count from the available CPUs when left alone.

Removes the `parallel.maximumNumberOfProcesses` entry. No other change.

Supersedes #3436 by @staabm, which can no longer be rebased: it was opened before `main` became the Thelia 3 line, so its diff now conflicts throughout.