### PR TITLE
chore: let PHPStan scale its worker count to the machine

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,4 @@
 parameters:
-    parallel:
-        maximumNumberOfProcesses: 2
     level: 0
     tmpDir: var/cache-ci/phpstan
     paths:


### PR DESCRIPTION
Same change as #3537, on the 2.6 line: `phpstan.neon` capped the analysis at two worker processes, which slows the run down on machines with more cores. PHPStan picks a worker count from the available CPUs when the cap is absent.

Refs #3436.