### PR TITLE
fix: restore the parser template definition when mail rendering fails

### DIFF
--- a/core/lib/Thelia/Model/Message.php
+++ b/core/lib/Thelia/Model/Message.php
@@ -112,20 +112,25 @@ class Message extends BaseMessage
             $useFallbackTemplate,
         );
 
-        $subject = $parser->renderString($this->getSubject());
-        $htmlMessage = $this->getHtmlMessageBody($parser);
-        $textMessage = $this->getTextMessageBody($parser);
+        try {
+            $subject = $parser->renderString($this->getSubject());
+            $htmlMessage = $this->getHtmlMessageBody($parser);
+            $textMessage = $this->getTextMessageBody($parser);
 
-        if (empty($htmlMessage) && empty($textMessage)) {
-            throw new \RuntimeException('Message body is empty for message ID: '.$this->getId());
+            if (empty($htmlMessage) && empty($textMessage)) {
+                throw new \RuntimeException('Message body is empty for message ID: '.$this->getId());
+            }
+
+            $messageInstance->subject($subject);
+            $messageInstance->text($textMessage);
+            $messageInstance->html($htmlMessage);
+        } finally {
+            // Restore the previous template on every path: MailerFactory::sendEmailMessage()
+            // swallows rendering failures so the request survives them, which would otherwise
+            // leave the parser stuck on the mail template for the rest of the request (e.g. a
+            // payment module rendering its own template right after order notification emails).
+            $parser->popTemplateDefinition();
         }
-
-        $messageInstance->subject($subject);
-        $messageInstance->text($textMessage);
-        $messageInstance->html($htmlMessage);
-
-        // Restore previous template
-        $parser->popTemplateDefinition();
 
         return $messageInstance;
     }

--- a/tests/Integration/Mailer/MailerFactoryTest.php
+++ b/tests/Integration/Mailer/MailerFactoryTest.php
@@ -116,6 +116,52 @@ final class MailerFactoryTest extends IntegrationTestCase
         self::assertSame('fr_FR', $session->getLang()->getLocale());
     }
 
+    public function testCreateEmailMessageRestoresTheParserTemplateWhenRenderingFails(): void
+    {
+        $templateHelper = $this->getService(TemplateHelperInterface::class);
+        $frontTemplate = $templateHelper->getActiveFrontTemplate();
+
+        // Parsers are shared services: the template definition MailerFactory leaves behind is
+        // the one every later render sees, hence resolving the very same instance here.
+        $parser = $this->getService(ParserResolver::class)->getParser(
+            $templateHelper->getActiveMailTemplate()->getAbsolutePath(),
+            'order_confirmation',
+        );
+
+        $initialTemplate = $parser->getTemplateDefinition();
+        $parser->setTemplateDefinition($frontTemplate);
+
+        // An existing template file so a parser is resolved, and a subject that cannot be
+        // compiled so rendering throws once the mail template has been pushed.
+        $message = new Message();
+        $message->setName('test_unrenderable_subject_message');
+        $message->setLocale('en_US');
+        $message->setSubject('{{ ');
+        $message->setHtmlTemplateFileName('order_confirmation.html');
+        $message->save();
+
+        try {
+            $this->mailerFactory->createEmailMessage(
+                'test_unrenderable_subject_message',
+                ['sender@example.com' => 'Sender'],
+                ['recipient@example.com' => 'Recipient'],
+                [],
+                'en_US',
+            );
+            self::fail('Rendering was expected to fail.');
+        } catch (\Exception) {
+            // The failure is the point: sendEmailMessage() swallows it in production.
+        }
+
+        $templateAfterFailure = $parser->getTemplateDefinition();
+
+        if (null !== $initialTemplate) {
+            $parser->setTemplateDefinition($initialTemplate);
+        }
+
+        self::assertSame($frontTemplate->getAbsolutePath(), $templateAfterFailure?->getAbsolutePath());
+    }
+
     public function testSendDoesNotThrowWithNullTransport(): void
     {
         $email = $this->mailerFactory->createSimpleEmailMessage(


### PR DESCRIPTION
`Message::buildMessage()` pushed the mail template definition onto the parser stack (core/lib/Thelia/Model/Message.php:110) and popped it only on the success path (line 128). Any failure in between skipped the pop: an uncompilable subject, or a missing body raising `Message body is empty for message ID`.

`MailerFactory::sendEmailMessage()` deliberately swallows those exceptions so a failed notification email does not abort the calling flow. The parser is a shared service, so it stayed stuck on `templates/email/default` for the rest of the request, and the next render could no longer find its templates. The usual victim is a payment module rendering its own template during `ORDER_PAY`, right after the order notification emails.

The pop now runs in a `finally`, next to the push, mirroring the `finally` that already restores the session locale in `MailerFactory::createEmailMessage()`. `Message::buildMessage()` is the only caller pushing a template definition, so no other site needs the same treatment. Nothing changes on the success path and there is no BC break.

Added `MailerFactoryTest::testCreateEmailMessageRestoresTheParserTemplateWhenRenderingFails`, which fails on `main` (parser left on `templates/email/default` instead of the front template) and passes with the fix.

Same fix as #3512 on `2.6`.

Fixes #3513
