### PR TITLE
fix: type OrderProduct API virtualDocument as string

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -261,7 +261,7 @@ class OrderProduct implements PropelResourceInterface
         Order::GROUP_ADMIN_WRITE,
         self::GROUP_FRONT_READ_SINGLE,
     ])]
-    public ?bool $virtualDocument;
+    public ?string $virtualDocument;
 
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ_SINGLE])]
     public ?\DateTime $createdAt;
@@ -530,12 +530,12 @@ class OrderProduct implements PropelResourceInterface
         return $this;
     }
 
-    public function getVirtualDocument(): ?bool
+    public function getVirtualDocument(): ?string
     {
         return $this->virtualDocument;
     }
 
-    public function setVirtualDocument(?bool $virtualDocument): self
+    public function setVirtualDocument(?string $virtualDocument): self
     {
         $this->virtualDocument = $virtualDocument;
 


### PR DESCRIPTION
`Api/Resource/OrderProduct::$virtualDocument` was typed `?bool` (`core/lib/Thelia/Api/Resource/OrderProduct.php:264`), but `order_product.virtual_document` is a nullable `VARCHAR(255)` (`setup/thelia.sql:882`, `local/config/schema.xml:757`) that holds the document file name written at order creation from `VirtualProductOrderHandleEvent::getPath()` (`core/lib/Thelia/Action/Order.php:315`; `VirtualProductDelivery` fills it with `ProductDocument::getFile()`).

The Propel-to-resource bridge therefore coerced the file name to `true`/`false`, and API consumers could not tell "virtual with document X" from "virtual with any document". The write direction was equally wrong: a boolean sent to the admin endpoint reached the Propel setter `setVirtualDocument(?string)` and was stored as `'1'`.

This types the property, getter and setter as `?string`. No document stays `null` (the column is nullable with no default and stays unset for non-virtual products). No filter, addon or serialization group depended on the boolean type — `BooleanFilter` only covers `virtual`.

BC note: `virtualDocument` now serializes as a string (the file name) or `null` instead of `true`/`false`. Strictly typed consumers must widen the field to `string|null` and replace truthiness checks on the value with a null check (`null !== virtualDocument`), which is equivalent to the previous boolean semantics. Rows written through the admin API before this fix may contain `'1'`; they are not migrated.

Refs #3519
