### PR TITLE
fix: type OrderProduct API virtualDocument as string

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -277,7 +277,7 @@ class OrderProduct implements PropelResourceInterface
         Order::GROUP_ADMIN_WRITE,
         self::GROUP_FRONT_READ_SINGLE,
     ])]
-    public ?bool $virtualDocument = null;
+    public ?string $virtualDocument = null;
 
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ_SINGLE])]
     public ?\DateTime $createdAt = null;
@@ -572,12 +572,12 @@ class OrderProduct implements PropelResourceInterface
         return $this;
     }
 
-    public function getVirtualDocument(): ?bool
+    public function getVirtualDocument(): ?string
     {
         return $this->virtualDocument;
     }
 
-    public function setVirtualDocument(?bool $virtualDocument): self
+    public function setVirtualDocument(?string $virtualDocument): self
     {
         $this->virtualDocument = $virtualDocument;
 

--- a/tests/Api/Admin/OrderApiTest.php
+++ b/tests/Api/Admin/OrderApiTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\Admin;
 
+use Thelia\Model\OrderProduct;
 use Thelia\Model\OrderStatusQuery;
 use Thelia\Test\ApiTestCase;
 
@@ -67,6 +68,35 @@ final class OrderApiTest extends ApiTestCase
         ], $token, 'merge-patch+json');
 
         self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testGetOrderProductExposesVirtualDocumentFileName(): void
+    {
+        $token = $this->authenticateAsAdmin();
+
+        $factory = $this->createFixtureFactory();
+        $order = $factory->order();
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('REF-VIRTUAL')
+            ->setProductSaleElementsRef('REF-VIRTUAL-PSE')
+            ->setTitle('Virtual product')
+            ->setQuantity(1.0)
+            ->setPrice('10.000000')
+            ->setPromoPrice('0.000000')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->setVirtual(1)
+            ->setVirtualDocument('user-guide.pdf')
+            ->save($this->getPropelConnection());
+
+        $response = $this->jsonRequest('GET', '/api/admin/order_products/'.$orderProduct->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+        self::assertSame('user-guide.pdf', $data['virtualDocument']);
     }
 
     public function testGetOrderReturns404ForNonExistent(): void


### PR DESCRIPTION
`Api/Resource/OrderProduct::$virtualDocument` was typed `?bool` (`core/lib/Thelia/Api/Resource/OrderProduct.php:280`), but `order_product.virtual_document` is a nullable `VARCHAR(255)` (`setup/thelia.sql:887`, `local/config/schema.xml:770`) holding the document file name, written from `VirtualProductContext::$virtualDocumentPath` — itself a `?string` (`core/lib/Thelia/Domain/Order/Service/OrderProductFactory.php:54`, `VirtualProductHandler.php:41`).

`TypeCasterService::castValueForSetter()` cast the file name to `true`/`false` before handing it to the resource setter, so API consumers could not tell "virtual with document X" from "virtual with any document". Writes were wrong too: a boolean reached the Propel setter `setVirtualDocument(?string)` and was stored as `'1'`.

This types the property, getter and setter as `?string`. No document stays `null` (nullable column, no default, left unset for non-virtual products). Nothing else depended on the boolean type — `BooleanFilter` only covers `virtual`, and no addon or serialization group references the field.

Adds an admin API test asserting the file name is returned verbatim.

BC note: `virtualDocument` now serializes as a string (the file name) or `null` instead of `true`/`false`. Strictly typed consumers must widen the field to `string|null` and replace truthiness checks with a null check (`null !== virtualDocument`), which matches the previous boolean semantics.

Fixes #3519
