### PR TITLE
fix: treat the customer discount as the decimal it is

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -223,7 +223,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $quantity = $event->getQuantity();
         $currency = $cart->getCurrency();
         $customer = $cart->getCustomer();
-        $discount = 0;
+        $discount = 0.0;
 
         if ($cart->isNew()) {
             $persistEvent = new CartPersistEvent($cart);
@@ -231,7 +231,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
         }
 
         if (null !== $customer && $customer->getDiscount() > 0) {
-            $discount = $customer->getDiscount();
+            // getDiscount() maps a DECIMAL column and returns a string.
+            $discount = (float) $customer->getDiscount();
         }
 
         $productSaleElementsId = $event->getProductSaleElementsId();
@@ -342,10 +343,11 @@ class Cart extends BaseAction implements EventSubscriberInterface
     protected function refreshCartItemPrices(CartModel $cart, CurrencyModel $currency): void
     {
         $customer = $cart->getCustomer();
-        $discount = 0;
+        $discount = 0.0;
 
         if (null !== $customer && $customer->getDiscount() > 0) {
-            $discount = $customer->getDiscount();
+            // getDiscount() maps a DECIMAL column and returns a string.
+            $discount = (float) $customer->getDiscount();
         }
 
         // cart item
@@ -558,7 +560,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
             // A customer is logged in.
             // If the customer has a discount, whe have to duplicate the cart,
             // so that the discount will be applied to the products in cart.
-            if (null === $cart->getCustomerId() && (0 === $customer->getDiscount() || 0 === $cart->countCartItems())) {
+            // getDiscount() maps a DECIMAL column, so it returns a string such as '0.000000'.
+            if (null === $cart->getCustomerId() && (0.0 === (float) $customer->getDiscount() || 0 === $cart->countCartItems())) {
                 // If no discount, or an empty cart, there's no need to duplicate.
                 $duplicateCart = false;
             }

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -254,10 +254,11 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
         $taxCountry = $this->taxEngine->getDeliveryCountry();
         /** @var SecurityContext $securityContext */
         $securityContext = $this->container->get('thelia.securityContext');
-        $discount = 0;
+        $discount = 0.0;
 
         if ($securityContext->hasCustomerUser() && $securityContext->getCustomerUser()->getDiscount() > 0) {
-            $discount = $securityContext->getCustomerUser()->getDiscount();
+            // getDiscount() maps a DECIMAL column and returns a string.
+            $discount = (float) $securityContext->getCustomerUser()->getDiscount();
         }
 
         /** @var \Thelia\Model\ProductSaleElements $PSEValue */

--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -48,7 +48,7 @@ class Cart extends BaseCart
         $cart->setAddressInvoiceId($this->getAddressInvoiceId());
         $cart->setToken($token);
 
-        $discount = 0;
+        $discount = 0.0;
 
         if (!$currency instanceof Currency) {
             $currencyQuery = CurrencyQuery::create();
@@ -61,7 +61,8 @@ class Cart extends BaseCart
             $cart->setCustomer($customer);
 
             if ($customer->getDiscount() > 0) {
-                $discount = $customer->getDiscount();
+                // getDiscount() maps a DECIMAL column and returns a string.
+                $discount = (float) $customer->getDiscount();
             }
         }
 

--- a/core/lib/Thelia/Model/ProductSaleElements.php
+++ b/core/lib/Thelia/Model/ProductSaleElements.php
@@ -28,7 +28,7 @@ class ProductSaleElements extends BaseProductSaleElements
     /**
      * @throws PropelException
      */
-    public function getPrice(string $virtualColumnName = 'price_PRICE', int $discount = 0): float
+    public function getPrice(string $virtualColumnName = 'price_PRICE', float $discount = 0.0): float
     {
         try {
             $amount = $this->getVirtualColumn($virtualColumnName);
@@ -46,7 +46,7 @@ class ProductSaleElements extends BaseProductSaleElements
     /**
      * @throws PropelException
      */
-    public function getPromoPrice(string $virtualColumnName = 'price_PROMO_PRICE', int $discount = 0): float
+    public function getPromoPrice(string $virtualColumnName = 'price_PROMO_PRICE', float $discount = 0.0): float
     {
         try {
             $amount = $this->getVirtualColumn($virtualColumnName);
@@ -64,7 +64,7 @@ class ProductSaleElements extends BaseProductSaleElements
     /**
      * @throws PropelException
      */
-    public function getTaxedPrice(Country $country, string $virtualColumnName = 'price_PRICE', int $discount = 0): float
+    public function getTaxedPrice(Country $country, string $virtualColumnName = 'price_PRICE', float $discount = 0.0): float
     {
         $taxCalculator = new Calculator();
 
@@ -74,7 +74,7 @@ class ProductSaleElements extends BaseProductSaleElements
     /**
      * @throws PropelException
      */
-    public function getTaxedPromoPrice(Country $country, string $virtualColumnName = 'price_PROMO_PRICE', int $discount = 0): float
+    public function getTaxedPromoPrice(Country $country, string $virtualColumnName = 'price_PROMO_PRICE', float $discount = 0.0): float
     {
         $taxCalculator = new Calculator();
 
@@ -92,7 +92,7 @@ class ProductSaleElements extends BaseProductSaleElements
      * @throws \RuntimeException
      * @throws PropelException
      */
-    public function getPricesByCurrency(Currency $currency, int $discount = 0): ProductPriceTools
+    public function getPricesByCurrency(Currency $currency, float $discount = 0.0): ProductPriceTools
     {
         $defaultCurrency = Currency::getDefaultCurrency();
 

--- a/tests/Integration/Action/CartActionTest.php
+++ b/tests/Integration/Action/CartActionTest.php
@@ -21,10 +21,12 @@ use Thelia\Core\Event\Cart\CartCreateEvent;
 use Thelia\Core\Event\Cart\CartEvent;
 use Thelia\Core\Event\Cart\CartRestoreEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\SecurityContext;
 use Thelia\Model\Cart;
 use Thelia\Model\CartItemQuery;
 use Thelia\Model\CartQuery;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\Customer;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Test\ActionIntegrationTestCase;
 
@@ -189,6 +191,31 @@ final class CartActionTest extends ActionIntegrationTestCase
         self::assertNotSame($cart->getToken(), $restored->getToken());
     }
 
+    public function testRestoreCurrentCartAssignsAnAnonymousCartToACustomerWithoutDiscount(): void
+    {
+        // getDiscount() maps a DECIMAL column, so "no discount" reads as the string '0.000000'.
+        $customer = $this->customerWithDiscount('0.000000');
+        $cart = $this->anonymousCartWithOneItem();
+
+        $restored = $this->restoreCartAsLoggedInCustomer($customer);
+
+        // No discount to apply: the very same cart is handed over to the customer.
+        self::assertSame($cart->getId(), $restored->getId());
+        self::assertSame($customer->getId(), $restored->getCustomerId());
+    }
+
+    public function testRestoreCurrentCartDuplicatesAnAnonymousCartForACustomerWithADiscount(): void
+    {
+        $customer = $this->customerWithDiscount('10.000000');
+        $cart = $this->anonymousCartWithOneItem();
+
+        $restored = $this->restoreCartAsLoggedInCustomer($customer);
+
+        // The discount has to be applied to the items, which requires a fresh cart.
+        self::assertNotSame($cart->getId(), $restored->getId());
+        self::assertSame($customer->getId(), $restored->getCustomerId());
+    }
+
     public function testRestoreCurrentCartRealignsItemPricesWithTheCatalog(): void
     {
         $cart = $this->factory->cart();
@@ -240,6 +267,47 @@ final class CartActionTest extends ActionIntegrationTestCase
     private function mainRequest(): Request
     {
         return $this->getService(RequestStack::class)->getMainRequest();
+    }
+
+    private function customerWithDiscount(string $discount): Customer
+    {
+        $customer = $this->factory->customer($this->factory->customerTitle());
+        $customer->setDiscount($discount)->save();
+
+        return $customer;
+    }
+
+    /**
+     * Creates a cart that belongs to nobody, holding a single item, and
+     * points the cart cookie at it.
+     */
+    private function anonymousCartWithOneItem(): Cart
+    {
+        $cart = $this->factory->cart();
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+            ['baseQuantity' => 100],
+        );
+        $this->dispatchAddItem($cart, $product->getId(), $this->defaultPseFor($product->getId())->getId(), 1);
+
+        $this->mainRequest()->cookies->set(
+            ConfigQuery::read('cart.cookie_name', 'thelia_cart'),
+            $cart->getToken(),
+        );
+
+        return $cart;
+    }
+
+    private function restoreCartAsLoggedInCustomer(Customer $customer): Cart
+    {
+        $this->getService(SecurityContext::class)->setCustomerUser($customer);
+
+        $event = new CartRestoreEvent();
+        $this->dispatch($event, TheliaEvents::CART_RESTORE_CURRENT);
+
+        return $event->getCart();
     }
 
     private function newEmptyCart(): Cart


### PR DESCRIPTION
`Customer::getDiscount()` maps a DECIMAL column, so the Propel getter returns `?string` (`'0.000000'` when there is no discount).

- `core/lib/Thelia/Action/Cart.php:561` compared it with `0 === ...`, which never matched: a customer without a discount always got their anonymous cart duplicated at login instead of simply taking it over. The comparison now runs on the decimal value.
- The sweep asked for in the issue found the same string reaching the `int $discount` parameter of `ProductSaleElements::getPricesByCurrency()` from `Model/Cart.php:64`, `Action/Cart.php:234` and `Action/Cart.php:348`, and `getPrice()` / `getTaxedPrice()` from `Loop/ProductSaleElements.php:260`. Under `declare(strict_types=1)` that is a `TypeError`, so adding an item to the cart of a customer with a discount was fatal.

The call sites now cast to `float` and the five `ProductSaleElements` methods take `float $discount` instead of `int $discount`, because the back-office stores the discount as a percentage with decimals (`NumberType`) and an `int` cast would truncate it.

Two integration tests in `tests/Integration/Action/CartActionTest.php` cover both branches: no discount keeps the cart, a discount duplicates it.

BC: widening `int $discount` to `float $discount` is safe for callers, but a subclass overriding one of those five methods with `int $discount` would have to widen it too.

Fixes #3534
