### PR TITLE
fix: render customer emails in the customer language when sent from the back office

### DIFF
--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -17,6 +17,8 @@ namespace Thelia\Mailer;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Thelia\Core\HttpFoundation\Request as TheliaRequest;
+use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Template\Parser\ParserResolver;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateHelperInterface;
@@ -180,12 +182,19 @@ class MailerFactory
         // As the parser uses the lang stored in the session, temporarly set the required language into the session.
         // This is required in the back office when sending emails to customers, that may use a different locale than
         // the current one.
-        $session = $parser->getRequest()->getSession();
+        // There is no session on the command line, where emails are sent from commands and
+        // scheduled tasks, so nothing to swap there: the requested locale is then only carried
+        // by the message itself.
+        $request = $parser->getRequest();
+        $session = $request?->hasSession() ? $request->getSession() : null;
+        $session = $session instanceof Session ? $session : null;
 
-        $currentLang = $session->getLang();
+        $currentLang = null !== $session
+            ? (TheliaRequest::$isAdminEnv ? $session->getAdminLang() : $session->getLang())
+            : null;
 
         if (null !== $requiredLang = LangQuery::create()->findOneByLocale($locale)) {
-            $session->setLang($requiredLang);
+            $this->setLanguageSession($session, $requiredLang);
         }
 
         try {
@@ -200,9 +209,27 @@ class MailerFactory
             // Restore on every path: sendEmailMessage() deliberately swallows a rendering
             // failure so the request survives it, which would otherwise leave the visitor's
             // session in the language of an email they never received.
-            if (null !== $currentLang) {
-                $session->setLang($currentLang);
-            }
+            $this->setLanguageSession($session, $currentLang);
+        }
+    }
+
+    /**
+     * Session::getLang(), which the parsers and the translator read to localize a render,
+     * returns the admin language as soon as the request runs in an admin environment. The
+     * language of an email therefore has to be written to that slot there: swapping the front
+     * office one would silently do nothing, and a customer email triggered by a back office
+     * action would render in the language of the administrator's interface.
+     */
+    protected function setLanguageSession(?Session $session, ?Lang $lang): void
+    {
+        if (null === $session || null === $lang) {
+            return;
+        }
+
+        if (TheliaRequest::$isAdminEnv) {
+            $session->setAdminLang($lang);
+        } else {
+            $session->setLang($lang);
         }
     }
 

--- a/tests/Integration/Mailer/MailerFactoryTest.php
+++ b/tests/Integration/Mailer/MailerFactoryTest.php
@@ -175,6 +175,7 @@ final class MailerFactoryTest extends IntegrationTestCase
 
         // The administrator browses the back office in English, the customer is French.
         $session->setAdminLang($english);
+        $session->setLang($french);
 
         $message = new Message();
         $message->setName('test_admin_triggered_customer_message');
@@ -207,6 +208,10 @@ final class MailerFactoryTest extends IntegrationTestCase
         Request::$isAdminEnv = true;
 
         try {
+            // Guard: in an admin environment Session::getLang() reads the admin language, so
+            // the assertions below cannot be satisfied by the front office language slot.
+            self::assertSame('en_US', $session->getLang()->getLocale());
+
             $mailerFactory->createEmailMessage(
                 'test_admin_triggered_customer_message',
                 ['sender@example.com' => 'Sender'],
@@ -214,13 +219,16 @@ final class MailerFactoryTest extends IntegrationTestCase
                 [],
                 'fr_FR',
             );
+
+            self::assertSame('en_US', $session->getAdminLang()->getLocale());
         } finally {
             Request::$isAdminEnv = $wasAdminEnvironment;
         }
 
         self::assertNotSame([], $renderedLocales);
         self::assertSame(['fr_FR'], array_values(array_unique($renderedLocales)));
-        self::assertSame('en_US', $session->getAdminLang()->getLocale());
+        // The front office language of the session is left untouched by an admin-side send.
+        self::assertSame('fr_FR', $session->getLang()->getLocale());
     }
 
     public function testSendDoesNotThrowWithNullTransport(): void

--- a/tests/Integration/Mailer/MailerFactoryTest.php
+++ b/tests/Integration/Mailer/MailerFactoryTest.php
@@ -16,7 +16,9 @@ namespace Thelia\Tests\Integration\Mailer;
 
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\MailerInterface;
+use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Template\Parser\ParserResolver;
+use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\LangQuery;
@@ -162,6 +164,65 @@ final class MailerFactoryTest extends IntegrationTestCase
         self::assertSame($frontTemplate->getAbsolutePath(), $templateAfterFailure?->getAbsolutePath());
     }
 
+    public function testCreateEmailMessageRendersInTheRequestedLocaleInAdminEnvironment(): void
+    {
+        $session = $this->getService(RequestStack::class)->getMainRequest()->getSession();
+
+        $french = LangQuery::create()->findOneByLocale('fr_FR');
+        $english = LangQuery::create()->findOneByLocale('en_US');
+        self::assertNotNull($french);
+        self::assertNotNull($english);
+
+        // The administrator browses the back office in English, the customer is French.
+        $session->setAdminLang($english);
+
+        $message = new Message();
+        $message->setName('test_admin_triggered_customer_message');
+        $message->setLocale('fr_FR');
+        $message->setSubject('Sujet');
+        $message->setHtmlMessage('<p>Corps</p>');
+        $message->setTextMessage('Corps');
+        $message->save();
+
+        $renderedLocales = [];
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('getRequest')->willReturn($this->getService(RequestStack::class)->getMainRequest());
+        $parser->method('getTemplateHelper')->willReturn($this->getService(TemplateHelperInterface::class));
+        $parser->method('renderString')->willReturnCallback(
+            static function (string $templateText) use (&$renderedLocales, $session): string {
+                // What the parsers and the translator actually read to localize a render.
+                $renderedLocales[] = $session->getLang()->getLocale();
+
+                return $templateText;
+            },
+        );
+
+        $mailerFactory = new MailerFactory(
+            $this->getService(TemplateHelperInterface::class),
+            $this->createParserResolverReturning($parser),
+            $this->getService(MailerInterface::class),
+        );
+
+        $wasAdminEnvironment = Request::$isAdminEnv;
+        Request::$isAdminEnv = true;
+
+        try {
+            $mailerFactory->createEmailMessage(
+                'test_admin_triggered_customer_message',
+                ['sender@example.com' => 'Sender'],
+                ['customer@example.com' => 'Customer'],
+                [],
+                'fr_FR',
+            );
+        } finally {
+            Request::$isAdminEnv = $wasAdminEnvironment;
+        }
+
+        self::assertNotSame([], $renderedLocales);
+        self::assertSame(['fr_FR'], array_values(array_unique($renderedLocales)));
+        self::assertSame('en_US', $session->getAdminLang()->getLocale());
+    }
+
     public function testSendDoesNotThrowWithNullTransport(): void
     {
         $email = $this->mailerFactory->createSimpleEmailMessage(
@@ -176,5 +237,23 @@ final class MailerFactoryTest extends IntegrationTestCase
         // should complete without error.
         $this->mailerFactory->send($email);
         self::assertTrue(true);
+    }
+
+    private function createParserResolverReturning(ParserInterface $parser): ParserResolver
+    {
+        return new class($this->getService(RequestStack::class), $this->getService(TemplateHelperInterface::class), $parser) extends ParserResolver {
+            public function __construct(
+                RequestStack $requestStack,
+                TemplateHelperInterface $templateHelper,
+                private readonly ParserInterface $parser,
+            ) {
+                parent::__construct([], [], $requestStack, $templateHelper);
+            }
+
+            public function getParser(string $pathTemplate, ?string $templateName): ParserInterface
+            {
+                return $this->parser;
+            }
+        };
     }
 }


### PR DESCRIPTION
A customer notification triggered by a back office action could be rendered in the language of the administrator's interface instead of the customer's own language.

`MailerFactory::createEmailMessage()` pushed the email language into the front office session slot (`Session::setLang()`, core/lib/Thelia/Mailer/MailerFactory.php:188), but `Session::getLang()` returns the admin language as soon as the request runs in an admin environment (core/lib/Thelia/Core/HttpFoundation/Session/Session.php:45). That is the value the parsers and the translator read to localize a render (TwigParser line 63, SmartyParser line 392, `Translator::getLocale()`), so the swap was a no-op in the back office.

The swap now targets the slot `Session::getLang()` actually reads, mirroring what 2.6 does since #3476, and it is still restored in a `finally`. The session lookup is also guarded so a send from the command line, where no session exists, no longer relies on a request being there.

Side effect worth noting: shop manager notifications (`sendEmailToShopManagers()`, no explicit locale) triggered from the back office now render in the store default language instead of the administrator's interface language, which is what the same email already did when triggered from the front office.

Fixes #3505