### PR TITLE
fix: treat the customer discount as the decimal it is

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -407,7 +407,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
                 // If the customer has a discount, whe have to duplicate the cart,
                 // so that the discount will be applied to the products in cart.
 
-                if (0 === $customer->getDiscount() || 0 === $cart->countCartItems()) {
+                // getDiscount() maps a DECIMAL column, so it returns a string such as '0.000000'.
+                if (0.0 === (float) $customer->getDiscount() || 0 === $cart->countCartItems()) {
                     // If no discount, or an empty cart, there's no need to duplicate.
                     $duplicateCart = false;
                 }


### PR DESCRIPTION
`Customer::getDiscount()` maps a DECIMAL column, so the Propel getter returns a string (`'0.000000'` when there is no discount).

`core/lib/Thelia/Action/Cart.php:410` compared it with `0 === ...`, which never matched: a customer without a discount always got their anonymous cart duplicated at login instead of simply taking it over. The comparison now runs on the decimal value.

The other DECIMAL misuses fixed on `main` (a string reaching the `int $discount` parameter of `ProductSaleElements`) do not apply here: 2.6 has no parameter types on those methods and no `declare(strict_types=1)`, so the string is coerced.

Refs #3534
