### PR TITLE
fix: report a virtual download only when the order has a virtual document

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -338,7 +338,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                 $discountWithoutTax = Calculator::getUntaxedOrderDiscount($order);
             }
 
-            $hasVirtualDownload = $order->hasVirtualProduct();
+            $hasVirtualDownload = $order->hasVirtualProductWithDocument();
 
             $loopResultRow = new LoopResultRow($order);
             $loopResultRow

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -365,9 +365,11 @@ class Order extends BaseOrder
     }
 
     /**
-     * Check if the current order contains at less 1 virtual product with a file to download.
+     * Check if the current order contains at least 1 virtual product, whether it has a document to
+     * download or not. Virtual delivery modules that do not rely on the core document mechanism use
+     * this method, so its scope is intentionally broad.
      *
-     * @return bool true if this order have at less 1 file to download, false otherwise
+     * @return bool true if this order has at least 1 virtual product, false otherwise
      */
     public function hasVirtualProduct(): bool
     {
@@ -377,6 +379,22 @@ class Order extends BaseOrder
             ->count();
 
         return 0 !== $virtualProductCount;
+    }
+
+    /**
+     * Check if the current order contains at least 1 virtual product having a document to download.
+     *
+     * @return bool true if this order has at least 1 file to download, false otherwise
+     */
+    public function hasVirtualProductWithDocument(): bool
+    {
+        $downloadableProductCount = OrderProductQuery::create()
+            ->filterByOrderId($this->getId())
+            ->filterByVirtual(1, Criteria::EQUAL)
+            ->filterByVirtualDocument(null, Criteria::NOT_EQUAL)
+            ->count();
+
+        return 0 !== $downloadableProductCount;
     }
 
     /**

--- a/tests/Integration/Model/OrderVirtualProductDocumentTest.php
+++ b/tests/Integration/Model/OrderVirtualProductDocumentTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Core\Template\Loop\LoopExecutor;
+use Thelia\Model\Order;
+use Thelia\Model\OrderProduct;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A virtual product is not necessarily downloadable: a subscription sold as a virtual
+ * product carries no virtual document. Order::hasVirtualProduct() stays broad for the
+ * delivery modules that do not use the core document mechanism, while
+ * Order::hasVirtualProductWithDocument() answers the question the download features ask.
+ */
+final class OrderVirtualProductDocumentTest extends IntegrationTestCase
+{
+    public function testAVirtualProductWithoutDocumentIsNotDownloadable(): void
+    {
+        $order = $this->createOrderWithVirtualProduct(null);
+
+        self::assertTrue(
+            $order->hasVirtualProduct(),
+            'The order does contain a virtual product; the broad check must stay true.',
+        );
+        self::assertFalse(
+            $order->hasVirtualProductWithDocument(),
+            'Without a virtual document there is nothing to download.',
+        );
+    }
+
+    public function testAVirtualProductWithADocumentIsDownloadable(): void
+    {
+        $order = $this->createOrderWithVirtualProduct('subscription-invoice.pdf');
+
+        self::assertTrue($order->hasVirtualProduct());
+        self::assertTrue($order->hasVirtualProductWithDocument());
+    }
+
+    public function testOrderLoopReportsNoVirtualDownloadWhenTheDocumentIsMissing(): void
+    {
+        $order = $this->createOrderWithVirtualProduct(null);
+
+        // The order_product loop only returns products having a document: the order loop
+        // must not announce a download the product loop will not be able to list.
+        self::assertSame(0, $this->getLoopExecutor()->count('order_product', [
+            'order' => $order->getId(),
+            'virtual' => 1,
+        ]));
+        self::assertFalse($this->getOrderLoopVirtualFlag($order));
+    }
+
+    public function testOrderLoopReportsAVirtualDownloadWhenTheDocumentIsPresent(): void
+    {
+        $order = $this->createOrderWithVirtualProduct('subscription-invoice.pdf');
+
+        self::assertSame(1, $this->getLoopExecutor()->count('order_product', [
+            'order' => $order->getId(),
+            'virtual' => 1,
+        ]));
+        self::assertTrue($this->getOrderLoopVirtualFlag($order));
+    }
+
+    private function createOrderWithVirtualProduct(?string $virtualDocument): Order
+    {
+        $factory = $this->createFixtureFactory();
+        $order = $factory->order();
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('virtual-ref')
+            ->setProductSaleElementsRef('virtual-pse-ref')
+            ->setTitle('Virtual product')
+            ->setQuantity(1.0)
+            ->setPrice('10.000000')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->setVirtual(1)
+            ->setVirtualDocument($virtualDocument)
+            ->save();
+
+        return $order;
+    }
+
+    private function getOrderLoopVirtualFlag(Order $order): bool
+    {
+        $result = $this->getLoopExecutor()->execute('order', [
+            'id' => $order->getId(),
+            'customer' => '*',
+            'status' => '*',
+        ]);
+
+        foreach ($result as $row) {
+            return (bool) $row->getVarVal()['VIRTUAL'];
+        }
+
+        self::fail('The order loop returned no row for order '.$order->getId().'.');
+    }
+
+    private function getLoopExecutor(): LoopExecutor
+    {
+        return $this->getService(LoopExecutor::class);
+    }
+}


### PR DESCRIPTION
`Order::hasVirtualProduct()` returns true for any virtual order product, but the features that
consume it need a downloadable file: `Core/Template/Loop/OrderProduct.php` only returns virtual
products whose `virtual_document` is not null. An order holding a virtual product without a
document (a subscription, for instance) therefore advertised a download that no product row could
back, so the customer account page rendered an empty file table.

`Model/Order.php` gains `hasVirtualProductWithDocument()`, which adds the `virtual_document`
condition, and `Core/Template/Loop/Order.php:341` now feeds its `VIRTUAL` output from it — the
local variable was already named `hasVirtualDownload`.

`hasVirtualProduct()` keeps its broad meaning so virtual delivery modules that do not use the core
document mechanism are unaffected. The `order` loop `VIRTUAL` output is the only behaviour change:
it is now false for a virtual order with no file, which is what themes gate the download table on.

Fixes #3517
