### PR TITLE
fix: tell the admin to deactivate a module that an order still references

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -226,6 +226,10 @@ class Module extends BaseAction implements EventSubscriberInterface
                             'The module "%name%" is currently in use by at least one order, and can\'t be deleted.',
                             ['%name%' => $module->getCode()]
                         )
+                        .' '
+                        .Translator::getInstance()->trans(
+                            'To stop offering it to your customers, deactivate the module instead of deleting it.'
+                        )
                     );
                 }
 

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -667,6 +667,7 @@ return [
     'Title *' => 'Title *',
     'Title ID not found' => 'Title ID not found',
     'To activate module %name, the following modules should be activated first: %modules' => 'To activate module %name, the following modules should be activated first: %modules',
+    'To stop offering it to your customers, deactivate the module instead of deleting it.' => 'To stop offering it to your customers, deactivate the module instead of deleting it.',
     'Tools' => 'Tools',
     'Translations' => 'Translations',
     'Change short title for' => 'Change short title for',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -663,6 +663,7 @@ return [
     'Title *' => 'Titre *',
     'Title ID not found' => 'ID de la civilité non trouvé',
     'To activate module %name, the following modules should be activated first: %modules' => 'Pour activer le module %name, les modules suivants doivent être tout d\'abord activés: %modules',
+    'To stop offering it to your customers, deactivate the module instead of deleting it.' => 'Pour ne plus le proposer à vos clients, désactivez le module au lieu de le supprimer.',
     'Tools' => 'Outils',
     'Translations' => 'Traductions',
     'Tried to download a file, but the URL was not valid: %url' => 'Le fichier n\'a pas été téléchargé, l\'url n\'est pas valide: %url',


### PR DESCRIPTION
Deleting a payment or delivery module that an order still references fails on the `ON DELETE RESTRICT` foreign keys `fk_order_payment_module_id` / `fk_order_delivery_module_id` (setup/thelia.sql:768-777).

That case is already guarded in `core/lib/Thelia/Action/Module.php:221` (since d011808f6), so the raw `ModelCriteria::delete is unable to delete.` message is no longer shown. What the admin gets instead only states that the module cannot be deleted, without saying what to do about it.

This adds a second sentence to that message, telling the admin to deactivate the module rather than delete it, with its English and French translations. The existing sentence and its nine translations are left untouched, so no locale regresses.

The deeper change discussed in the issue (a link table between order and module, so obsolete payment/delivery modules can actually be removed) is not addressed here.

Refs #1145
