### PR TITLE
fix: report a virtual download only when the order has a virtual document

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -328,7 +328,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
                 Calculator::getUntaxedOrderDiscount($order)
             ;
 
-            $hasVirtualDownload = $order->hasVirtualProduct();
+            $hasVirtualDownload = $order->hasVirtualProductWithDocument();
 
             $loopResultRow = new LoopResultRow($order);
             $loopResultRow

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -335,9 +335,11 @@ class Order extends BaseOrder
     }
 
     /**
-     * Check if the current order contains at less 1 virtual product with a file to download.
+     * Check if the current order contains at least 1 virtual product, whether it has a document to
+     * download or not. Virtual delivery modules that do not rely on the core document mechanism use
+     * this method, so its scope is intentionally broad.
      *
-     * @return bool true if this order have at less 1 file to download, false otherwise
+     * @return bool true if this order has at least 1 virtual product, false otherwise
      */
     public function hasVirtualProduct()
     {
@@ -348,6 +350,23 @@ class Order extends BaseOrder
         ;
 
         return $virtualProductCount !== 0;
+    }
+
+    /**
+     * Check if the current order contains at least 1 virtual product having a document to download.
+     *
+     * @return bool true if this order has at least 1 file to download, false otherwise
+     */
+    public function hasVirtualProductWithDocument()
+    {
+        $downloadableProductCount = OrderProductQuery::create()
+            ->filterByOrderId($this->getId())
+            ->filterByVirtual(1, Criteria::EQUAL)
+            ->filterByVirtualDocument(null, Criteria::NOT_EQUAL)
+            ->count()
+        ;
+
+        return $downloadableProductCount !== 0;
     }
 
     /**

--- a/local/modules/VirtualProductDelivery/EventListeners/SendMail.php
+++ b/local/modules/VirtualProductDelivery/EventListeners/SendMail.php
@@ -12,14 +12,12 @@
 
 namespace VirtualProductDelivery\EventListeners;
 
-use Propel\Runtime\ActiveQuery\Criteria;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Log\Tlog;
 use Thelia\Mailer\MailerFactory;
-use Thelia\Model\OrderProductQuery;
 use VirtualProductDelivery\Events\VirtualProductDeliveryEvents;
 
 /**
@@ -45,7 +43,9 @@ class SendMail implements EventSubscriberInterface
     {
         $order = $event->getOrder();
 
-        if ($order->hasVirtualProduct() && $order->isPaid(true)) {
+        // A virtual product without a virtual document has nothing to download, so there is
+        // no download notification to send: do not dispatch the event at all in that case.
+        if ($order->hasVirtualProductWithDocument() && $order->isPaid(true)) {
             $this->eventDispatcher->dispatch(
                 $event,
                 VirtualProductDeliveryEvents::ORDER_VIRTUAL_FILES_AVAILABLE
@@ -62,32 +62,30 @@ class SendMail implements EventSubscriberInterface
     {
         $order = $event->getOrder();
 
-        // Be sure that we have a document to download
-        $virtualProductCount = OrderProductQuery::create()
-            ->filterByOrderId($order->getId())
-            ->filterByVirtual(true)
-            ->filterByVirtualDocument(null, Criteria::NOT_EQUAL)
-            ->count();
-
-        if ($virtualProductCount > 0) {
-            $customer = $order->getCustomer();
-
-            $this->mailer->sendEmailToCustomer(
-                'mail_virtualproduct',
-                $customer,
-                [
-                    'customer_id' => $customer->getId(),
-                    'order_id' => $order->getId(),
-                    'order_ref' => $order->getRef(),
-                    'order_date' => $order->getCreatedAt(),
-                    'update_date' => $order->getUpdatedAt(),
-                ]
+        // The event may also be dispatched by a third party: be sure that we have a document
+        // to download. Having none is a legitimate case, not something to warn about.
+        if (!$order->hasVirtualProductWithDocument()) {
+            Tlog::getInstance()->debug(
+                'Virtual product download message not sent to customer: order '
+                .$order->getRef().' has no document to download'
             );
-        } else {
-            Tlog::getInstance()->warning(
-                "Virtual product download message not sent to customer: there's nothing to downnload"
-            );
+
+            return;
         }
+
+        $customer = $order->getCustomer();
+
+        $this->mailer->sendEmailToCustomer(
+            'mail_virtualproduct',
+            $customer,
+            [
+                'customer_id' => $customer->getId(),
+                'order_id' => $order->getId(),
+                'order_ref' => $order->getRef(),
+                'order_date' => $order->getCreatedAt(),
+                'update_date' => $order->getUpdatedAt(),
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
`Order::hasVirtualProduct()` (`core/lib/Thelia/Model/Order.php:342`) returns true for any virtual
order product, but the features that consume it need a downloadable file:
`core/lib/Thelia/Core/Template/Loop/OrderProduct.php:86-89` only returns virtual products whose
`virtual_document` is not null. An order holding a virtual product without a document (a
subscription, for instance) therefore advertised a download that no product row could back, and
`templates/frontOffice/default/account-order.html:210` rendered the module table header with no
row. `VirtualProductDelivery/EventListeners/SendMail.php:48` also dispatched the notification event
only for its `sendEmail()` guard to log a warning.

`Model/Order.php` gains `hasVirtualProductWithDocument()`, which adds the `virtual_document`
condition. `Core/Template/Loop/Order.php:331` now feeds its `VIRTUAL` output from it (the local
variable was already named `hasVirtualDownload`), and `SendMail` uses it both to gate the dispatch
and to guard the mail, downgrading the "nothing to download" message from a warning to debug since
it is a legitimate case.

`hasVirtualProduct()` keeps its broad meaning so virtual delivery modules that do not use the core
document mechanism are unaffected. The `order` loop `VIRTUAL` output is the only behaviour change:
it is now false for a virtual order with no file, which is what themes gate the download table on.

Refs #3517
