### PR TITLE
fix(product): persist the virtual product document on product update

### DIFF
--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -25,6 +25,8 @@ use Thelia\Core\Event\Feature\FeatureAvDeleteEvent;
 use Thelia\Core\Event\FeatureProduct\FeatureProductDeleteEvent;
 use Thelia\Core\Event\FeatureProduct\FeatureProductUpdateEvent;
 use Thelia\Core\Event\File\FileDeleteEvent;
+use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
+use Thelia\Core\Event\MetaData\MetaDataDeleteEvent;
 use Thelia\Core\Event\Product\ProductAddAccessoryEvent;
 use Thelia\Core\Event\Product\ProductAddCategoryEvent;
 use Thelia\Core\Event\Product\ProductAddContentEvent;
@@ -58,6 +60,7 @@ use Thelia\Model\Map\AttributeTemplateTableMap;
 use Thelia\Model\Map\FeatureTemplateTableMap;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
 use Thelia\Model\Map\ProductTableMap;
+use Thelia\Model\MetaData as MetaDataModel;
 use Thelia\Model\Product as ProductModel;
 use Thelia\Model\ProductAssociatedContent;
 use Thelia\Model\ProductAssociatedContentQuery;
@@ -372,6 +375,47 @@ class Product extends BaseAction implements EventSubscriberInterface
 
             throw $e;
         }
+
+        $this->updateVirtualDocumentAssociation($event);
+    }
+
+    /**
+     * Store the document a virtual product is downloaded from, for the default sale element.
+     * The association lives in a meta_data row (virtual key, pse element).
+     *
+     * A null or negative value means the caller does not handle the association (a product with
+     * several combinations sets it per combination), 0 removes it, and a document id sets it.
+     */
+    private function updateVirtualDocumentAssociation(ProductUpdateEvent $event): void
+    {
+        $virtualDocumentId = $event->getVirtualDocumentId();
+
+        if (null === $virtualDocumentId || (int) $virtualDocumentId < 0) {
+            return;
+        }
+
+        $defaultPse = ProductSaleElementsQuery::create()
+            ->filterByProductId($event->getProductId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        if (null === $defaultPse) {
+            return;
+        }
+
+        if (0 === (int) $virtualDocumentId) {
+            $this->eventDispatcher->dispatch(
+                new MetaDataDeleteEvent('virtual', MetaDataModel::PSE_KEY, $defaultPse->getId()),
+                TheliaEvents::META_DATA_DELETE
+            );
+
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(
+            new MetaDataCreateOrUpdateEvent('virtual', MetaDataModel::PSE_KEY, $defaultPse->getId(), (int) $virtualDocumentId),
+            TheliaEvents::META_DATA_UPDATE
+        );
     }
 
     public function updateSeo(UpdateSeoEvent $event, $eventName, EventDispatcherInterface $dispatcher): mixed

--- a/tests/Integration/Action/ProductActionTest.php
+++ b/tests/Integration/Action/ProductActionTest.php
@@ -17,9 +17,15 @@ namespace Thelia\Tests\Integration\Action;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Product\ProductCreateEvent;
 use Thelia\Core\Event\Product\ProductDeleteEvent;
+use Thelia\Core\Event\Product\ProductUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductDocument;
 use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductQuery;
+use Thelia\Model\ProductSaleElements;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Test\FixtureFactory;
 use Thelia\Test\IntegrationTestCase;
@@ -159,5 +165,112 @@ final class ProductActionTest extends IntegrationTestCase
             ->filterByProductId($productId)
             ->count();
         self::assertSame(0, $remainingPse);
+    }
+
+    public function testUpdateStoresVirtualDocumentOfTheDefaultSaleElement(): void
+    {
+        $product = $this->createVirtualProduct();
+        $document = $this->createDocument($product);
+
+        $this->dispatcher->dispatch(
+            $this->virtualDocumentUpdateEvent($product, $document->getId()),
+            TheliaEvents::PRODUCT_UPDATE,
+        );
+
+        self::assertSame(
+            $document->getId(),
+            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $this->defaultSaleElement($product)->getId()),
+        );
+    }
+
+    public function testUpdateRemovesVirtualDocumentWhenNoneIsSelected(): void
+    {
+        $product = $this->createVirtualProduct();
+        $document = $this->createDocument($product);
+        $defaultPse = $this->defaultSaleElement($product);
+
+        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultPse->getId(), $document->getId());
+
+        $this->dispatcher->dispatch(
+            $this->virtualDocumentUpdateEvent($product, 0),
+            TheliaEvents::PRODUCT_UPDATE,
+        );
+
+        self::assertNull(MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $defaultPse->getId()));
+    }
+
+    public function testUpdateKeepsTheAssociationsOfAProductWithSeveralCombinations(): void
+    {
+        $product = $this->createVirtualProduct();
+        $document = $this->createDocument($product);
+        $defaultPse = $this->defaultSaleElement($product);
+        $secondPse = $this->factory->productSaleElement($product);
+
+        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultPse->getId(), $document->getId());
+        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $secondPse->getId(), $document->getId());
+
+        // -1 is what the back office sends when the association is managed per combination.
+        $this->dispatcher->dispatch(
+            $this->virtualDocumentUpdateEvent($product, -1),
+            TheliaEvents::PRODUCT_UPDATE,
+        );
+
+        self::assertSame(
+            $document->getId(),
+            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $defaultPse->getId()),
+        );
+        self::assertSame(
+            $document->getId(),
+            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $secondPse->getId()),
+        );
+    }
+
+    private function createVirtualProduct(): Product
+    {
+        return $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+        );
+    }
+
+    private function createDocument(Product $product): ProductDocument
+    {
+        $document = new ProductDocument();
+        $document
+            ->setProductId($product->getId())
+            ->setFile('handbook.pdf')
+            ->setVisible(0)
+            ->setPosition(1)
+            ->save();
+
+        return $document;
+    }
+
+    private function defaultSaleElement(Product $product): ProductSaleElements
+    {
+        $defaultPse = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        self::assertNotNull($defaultPse);
+
+        return $defaultPse;
+    }
+
+    private function virtualDocumentUpdateEvent(Product $product, int $virtualDocumentId): ProductUpdateEvent
+    {
+        $event = new ProductUpdateEvent($product->getId());
+        $event
+            ->setLocale('en_US')
+            ->setRef($product->getRef())
+            ->setTitle('Digital handbook')
+            ->setDefaultCategory($product->getDefaultCategoryId())
+            ->setVisible(true)
+            ->setVirtual(true)
+            ->setVirtualDocumentId($virtualDocumentId);
+
+        return $event;
     }
 }


### PR DESCRIPTION
The virtual product document chosen in the back office was never stored: `ProductUpdateEvent::getVirtualDocumentId()` had no consumer in the core, only the legacy Smarty back office read it back (core/lib/Thelia/Action/Product.php:332, product update listener).

`Thelia\\Action\\Product::update()` now writes the association on the product default sale element, in the `meta_data` row (`virtual` key, `pse` element) already used by the combinations tab and by the order process. A document id sets it, 0 removes it, and null or a negative value leaves it untouched, which is what a product managing one document per combination sends.

The REST/domain path benefits from the same behaviour through `ProductUpdateDTO::$virtualDocumentId` (null by default, so no existing caller changes behaviour).

Three integration tests cover the three cases (tests/Integration/Action/ProductActionTest.php).

Fixes #3516