### PR TITLE
fix: return null instead of rounding a null price in the OrderProduct resource

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -461,7 +461,7 @@ class OrderProduct implements PropelResourceInterface
 
     public function getPromoPrice(): ?float
     {
-        return round($this->promoPrice, 2);
+        return null === $this->promoPrice ? null : round($this->promoPrice, 2);
     }
 
     public function setPromoPrice(?float $promoPrice): self
@@ -473,7 +473,7 @@ class OrderProduct implements PropelResourceInterface
 
     public function getUnitTaxedPrice(): ?float
     {
-        return round($this->unitTaxedPrice, 2);
+        return null === $this->unitTaxedPrice ? null : round($this->unitTaxedPrice, 2);
     }
 
     public function isWasNew(): bool


### PR DESCRIPTION
`getUnitTaxedPrice()` and `getPromoPrice()` call `round()` on a property that is legitimately null, so `GET /api/admin/order_products/{id}` answers a 500 for any order product with no row in `order_product_tax`.

`afterModelToResource()` fills `unitTaxedPrice` only when the taxes collection is not empty (core/lib/Thelia/Api/Resource/OrderProduct.php:632), which is the documented case for a product carrying no tax. Both getters already declare `?float`, so they now return null instead of feeding null to `round()`.

Fixes #3552
