### PR TITLE
fix: return null instead of rounding a null price in the OrderProduct resource

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -419,7 +419,7 @@ class OrderProduct implements PropelResourceInterface
 
     public function getPromoPrice(): ?float
     {
-        return round($this->promoPrice, 2);
+        return null === $this->promoPrice ? null : round($this->promoPrice, 2);
     }
 
     public function setPromoPrice(?float $promoPrice): self
@@ -431,7 +431,7 @@ class OrderProduct implements PropelResourceInterface
 
     public function getUnitTaxedPrice(): ?float
     {
-        return round($this->unitTaxedPrice, 2);
+        return null === $this->unitTaxedPrice ? null : round($this->unitTaxedPrice, 2);
     }
 
     public function isWasNew(): bool


### PR DESCRIPTION
Same fix as #3553, on the 2.6 line.

`getUnitTaxedPrice()` and `getPromoPrice()` pass a null property to `round()` (core/lib/Thelia/Api/Resource/OrderProduct.php:422 and 434) whenever the order product has no row in `order_product_tax`, which `afterModelToResource()` treats as a normal case. The API resource file has no `declare(strict_types=1)`, so 2.6 answers `0` with a deprecation notice where the nullable return type says it should answer `null`.

Refs #3552
