### PR TITLE
fix: keep the hook positions and the ignored hooks when running hook:clean

### DIFF
--- a/core/lib/Thelia/Command/HookCleanCommand.php
+++ b/core/lib/Thelia/Command/HookCleanCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Thelia\Core\Event\Cache\CacheEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
 use Thelia\Model\IgnoredModuleHookQuery;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleHookQuery;
@@ -38,12 +39,25 @@ class HookCleanCommand extends ContainerAwareCommand
     {
         $this
             ->setName('hook:clean')
-            ->setDescription('Clean hooks. It will delete all hooks, then recreate it.')
+            ->setDescription('Clean hooks. It will delete all hooks, then recreate them from the module declarations.')
+            ->setHelp(
+                'Delete the module hooks, so that they are recreated from the module declarations on the next '
+                ."container build.\n"
+                .'The positions and the active states set in the back office are restored on the recreated hooks, '
+                .'and the hooks removed in the back office are not restored. Use --reset-positions to drop that '
+                .'configuration and start over.'
+            )
             ->addOption(
                 'assume-yes',
                 'y',
                 InputOption::VALUE_NONE,
                 'Assume to answer yes to all questions'
+            )
+            ->addOption(
+                'reset-positions',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not keep the positions and the active states set in the back office, and restore the hooks removed in the back office'
             )
             ->addArgument(
                 'module',
@@ -61,7 +75,7 @@ class HookCleanCommand extends ContainerAwareCommand
                 return 1;
             }
 
-            $this->deleteHooks($module);
+            $this->deleteHooks($module, !$input->getOption('reset-positions'));
 
             $output->writeln('<info>Hooks have been successfully deleted</info>');
 
@@ -116,15 +130,28 @@ class HookCleanCommand extends ContainerAwareCommand
     }
 
     /**
-     * Delete module hooks.
+     * Delete module hooks. They are recreated by RegisterHookListenersPass on the next container build.
      *
-     * @param Module|null $module if specified it will only delete hooks related to this module
+     * @param Module|null $module                if specified it will only delete hooks related to this module
+     * @param bool        $preserveConfiguration keep the positions and the active states set in the back office,
+     *                                           and keep the hooks removed in the back office removed
      *
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    protected function deleteHooks($module): void
+    protected function deleteHooks($module, $preserveConfiguration = true): void
     {
+        if ($preserveConfiguration) {
+            $savedHooks = ModuleHookQuery::create();
+            if (null !== $module) {
+                $savedHooks->filterByModule($module);
+            }
+
+            ModuleHookConfigurationStore::save($savedHooks->find());
+        } else {
+            ModuleHookConfigurationStore::discard();
+        }
+
         $query = ModuleHookQuery::create();
         if (null !== $module) {
             $query
@@ -132,6 +159,11 @@ class HookCleanCommand extends ContainerAwareCommand
                 ->delete();
         } else {
             $query->deleteAll();
+        }
+
+        if ($preserveConfiguration) {
+            // A hook removed in the back office must stay removed.
+            return;
         }
 
         $query = IgnoredModuleHookQuery::create();

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Thelia\Core\Hook\BaseHook;
 use Thelia\Core\Hook\HookDefinition;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Log\Tlog;
 use Thelia\Model\Base\IgnoredModuleHookQuery;
@@ -126,6 +127,9 @@ class RegisterHookListenersPass implements CompilerPassInterface
 
         // now we can add listeners for active hooks and active module
         $this->addHooksMethodCall($container, $definition);
+
+        // the hooks saved by hook:clean have been recreated, the saved configuration is not needed anymore
+        ModuleHookConfigurationStore::discard();
     }
 
     /**
@@ -189,6 +193,13 @@ class RegisterHookListenersPass implements CompilerPassInterface
                 ->count();
 
             if (0 === $ignoreCount) {
+                // restore the configuration saved by hook:clean, if this hook was one of the deleted ones
+                $savedConfiguration = ModuleHookConfigurationStore::find(
+                    $module->getId(),
+                    $hook->getId(),
+                    $attributes['method']
+                );
+
                 // hook for module doesn't exist, we add it with default registered values
                 $moduleHook = new ModuleHook();
 
@@ -196,10 +207,10 @@ class RegisterHookListenersPass implements CompilerPassInterface
                     ->setModuleId($module->getId())
                     ->setClassname($id)
                     ->setMethod($attributes['method'])
-                    ->setActive($active)
+                    ->setActive($savedConfiguration['active'] ?? $active)
                     ->setHookActive(true)
                     ->setModuleActive(true)
-                    ->setPosition(ModuleHook::MAX_POSITION);
+                    ->setPosition($savedConfiguration['position'] ?? ModuleHook::MAX_POSITION);
 
                 if (isset($attributes['templates'])) {
                     $moduleHook->setTemplates($attributes['templates']);

--- a/core/lib/Thelia/Core/Hook/ModuleHookConfigurationStore.php
+++ b/core/lib/Thelia/Core/Hook/ModuleHookConfigurationStore.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Hook;
+
+use Propel\Runtime\Collection\ObjectCollection;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\ModuleHook;
+
+/**
+ * Remembers the part of a module hook that only the administrator can set: its rendering position
+ * and its active state.
+ *
+ * The hook:clean command deletes the module_hook rows, and RegisterHookListenersPass recreates them
+ * during the next container build, in another process. The saved configuration is therefore kept in
+ * the config table: the command wipes the cache directory right after the deletion, and the
+ * container may be rebuilt by another system user or on another server.
+ */
+final class ModuleHookConfigurationStore
+{
+    public const CONFIG_NAME = 'saved-module-hook-configuration';
+
+    /**
+     * @var array<string, array{position: int, active: bool}>|null
+     */
+    private static $configuration;
+
+    /**
+     * Saves the configuration of the given module hooks, keeping the previously saved one.
+     */
+    public static function save(ObjectCollection $moduleHooks): void
+    {
+        $configuration = self::read();
+
+        /** @var ModuleHook $moduleHook */
+        foreach ($moduleHooks as $moduleHook) {
+            $key = self::key($moduleHook->getModuleId(), $moduleHook->getHookId(), (string) $moduleHook->getMethod());
+
+            $configuration[$key] = [
+                'position' => $moduleHook->getPosition(),
+                'active' => (bool) $moduleHook->getActive(),
+            ];
+        }
+
+        if ([] === $configuration) {
+            return;
+        }
+
+        self::$configuration = $configuration;
+
+        ConfigQuery::write(self::CONFIG_NAME, json_encode($configuration, \JSON_THROW_ON_ERROR), true, true);
+    }
+
+    /**
+     * @return array{position: int, active: bool}|null
+     */
+    public static function find(int $moduleId, int $hookId, string $method): ?array
+    {
+        $configuration = self::read();
+        $key = self::key($moduleId, $hookId, $method);
+
+        if (!isset($configuration[$key]) || !\is_array($configuration[$key])) {
+            return null;
+        }
+
+        $saved = $configuration[$key];
+
+        return [
+            'position' => (int) ($saved['position'] ?? ModuleHook::MAX_POSITION),
+            'active' => (bool) ($saved['active'] ?? true),
+        ];
+    }
+
+    public static function discard(): void
+    {
+        self::$configuration = [];
+
+        ConfigQuery::create()->filterByName(self::CONFIG_NAME)->delete();
+    }
+
+    /**
+     * @return array<string, array{position: int, active: bool}>
+     */
+    private static function read(): array
+    {
+        if (null !== self::$configuration) {
+            return self::$configuration;
+        }
+
+        $config = ConfigQuery::create()->findOneByName(self::CONFIG_NAME);
+
+        try {
+            $configuration = null === $config
+                ? []
+                : json_decode((string) $config->getValue(), true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $configuration = [];
+        }
+
+        return self::$configuration = \is_array($configuration) ? $configuration : [];
+    }
+
+    private static function key(int $moduleId, int $hookId, string $method): string
+    {
+        return $moduleId.':'.$hookId.':'.$method;
+    }
+}


### PR DESCRIPTION
`php Thelia hook:clean` truncates `module_hook` and `ignored_module_hook` (`HookCleanCommand::deleteHooks()`, core/lib/Thelia/Command/HookCleanCommand.php:126). `module_hook.position` is the only lever that orders the listeners of a hook: `RegisterHookListenersPass::addHooksMethodCall()` reads it (RegisterHookListenersPass.php:249) and turns it into the Symfony listener priority (`ModuleHook::MAX_POSITION - $moduleHook->getPosition()`, :307). A maintenance command therefore resets every rendering order the administrator set in the back office, and brings back every hook that was explicitly removed there.

The command now records the `(module_id, hook_id, method) -> position, active` map before deleting the rows, and `RegisterHookListenersPass::registerHook()` reapplies it when it recreates them during the next container build. The map is kept in the `config` table (`saved-module-hook-configuration`, hidden and secured): the command wipes the cache directory right after the deletion, and the container is rebuilt by another process, possibly under another system user. It is deleted once the hooks have been recreated. `ignored_module_hook` is no longer touched. No schema change.

The purpose of the command is unchanged: hooks are still deleted and recreated from the module declarations, so rows that are no longer declared are still purged.

`--reset-positions` restores the previous behaviour: drop the saved configuration and clear the ignored hooks.

Verified on a Thelia install: a hook set to position 42 and inactive in the back office, plus an ignored hook, both survive `hook:clean` followed by a container rebuild.

Refs #3073. The declarative position asked for in the issue (a `position` attribute on the hook declaration) is a separate change, tracked on `main`.
