### PR TITLE
fix: keep the hook positions and the ignored hooks when running hook:clean

### DIFF
--- a/core/lib/Thelia/Command/HookCleanCommand.php
+++ b/core/lib/Thelia/Command/HookCleanCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Thelia\Core\Event\Cache\CacheEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
 use Thelia\Model\IgnoredModuleHookQuery;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleHookQuery;
@@ -36,17 +37,30 @@ use Thelia\Model\ModuleQuery;
  *
  * @author Julien Chanséaume <julien@thelia.net>
  */
-#[AsCommand(name: 'hook:clean', description: 'Clean hooks. It will delete all hooks, then recreate it.')]
+#[AsCommand(name: 'hook:clean', description: 'Clean hooks. It will delete all hooks, then recreate them from the module declarations.')]
 class HookCleanCommand extends ContainerAwareCommand
 {
     protected function configure(): void
     {
         $this
+            ->setHelp(
+                'Delete the module hooks, so that they are recreated from the module declarations on the next '
+                ."container build.\n"
+                .'The positions and the active states set in the back office are restored on the recreated hooks, '
+                .'and the hooks removed in the back office are not restored. Use --reset-positions to drop that '
+                .'configuration and start over.',
+            )
             ->addOption(
                 'assume-yes',
                 'y',
                 InputOption::VALUE_NONE,
                 'Assume to answer yes to all questions',
+            )
+            ->addOption(
+                'reset-positions',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not keep the positions and the active states set in the back office, and restore the hooks removed in the back office',
             )
             ->addArgument(
                 'module',
@@ -64,7 +78,7 @@ class HookCleanCommand extends ContainerAwareCommand
                 return 1;
             }
 
-            $this->deleteHooks($module);
+            $this->deleteHooks($module, !$input->getOption('reset-positions'));
 
             $output->writeln('<info>Hooks have been successfully deleted</info>');
 
@@ -117,15 +131,29 @@ class HookCleanCommand extends ContainerAwareCommand
     }
 
     /**
-     * Delete module hooks.
+     * Delete module hooks. They are recreated by RegisterHookListenersPass on the next container build.
      *
-     * @param Module|null $module if specified it will only delete hooks related to this module
+     * @param Module|null $module                if specified it will only delete hooks related to this module
+     * @param bool        $preserveConfiguration keep the positions and the active states set in the back office,
+     *                                           and keep the hooks removed in the back office removed
      *
      * @throws \Exception
      * @throws PropelException
      */
-    protected function deleteHooks(?Module $module): void
+    protected function deleteHooks(?Module $module, bool $preserveConfiguration = true): void
     {
+        if ($preserveConfiguration) {
+            $savedHooks = ModuleHookQuery::create();
+
+            if ($module instanceof Module) {
+                $savedHooks->filterByModule($module);
+            }
+
+            ModuleHookConfigurationStore::save($savedHooks->find());
+        } else {
+            ModuleHookConfigurationStore::discard();
+        }
+
         $query = ModuleHookQuery::create();
 
         if ($module instanceof Module) {
@@ -134,6 +162,11 @@ class HookCleanCommand extends ContainerAwareCommand
                 ->delete();
         } else {
             $query->deleteAll();
+        }
+
+        if ($preserveConfiguration) {
+            // A hook removed in the back office must stay removed.
+            return;
         }
 
         $query = IgnoredModuleHookQuery::create();

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Thelia\Core\Hook\BaseHook;
 use Thelia\Core\Hook\HookDefinition;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Log\Tlog;
 use Thelia\Model\Base\IgnoredModuleHookQuery;
@@ -131,6 +132,9 @@ class RegisterHookListenersPass implements CompilerPassInterface
 
         // now we can add listeners for active hooks and active module
         $this->addHooksMethodCall($container, $definition);
+
+        // the hooks saved by hook:clean have been recreated, the saved configuration is not needed anymore
+        ModuleHookConfigurationStore::discard();
     }
 
     /**
@@ -173,15 +177,18 @@ class RegisterHookListenersPass implements CompilerPassInterface
             }
 
             if (!IgnoredModuleHookQuery::create()->filterByHook($hook)->filterByModuleId($module->getId())->exists()) {
+                // restore the configuration saved by hook:clean, if this hook was one of the deleted ones
+                $savedConfiguration = ModuleHookConfigurationStore::find($module->getId(), $hook->getId(), $method);
+
                 (new ModuleHook())
                     ->setHook($hook)
                     ->setModuleId($module->getId())
                     ->setClassname($id)
                     ->setMethod($method)
-                    ->setActive($active)
+                    ->setActive($savedConfiguration['active'] ?? $active)
                     ->setHookActive(true)
                     ->setModuleActive(true)
-                    ->setPosition(ModuleHook::MAX_POSITION)
+                    ->setPosition($savedConfiguration['position'] ?? ModuleHook::MAX_POSITION)
                     ->setTemplates($templates)
                     ->save();
             }

--- a/core/lib/Thelia/Core/Hook/ModuleHookConfigurationStore.php
+++ b/core/lib/Thelia/Core/Hook/ModuleHookConfigurationStore.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Hook;
+
+use Propel\Runtime\Collection\ObjectCollection;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\ModuleHook;
+
+/**
+ * Remembers the part of a module hook that only the administrator can set: its rendering position
+ * and its active state.
+ *
+ * The hook:clean command deletes the module_hook rows, and RegisterHookListenersPass recreates them
+ * during the next container build, in another process. The saved configuration is therefore kept in
+ * the config table: the command wipes the cache directory right after the deletion, and the
+ * container may be rebuilt by another system user or on another server.
+ */
+final class ModuleHookConfigurationStore
+{
+    public const CONFIG_NAME = 'saved-module-hook-configuration';
+
+    /**
+     * @var array<string, array{position: int, active: bool}>|null
+     */
+    private static ?array $configuration = null;
+
+    /**
+     * Saves the configuration of the given module hooks, keeping the previously saved one.
+     */
+    public static function save(ObjectCollection $moduleHooks): void
+    {
+        $configuration = self::read();
+
+        /** @var ModuleHook $moduleHook */
+        foreach ($moduleHooks as $moduleHook) {
+            $key = self::key($moduleHook->getModuleId(), $moduleHook->getHookId(), (string) $moduleHook->getMethod());
+
+            $configuration[$key] = [
+                'position' => $moduleHook->getPosition(),
+                'active' => (bool) $moduleHook->getActive(),
+            ];
+        }
+
+        if ([] === $configuration) {
+            return;
+        }
+
+        self::$configuration = $configuration;
+
+        ConfigQuery::write(self::CONFIG_NAME, json_encode($configuration, \JSON_THROW_ON_ERROR), true, true);
+    }
+
+    /**
+     * @return array{position: int, active: bool}|null
+     */
+    public static function find(int $moduleId, int $hookId, string $method): ?array
+    {
+        $configuration = self::read();
+        $key = self::key($moduleId, $hookId, $method);
+
+        if (!isset($configuration[$key]) || !\is_array($configuration[$key])) {
+            return null;
+        }
+
+        $saved = $configuration[$key];
+
+        return [
+            'position' => (int) ($saved['position'] ?? ModuleHook::MAX_POSITION),
+            'active' => (bool) ($saved['active'] ?? true),
+        ];
+    }
+
+    public static function discard(): void
+    {
+        self::$configuration = [];
+
+        ConfigQuery::create()->filterByName(self::CONFIG_NAME)->delete();
+    }
+
+    /**
+     * @return array<string, array{position: int, active: bool}>
+     */
+    private static function read(): array
+    {
+        if (null !== self::$configuration) {
+            return self::$configuration;
+        }
+
+        $config = ConfigQuery::create()->findOneByName(self::CONFIG_NAME);
+
+        try {
+            $configuration = null === $config
+                ? []
+                : json_decode((string) $config->getValue(), true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $configuration = [];
+        }
+
+        return self::$configuration = \is_array($configuration) ? $configuration : [];
+    }
+
+    private static function key(int $moduleId, int $hookId, string $method): string
+    {
+        return $moduleId.':'.$hookId.':'.$method;
+    }
+}

--- a/tests/Integration/Command/HookCleanCommandTest.php
+++ b/tests/Integration/Command/HookCleanCommandTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Command;
+
+use Thelia\Command\HookCleanCommand;
+use Thelia\Core\DependencyInjection\Compiler\RegisterHookListenersPass;
+use Thelia\Core\Hook\DefaultHook;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Hook;
+use Thelia\Model\IgnoredModuleHook;
+use Thelia\Model\IgnoredModuleHookQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
+use Thelia\Model\ModuleQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * hook:clean deletes the module hooks and RegisterHookListenersPass recreates them on the next
+ * container build. Both halves are exercised here, but not the container build itself: the command
+ * is not run through the console, because it clears the cache directory of the running kernel.
+ */
+final class HookCleanCommandTest extends IntegrationTestCase
+{
+    private const HOOK_METHOD = 'insertTemplate';
+
+    private const SERVICE_ID = 'test.hook.clean.listener';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ModuleHookConfigurationStore::discard();
+    }
+
+    public function testCleanRestoresThePositionAndTheActiveStateSetInTheBackOffice(): void
+    {
+        $module = $this->getActiveModule();
+        $hook = $this->createHook('test.hook.clean.position');
+        $this->createModuleHook($module, $hook, position: 7, active: false);
+
+        $this->cleanHooks(preserveConfiguration: true);
+
+        self::assertNull($this->findModuleHook($hook));
+        self::assertNotNull(
+            ConfigQuery::create()->findOneByName(ModuleHookConfigurationStore::CONFIG_NAME),
+            'the configuration must be saved in database, the container is rebuilt in another process',
+        );
+
+        $this->registerHook($module, $hook);
+
+        $recreated = $this->findModuleHook($hook);
+        self::assertNotNull($recreated);
+        self::assertSame(7, $recreated->getPosition());
+        self::assertFalse($recreated->getActive());
+    }
+
+    public function testCleanKeepsTheHooksRemovedInTheBackOfficeRemoved(): void
+    {
+        $module = $this->getActiveModule();
+        $hook = $this->createHook('test.hook.clean.ignored');
+
+        (new IgnoredModuleHook())
+            ->setModuleId($module->getId())
+            ->setHookId($hook->getId())
+            ->setMethod(self::HOOK_METHOD)
+            ->setClassname(self::SERVICE_ID)
+            ->save();
+
+        $this->cleanHooks(preserveConfiguration: true);
+
+        self::assertTrue(
+            IgnoredModuleHookQuery::create()->filterByHookId($hook->getId())->exists(),
+        );
+
+        $this->registerHook($module, $hook);
+
+        self::assertNull($this->findModuleHook($hook));
+    }
+
+    public function testResetPositionsOptionStartsOver(): void
+    {
+        $module = $this->getActiveModule();
+        $hook = $this->createHook('test.hook.clean.reset');
+        $this->createModuleHook($module, $hook, position: 7, active: false);
+
+        (new IgnoredModuleHook())
+            ->setModuleId($module->getId())
+            ->setHookId($hook->getId())
+            ->setMethod('onSomethingElse')
+            ->setClassname(self::SERVICE_ID)
+            ->save();
+
+        $this->cleanHooks(preserveConfiguration: false);
+
+        self::assertFalse(
+            IgnoredModuleHookQuery::create()->filterByHookId($hook->getId())->exists(),
+        );
+
+        $this->registerHook($module, $hook);
+
+        $recreated = $this->findModuleHook($hook);
+        self::assertNotNull($recreated);
+        self::assertSame(ModuleHook::MAX_POSITION, $recreated->getPosition());
+        self::assertTrue($recreated->getActive());
+    }
+
+    private function getActiveModule(): Module
+    {
+        $module = ModuleQuery::create()->findOneByCode('Cheque');
+        self::assertNotNull($module, 'Cheque module must be registered by bin/test-prepare');
+
+        return $module;
+    }
+
+    private function createHook(string $code): Hook
+    {
+        $hook = new Hook();
+        $hook
+            ->setCode($code)
+            ->setType(TemplateDefinition::FRONT_OFFICE)
+            ->setNative(false)
+            ->setActivate(true)
+            ->setBlock(false)
+            ->setByModule(false);
+        $hook
+            ->setLocale('en_US')
+            ->setTitle('Hook '.$code);
+        $hook->save();
+
+        return $hook;
+    }
+
+    private function createModuleHook(Module $module, Hook $hook, int $position, bool $active): void
+    {
+        (new ModuleHook())
+            ->setHook($hook)
+            ->setModuleId($module->getId())
+            ->setClassname(self::SERVICE_ID)
+            ->setMethod(self::HOOK_METHOD)
+            ->setActive($active)
+            ->setHookActive(true)
+            ->setModuleActive(true)
+            ->setPosition($position)
+            ->setTemplates('')
+            ->save();
+    }
+
+    private function findModuleHook(Hook $hook): ?ModuleHook
+    {
+        return ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+    }
+
+    private function cleanHooks(bool $preserveConfiguration): void
+    {
+        $command = new HookCleanCommand();
+
+        (new \ReflectionMethod($command, 'deleteHooks'))
+            ->invoke($command, null, $preserveConfiguration);
+    }
+
+    /**
+     * Replays what RegisterHookListenersPass does for a hook declared by a module.
+     */
+    private function registerHook(Module $module, Hook $hook): void
+    {
+        $pass = new RegisterHookListenersPass();
+
+        (new \ReflectionMethod($pass, 'registerHook'))->invoke(
+            $pass,
+            DefaultHook::class,
+            $module,
+            self::SERVICE_ID,
+            ['event' => $hook->getCode(), 'type' => 'front', 'method' => self::HOOK_METHOD],
+        );
+    }
+}


### PR DESCRIPTION
`php Thelia hook:clean` truncates `module_hook` and `ignored_module_hook` (`HookCleanCommand::deleteHooks()`, core/lib/Thelia/Command/HookCleanCommand.php:127). `module_hook.position` is the only lever that orders the listeners of a hook: `RegisterHookListenersPass::addHooksMethodCall()` reads it (RegisterHookListenersPass.php:205) and turns it into the Symfony listener priority (`ModuleHook::MAX_POSITION - $moduleHook->getPosition()`, :263). A maintenance command therefore resets every rendering order the administrator set in the back office, and brings back every hook that was explicitly removed there.

The command now records the `(module_id, hook_id, method) -> position, active` map before deleting the rows, and `RegisterHookListenersPass::registerHook()` reapplies it when it recreates them during the next container build. The map is kept in the `config` table (`saved-module-hook-configuration`, hidden and secured): the command wipes the cache directory right after the deletion, and the container is rebuilt by another process, possibly under another system user. It is deleted once the hooks have been recreated. `ignored_module_hook` is no longer touched. No schema change.

The purpose of the command is unchanged: hooks are still deleted and recreated from the module declarations, so rows that are no longer declared are still purged.

`--reset-positions` restores the previous behaviour: drop the saved configuration and clear the ignored hooks.

`tests/Integration/Command/HookCleanCommandTest.php` covers the two halves, deletion and recreation, but not the container build itself: running the command through the console would clear the cache directory of the kernel running the tests. The whole path was checked by hand on an install, where a hook set to position 42 and inactive, plus an ignored hook, survive `hook:clean` followed by a container rebuild.

Refs #3073. The issue also asks for a position stated in the hook declaration itself, which needs a new `module_hook` column and a ruling on who wins between the module and the administrator, so it stays open.
