### PR TITLE
fix: pass the validated form to the customer events instead of calling getForm on it

### DIFF
--- a/local/modules/Front/Controller/CustomerController.php
+++ b/local/modules/Front/Controller/CustomerController.php
@@ -155,7 +155,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerCreation, 'post');
 
                 $customerCreateEvent = $this->createEventInstance($form->getData());
-                $customerCreateEvent->bindForm($form->getForm());
+                $customerCreateEvent->bindForm($form);
 
                 $eventDispatcher->dispatch($customerCreateEvent, TheliaEvents::CUSTOMER_CREATEACCOUNT);
 
@@ -273,7 +273,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerPasswordUpdateForm, 'post');
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
-                $customerChangeEvent->bindForm($form->getForm());
+                $customerChangeEvent->bindForm($form);
                 $customerChangeEvent->setCustomer($customer);
                 $eventDispatcher->dispatch($customerChangeEvent, TheliaEvents::CUSTOMER_UPDATEPROFILE);
 
@@ -330,7 +330,7 @@ class CustomerController extends BaseFrontController
                 $form = $this->validateForm($customerProfileUpdateForm, 'post');
 
                 $customerChangeEvent = $this->createEventInstance($form->getData());
-                $customerChangeEvent->bindForm($form->getForm());
+                $customerChangeEvent->bindForm($form);
                 $customerChangeEvent->setCustomer($customer);
 
                 $customerChangeEvent->setEmailUpdateAllowed(


### PR DESCRIPTION
Creating an account from the front office answers a 500 on `2.6`:

```
UndefinedMethodError: Attempted to call an undefined method named "getForm"
of class "Symfony\Component\Form\Form".
at local/modules/Front/Controller/CustomerController.php line 158
```

`BaseController::validateForm()` already returns the Symfony form (`TheliaFormValidator::validateForm()` starts with `$form = $aBaseForm->getForm()`), and `ActionEvent::bindForm()` takes that same type. Calling `getForm()` on it is a fatal.

Three call sites, all added in #3515: account creation (line 158) and the two account update paths (276 and 333). So front office registration and account edition are both broken on the current `2.6` head.

Verified on a fresh 2.6 install with the demo data: `POST /register` answered 500 before the change and 302 with the customer row created after it.

Refs #3515
