### PR TITLE
fix: default missing request parameters in front and back office templates

### DIFF
--- a/templates/backOffice/default/coupon/type-fragments/ajax-attribute-avs-list.html
+++ b/templates/backOffice/default/coupon/type-fragments/ajax-attribute-avs-list.html
@@ -1,3 +1,3 @@
-{loop type="attribute_availability" attribute={$smarty.post.attribute_id} name="list-of-attribute_avs" backend_context="1"}
+{loop type="attribute_availability" attribute={$smarty.post.attribute_id|default:''} name="list-of-attribute_avs" backend_context="1"}
     <option value="{$ID}">{$TITLE}</option>
 {/loop}

--- a/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
+++ b/templates/backOffice/default/coupon/type-fragments/ajax-products-list.html
@@ -1,3 +1,3 @@
-{loop type="product" category={$smarty.post.category_id} name="list-of-products" backend_context="1" return_url=false}
+{loop type="product" category={$smarty.post.category_id|default:''} name="list-of-products" backend_context="1" return_url=false}
     <option value="{$ID}">{option_offset l=$LEVEL|default:0 label={$TITLE}}</option>
 {/loop}

--- a/templates/backOffice/default/search.html
+++ b/templates/backOffice/default/search.html
@@ -6,7 +6,7 @@
 {block name="check-access"}view{/block}
 
 {block name="main-content"}
-{$searchTerm = {$smarty.get.search_term|trim}}
+{$searchTerm = {$smarty.get.search_term|default:''|trim}}
 {$page = $page|default:0}
 
 {capture name="more_results"}

--- a/templates/frontOffice/default/includes/addedToCart.html
+++ b/templates/frontOffice/default/includes/addedToCart.html
@@ -2,6 +2,7 @@
 {set_previous_url ignore_current="1"}
 
 {default_translation_domain domain='fo.default'}
+{$pse_id={$smarty.get.pse_id|default:''}}
 {loop type="product" name="add_product_to_cart" id={product attr="id"}}
 <div class="clearfix">
     <table>
@@ -13,7 +14,7 @@
         <tr>
             <td class="col-md-4">
                 {ifloop rel="pse-first-image"}
-                    {loop type="product-sale-elements-image" name="pse-first-image" product_sale_elements_id={$smarty.get.pse_id} limit="1"}
+                    {loop type="product-sale-elements-image" name="pse-first-image" product_sale_elements_id=$pse_id limit="1"}
                         {loop type="image" name="product-image" id=$PRODUCT_IMAGE_ID product=$ID limit="1" width="218" height="146" resize_mode="borders"}
                             <img itemprop="image" src="{$IMAGE_URL nofilter}" alt="Product #{$LOOP_COUNT}">
                         {/loop}
@@ -27,12 +28,12 @@
             </td>
             <td class="col-md-4">
                 <h2>{$TITLE}</h2>
-                {loop type="attribute_combination" name="product_options" product_sale_elements={$smarty.get.pse_id} order="manual"}
+                {loop type="attribute_combination" name="product_options" product_sale_elements=$pse_id order="manual"}
                     <p>{$ATTRIBUTE_TITLE} : {$ATTRIBUTE_AVAILABILITY_TITLE}</p>
                 {/loop}
             </td>
             <td class="col-md-4">
-                {loop type="product_sale_elements" name="product_price" id={$smarty.get.pse_id}}
+                {loop type="product_sale_elements" name="product_price" id=$pse_id}
                     {if $IS_PROMO == 1}
                         <div class="special-price"><span class="price">{format_money number=$TAXED_PROMO_PRICE}</span></div>
                         <small class="old-price"> <span class="price">{format_money number=$TAXED_PRICE}</span></small>

--- a/templates/frontOffice/default/search.html
+++ b/templates/frontOffice/default/search.html
@@ -16,17 +16,18 @@
     {$limit={$smarty.get.limit|default:8}}
     {$product_page={$smarty.get.page|default:1}}
     {$product_order={$smarty.get.order|default:'alpha'}}
+    {$search_query={$smarty.get.q|default:''}}
 
     <article class="col-main  {$smarty.get.mode|default:"grid"}"  role="main" aria-labelledby="main-label">
 
-        <h1 id="main-label" class="page-header">{intl l="Search Result for"} <small>{$smarty.get.q}</small></h1>
-        {assign var="amount" value={count type="product" title={$smarty.get.q}}}
+        <h1 id="main-label" class="page-header">{intl l="Search Result for"} <small>{$search_query}</small></h1>
+        {assign var="amount" value={count type="product" title=$search_query}}
         {include file="includes/toolbar.html" toolbar="top" limit=$limit order=$product_order amount={$amount}}
         <div id="category-products">
             <div class="products-content">
                 {ifloop rel="product_list"}
                     <ul class="list-unstyled row">
-                        {loop type="product" name="product_list" title={$smarty.get.q}  limit=$limit page=$product_page order=$product_order}
+                        {loop type="product" name="product_list" title=$search_query  limit=$limit page=$product_page order=$product_order}
                             {include file="includes/single-product.html" product_id=$ID hasBtn=true hasDescription=true width="369" height="247"}
                         {/loop}
                     </ul>


### PR DESCRIPTION
`GET /search` returns a 500 (`Warning: Undefined array key "q"`, promoted to an `ErrorException`) when the `q` parameter is absent: `templates/frontOffice/default/search.html:22,23,29` read `$smarty.get.q` with no default. `/search?q=` (empty value) renders fine.

Two other shipped templates have the same hole on a reachable URL:

- `templates/backOffice/default/search.html:9`, `GET /admin/search` without `search_term`
- `templates/frontOffice/default/includes/addedToCart.html:16,30,35`, `GET /ajax/addCartMessage` without `pse_id` (route `ajax.addCartMessage`, `local/modules/Front/Config/front.xml:12`)

Each template now reads its parameter once into a local variable with an empty default, so a missing parameter behaves exactly like an empty one. No behaviour change when the parameter is present: on a fresh 2.6 install with demo data, `/search?q=chaise` renders byte-identically before and after (CSRF tokens aside).

Verified on a fresh 2.6 install: `/search` 200, `/search?q=chaise` 200 with the same results, `/ajax/addCartMessage` 200, `/admin/search` 200.

Refs #3562

