### PR TITLE
fix: return a 404 instead of a 500 for an unknown back-office template

### DIFF
--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -18,6 +18,7 @@ use Thelia\Controller\BaseController;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\Exception\AuthorizationException;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Form\Exception\FormValidationException;
@@ -58,6 +59,9 @@ class BaseAdminController extends BaseController
             if (null != $view = $this->getRequest()->get('view')) {
                 return $this->render($view);
             }
+        } catch (ResourceNotFoundException) {
+            // The requested template does not exist: this is a 404, not a server error.
+            return $this->pageNotFound();
         } catch (\Exception $ex) {
             return $this->errorPage($ex->getMessage());
         }


### PR DESCRIPTION
Any `/admin/<unknown path>` answers 500 with `Template file <name>.html cannot be found.` instead of a 404, for example `/admin/tools/import`.

The catch-all route `admin.processTemplate` (`core/lib/Thelia/Config/Resources/routing/admin.xml:1570`) forwards to `BaseAdminController::processTemplateAction()`, which catches every `\Exception` and turns it into `errorPage()`: HTTP 500 plus an error log entry (`core/lib/Thelia/Controller/Admin/BaseAdminController.php:61-63`). The parser reports a missing template with `Thelia\Core\Template\Exception\ResourceNotFoundException` (`local/modules/TheliaSmarty/Template/SmartyParser.php:540`), so it was indistinguishable from a genuine rendering failure.

`processTemplateAction()` now catches `ResourceNotFoundException` first and returns `pageNotFound()`, the back-office 404 template, HTTP 404, no error log. Every other rendering failure still goes through `errorPage()` with a 500.

Verified on a fresh 2.6 install with demo data: `/admin/tools/import` → 404 (back-office "Page not found", no CRITICAL entry in `var/log`), `/admin/import` and `/admin/catalog` → 200, and a back-office template with a Smarty syntax error or with a missing `{include}` still → 500.

Refs #3563

