### PR TITLE
fix: return a 404 instead of a 500 for an unknown back-office template

### DIFF
--- a/core/lib/Thelia/Controller/Admin/BaseAdminController.php
+++ b/core/lib/Thelia/Controller/Admin/BaseAdminController.php
@@ -23,6 +23,7 @@ use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Security\Exception\AuthenticationException;
 use Thelia\Core\Security\Exception\AuthorizationException;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Log\Tlog;
@@ -53,6 +54,9 @@ class BaseAdminController extends BaseController
             if (null !== $view) {
                 return $this->render($view);
             }
+        } catch (ResourceNotFoundException) {
+            // The requested template does not exist: this is a 404, not a server error.
+            return $this->pageNotFound();
         } catch (\Exception $exception) {
             return $this->errorPage($exception->getMessage());
         }


### PR DESCRIPTION
Port of #3570 to the Thelia 3 line, where the defect is reachable too.

An unknown `/admin/<path>` answers 500 with `Template file <name>.html cannot be found.` A Thelia 3 install enables `BackOfficeDefaultBundle` alongside `BackOfficeDefaultTwigBundle`, so the Smarty back office routes stay registered and the `admin.processTemplate` catch-all still answers, whatever the active admin template is.

`BaseAdminController::processTemplateAction()` caught every `\Exception` and returned `errorPage()` (core/lib/Thelia/Controller/Admin/BaseAdminController.php:55-57). The parser reports a missing template with `Thelia\Core\Template\Exception\ResourceNotFoundException` (vendor TheliaSmarty `SmartyParser.php:455`), which is now caught first and answered with `pageNotFound()`. Every other rendering failure still gives a 500.

Verified on a fresh install of `main` with the default-twig back office and the demo data: `/admin/product/1` and `/admin/configuration/taxes` answer 404, while `/admin/products`, `/admin/products/update?product_id=1` and `/admin/orders` still answer 200.

Fixes #3563
