### PR TITLE
fix: generate the JWT key pair from bin/install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -367,7 +367,7 @@ foreach ($commands as $cmd) {
 restore_error_handler();
 
 if (!is_file($jwtPrivateKeyPath) || !is_file($jwtPublicKeyPath)) {
-    fwrite(STDERR, "  ERROR: JWT key pair missing ({$jwtPrivateKeyPath}, {$jwtPublicKeyPath}) — the API login endpoints would return 500. Run \"php bin/console lexik:jwt:generate-keypair --overwrite\".\n");
+    fwrite(STDERR, "  ERROR: JWT key pair missing ({$jwtPrivateKeyPath}, {$jwtPublicKeyPath}): the API login endpoints would answer 500. Run \"php bin/console lexik:jwt:generate-keypair --overwrite\".\n");
     ++$errors;
 }
 

--- a/bin/install
+++ b/bin/install
@@ -251,6 +251,32 @@ foreach ($themes as $type => $name) {
 
 $commands = [];
 
+// The API login endpoints sign their tokens with the LexikJWTAuthenticationBundle
+// key pair. composer.json only generates it on post-install-cmd, so an install
+// whose composer step ran with --no-scripts, or ended on a "composer update"
+// (post-update-cmd only clears the cache), starts without keys and every call to
+// /api/admin/login answers 500. Generating the pair here makes bin/install
+// self-sufficient, whatever the composer flow was.
+$jwtPrivateKeyPath = resolveJwtKeyPath('JWT_SECRET_KEY', 'private.pem');
+$jwtPublicKeyPath = resolveJwtKeyPath('JWT_PUBLIC_KEY', 'public.pem');
+
+if (!is_file($jwtPrivateKeyPath) || !is_file($jwtPublicKeyPath)) {
+    // lexik:jwt:generate-keypair skips as soon as ONE of the two files exists, so
+    // --skip-if-exists would leave a half pair broken forever: an incomplete pair
+    // is overwritten instead. A lone private key signs tokens nobody can verify,
+    // there is nothing to preserve.
+    $isHalfKeyPair = is_file($jwtPrivateKeyPath) || is_file($jwtPublicKeyPath);
+
+    $commands[] = [
+        'label' => 'Generating JWT key pair',
+        'input' => [
+            'command' => 'lexik:jwt:generate-keypair',
+            ($isHalfKeyPair ? '--overwrite' : '--skip-if-exists') => true,
+            '--no-interaction' => true,
+        ],
+    ];
+}
+
 foreach ($themes as $type => $name) {
     $name = trim($name);
     if ('' !== $name) {
@@ -340,6 +366,11 @@ foreach ($commands as $cmd) {
 
 restore_error_handler();
 
+if (!is_file($jwtPrivateKeyPath) || !is_file($jwtPublicKeyPath)) {
+    fwrite(STDERR, "  ERROR: JWT key pair missing ({$jwtPrivateKeyPath}, {$jwtPublicKeyPath}) — the API login endpoints would return 500. Run \"php bin/console lexik:jwt:generate-keypair --overwrite\".\n");
+    ++$errors;
+}
+
 // ── Result ───────────────────────────────────────────────────────────
 
 if ($errors > 0) {
@@ -350,6 +381,23 @@ if ($errors > 0) {
 echo "\nThelia installed successfully.\n";
 
 // ─── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve a JWT key file path from the environment, without booting the kernel.
+ *
+ * The dotenv values hold the %kernel.project_dir% placeholder, which only the
+ * container resolves, hence the manual substitution.
+ */
+function resolveJwtKeyPath(string $envName, string $defaultFileName): string
+{
+    $path = (string) ($_SERVER[$envName] ?? '');
+
+    if ('' === $path) {
+        $path = '%kernel.project_dir%/config/jwt/'.$defaultFileName;
+    }
+
+    return str_replace('%kernel.project_dir%/', THELIA_ROOT, $path);
+}
 
 /**
  * Drop bundles whose template is shipped with another package than the one selected.


### PR DESCRIPTION
`POST /api/admin/login` answers 500 ("An error occurred while trying to encode the JWT token") right after `composer install` and `php bin/install`, because `config/jwt/` holds no key pair.

The generation is wired to composer only: `composer.json:119` runs `lexik:jwt:generate-key --skip-if-exists` on `post-install-cmd`. Any flow that does not end on an `install` running its scripts leaves the install keyless: `--no-scripts`, a `vendor/` built elsewhere, or a last command being `composer update`, whose `post-update-cmd` (`composer.json:121-123`) only clears the cache.

`bin/install` now generates the pair itself, with the kernel it already boots for `template:set` and `admin:create`, and reports an error if the two files are still missing when it ends. A pair already in place is left untouched (`--skip-if-exists`), so re-running the installer stays idempotent.

An incomplete pair is regenerated with `--overwrite`: `lexik:jwt:generate-keypair` skips as soon as one of the two files exists, so `--skip-if-exists` would leave a lone `private.pem` broken forever — the state reported in the issue.

Verified on a fresh install: with `config/jwt/` deleted, `bin/install` recreates both keys and `POST /api/admin/login` returns a token.

Fixes #3574
