### PR TITLE
fix: write the running version in the database on a fresh install

### DIFF
--- a/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
+++ b/core/lib/Thelia/Install/Standalone/DatabaseSetup.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace Thelia\Install\Standalone;
 
 use Thelia\Core\Install\Database;
+use Thelia\Core\TheliaKernel;
+use Thelia\Tools\Version\Version;
 
 final class DatabaseSetup
 {
@@ -69,6 +71,27 @@ final class DatabaseSetup
         $database = new Database($this->pdo);
         $database->insertSql(null, [THELIA_SETUP_DIRECTORY.'thelia.sql']);
         $database->insertSql(null, [THELIA_SETUP_DIRECTORY.'insert.sql']);
+        $this->writeTheliaVersion();
+    }
+
+    /**
+     * Overwrites the version seeded by insert.sql with the version of the running code.
+     *
+     * insert.sql is generated from insert.sql.tpl by the generate:sql command, so its version
+     * number is a snapshot of the code version at generation time and drifts as soon as a
+     * release bumps TheliaKernel::THELIA_VERSION. A fresh install left with an older number
+     * announces the wrong version and makes setup/update.php replay every update script above
+     * it, on a database that already has the latest schema.
+     */
+    private function writeTheliaVersion(): void
+    {
+        $parsedVersion = Version::parse(TheliaKernel::THELIA_VERSION);
+
+        $this->setConfig('thelia_version', $parsedVersion['version']);
+        $this->setConfig('thelia_major_version', $parsedVersion['major']);
+        $this->setConfig('thelia_minus_version', $parsedVersion['minus']);
+        $this->setConfig('thelia_release_version', $parsedVersion['release']);
+        $this->setConfig('thelia_extra_version', $parsedVersion['extra']);
     }
 
     public function generateFormSecret(): void

--- a/tests/Integration/Install/DatabaseSetupTest.php
+++ b/tests/Integration/Install/DatabaseSetupTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Install;
 
+use Thelia\Core\TheliaKernel;
 use Thelia\Install\Standalone\DatabaseSetup;
+use Thelia\Model\ConfigQuery;
 use Thelia\Test\IntegrationTestCase;
+use Thelia\Tools\Version\Version;
 
 final class DatabaseSetupTest extends IntegrationTestCase
 {
@@ -60,6 +63,22 @@ final class DatabaseSetupTest extends IntegrationTestCase
 
         // If we get here, it didn't throw.
         self::assertTrue(true);
+    }
+
+    public function testSeededVersionIsTheVersionOfTheRunningCode(): void
+    {
+        // This database is built by bin/test-prepare through DatabaseSetup, exactly like a
+        // fresh install. The version it carries must be the code version: any older value
+        // makes setup/update.php replay the update scripts above it (#3571).
+        $parsedVersion = Version::parse(TheliaKernel::THELIA_VERSION);
+
+        // Reading past the config cache: that pool outlives a database rebuild, so the
+        // cached copy would answer for a row this test is precisely about.
+        self::assertSame($parsedVersion['version'], ConfigQuery::read('thelia_version', null, true));
+        self::assertSame($parsedVersion['major'], ConfigQuery::read('thelia_major_version', null, true));
+        self::assertSame($parsedVersion['minus'], ConfigQuery::read('thelia_minus_version', null, true));
+        self::assertSame($parsedVersion['release'], ConfigQuery::read('thelia_release_version', null, true));
+        self::assertSame($parsedVersion['extra'], ConfigQuery::read('thelia_extra_version', null, true));
     }
 
     /**


### PR DESCRIPTION
A fresh install of `main` records `thelia_version = 2.6.0` while the code is `3.0.0-beta1` (`core/lib/Thelia/Core/TheliaKernel.php:87`). The number comes from the seed, `setup/insert.sql:53`, which `generate:sql` renders from `setup/insert.sql.tpl:54`: the value is a snapshot of the version that was current when the file was last regenerated, and it drifts at every release that does not regenerate it.

`DatabaseSetup::applyCoreSchemaAndSeed()` now writes `THELIA_VERSION` and its parsed parts over the seeded values, right after loading `insert.sql`. Both entry points go through it (`bin/install` and `bin/test-prepare`), it needs no kernel, and it stays idempotent.

Consequence of the stale value: `setup/update.php` on a fresh install replayed `3.0.0-alpha1`, `3.0.0-beta1` and `3.0.0-beta2` on a database that already had the current schema. With the version written by the installer only `3.0.0-beta2` is left, because that script exists while `THELIA_VERSION` is still `3.0.0-beta1`; bumping the constant at release time closes the gap.

An integration test asserts that the version recorded in the database is the version of the running code.

Fixes #3571
