### PR TITLE
fix: make setup/update.php runnable again on the Thelia 3 line

### DIFF
--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Thelia\Core\Install;
 
 use Michelf\Markdown;
+use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Propel;
 use Symfony\Component\Filesystem\Filesystem;
@@ -50,7 +51,7 @@ class Update
     protected array $postInstructions = [];
 
     protected array $updatedVersions = [];
-    protected \PDO $connection;
+    protected ConnectionInterface|\PDO $connection;
     protected ?string $backupFile = null;
     protected string $backupDir = 'local/backup/';
     protected array $messages = [];
@@ -69,14 +70,17 @@ class Update
         }
 
         try {
-            $this->connection = Propel::getConnection(
+            $connection = Propel::getConnection(
                 ProductTableMap::DATABASE_NAME,
             );
 
-            // Get the PDO connection from the WrappedConnection
-            if ($this->connection instanceof ConnectionWrapper) {
-                $this->connection = $this->connection->getWrappedConnection();
+            // Unwrap before assigning: the property is typed \PDO, so the wrapper
+            // cannot transit through it.
+            if ($connection instanceof ConnectionWrapper) {
+                $connection = $connection->getWrappedConnection();
             }
+
+            $this->connection = $connection;
         } catch (ParseException $ex) {
             throw new UpdateException('database.yml is not a valid file : '.$ex->getMessage());
         } catch (\PDOException $ex) {

--- a/setup/update.php
+++ b/setup/update.php
@@ -239,7 +239,9 @@ cliOutput(sprintf('Try to delete cache in : %s', THELIA_CACHE_DIR), 'info');
 
 foreach ($finder as $file) {
     try {
-        $fs->remove($file);
+        // remove() takes a path, a Traversable or an array: a Finder entry is an
+        // SplFileInfo and would raise a TypeError.
+        $fs->remove($file->getPathname());
     } catch (Symfony\Component\Filesystem\Exception\IOException $ex) {
         $hasDeleteError = true;
     }
@@ -259,10 +261,18 @@ exit(0);
 
 function readStdin($normalize = false)
 {
-    $fr = fopen('php://stdin', 'r');
-    $input = fgets($fr, 128);
-    $input = rtrim($input);
-    fclose($fr);
+    // Kept open across calls: closing php://stdin makes every later read fail,
+    // and a piped input then dies on the second question.
+    static $stream = null;
+
+    if (null === $stream) {
+        $stream = fopen('php://stdin', 'r');
+    }
+
+    $input = fgets($stream, 128);
+
+    // End of input (a pipe that ran out, or no stdin at all): behave like an empty answer.
+    $input = false === $input ? '' : rtrim($input);
 
     if ($normalize) {
         $input = strtolower(trim($input));


### PR DESCRIPTION
`php setup/update.php` could not run at all on the Thelia 3 line. Three fatals in a row, each one hiding the next.

**1. The Propel connection cannot transit through a `\PDO` property.** `Update::$connection` is declared `\PDO` (core/lib/Thelia/Core/Install/Update.php:53) and the constructor assigned the Propel connection to it before unwrapping it three lines later, so the assignment threw first. Unwrapping into a local variable is not enough either: in the Thelia fork, `ConnectionWrapper::getWrappedConnection()` returns a `PdoConnection`, which implements `ConnectionInterface` and does not extend `\PDO`. The property is now typed `ConnectionInterface|\PDO`, which is what `Install\Database::__construct()` already accepts, and the unwrap happens before the assignment.

**2. `readStdin()` closed `php://stdin`.** Each call reopened the stream and closed it at the end (setup/update.php:259-265), so from the second question on `fgets()` returned `false` and `rtrim(false)` was a TypeError. The handle is now kept across calls, and an exhausted input reads as an empty answer instead of crashing. That is what a piped invocation does after its last line.

**3. The cache cleanup passed a `Finder` entry to `Filesystem::remove()`** (line 242), which takes a path, an array or a `Traversable`, not an `SplFileInfo`. Passing the path.

Verified on a fresh install of `main`: the script now announces `3.0.0-beta1` to `3.0.0-beta2`, applies the pending script, clears the cache and finishes. Nothing here changes what the update scripts do or the version semantics settled in #3509.

Worth a separate look, not touched: the closing message says "successfully updated to version 3.0.0-beta1" while the script just applied `3.0.0-beta2.sql`, because the message reads `THELIA_VERSION`, which the next release will bump.

Fixes #3578
