### PR TITLE
fix: apply an upload policy to every file upload, configurable per shop

### DIFF
--- a/core/lib/Thelia/Core/File/FileConfiguration.php
+++ b/core/lib/Thelia/Core/File/FileConfiguration.php
@@ -14,42 +14,152 @@ declare(strict_types=1);
 
 namespace Thelia\Core\File;
 
+use Thelia\Model\ConfigQuery;
+
 /**
- * Class FileConfiguration.
+ * Single source of truth for what may be uploaded in a Thelia shop.
+ *
+ * Images are restricted by a mime type whitelist, documents by an extension
+ * blacklist. Both lists ship with a safe default and can be adjusted per shop
+ * through a configuration variable, so that a legitimate file type nobody
+ * anticipated does not require a core patch:
+ *
+ *   image_upload_allowed_mime_types    image/jpeg, image/png, image/avif
+ *   document_upload_forbidden_extensions   php, phtml, exe
+ *
+ * An empty or missing variable means "use the default list". Loosening these
+ * variables can never re-enable a server-executable extension: that floor is
+ * enforced unconditionally by FileProcessorService.
  *
  * @author manuel raynaud <manu@raynaud.io>
  */
 class FileConfiguration
 {
+    public const IMAGE_MIME_TYPES_VARIABLE = 'image_upload_allowed_mime_types';
+
+    public const DOCUMENT_EXTENSION_BLACKLIST_VARIABLE = 'document_upload_forbidden_extensions';
+
+    /**
+     * Mime types accepted for an image upload, in the absence of a shop configuration.
+     */
+    public const DEFAULT_IMAGE_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/svg+xml',
+    ];
+
+    /**
+     * Extensions refused for a document upload, in the absence of a shop configuration.
+     */
+    public const DEFAULT_DOCUMENT_EXTENSION_BLACKLIST = [
+        'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
+        'phtml', 'phtm', 'pht', 'phps', 'phpt', 'phar',
+        'shtml', 'shtm', 'stm',
+        'asp', 'aspx', 'jsp', 'jspx',
+        'cgi', 'pl', 'py', 'sh',
+        'htaccess', 'htpasswd',
+        'exe', 'bat', 'cmd', 'com',
+    ];
+
+    /**
+     * Extensions a mime type is allowed to carry, so that a PNG named ".jpg"
+     * is rejected. A mime type absent from this table is matched on the mime
+     * type alone, which lets a shop add a new one without a core change.
+     */
+    private const MIME_TYPE_EXTENSIONS = [
+        'image/jpeg' => ['jpg', 'jpeg'],
+        'image/png' => ['png'],
+        'image/gif' => ['gif'],
+        'image/webp' => ['webp'],
+        'image/svg+xml' => ['svg'],
+        'image/avif' => ['avif'],
+        'image/bmp' => ['bmp'],
+        'image/tiff' => ['tif', 'tiff'],
+        'image/vnd.microsoft.icon' => ['ico'],
+        'image/x-icon' => ['ico'],
+        'image/heic' => ['heic'],
+    ];
+
+    /**
+     * @return array{objectType: string, validMimeTypes: array<string, list<string>>, extBlackList: list<string>}
+     */
     public static function getImageConfig(): array
     {
         return [
             'objectType' => 'image',
-            'validMimeTypes' => [
-                'image/jpeg' => ['jpg', 'jpeg'],
-                'image/png' => ['png'],
-                'image/gif' => ['gif'],
-                'image/webp' => ['webp'],
-                'image/svg+xml' => ['svg'],
-            ],
+            'validMimeTypes' => self::buildMimeTypeMap(
+                self::readList(self::IMAGE_MIME_TYPES_VARIABLE, self::DEFAULT_IMAGE_MIME_TYPES),
+            ),
             'extBlackList' => [],
         ];
     }
 
+    /**
+     * @return array{objectType: string, validMimeTypes: array<string, list<string>>, extBlackList: list<string>}
+     */
     public static function getDocumentConfig(): array
     {
         return [
             'objectType' => 'document',
             'validMimeTypes' => [],
-            'extBlackList' => [
-                'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
-                'phtml', 'phtm', 'pht', 'phps', 'phpt', 'phar',
-                'shtml', 'shtm', 'stm',
-                'asp', 'aspx', 'jsp', 'jspx',
-                'cgi', 'pl', 'py', 'sh',
-                'htaccess', 'htpasswd',
-                'exe', 'bat', 'cmd', 'com',
-            ],
+            'extBlackList' => self::readList(
+                self::DOCUMENT_EXTENSION_BLACKLIST_VARIABLE,
+                self::DEFAULT_DOCUMENT_EXTENSION_BLACKLIST,
+            ),
         ];
+    }
+
+    /**
+     * Constraints to apply to an upload of the given object type, for callers
+     * that do not carry their own policy. Unknown object types get no constraint.
+     *
+     * @return array{objectType: string, validMimeTypes: array<string, list<string>>, extBlackList: list<string>}
+     */
+    public static function getConfig(string $objectType): array
+    {
+        return match ($objectType) {
+            'image' => self::getImageConfig(),
+            'document' => self::getDocumentConfig(),
+            default => ['objectType' => $objectType, 'validMimeTypes' => [], 'extBlackList' => []],
+        };
+    }
+
+    /**
+     * @param list<string> $default
+     *
+     * @return list<string>
+     */
+    private static function readList(string $variableName, array $default): array
+    {
+        $raw = ConfigQuery::read($variableName);
+
+        if (!\is_string($raw) || '' === trim($raw)) {
+            return $default;
+        }
+
+        $values = array_values(array_filter(array_map(
+            static fn (string $value): string => strtolower(trim($value)),
+            explode(',', $raw),
+        ), static fn (string $value): bool => '' !== $value));
+
+        return [] === $values ? $default : $values;
+    }
+
+    /**
+     * @param list<string> $mimeTypes
+     *
+     * @return array<string, list<string>>
+     */
+    private static function buildMimeTypeMap(array $mimeTypes): array
+    {
+        $map = [];
+
+        foreach ($mimeTypes as $mimeType) {
+            $map[$mimeType] = self::MIME_TYPE_EXTENSIONS[$mimeType] ?? [];
+        }
+
+        return $map;
     }
 }

--- a/core/lib/Thelia/Core/File/Service/FileProcessorService.php
+++ b/core/lib/Thelia/Core/File/Service/FileProcessorService.php
@@ -20,6 +20,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 use Thelia\Core\Event\File\FileCreateOrUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\File\Exception\ProcessFileException;
+use Thelia\Core\File\FileConfiguration;
 use Thelia\Core\File\FileManager;
 use Thelia\Model\Lang;
 
@@ -32,6 +33,10 @@ readonly class FileProcessorService
     }
 
     /**
+     * @param array<string, list<string>>|null $validMimeTypes accepted mime types, mapped to the extensions they may carry.
+     *                                                         Null applies the shop policy for $objectType.
+     * @param list<string>|null                $extBlackList   refused extensions. Null applies the shop policy for $objectType.
+     *
      * @throws ProcessFileException If file processing fails
      */
     public function processFile(
@@ -40,79 +45,12 @@ readonly class FileProcessorService
         int $parentId,
         string $parentType,
         string $objectType,
-        array $validMimeTypes = [],
-        array $extBlackList = [],
+        ?array $validMimeTypes = null,
+        ?array $extBlackList = null,
         string $moduleRight = 'thelia',
     ): FileCreateOrUpdateEvent {
-        // Validate if file is too big
-        if (1 === $fileBeingUploaded->getError()) {
-            $message = $this->translator->trans(
-                'File is too large, please retry with a file having a size less than %size%.',
-                ['%size%' => \ini_get('upload_max_filesize')],
-                'core',
-            );
-
-            throw new ProcessFileException($message, 403);
-        }
-
-        $message = null;
-        $realFileName = $fileBeingUploaded->getClientOriginalName();
-
-        if ([] !== $validMimeTypes) {
-            $mimeType = $fileBeingUploaded->getMimeType();
-
-            if (!isset($validMimeTypes[$mimeType])) {
-                $message = $this->translator->trans(
-                    'Only files having the following mime type are allowed: %types%',
-                    ['%types%' => implode(', ', array_keys($validMimeTypes))],
-                );
-            } else {
-                $regex = '#^(.+)\\.('.implode('|', $validMimeTypes[$mimeType]).')$#i';
-
-                if (!preg_match($regex, $realFileName)) {
-                    $message = $this->translator->trans(
-                        "There's a conflict between your file extension \"%ext\" and the mime type \"%mime\"",
-                        [
-                            '%mime' => $mimeType,
-                            '%ext' => $fileBeingUploaded->getClientOriginalExtension(),
-                        ],
-                    );
-                }
-            }
-        }
-
-        if ([] !== $extBlackList) {
-            $regex = '#^(.+)\\.('.implode('|', $extBlackList).')$#i';
-
-            if (preg_match($regex, $realFileName)) {
-                $message = $this->translator->trans(
-                    'Files with the following extension are not allowed: %extension, please do an archive of the file if you want to upload it',
-                    [
-                        '%extension' => $fileBeingUploaded->getClientOriginalExtension(),
-                    ],
-                );
-            }
-        }
-
-        // Defense in depth against double-extension bypasses (e.g. "shell.php.jpg"):
-        // reject any file whose name contains a server-executable segment, not just the
-        // terminal one. Applies to every upload, regardless of the caller's configuration.
-        if (null === $message && null !== ($dangerousExtension = $this->findExecutableExtension($realFileName))) {
-            $message = $this->translator->trans(
-                'Files with the following extension are not allowed: %extension, please do an archive of the file if you want to upload it',
-                [
-                    '%extension' => $dangerousExtension,
-                ],
-            );
-        }
-
-        if (null !== $message) {
-            throw new ProcessFileException($message, 415);
-        }
-
-        // Uploaded SVG files are served from the shop origin: strip any active content
-        // so they cannot be used for stored XSS (CWE-79).
-        $this->sanitizeSvgUpload($fileBeingUploaded);
+        $this->validateUpload($fileBeingUploaded, $objectType, $validMimeTypes, $extBlackList);
+        $this->sanitizeUpload($fileBeingUploaded);
 
         $fileModel = $this->fileManager->getModelInstance($objectType, $parentType);
 
@@ -141,6 +79,106 @@ readonly class FileProcessorService
         );
 
         return $fileCreateOrUpdateEvent;
+    }
+
+    /**
+     * Checks an uploaded file against the upload policy before anything is written.
+     *
+     * Callers that have their own policy pass it explicitly; the others get the shop
+     * policy for $objectType (see FileConfiguration). Whatever the policy says, a file
+     * name carrying a server-executable segment is always refused.
+     *
+     * @param array<string, list<string>>|null $validMimeTypes
+     * @param list<string>|null                $extBlackList
+     *
+     * @throws ProcessFileException when the file may not be uploaded
+     */
+    public function validateUpload(
+        UploadedFile $fileBeingUploaded,
+        string $objectType,
+        ?array $validMimeTypes = null,
+        ?array $extBlackList = null,
+    ): void {
+        // Validate if file is too big
+        if (\UPLOAD_ERR_INI_SIZE === $fileBeingUploaded->getError()) {
+            $message = $this->translator->trans(
+                'File is too large, please retry with a file having a size less than %size%.',
+                ['%size%' => \ini_get('upload_max_filesize')],
+                'core',
+            );
+
+            throw new ProcessFileException($message, 403);
+        }
+
+        $policy = FileConfiguration::getConfig($objectType);
+        $validMimeTypes ??= $policy['validMimeTypes'];
+        $extBlackList ??= $policy['extBlackList'];
+
+        $message = null;
+        $realFileName = $fileBeingUploaded->getClientOriginalName();
+
+        if ([] !== $validMimeTypes) {
+            $mimeType = $fileBeingUploaded->getMimeType();
+
+            if (!isset($validMimeTypes[$mimeType])) {
+                $message = $this->translator->trans(
+                    'Only files having the following mime type are allowed: %types%',
+                    ['%types%' => implode(', ', array_keys($validMimeTypes))],
+                );
+            } elseif ([] !== $validMimeTypes[$mimeType]) {
+                $regex = '#^(.+)\\.('.implode('|', $validMimeTypes[$mimeType]).')$#i';
+
+                if (!preg_match($regex, $realFileName)) {
+                    $message = $this->translator->trans(
+                        "There's a conflict between your file extension \"%ext\" and the mime type \"%mime\"",
+                        [
+                            '%mime' => $mimeType,
+                            '%ext' => $fileBeingUploaded->getClientOriginalExtension(),
+                        ],
+                    );
+                }
+            }
+        }
+
+        if (null === $message && [] !== $extBlackList) {
+            $regex = '#^(.+)\\.('.implode('|', $extBlackList).')$#i';
+
+            if (preg_match($regex, $realFileName)) {
+                $message = $this->translator->trans(
+                    'Files with the following extension are not allowed: %extension, please do an archive of the file if you want to upload it',
+                    [
+                        '%extension' => $fileBeingUploaded->getClientOriginalExtension(),
+                    ],
+                );
+            }
+        }
+
+        // Defense in depth against double-extension bypasses (e.g. "shell.php.jpg"):
+        // reject any file whose name contains a server-executable segment, not just the
+        // terminal one. Applies to every upload, regardless of the caller's configuration.
+        if (null === $message && null !== ($dangerousExtension = $this->findExecutableExtension($realFileName))) {
+            $message = $this->translator->trans(
+                'Files with the following extension are not allowed: %extension, please do an archive of the file if you want to upload it',
+                [
+                    '%extension' => $dangerousExtension,
+                ],
+            );
+        }
+
+        if (null !== $message) {
+            throw new ProcessFileException($message, 415);
+        }
+    }
+
+    /**
+     * Uploaded SVG files are served from the shop origin: strip any active content
+     * so they cannot be used for stored XSS (CWE-79). Other files are left untouched.
+     *
+     * @throws ProcessFileException when the file is declared as SVG but cannot be parsed
+     */
+    public function sanitizeUpload(UploadedFile $fileBeingUploaded): void
+    {
+        $this->sanitizeSvgUpload($fileBeingUploaded);
     }
 
     /**

--- a/tests/Integration/Core/File/FileProcessorServiceTest.php
+++ b/tests/Integration/Core/File/FileProcessorServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\File;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\File\Exception\ProcessFileException;
+use Thelia\Core\File\FileConfiguration;
+use Thelia\Core\File\Service\FileProcessorService;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Tests\Support\Trait\CreatesTestFiles;
+
+/**
+ * A caller that passes no constraint must still get the shop upload policy:
+ * that is what the Twig back office does, and forgetting it let an administrator
+ * upload any file type.
+ */
+final class FileProcessorServiceTest extends IntegrationTestCase
+{
+    use CreatesTestFiles;
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpTestFiles();
+        // The database changes are rolled back, the static config cache is not.
+        ConfigQuery::resetCache();
+        parent::tearDown();
+    }
+
+    public function testImageUploadWithoutExplicitConstraintsRefusesANonImage(): void
+    {
+        $this->expectException(ProcessFileException::class);
+
+        $this->process('payload.exe', 'not an image', 'image');
+    }
+
+    public function testDocumentUploadWithoutExplicitConstraintsRefusesABlacklistedExtension(): void
+    {
+        $this->expectException(ProcessFileException::class);
+
+        $this->process('payload.exe', 'MZ', 'document');
+    }
+
+    public function testLegitimateUploadsAreStillAccepted(): void
+    {
+        $this->validate('kitten.png', $this->pngBytes(), 'image');
+        $this->validate('invoice.pdf', '%PDF-1.4', 'document');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testAllowedImageMimeTypesCanBeNarrowedByConfiguration(): void
+    {
+        ConfigQuery::write(FileConfiguration::IMAGE_MIME_TYPES_VARIABLE, 'image/png');
+
+        $this->validate('kitten.png', $this->pngBytes(), 'image');
+
+        $this->expectException(ProcessFileException::class);
+
+        $this->validate('kitten.gif', 'GIF89a'.str_repeat("\x00", 16), 'image');
+    }
+
+    public function testAllowedImageMimeTypesCanBeExtendedByConfiguration(): void
+    {
+        ConfigQuery::write(FileConfiguration::IMAGE_MIME_TYPES_VARIABLE, 'image/png, text/plain');
+
+        $this->validate('notes.txt', 'plain text', 'image');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testConfigurationCannotReEnableAServerExecutableExtension(): void
+    {
+        ConfigQuery::write(FileConfiguration::DOCUMENT_EXTENSION_BLACKLIST_VARIABLE, 'nothing');
+
+        $this->expectException(ProcessFileException::class);
+
+        $this->validate('shell.php', '<?php echo 1;', 'document');
+    }
+
+    public function testExplicitConstraintsTakePrecedenceOverTheShopPolicy(): void
+    {
+        // The Smarty back office passes its own policy; it must not be overridden.
+        $this->getService(FileProcessorService::class)->validateUpload(
+            $this->upload('notes.txt', 'plain text'),
+            'image',
+            ['text/plain' => ['txt']],
+            [],
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * The call the Twig back office makes: no constraint argument at all. The upload
+     * has to be refused before the processor reaches the persistence layer.
+     */
+    private function process(string $fileName, string $content, string $objectType): void
+    {
+        $this->getService(FileProcessorService::class)->processFile(
+            $this->getService(EventDispatcherInterface::class),
+            $this->upload($fileName, $content),
+            1,
+            'product',
+            $objectType,
+        );
+    }
+
+    private function validate(string $fileName, string $content, string $objectType): void
+    {
+        $this->getService(FileProcessorService::class)->validateUpload(
+            $this->upload($fileName, $content),
+            $objectType,
+        );
+    }
+
+    private function upload(string $fileName, string $content): UploadedFile
+    {
+        $path = $this->createTestTextFile($content);
+        $this->trackFileForCleanup($path);
+
+        return $this->createUploadedFile($path, $fileName, 'application/octet-stream');
+    }
+
+    private function pngBytes(): string
+    {
+        return (string) base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+            true,
+        );
+    }
+}


### PR DESCRIPTION
Refs #3555 — this covers the upload constraints; exposing them read-only on the API resources is still open, so the issue stays open after this merge.

## Symptom

An administrator can upload any file type through the Twig back office: a `.exe`
as a product image, an executable as a document. The legacy Smarty back office
refuses both, so this is a parity regression.

## Cause

Three definitions of "what may be uploaded" existed and only two were wired.

- `core/lib/Thelia/Core/File/FileConfiguration.php` held the extension/mime table,
  but on `main` its only callers live in the Smarty theme
  (`thelia-templates/back`, `Controller/Admin/FileController.php:89` and `:108`).
- `FileProcessorService::processFile()` declared `array $validMimeTypes = []` and
  `array $extBlackList = []` (`core/lib/Thelia/Core/File/Service/FileProcessorService.php:43-44`
  before this change), and both checks are guarded by `[] !== $…`
  (lines `61` and `84`). A caller that passes nothing therefore gets **no check at
  all** instead of the shop policy.
- The Twig back office is exactly such a caller
  (`thelia-templates/default-twig`, `src/Controller/File/FileController.php:455`).

## Fix

Secure by default, configurable on purpose.

1. `FileConfiguration` becomes the single source of truth and reads two optional
   shop variables, each falling back to the shipped list when absent or empty:

   | variable | default |
   |---|---|
   | `image_upload_allowed_mime_types` | `image/jpeg, image/png, image/gif, image/webp, image/svg+xml` |
   | `document_upload_forbidden_extensions` | `php, phtml, phar, asp, jsp, cgi, pl, py, sh, htaccess, exe, bat, …` |

   Both are comma separated lists, editable from Configuration → Variables, so an
   integrator who needs `image/avif` or has to allow a shell script does not need a
   core patch. A mime type the core does not know is matched on the mime type alone;
   a known one still has to agree with the file extension.

2. `processFile()` now takes `?array` instead of `array` for the two constraint
   arguments. `null` — which is what a caller who passes nothing gets — means
   "apply the shop policy for this object type". Callers that pass their own policy,
   like the Smarty back office, are unaffected.

3. The validation is extracted into a public `validateUpload()` and the SVG
   sanitisation into a public `sanitizeUpload()`, so the other upload paths (the
   back office "replace this file" form) can reuse the same policy instead of
   re-implementing it.

Loosening the configuration can never re-enable a server-executable extension:
`findExecutableExtension()` is applied unconditionally, whatever the variables say.

## How to verify

`tests/Integration/Core/File/FileProcessorServiceTest.php` covers it:

```
composer test:integration -- --filter FileProcessorServiceTest
```

`testImageUploadWithoutExplicitConstraintsRefusesANonImage` and
`testDocumentUploadWithoutExplicitConstraintsRefusesABlacklistedExtension` call
`processFile()` the way the Twig back office does — no constraint argument. Before
this change no `ProcessFileException` is raised and the upload goes through, so both
fail; after, both pass.
`testConfigurationCannotReEnableAServerExecutableExtension` pins the hard floor,
and `testExplicitConstraintsTakePrecedenceOverTheShopPolicy` pins the Smarty path.

Manually: back office → a product → Images → upload any non-image file. It is now
refused with "Only files having the following mime type are allowed: …".

## Not in this pull request

The second half of #3555 — exposing the constraints read only over the API so a
client can ask what it may send — is untouched. The API already declares its own
constraints per resource as PHP attributes (`Api/Resource/ProductImage.php:166-177`),
so aligning it with `FileConfiguration` and publishing it is a separate change.

The companion change for the "replace current file" form of the Twig back office is
`thelia-templates/default-twig`; it depends on `validateUpload()` and must be merged
after this one.

