### PR TITLE
ci: run the unit and functional test suites on the 2.6 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,5 +58,10 @@ jobs:
           php Thelia thelia:install --env=test --db_host=127.0.0.1:${{ job.services.mysql.ports['3306'] }} --db_username=root --db_name=thelia --db_password=thelia
           php Thelia module:refresh --env=test
           php Thelia admin:create --env=test --login_name thelia2 --password thelia2 --last_name thelia2 --first_name thelia2 --email thelia2@example.com
-      - name: Run CI
+      - name: Publish the database credentials to the test environment
+        # thelia:install only writes .env.local, which Symfony ignores when APP_ENV
+        # is test. Without this file Thelia::isInstalled() returns false and every
+        # functional test errors with "Thelia is not installed".
+        run: grep '^DB_' .env.local > .env.test.local
+      - name: Run CI (coding standard, unit and functional suites)
         run: composer ci

--- a/composer.json
+++ b/composer.json
@@ -118,15 +118,16 @@
             "php ./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=-1"
         ],
         "test-unit": [
-            "./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuit unit"
+            "./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite unit"
         ],
         "demo-database": [
             "php Thelia thelia:dev:reloadDB -f",
             "php setup/import.php",
-            "php Thelia admin:create --login_name thelia --password thelia --last_name thelia --first_name thelia --email thelia@example.com"
+            "php Thelia admin:create --login_name thelia --password thelia --last_name thelia --first_name thelia --email thelia@example.com",
+            "@cache-clear"
         ],
         "test-functional": [
-            "./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuit functional"
+            "./vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite functional"
         ],
         "test-legacy": [
             "php Thelia module:activate CustomDelivery -s",
@@ -141,7 +142,8 @@
             "@test-functional"
         ],
         "ci": [
-            "@cs-diff"
+            "@cs-diff",
+            "@test"
         ],
         "cache-clear": [
             "rm -Rf var/cache/*"

--- a/core/lib/Thelia/Config/Resources/test.xml
+++ b/core/lib/Thelia/Config/Resources/test.xml
@@ -13,7 +13,7 @@
 
     <services>
         <service id="test.client" class="%test.client.class%" public="true">
-            <argument type="service" id="http_kernel" />
+            <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>
             <argument type="service" id="test.client.history" />
             <argument type="service" id="test.client.cookiejar" />

--- a/core/lib/Thelia/Controller/Admin/CurrencyController.php
+++ b/core/lib/Thelia/Controller/Admin/CurrencyController.php
@@ -209,6 +209,7 @@ class CurrencyController extends AbstractCrudController
 
             if ($event->hasUndefinedRates()) {
                 return $this->render('currencies', [
+                    'order' => $this->getCurrentListOrder(),
                     'undefined_rates' => $event->getUndefinedRates(),
                 ]);
             }

--- a/core/lib/Thelia/Controller/Admin/MailingSystemController.php
+++ b/core/lib/Thelia/Controller/Admin/MailingSystemController.php
@@ -108,7 +108,7 @@ class MailingSystemController extends BaseAdminController
             );
 
             // At this point, the form has errors, and should be redisplayed.
-            $response = $this->render('mailing-system');
+            $response = $this->render('mailing-system', ['editDisabled' => ConfigQuery::isSmtpInEnv()]);
         }
 
         return $response;

--- a/core/lib/Thelia/Controller/Admin/ModuleController.php
+++ b/core/lib/Thelia/Controller/Admin/ModuleController.php
@@ -323,6 +323,8 @@ class ModuleController extends AbstractCrudController
 
         if (false !== $message) {
             $response = $this->render('modules', [
+                'module_order' => $this->getCurrentListOrder(),
+                'module_errors' => $this->moduleErrors,
                 'error_message' => $message,
             ]);
         } else {
@@ -387,7 +389,7 @@ class ModuleController extends AbstractCrudController
             ->addForm($moduleInstall)
             ->setGeneralError($message);
 
-        return $this->render('modules');
+        return $this->renderListTemplate($this->getCurrentListOrder());
     }
 
     public function informationAction($module_id)

--- a/core/lib/Thelia/Core/HttpKernel/Client.php
+++ b/core/lib/Thelia/Core/HttpKernel/Client.php
@@ -12,8 +12,8 @@
 
 namespace Thelia\Core\HttpKernel;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\BrowserKit\Request as DomRequest;
-use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Thelia\Core\HttpFoundation\Request;
 
 /**
@@ -21,7 +21,7 @@ use Thelia\Core\HttpFoundation\Request;
  *
  * @author Manuel Raynaud <manu@raynaud.io>
  */
-class Client extends HttpKernelBrowser
+class Client extends KernelBrowser
 {
     /**
      * Converts the BrowserKit request to a HttpKernel request.


### PR DESCRIPTION
Reported in #3565.

The `test` workflow on `2.6` ended on `composer ci`, and `ci` was `@cs-diff` alone: no PHPUnit suite ever ran. This wires the unit and functional suites into that same entry point and repairs what stood in the way of the functional one.

### Why the functional suite could not run

Two blockers, both reproduced on a fresh `2.6` install before touching anything.

1. `Thelia\Core\HttpKernel\Client` (`core/lib/Thelia/Core/HttpKernel/Client.php:24`) extended `HttpKernelBrowser`, while `WebTestCase::createClient()` has declared a `KernelBrowser` return type since Symfony 6.4 (`vendor/symfony/framework-bundle/Test/WebTestCase.php:57`). The first test died on a `TypeError`, and because the kernel had already been booted at that point, the 75 that followed died on `Booting the kernel before calling WebTestCase::createClient() is not supported`. The whole suite was 76 tests, 0 assertions, 76 errors. `Client` now extends `KernelBrowser` and `test.xml` injects the `kernel` service instead of `http_kernel`, matching the FrameworkBundle definition. The `filterRequest()` override stays: production builds a `Thelia\Core\HttpFoundation\Request` (`web/index.php`), so the test client must too.

2. `thelia:install` writes the database credentials to `.env.local` (`core/lib/Thelia/Command/Install.php:197`), which Symfony deliberately ignores when `APP_ENV` is `test`, so `Thelia::isInstalled()` (`core/lib/Thelia/Core/Thelia.php:168`) returned false and every test errored with `Thelia is not installed`. The workflow now mirrors the `DB_*` lines into `.env.test.local` right after the install step.

### Three 500s the repaired suite immediately caught

All three are pages rendered by an action that does not pass the context its template needs, which raises `Warning: Undefined array key` and turns into a 500:

- `GET /admin/configuration/currencies/update-rates` when a rate is missing — `currencies.html:159` reads `$order`, `CurrencyController::updateRatesAction()` passed only `undefined_rates`.
- `POST /admin/configuration/mailingSystem/save` when the form has an error — `mailing-system.html:31` reads `$editDisabled`, `MailingSystemController::updateAction()` re-rendered with no context.
- `POST /admin/module/install` on failure, and module deletion on failure — `modules.html:29` reads `$module_errors` and `includes/module-block.html:11` reads `$module_order`, neither was passed.

### Also

`test-unit` and `test-functional` passed `--testsuit`, a truncated form of `--testsuite` that only works by PHPUnit's option abbreviation. Spelled out.

`demo-database` ends with `@cache-clear`. `thelia:dev:reloadDB` wipes the `import` and `export` rows, which are recreated by `XmlFileLoader` when the container is built; without the cache clear the container is never rebuilt, the rows stay missing and `ExportTest`/`ImportTest` fail on a 404.

### Verified

On a fresh `2.6` install with the demo data, `composer ci` end to end:

- `cs-diff`: 0 of 1954 files
- `test-unit`: OK, 22 tests, 31 assertions
- `test-functional`: OK, 76 tests, 169 assertions

Each fix was checked red before and green after: reverting `Client.php` alone puts the suite back to 76 errors, reverting the three controllers alone puts it back to 3 failures.

### Still out

`test-legacy` (116 test files) stays out of `ci`. Its bootstrap never loads the dotenv files and instantiates `Thelia` rather than `App\Kernel`, so the suite does not reach a single test; past that, tests error inside listeners that expect a request in the stack. That is a repair of its own, scoped in #3584.