### PR TITLE
feat: let a module declare the position of its hooks

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -150,6 +150,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
         $type = $this->getHookType($attributes['type'] ?? TemplateDefinition::FRONT_OFFICE);
         $templates = (string) ($attributes['templates'] ?? '');
         $method = $this->getMethodName($attributes)['method'];
+        $declaredPosition = $this->getDeclaredPosition($attributes, $class);
 
         $hook = $this->getHook($attributes['event'], $type);
 
@@ -188,7 +189,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
                     ->setActive($savedConfiguration['active'] ?? $active)
                     ->setHookActive(true)
                     ->setModuleActive(true)
-                    ->setPosition($savedConfiguration['position'] ?? ModuleHook::MAX_POSITION)
+                    ->setPosition($savedConfiguration['position'] ?? $declaredPosition ?? ModuleHook::MAX_POSITION)
                     ->setTemplates($templates)
                     ->save();
             }
@@ -203,6 +204,33 @@ class RegisterHookListenersPass implements CompilerPassInterface
         } elseif ($moduleHook->getClassname() !== $id) {
             $moduleHook->setClassname($id)->save();
         }
+    }
+
+    /**
+     * A module may declare the position it wants for one of its hooks. The value is read only when the
+     * module_hook row is created: once the row exists, the position belongs to the back office and the
+     * declaration must not overwrite it.
+     */
+    protected function getDeclaredPosition(array $attributes, string $class): ?int
+    {
+        if (!isset($attributes['position']) || '' === $attributes['position']) {
+            return null;
+        }
+
+        $position = (int) $attributes['position'];
+
+        if ($position < 1 || $position >= ModuleHook::MAX_POSITION) {
+            $this->logAlertMessage(\sprintf(
+                'Hook class [%s] declares position [%s], which is out of the allowed range [1, %d]. The hook is appended at the end of the queue instead.',
+                $class,
+                $attributes['position'],
+                ModuleHook::MAX_POSITION - 1,
+            ));
+
+            return null;
+        }
+
+        return $position;
     }
 
     protected function addHooksMethodCall(ContainerBuilder $container, Definition $definition): void

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
@@ -210,7 +210,15 @@
         <xsd:attribute name="type" type="hook_type" />
         <xsd:attribute name="active" type="hook_active" />
         <xsd:attribute name="templates" type="xsd:string" />
+        <xsd:attribute name="position" type="hook_position" />
     </xsd:complexType>
+
+    <xsd:simpleType name="hook_position">
+        <xsd:restriction base="xsd:integer">
+            <xsd:minInclusive value="1" />
+            <xsd:maxInclusive value="999" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="hook_type">
         <xsd:restriction base="xsd:string">

--- a/core/lib/Thelia/Core/Hook/BaseHook.php
+++ b/core/lib/Thelia/Core/Hook/BaseHook.php
@@ -424,11 +424,16 @@ abstract class BaseHook implements BaseHookInterface
      *          ],
      *          [
      *              type => "front",
-     *              method => "displaySomething"
+     *              method => "displaySomething",
+     *              position => 10
      *          ],
      *      ],
      *      'another.hook' => [[...]]
      *  ]
+     *
+     *  The optional position, between 1 and 999, states where the module wants to be rendered among the
+     *  listeners of that hook: the lower the position, the earlier the render. It is applied when the hook
+     *  is registered, and never afterwards: an order set in the back office always wins.
      */
     public static function getSubscribedHooks(): array
     {

--- a/tests/Integration/Core/DependencyInjection/RegisterHookListenersPassTest.php
+++ b/tests/Integration/Core/DependencyInjection/RegisterHookListenersPassTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Thelia\Core\DependencyInjection\Compiler\RegisterHookListenersPass;
+use Thelia\Core\Hook\DefaultHook;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Model\Hook;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
+use Thelia\Model\ModuleQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The order in which the listeners of a hook are rendered is frozen at container build time, from the
+ * module_hook.position column. These tests cover the position a module declares in its hook declaration,
+ * which is the only order a module can express before an administrator reorders the hooks.
+ */
+final class RegisterHookListenersPassTest extends IntegrationTestCase
+{
+    private const HOOK_METHOD = 'insertTemplate';
+
+    private const FIRST_SERVICE_ID = 'test.hook.position.first';
+
+    private const SECOND_SERVICE_ID = 'test.hook.position.second';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ModuleHookConfigurationStore::discard();
+    }
+
+    public function testDeclaredPositionIsUsedWhenTheHookIsRegistered(): void
+    {
+        $hook = $this->createHook('test.hook.position.declared');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, position: 3);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(3, $moduleHook->getPosition());
+    }
+
+    public function testHookWithoutDeclaredPositionIsAppendedAtTheEndOfTheQueue(): void
+    {
+        $hook = $this->createHook('test.hook.position.undeclared');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(ModuleHook::MAX_POSITION, $moduleHook->getPosition());
+    }
+
+    public function testOutOfRangeDeclaredPositionIsIgnored(): void
+    {
+        $hook = $this->createHook('test.hook.position.out-of-range');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, position: 0);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(ModuleHook::MAX_POSITION, $moduleHook->getPosition());
+    }
+
+    public function testPositionSetInTheBackOfficeWinsOverTheDeclaredOne(): void
+    {
+        $module = $this->getModule('Cheque');
+        $hook = $this->createHook('test.hook.position.back-office');
+
+        $this->registerHook($module, self::FIRST_SERVICE_ID, $hook, position: 3);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        $moduleHook->setPosition(9)->save();
+
+        $this->registerHook($module, self::FIRST_SERVICE_ID, $hook, position: 3);
+
+        self::assertSame(9, ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne()?->getPosition());
+    }
+
+    /**
+     * A module loaded after another one can no longer be forced to render after it: the declared
+     * position, not the module load order, decides.
+     */
+    public function testDeclaredPositionOrdersTheListenersOfAHook(): void
+    {
+        $hook = $this->createHook('test.hook.position.ordering');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, position: 20);
+        $this->registerHook($this->getModule('FreeOrder'), self::SECOND_SERVICE_ID, $hook, position: 10);
+
+        $listeners = $this->compileListenersOf($hook);
+
+        self::assertSame([self::SECOND_SERVICE_ID, self::FIRST_SERVICE_ID], array_keys($listeners));
+        self::assertGreaterThan($listeners[self::FIRST_SERVICE_ID], $listeners[self::SECOND_SERVICE_ID]);
+    }
+
+    private function getModule(string $code): Module
+    {
+        $module = ModuleQuery::create()->findOneByCode($code);
+        self::assertNotNull($module, \sprintf('%s module must be registered by bin/test-prepare', $code));
+
+        return $module;
+    }
+
+    private function createHook(string $code): Hook
+    {
+        $hook = new Hook();
+        $hook
+            ->setCode($code)
+            ->setType(TemplateDefinition::FRONT_OFFICE)
+            ->setNative(false)
+            ->setActivate(true)
+            ->setBlock(false)
+            ->setByModule(false);
+        $hook
+            ->setLocale('en_US')
+            ->setTitle('Hook '.$code);
+        $hook->save();
+
+        return $hook;
+    }
+
+    private function registerHook(Module $module, string $serviceId, Hook $hook, ?int $position = null): void
+    {
+        $attributes = ['event' => $hook->getCode(), 'type' => 'front', 'method' => self::HOOK_METHOD];
+
+        if (null !== $position) {
+            $attributes['position'] = $position;
+        }
+
+        (new \ReflectionMethod(RegisterHookListenersPass::class, 'registerHook'))->invoke(
+            new RegisterHookListenersPass(),
+            DefaultHook::class,
+            $module,
+            $serviceId,
+            $attributes,
+        );
+    }
+
+    /**
+     * Runs the part of the compiler pass that turns module_hook rows into event dispatcher listeners,
+     * and returns the priority given to each of the hook's listeners, in registration order.
+     *
+     * @return array<string, int>
+     */
+    private function compileListenersOf(Hook $hook): array
+    {
+        $container = new ContainerBuilder();
+        $container->register(self::FIRST_SERVICE_ID, DefaultHook::class);
+        $container->register(self::SECOND_SERVICE_ID, DefaultHook::class);
+
+        $dispatcher = new Definition();
+
+        (new \ReflectionMethod(RegisterHookListenersPass::class, 'addHooksMethodCall'))->invoke(
+            new RegisterHookListenersPass(),
+            $container,
+            $dispatcher,
+        );
+
+        $eventName = \sprintf('hook.%s.%s', $hook->getType(), $hook->getCode());
+        $priorities = [];
+
+        foreach ($dispatcher->getMethodCalls() as [$method, $arguments]) {
+            if ('addListener' !== $method || $eventName !== $arguments[0]) {
+                continue;
+            }
+
+            $priorities[(string) $arguments[1][0]->getValues()[0]] = $arguments[2];
+        }
+
+        return $priorities;
+    }
+}


### PR DESCRIPTION
Refs #3073.

## Symptom

A module cannot state where it wants to be rendered among the listeners of a hook. When two modules
subscribe to the same hook, their order is decided by the order in which the modules were loaded, which
is why the report gets a working page with `TheliaLibrary` before `ProjectModule` and a broken one the
other way round. The only way to fix an order is to drag the hooks in the back office, once per install.

## What we checked first

The order of a hook's listeners is frozen when the container is built. `addHooksMethodCall()` reads
`module_hook` sorted by `hook_id, position, id` (`core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php:210-214`)
and turns each row into a Symfony listener priority, `ModuleHook::MAX_POSITION - $moduleHook->getPosition()`
(same file, `:270`). Nothing reads `module_hook.position` at render time.

That freeze is already invalidated when an administrator reorders the hooks:
`Thelia\Action\ModuleHook::updateModuleHookPosition()` calls `cacheClear()`
(`core/lib/Thelia/Action/ModuleHook.php:188-194`), which removes the whole kernel cache directory
(`core/lib/Thelia/Action/Cache.php:72-84`). Measured on an install with the demo data, a single reorder
from the back office is honoured on the very next page. So a change made in the back office is not the
defect here; the defect is that a module has no way to express an order in the first place, and that a
fresh install therefore depends on module load order.

## The two families of runtime solutions, and why neither is the answer

*Invalidate the container when a position changes.* Already in place, and it is expensive: on a reorder,
the next request rebuilds the container and the Propel schema cache. Measured on the demo install,
warm request 0.13 s, first request after a reorder 7.25 s, second 0.97 s, back to 0.21 s afterwards, for
60 MB of cache rebuilt. That is heavy for a drag-and-drop, but it is correct, it happens only on an
administrator action, and narrowing it belongs to the shared `CACHE_CLEAR` path rather than to this issue.

*Sort a hook's listeners at render time from the positions.* This buys nothing here and costs on every
page. The dispatcher sorts the listeners of an event once and keeps the sorted list; re-deriving the order
per render means reading `module_hook` on each request and dropping that cache on every hook dispatch. The
front-office Flexy templates call hooks from 21 places and the Twig back office from 343, so this lands
squarely on the hot path, to solve a problem that only occurs on an administrator click which is already
handled. A per-hook, per-page query is out of the question for the same reason.

## The fix

A hook declaration now accepts an optional `position`, the same way an event listener accepts a priority:

```xml
<tag name="hook.event_listener" event="thelia.blocks.plugins" type="back" position="10" />
```

```php
public static function getSubscribedHooks(): array
{
    return ['thelia.blocks.plugins' => [['type' => 'back', 'method' => 'onPlugins', 'position' => 10]]];
}
```

The value is read by `registerHook()` and used as the initial `module_hook.position` instead of the
`MAX_POSITION` sentinel. It is applied only when the row is created, so an order set in the back office
always wins, and the renumbering loop already leaves explicit positions alone. Lower position renders
earlier. Values outside `[1, 999]` are refused with a log entry and the hook falls back to the end of the
queue; `999` is the last usable value because `1000` is the sentinel that means "not ordered yet".

Runtime cost: none. Nothing changes on the render path, and modules that declare no position keep exactly
the order they have today.

## Verifying

`tests/Integration/Core/DependencyInjection/RegisterHookListenersPassTest.php` covers the declared position,
the absence of one, an out-of-range value, the back-office order winning over the declaration, and the case
from the report: two modules on the same hook, the second one loaded declaring the lower position, and the
compiled listener priorities following the declaration rather than the load order. The last two assertions
fail on `main` without this change.

`hook:clean` now preserves positions, so a declared order survives it as well.

The documentation of the hook declaration in `thelia/docs` needs the new attribute; it is not part of this
repository.
