### PR TITLE
fix: make a customer's first address the default one

### DIFF
--- a/core/lib/Thelia/Action/Address.php
+++ b/core/lib/Thelia/Action/Address.php
@@ -70,6 +70,8 @@ class Address extends BaseAction implements EventSubscriberInterface
         $con = Propel::getWriteConnection(AddressTableMap::DATABASE_NAME);
         $con->beginTransaction();
 
+        $isNewAddress = $addressModel->isNew();
+
         try {
             $addressModel
                 ->setLabel($event->getLabel())
@@ -88,7 +90,13 @@ class Address extends BaseAction implements EventSubscriberInterface
                 ->setCompany($event->getCompany())
                 ->save();
 
-            if ($event->getIsDefault() && !$addressModel->getIsDefault()) {
+            // A customer whose addresses are all is_default = 0 has no default address at all:
+            // getDefaultAddress() returns null and every caller relying on it breaks. The first
+            // address a customer gets therefore becomes the default one, whatever the form sent.
+            $becomesDefault = $event->getIsDefault()
+                || ($isNewAddress && null === $addressModel->getCustomer()?->getDefaultAddress());
+
+            if ($becomesDefault && !$addressModel->getIsDefault()) {
                 $addressModel->makeItDefault();
             }
 

--- a/tests/Integration/Action/AddressActionTest.php
+++ b/tests/Integration/Action/AddressActionTest.php
@@ -54,6 +54,70 @@ final class AddressActionTest extends ActionIntegrationTestCase
         self::assertSame('75002', $address->getZipcode());
     }
 
+    public function testCreateMakesTheFirstAddressTheDefaultOne(): void
+    {
+        $title = $this->factory->customerTitle();
+        $customer = $this->factory->customer($title);
+        $country = $this->factory->country();
+
+        // The front-office checkout renders the "primary address" checkbox disabled, so the
+        // browser never posts it and the event carries isDefault = 0 for a first address.
+        $event = new AddressCreateOrUpdateEvent(
+            label: 'Home',
+            title: $title->getId(),
+            firstname: 'John',
+            lastname: 'Doe',
+            address1: '10 rue de la Paix',
+            address2: '',
+            address3: '',
+            zipcode: '75002',
+            city: 'Paris',
+            country: $country->getId(),
+            cellphone: '',
+            phone: '',
+            company: null,
+            isDefault: 0,
+        );
+        $event->setCustomer($customer);
+
+        $this->dispatch($event, TheliaEvents::ADDRESS_CREATE);
+
+        self::assertSame(1, (int) AddressQuery::create()->findPk($event->getAddress()->getId())->getIsDefault());
+        self::assertSame($event->getAddress()->getId(), $customer->getDefaultAddress()?->getId());
+    }
+
+    public function testCreateLeavesTheExistingDefaultAddressAloneForTheNextAddresses(): void
+    {
+        $title = $this->factory->customerTitle();
+        $customer = $this->factory->customer($title);
+        $country = $this->factory->country();
+        $existing = $this->factory->address($customer, $country, $title);
+        $existing->makeItDefault();
+
+        $event = new AddressCreateOrUpdateEvent(
+            label: 'Office',
+            title: $title->getId(),
+            firstname: 'John',
+            lastname: 'Doe',
+            address1: '20 rue de la Paix',
+            address2: '',
+            address3: '',
+            zipcode: '75002',
+            city: 'Paris',
+            country: $country->getId(),
+            cellphone: '',
+            phone: '',
+            company: null,
+            isDefault: 0,
+        );
+        $event->setCustomer($customer);
+
+        $this->dispatch($event, TheliaEvents::ADDRESS_CREATE);
+
+        self::assertSame(0, (int) AddressQuery::create()->findPk($event->getAddress()->getId())->getIsDefault());
+        self::assertSame($existing->getId(), $customer->getDefaultAddress()?->getId());
+    }
+
     public function testUpdateChangesAddressFields(): void
     {
         $title = $this->factory->customerTitle();


### PR DESCRIPTION
## Symptom

A customer who creates their very first address from the Flexy checkout ends up with an address
but no default address: `address.is_default = 0`, and `Customer::getDefaultAddress()` returns
`null`. Every caller that resolves the delivery or invoice address from the default one then
finds nothing — the state that produced the 500 on the delivery step reported in #3575.

Reproduced on a fresh install of `main` with the demo data, on a customer registered through
`/customer/register` (0 address), submitting the checkout address form:

```
persisted address #13 is_default=0
customer->getDefaultAddress() => NULL
```

## Cause

Four steps, all in the core:

1. `core/lib/Thelia/Form/AddressCreateForm.php:220-223` — for a customer with no address, the
   `is_default` checkbox is built with `disabled => true` and `data => true`. It is rendered
   checked, but a disabled input is never posted.
2. Symfony's data mapper skips disabled children when mapping the submitted form back to its
   data (`PropertyPathMapper::mapFormsToData` requires `!$form->isDisabled()`), so `is_default`
   is **absent** from `$form->getData()` — not `false`, absent.
3. `core/lib/Thelia/Domain/Addressing/Service/AddressService.php:151` — the event is built from
   `$data['is_default'] ?? false`, which therefore yields `false`.
4. `core/lib/Thelia/Action/Address.php:91` — `if ($event->getIsDefault() && …)` never fires, so
   `makeItDefault()` is never called and the address is stored with `is_default = 0`.

Nothing downstream repairs it: `Address::makeItDefault()` is only reached through an explicit
flag or the "use this address" action.

## Fix

`core/lib/Thelia/Action/Address.php` — a newly created address becomes the default one when the
customer has no default address yet, whatever the form submitted. This is the invariant the
back office already enforces on its own side
(`templates/backOffice/default-twig/src/Controller/Customer/AddressController.php:109`), applied
once at the action level so every entry point benefits: front office, back office, API and
modules.

The check is limited to newly created addresses (`$addressModel->isNew()`), so updating an
address never silently steals or reassigns the default flag.

With the invariant enforced server-side, the checkbox rendered checked and disabled is no longer
a lie, so the form is left untouched.

## Verification

Same fresh install, same scenario, after the fix:

```
persisted address #14 is_default=1
customer->getDefaultAddress() => 14
```

`tests/Integration/Action/AddressActionTest` gets two cases:

- `testCreateMakesTheFirstAddressTheDefaultOne` — fails before the fix
  (`Failed asserting that 0 is identical to 1`), passes after it;
- `testCreateLeavesTheExistingDefaultAddressAloneForTheNextAddresses` — guards the other
  direction: a second address created with `isDefault: 0` stays non-default and the existing
  default is untouched. Green before and after.

Full suite on that install: 256 + 435 + 188 (1 skip) + 11 + 11 green, `cs-diff` 0/1769,
`phpstan` no errors.

Fixes #3581
