### PR TITLE
feat: make the tax calculator replaceable through a factory service

### DIFF
--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -28,7 +28,8 @@ use Thelia\Core\Event\Sale\SaleDeleteEvent;
 use Thelia\Core\Event\Sale\SaleToggleActivityEvent;
 use Thelia\Core\Event\Sale\SaleUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
 use Thelia\Model\Country as CountryModel;
 use Thelia\Model\Map\SaleTableMap;
 use Thelia\Model\ProductPriceQuery;
@@ -48,14 +49,19 @@ use Thelia\Model\SaleQuery;
  */
 class Sale extends BaseAction implements EventSubscriberInterface
 {
+    public function __construct(
+        private readonly TaxCalculatorFactoryInterface $taxCalculatorFactory,
+    ) {
+    }
+
     /**
      * Update PSE for a given product.
      *
-     * @param array      $pseList              an array of priduct sale elements
-     * @param bool       $promoStatus          true if the PSEs are on sale, false otherwise
-     * @param int        $offsetType           the offset type, see SaleModel::OFFSET_* constants
-     * @param Calculator $taxCalculator        the tax calculator
-     * @param array      $saleOffsetByCurrency an array of price offset for each currency (currency ID => offset_amount)
+     * @param array                  $pseList              an array of priduct sale elements
+     * @param bool                   $promoStatus          true if the PSEs are on sale, false otherwise
+     * @param int                    $offsetType           the offset type, see SaleModel::OFFSET_* constants
+     * @param TaxCalculatorInterface $taxCalculator        the tax calculator
+     * @param array                  $saleOffsetByCurrency an array of price offset for each currency (currency ID => offset_amount)
      *
      * @throws PropelException
      */
@@ -63,7 +69,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
         array $pseList,
         bool $promoStatus,
         int $offsetType,
-        Calculator $taxCalculator,
+        TaxCalculatorInterface $taxCalculator,
         array $saleOffsetByCurrency,
         ConnectionInterface $con,
     ): void {
@@ -114,7 +120,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
      */
     public function updateProductsSaleStatus(ProductSaleStatusUpdateEvent $event): void
     {
-        $taxCalculator = new Calculator();
+        $taxCalculator = $this->taxCalculatorFactory->createTaxCalculator();
 
         $sale = $event->getSale();
 

--- a/core/lib/Thelia/Action/Tax.php
+++ b/core/lib/Thelia/Action/Tax.php
@@ -18,8 +18,10 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\Tax\TaxCalculatorEvent;
 use Thelia\Core\Event\Tax\TaxEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
 use Thelia\Model\Tax as TaxModel;
 use Thelia\Model\TaxQuery;
 
@@ -30,6 +32,7 @@ class Tax extends BaseAction implements EventSubscriberInterface
     public function __construct(
         #[AutowireLocator('thelia.taxType')]
         ServiceLocator $taxTypeLocator,
+        private readonly TaxCalculatorFactoryInterface $taxCalculatorFactory,
     ) {
         $this->taxTypeLocator = $taxTypeLocator;
     }
@@ -87,6 +90,18 @@ class Tax extends BaseAction implements EventSubscriberInterface
         }
     }
 
+    /**
+     * Supplies the calculator built by the configured factory, unless another
+     * listener already provided one. Runs last on purpose, so a module only has
+     * to register a listener at any regular priority to take over.
+     */
+    public function getTaxCalculator(TaxCalculatorEvent $event): void
+    {
+        if (!$event->hasTaxCalculator()) {
+            $event->setTaxCalculator($this->taxCalculatorFactory->createTaxCalculator());
+        }
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
@@ -94,6 +109,7 @@ class Tax extends BaseAction implements EventSubscriberInterface
             TheliaEvents::TAX_UPDATE => ['update', 128],
             TheliaEvents::TAX_DELETE => ['delete', 128],
             TheliaEvents::TAX_GET_TYPE_SERVICE => ['getTaxTypeService', 128],
+            TheliaEvents::TAX_GET_CALCULATOR => ['getTaxCalculator', -128],
         ];
     }
 }

--- a/core/lib/Thelia/Config/Resources/services/core/taxation.php
+++ b/core/lib/Thelia/Config/Resources/services/core/taxation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactory;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
+
+/*
+ * Single substitution point for the tax engine: alias
+ * TaxCalculatorFactoryInterface to your own factory from a module
+ * configureServices() to replace the calculator everywhere at once.
+ *
+ * The alias is public so that code holding only the container, such as a
+ * module built on BaseModule, can fetch the factory without autowiring.
+ */
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->alias(TaxCalculatorFactoryInterface::class, TaxCalculatorFactory::class)
+        ->public();
+};

--- a/core/lib/Thelia/Core/Event/Tax/TaxCalculatorEvent.php
+++ b/core/lib/Thelia/Core/Event/Tax/TaxCalculatorEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Event\Tax;
+
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+
+/**
+ * Carries the tax calculator to use for one computation.
+ *
+ * Dispatched as TheliaEvents::TAX_GET_CALCULATOR by call sites that have no
+ * access to the container, typically Propel models. Thelia answers it last, so
+ * any listener that sets a calculator wins over the default one.
+ */
+class TaxCalculatorEvent extends ActionEvent
+{
+    protected ?TaxCalculatorInterface $taxCalculator = null;
+
+    public function hasTaxCalculator(): bool
+    {
+        return $this->taxCalculator instanceof TaxCalculatorInterface;
+    }
+
+    public function getTaxCalculator(): ?TaxCalculatorInterface
+    {
+        return $this->taxCalculator;
+    }
+
+    public function setTaxCalculator(TaxCalculatorInterface $taxCalculator): static
+    {
+        $this->taxCalculator = $taxCalculator;
+
+        return $this;
+    }
+}

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -387,6 +387,14 @@ final class TheliaEvents
     public const TAX_DELETE = 'action.deleteTax';
     public const TAX_GET_TYPE_SERVICE = 'action.getTaxService';
 
+    /**
+     * Sent by a call site with no container to obtain a tax calculator.
+     * Listen to it to substitute your own implementation.
+     *
+     * @see Tax\TaxCalculatorEvent
+     */
+    public const TAX_GET_CALCULATOR = 'action.getTaxCalculator';
+
     // -- Profile management ---------------------------------------------
 
     public const PROFILE_CREATE = 'action.createProfile';

--- a/core/lib/Thelia/Domain/DataTransfer/Export/Type/ProductTaxedPricesExport.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Export/Type/ProductTaxedPricesExport.php
@@ -17,7 +17,8 @@ namespace Thelia\Domain\DataTransfer\Export\Type;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\Propel;
 use Thelia\Domain\DataTransfer\Export\JsonFileAbstractExport;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\ProductQuery;
 use Thelia\Model\TaxRuleQuery;
 
@@ -30,11 +31,13 @@ use Thelia\Model\TaxRuleQuery;
  */
 class ProductTaxedPricesExport extends JsonFileAbstractExport
 {
-    protected Calculator $calculator;
+    use TaxCalculatorResolverTrait;
+
+    protected TaxCalculatorInterface $calculator;
 
     public function __construct()
     {
-        $this->calculator = new Calculator();
+        $this->calculator = $this->createTaxCalculator();
     }
 
     public const FILE_NAME = 'product_taxed_price';

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
@@ -38,7 +38,7 @@ use Thelia\Tools\I18n;
  * @author Franck Allimant <fallimant@openstudio.fr>
  * @author Vincent Lopes <vlopes@openstudio.fr>
  */
-class Calculator
+class Calculator implements TaxCalculatorInterface
 {
     protected TaxRuleQuery $taxRuleQuery;
     protected ?ObjectCollection $taxRulesCollection = null;

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorFactory.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Taxation\TaxEngine;
+
+/**
+ * Default factory: hands out the tax calculator shipped with Thelia.
+ */
+class TaxCalculatorFactory implements TaxCalculatorFactoryInterface
+{
+    public function createTaxCalculator(): TaxCalculatorInterface
+    {
+        return new Calculator();
+    }
+}

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorFactoryInterface.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Taxation\TaxEngine;
+
+/**
+ * Builds the tax calculator used by Thelia.
+ *
+ * Replace the default implementation to plug a custom tax engine in, for example
+ * from a module configureServices():
+ *
+ *     $services->set(MyTaxCalculatorFactory::class)->autowire();
+ *     $services->alias(TaxCalculatorFactoryInterface::class, MyTaxCalculatorFactory::class);
+ *
+ * Each call must return a new instance: a calculator carries the product, country
+ * and state it was loaded with.
+ */
+interface TaxCalculatorFactoryInterface
+{
+    public function createTaxCalculator(): TaxCalculatorInterface;
+}

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorInterface.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Taxation\TaxEngine;
+
+use Thelia\Model\Country;
+use Thelia\Model\Product;
+use Thelia\Model\State;
+use Thelia\Model\TaxRule;
+
+/**
+ * Contract of the tax calculator used by the whole catalog, cart and order chain.
+ *
+ * An implementation is stateful: a load*() method selects the tax rules to apply,
+ * then the get*Price() methods use that selection. Never share an instance between
+ * two unrelated computations, always ask a TaxCalculatorFactoryInterface for a new one.
+ */
+interface TaxCalculatorInterface
+{
+    public function load(Product $product, Country $country, ?State $state = null): static;
+
+    public function loadTaxRule(TaxRule $taxRule, Country $country, Product $product, ?State $state = null): static;
+
+    public function loadTaxRuleWithoutCountry(TaxRule $taxRule, Product $product): static;
+
+    public function loadTaxRuleWithoutProduct(TaxRule $taxRule, Country $country, ?State $state = null): static;
+
+    public function getTaxAmountFromUntaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null): int|float;
+
+    public function getTaxAmountFromTaxedPrice($taxedPrice): int|float;
+
+    public function getTaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null, ?string $askedLocale = null): int|float;
+
+    public function getUntaxedPrice($taxedPrice): int|float;
+}

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorResolverTrait.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorResolverTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Taxation\TaxEngine;
+
+use Propel\Runtime\Propel;
+use Thelia\Core\Event\Tax\TaxCalculatorEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\Map\TaxTableMap;
+
+/**
+ * Obtains a tax calculator from a call site that has no container.
+ *
+ * Propel models, export types built with `new` and module base classes cannot
+ * receive a TaxCalculatorFactoryInterface through autowiring. They reach the
+ * factory through the event dispatcher carried by the Propel connection, the
+ * same route Model\Tax::getTypeInstance() already uses for tax types.
+ */
+trait TaxCalculatorResolverTrait
+{
+    protected function createTaxCalculator(): TaxCalculatorInterface
+    {
+        $connection = Propel::getServiceContainer()->getWriteConnection(TaxTableMap::DATABASE_NAME);
+
+        // No dispatcher outside of a booted kernel (install scripts, standalone CLI).
+        if (!method_exists($connection, 'getEventDispatcher') || null === $eventDispatcher = $connection->getEventDispatcher()) {
+            return new Calculator();
+        }
+
+        $event = new TaxCalculatorEvent();
+        $eventDispatcher->dispatch($event, TheliaEvents::TAX_GET_CALCULATOR);
+
+        return $event->getTaxCalculator() ?? new Calculator();
+    }
+}

--- a/core/lib/Thelia/Model/CartItem.php
+++ b/core/lib/Thelia/Model/CartItem.php
@@ -22,11 +22,13 @@ use Thelia\Core\Event\Cart\CartItemEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Translation\Translator;
 use Thelia\Domain\Cart\Exception\NotEnoughStockException;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Base\CartItem as BaseCartItem;
 
 class CartItem extends BaseCartItem
 {
+    use TaxCalculatorResolverTrait;
+
     protected ?EventDispatcherInterface $dispatcher = null;
 
     public function setDispatcher(EventDispatcherInterface $dispatcher): void
@@ -179,9 +181,7 @@ class CartItem extends BaseCartItem
      */
     public function getTaxedPrice(Country $country, ?State $state = null): float
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this->getProduct(), $country, $state)->getTaxedPrice((float) $this->getPrice());
+        return $this->createTaxCalculator()->load($this->getProduct(), $country, $state)->getTaxedPrice((float) $this->getPrice());
     }
 
     /**
@@ -189,9 +189,7 @@ class CartItem extends BaseCartItem
      */
     public function getTaxedPromoPrice(Country $country, ?State $state = null): float
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this->getProduct(), $country, $state)->getTaxedPrice((float) $this->getPromoPrice());
+        return $this->createTaxCalculator()->load($this->getProduct(), $country, $state)->getTaxedPrice((float) $this->getPromoPrice());
     }
 
     /**

--- a/core/lib/Thelia/Model/Product.php
+++ b/core/lib/Thelia/Model/Product.php
@@ -19,7 +19,7 @@ use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Thelia\Core\File\FileModelParentInterface;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Base\Product as BaseProduct;
 use Thelia\Model\Map\ProductTableMap;
 use Thelia\Model\Tools\PositionManagementTrait;
@@ -28,6 +28,7 @@ use Thelia\Model\Tools\UrlRewritingTrait;
 class Product extends BaseProduct implements FileModelParentInterface
 {
     use PositionManagementTrait;
+    use TaxCalculatorResolverTrait;
     use UrlRewritingTrait;
 
     public function getRewrittenUrlViewName()
@@ -48,16 +49,12 @@ class Product extends BaseProduct implements FileModelParentInterface
 
     public function getTaxedPrice(Country $country, $price, ?State $state = null)
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this, $country, $state)->getTaxedPrice((float) $price);
+        return $this->createTaxCalculator()->load($this, $country, $state)->getTaxedPrice((float) $price);
     }
 
     public function getTaxedPromoPrice(Country $country, $price, ?State $state = null)
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this, $country, $state)->getTaxedPrice((float) $price);
+        return $this->createTaxCalculator()->load($this, $country, $state)->getTaxedPrice((float) $price);
     }
 
     /**

--- a/core/lib/Thelia/Model/ProductSaleElements.php
+++ b/core/lib/Thelia/Model/ProductSaleElements.php
@@ -16,7 +16,7 @@ namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Base\ProductSaleElements as BaseProductSaleElements;
 use Thelia\Model\Tools\PositionManagementTrait;
 use Thelia\Model\Tools\ProductPriceTools;
@@ -24,6 +24,7 @@ use Thelia\Model\Tools\ProductPriceTools;
 class ProductSaleElements extends BaseProductSaleElements
 {
     use PositionManagementTrait;
+    use TaxCalculatorResolverTrait;
 
     /**
      * @throws PropelException
@@ -66,9 +67,7 @@ class ProductSaleElements extends BaseProductSaleElements
      */
     public function getTaxedPrice(Country $country, string $virtualColumnName = 'price_PRICE', float $discount = 0.0): float
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this->getProduct(), $country)->getTaxedPrice($this->getPrice($virtualColumnName, $discount));
+        return $this->createTaxCalculator()->load($this->getProduct(), $country)->getTaxedPrice($this->getPrice($virtualColumnName, $discount));
     }
 
     /**
@@ -76,9 +75,7 @@ class ProductSaleElements extends BaseProductSaleElements
      */
     public function getTaxedPromoPrice(Country $country, string $virtualColumnName = 'price_PROMO_PRICE', float $discount = 0.0): float
     {
-        $taxCalculator = new Calculator();
-
-        return $taxCalculator->load($this->getProduct(), $country)->getTaxedPrice($this->getPromoPrice($virtualColumnName, $discount));
+        return $this->createTaxCalculator()->load($this->getProduct(), $country)->getTaxedPrice($this->getPromoPrice($virtualColumnName, $discount));
     }
 
     /**

--- a/core/lib/Thelia/Model/TaxRule.php
+++ b/core/lib/Thelia/Model/TaxRule.php
@@ -14,15 +14,17 @@ declare(strict_types=1);
 
 namespace Thelia\Model;
 
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
 use Thelia\Domain\Taxation\TaxEngine\OrderProductTaxCollection;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Base\TaxRule as BaseTaxRule;
 
 class TaxRule extends BaseTaxRule
 {
+    use TaxCalculatorResolverTrait;
+
     public function getTaxDetail(Product $product, Country $country, $untaxedAmount, $untaxedPromoAmount, $askedLocale = null): OrderProductTaxCollection
     {
-        $taxCalculator = new Calculator();
+        $taxCalculator = $this->createTaxCalculator();
 
         $taxCollection = new OrderProductTaxCollection();
         $taxCalculator->loadTaxRule($this, $country, $product)->getTaxedPrice((float) $untaxedAmount, $taxCollection, $askedLocale);

--- a/core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php
+++ b/core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace Thelia\Module;
 
 use Propel\Runtime\ActiveQuery\Criteria;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Area;
 use Thelia\Model\AreaDeliveryModuleQuery;
 use Thelia\Model\ConfigQuery;
@@ -26,6 +26,8 @@ use Thelia\Model\TaxRuleQuery;
 
 abstract class AbstractDeliveryModuleWithState extends BaseModule implements DeliveryModuleWithStateInterface
 {
+    use TaxCalculatorResolverTrait;
+
     // This class is the base class for delivery modules
     // It may contains common methods in the future.
 
@@ -73,7 +75,7 @@ abstract class AbstractDeliveryModuleWithState extends BaseModule implements Del
         $orderPostage = new OrderPostage();
 
         if ($taxRule) {
-            $taxCalculator = new Calculator();
+            $taxCalculator = $this->createTaxCalculator();
             $taxCalculator->loadTaxRuleWithoutProduct($taxRule, $country);
 
             $orderPostage->setAmount($taxCalculator->getTaxedPrice($untaxedPostage));

--- a/tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php
+++ b/tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Taxation;
+
+use Thelia\Core\Event\Tax\TaxCalculatorEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\OrderProductTaxCollection;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\CartItem;
+use Thelia\Model\Country;
+use Thelia\Model\OrderProductTax;
+use Thelia\Model\Product;
+use Thelia\Model\State;
+use Thelia\Model\TaxRule;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A shop with its own tax rules must be able to swap the calculator, including
+ * on the Propel models, which have no access to the container.
+ */
+final class TaxCalculatorReplacementTest extends IntegrationTestCase
+{
+    public const SUBSTITUTED_TAXED_PRICE = 133.7;
+
+    private ?\Closure $listener = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->listener instanceof \Closure) {
+            static::getContainer()->get('event_dispatcher')
+                ->removeListener(TheliaEvents::TAX_GET_CALCULATOR, $this->listener);
+            $this->listener = null;
+        }
+
+        parent::tearDown();
+    }
+
+    public function testProductTaxedPriceGoesThroughTheReplacedCalculator(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+        $country = $factory->country();
+
+        self::assertSame(
+            100.0,
+            (float) $product->getTaxedPrice($country, 100.0),
+            'The shipped calculator adds nothing when the tax rule carries no tax.',
+        );
+
+        $this->replaceCalculator();
+
+        self::assertSame(
+            self::SUBSTITUTED_TAXED_PRICE,
+            (float) $product->getTaxedPrice($country, 100.0),
+            'Product::getTaxedPrice() must use the substituted calculator.',
+        );
+    }
+
+    public function testCartItemAlsoUsesTheReplacedCalculator(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+        $country = $factory->country();
+
+        $cartItem = new CartItem();
+        $cartItem
+            ->setCart($factory->cart())
+            ->setProduct($product)
+            ->setProductSaleElements($product->getDefaultSaleElements())
+            ->setQuantity(1)
+            ->setPrice('100')
+            ->setPromoPrice('90')
+            ->setPromo(0)
+            ->save($this->getPropelConnection());
+
+        self::assertSame(100.0, $cartItem->getTaxedPrice($country));
+
+        $this->replaceCalculator();
+
+        self::assertSame(self::SUBSTITUTED_TAXED_PRICE, $cartItem->getTaxedPrice($country));
+    }
+
+    public function testTaxRuleDetailAlsoUsesTheReplacedCalculator(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $taxRule = $factory->taxRule();
+        $product = $factory->product($factory->category(), $taxRule, $factory->currency());
+        $country = $factory->country();
+
+        self::assertSame(0, $taxRule->getTaxDetail($product, $country, 100.0, 90.0)->getCount());
+
+        $this->replaceCalculator();
+
+        $taxDetail = $taxRule->getTaxDetail($product, $country, 100.0, 90.0);
+
+        self::assertSame(1, $taxDetail->getCount());
+        self::assertSame('substituted', $taxDetail->getKey(0)->getTitle());
+    }
+
+    public function testFactoryIsAliasedAndHandsOutAFreshInstanceEveryTime(): void
+    {
+        $factory = $this->getService(TaxCalculatorFactoryInterface::class);
+
+        $first = $factory->createTaxCalculator();
+        $second = $factory->createTaxCalculator();
+
+        self::assertInstanceOf(TaxCalculatorInterface::class, $first);
+        self::assertNotSame($first, $second, 'A calculator holds the product it was loaded with: never share one.');
+    }
+
+    public function testShippedCalculatorRemainsUsableOnItsOwn(): void
+    {
+        self::assertInstanceOf(TaxCalculatorInterface::class, new Calculator());
+    }
+
+    private function replaceCalculator(): void
+    {
+        $this->listener = static function (TaxCalculatorEvent $event): void {
+            $event->setTaxCalculator(new class implements TaxCalculatorInterface {
+                public function load(Product $product, Country $country, ?State $state = null): static
+                {
+                    return $this;
+                }
+
+                public function loadTaxRule(TaxRule $taxRule, Country $country, Product $product, ?State $state = null): static
+                {
+                    return $this;
+                }
+
+                public function loadTaxRuleWithoutCountry(TaxRule $taxRule, Product $product): static
+                {
+                    return $this;
+                }
+
+                public function loadTaxRuleWithoutProduct(TaxRule $taxRule, Country $country, ?State $state = null): static
+                {
+                    return $this;
+                }
+
+                public function getTaxAmountFromUntaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null): int|float
+                {
+                    return TaxCalculatorReplacementTest::SUBSTITUTED_TAXED_PRICE - $untaxedPrice;
+                }
+
+                public function getTaxAmountFromTaxedPrice($taxedPrice): int|float
+                {
+                    return 0;
+                }
+
+                public function getTaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null, ?string $askedLocale = null): int|float
+                {
+                    if ($taxCollection instanceof OrderProductTaxCollection) {
+                        $taxCollection->addTax(
+                            (new OrderProductTax())
+                                ->setTitle('substituted')
+                                ->setDescription('')
+                                ->setAmount((string) (TaxCalculatorReplacementTest::SUBSTITUTED_TAXED_PRICE - $untaxedPrice)),
+                        );
+                    }
+
+                    return TaxCalculatorReplacementTest::SUBSTITUTED_TAXED_PRICE;
+                }
+
+                public function getUntaxedPrice($taxedPrice): int|float
+                {
+                    return $taxedPrice;
+                }
+            });
+        };
+
+        static::getContainer()->get('event_dispatcher')
+            ->addListener(TheliaEvents::TAX_GET_CALCULATOR, $this->listener);
+    }
+}


### PR DESCRIPTION
Addresses the part of https://github.com/thelia/thelia/issues/2424 that was still open. Not a full close: see the last section.

## Symptom

`Thelia\Domain\Taxation\TaxEngine\Calculator` was built with `new` on every call site, so an integrator with its own tax rules (rounding, business rules, country specifics) had no way to substitute an implementation. Tax types became services in #3094, but the calculator that drives them did not.

## Where it was hardwired

Ten `new Calculator()` in seven files:

| File | Line | How it could reach the container |
|---|---|---|
| `core/lib/Thelia/Model/Product.php` | 51, 58 | Propel model, no container |
| `core/lib/Thelia/Model/ProductSaleElements.php` | 69, 79 | Propel model, no container |
| `core/lib/Thelia/Model/CartItem.php` | 182, 192 | Propel model, no container |
| `core/lib/Thelia/Model/TaxRule.php` | 25 | Propel model, no container |
| `core/lib/Thelia/Domain/DataTransfer/Export/Type/ProductTaxedPricesExport.php` | 37 | built with `new $class()` by `Model\Export::getHandleClassInstance()` |
| `core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php` | 76 | base class of third-party delivery modules, a constructor change would break them |
| `core/lib/Thelia/Action/Sale.php` | 117 | plain service, autowiring available |

Only one of the seven can be autowired, which is what shaped the solution.

## Fix

- `TaxCalculatorInterface` states the contract; `Calculator` now implements it and is otherwise untouched.
- `TaxCalculatorFactoryInterface` / `TaxCalculatorFactory` is the substitution point. It is a factory rather than a plain service because a calculator is stateful: `load()`, `loadTaxRule()`, `loadTaxRuleWithoutCountry()` and `loadTaxRuleWithoutProduct()` mutate the instance, and `loadTaxRuleWithoutCountry()` leaves the previous country in place, so a shared instance would leak state between two computations.
- `Action\Sale` takes the factory through its constructor.
- The six call sites with no container use `TaxCalculatorResolverTrait`, which asks for a calculator through the new `TheliaEvents::TAX_GET_CALCULATOR` event carried by the Propel connection dispatcher. This is the route `Model\Tax::getTypeInstance()` already uses for tax types. `Action\Tax` answers it last, with the calculator built by the factory, so a listener registered at any regular priority wins.

Replacing the engine from a module:

```php
public static function configureServices(ServicesConfigurator $services): void
{
    $services->set(MyTaxCalculatorFactory::class)->autowire();
    $services->alias(TaxCalculatorFactoryInterface::class, MyTaxCalculatorFactory::class);
}
```

## Backward compatibility

`new Calculator()` keeps working, and several published modules rely on it. Nothing is removed, no constructor of a class extended by modules changes, and no public signature changes. `TaxCalculatorResolverTrait` falls back to the shipped calculator when no dispatcher is attached to the connection, which is the case in the install scripts and in standalone CLI.

## Verification

`tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php` registers a substitute calculator through the event and asserts that `Product::getTaxedPrice()`, `CartItem::getTaxedPrice()` and `TaxRule::getTaxDetail()` return its values.

Checked failing before the fix and passing after: with the new classes in place but the seven call sites left on `new Calculator()`, the three substitution tests fail (`Failed asserting that 100.0 is identical to 133.7`); with the call sites routed through the resolver they pass. Full suite green (5 suites, 901 tests, 1 legitimate api skip), `cs-diff` 0/1776, PHPStan 0 errors.

## Still open in #2424

`Calculator::getUntaxedCartDiscount()`, `getUntaxedOrderDiscount()`, `getCartTaxFactor()` and `getOrderTaxFactor()` are static and called from `Model\Cart.php:261`, `Model\Order.php:265` and `Core/Template/Loop/Order.php:338`. Making them replaceable means turning them into instance methods, which PHP does not allow alongside statics of the same name, so it needs either a rename or a removal. Left out of this change to keep it backward compatible.

The back-office themes also build the calculator directly, in their own repositories: `templates/backOffice/default-twig/src/Service/Catalog/ProductPricingProvider.php:188` and `templates/backOffice/default/Controller/Admin/ProductController.php:1348` and `:1417`.
