### PR TITLE
feat: provide the core anonymisation and personal data export path a GDPR module needs

### DIFF
--- a/core/lib/Thelia/Action/CustomerPersonalData.php
+++ b/core/lib/Thelia/Action/CustomerPersonalData.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Action;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\Customer\CustomerAnonymizeEvent;
+use Thelia\Core\Event\Customer\CustomerPersonalDataExportEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Customer\Service\CustomerAnonymizer;
+use Thelia\Domain\Customer\Service\CustomerPersonalDataExporter;
+
+/**
+ * Entry point of the two personal data operations a compliance module needs:
+ * exporting the data of one person, and erasing it without losing the orders.
+ */
+class CustomerPersonalData extends BaseAction implements EventSubscriberInterface
+{
+    public function __construct(
+        protected CustomerAnonymizer $customerAnonymizer,
+        protected CustomerPersonalDataExporter $customerPersonalDataExporter,
+    ) {
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function anonymize(CustomerAnonymizeEvent $event): void
+    {
+        $this->customerAnonymizer->anonymize($event->getCustomer());
+    }
+
+    public function export(CustomerPersonalDataExportEvent $event): void
+    {
+        $event->setPersonalData($this->customerPersonalDataExporter->export($event->getCustomer()));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TheliaEvents::CUSTOMER_ANONYMIZE => ['anonymize', 128],
+            TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT => ['export', 128],
+        ];
+    }
+}

--- a/core/lib/Thelia/Command/CustomerAnonymizeCommand.php
+++ b/core/lib/Thelia/Command/CustomerAnonymizeCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Thelia\Core\Event\Customer\CustomerAnonymizeEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CustomerQuery;
+
+/**
+ * Erases the identifying data of one customer, keeping the orders.
+ */
+class CustomerAnonymizeCommand extends ContainerAwareCommand
+{
+    public function configure(): void
+    {
+        $this
+            ->setName('customer:anonymize')
+            ->setDescription(
+                'Erase the identifying data of a customer, keeping the accounting record of the orders.'
+            )
+            ->addArgument('email', InputArgument::REQUIRED, 'Email address of the customer to anonymize')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Do not ask for confirmation');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = (string) $input->getArgument('email');
+        $customer = CustomerQuery::create()->findOneByEmail($email);
+
+        if (null === $customer) {
+            $output->writeln(\sprintf('<error>No customer found with email "%s".</error>', $email));
+
+            return 1;
+        }
+
+        if (!$input->getOption('force')) {
+            $question = new ConfirmationQuestion(
+                \sprintf(
+                    'Anonymize customer %s (%s)? This cannot be undone. [y/N] ',
+                    $customer->getRef(),
+                    $email,
+                ),
+                false,
+            );
+
+            if (!$this->getHelper('question')->ask($input, $output, $question)) {
+                $output->writeln('<comment>Aborted.</comment>');
+
+                return 0;
+            }
+        }
+
+        $this->getDispatcher()->dispatch(
+            new CustomerAnonymizeEvent($customer),
+            TheliaEvents::CUSTOMER_ANONYMIZE,
+        );
+
+        $output->writeln(\sprintf(
+            '<info>Customer %s anonymized. Orders kept, account disabled.</info>',
+            $customer->getRef(),
+        ));
+
+        return 0;
+    }
+}

--- a/core/lib/Thelia/Command/CustomerPersonalDataExportCommand.php
+++ b/core/lib/Thelia/Command/CustomerPersonalDataExportCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Thelia\Core\Event\Customer\CustomerPersonalDataExportEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CustomerQuery;
+
+/**
+ * Writes everything the shop knows about one customer as JSON.
+ */
+class CustomerPersonalDataExportCommand extends ContainerAwareCommand
+{
+    public function configure(): void
+    {
+        $this
+            ->setName('customer:export-personal-data')
+            ->setDescription('Export everything the shop knows about one customer, as JSON.')
+            ->addArgument('email', InputArgument::REQUIRED, 'Email address of the customer')
+            ->addOption(
+                'output-file',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Write the archive to this file instead of the standard output'
+            );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $email = (string) $input->getArgument('email');
+        $customer = CustomerQuery::create()->findOneByEmail($email);
+
+        if (null === $customer) {
+            $output->writeln(\sprintf('<error>No customer found with email "%s".</error>', $email));
+
+            return 1;
+        }
+
+        $event = new CustomerPersonalDataExportEvent($customer);
+        $this->getDispatcher()->dispatch($event, TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT);
+
+        $json = json_encode(
+            $event->getPersonalData(),
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR,
+        );
+
+        $outputFile = $input->getOption('output-file');
+
+        if (null === $outputFile) {
+            $output->writeln($json);
+
+            return 0;
+        }
+
+        if (false === file_put_contents($outputFile, $json)) {
+            $output->writeln(\sprintf('<error>Unable to write to "%s".</error>', $outputFile));
+
+            return 1;
+        }
+
+        $output->writeln(\sprintf('<info>Personal data of %s written to %s</info>', $email, $outputFile));
+
+        return 0;
+    }
+}

--- a/core/lib/Thelia/Core/Event/Customer/CustomerAnonymizeEvent.php
+++ b/core/lib/Thelia/Core/Event/Customer/CustomerAnonymizeEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Event\Customer;
+
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Model\Customer;
+
+/**
+ * Requests the erasure of the identifying data of a customer, keeping the
+ * accounting record of the orders intact.
+ *
+ * Dispatched with TheliaEvents::CUSTOMER_ANONYMIZE.
+ */
+class CustomerAnonymizeEvent extends ActionEvent
+{
+    public function __construct(private readonly Customer $customer)
+    {
+    }
+
+    public function getCustomer(): Customer
+    {
+        return $this->customer;
+    }
+}

--- a/core/lib/Thelia/Core/Event/Customer/CustomerPersonalDataExportEvent.php
+++ b/core/lib/Thelia/Core/Event/Customer/CustomerPersonalDataExportEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Event\Customer;
+
+use Thelia\Core\Event\ActionEvent;
+use Thelia\Model\Customer;
+
+/**
+ * Collects everything the shop knows about one person.
+ *
+ * Dispatched with TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT. Core fills the
+ * event with the account, its addresses, orders, carts and newsletter
+ * subscription; listeners registered after it may add their own sections.
+ */
+class CustomerPersonalDataExportEvent extends ActionEvent
+{
+    /** @var array<string, mixed> */
+    private array $personalData = [];
+
+    public function __construct(private readonly Customer $customer)
+    {
+    }
+
+    public function getCustomer(): Customer
+    {
+        return $this->customer;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPersonalData(): array
+    {
+        return $this->personalData;
+    }
+
+    /**
+     * @param array<string, mixed> $personalData
+     *
+     * @return $this
+     */
+    public function setPersonalData(array $personalData): static
+    {
+        $this->personalData = $personalData;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addSection(string $sectionName, mixed $data): static
+    {
+        $this->personalData[$sectionName] = $data;
+
+        return $this;
+    }
+}

--- a/core/lib/Thelia/Core/Event/TheliaEvents.php
+++ b/core/lib/Thelia/Core/Event/TheliaEvents.php
@@ -131,6 +131,15 @@ final class TheliaEvents
     /** sent on customer removal. */
     public const CUSTOMER_DELETEACCOUNT = 'action.deleteCustomer';
 
+    /**
+     * Sent to erase the identifying data of a customer while keeping the
+     * accounting record of the orders, which cannot be deleted.
+     */
+    public const CUSTOMER_ANONYMIZE = 'action.anonymizeCustomer';
+
+    /** Sent to collect everything the shop knows about one customer. */
+    public const CUSTOMER_PERSONAL_DATA_EXPORT = 'action.exportCustomerPersonalData';
+
     /** sent when a customer need a new password. */
     public const LOST_PASSWORD = 'action.lostPassword';
 

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -72,6 +72,7 @@ use Thelia\Core\Template\Parser\ParserResolver;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Core\Translation\Translator;
+use Thelia\Domain\Customer\Service\CustomerPersonalDataProviderInterface;
 use Thelia\Domain\Promotion\Coupon\Type\CouponInterface;
 use Thelia\Domain\Taxation\TaxEngine\TaxTypeInterface;
 use Thelia\Form\FormInterface;
@@ -469,6 +470,7 @@ class TheliaKernel extends Kernel
             ContainerAwareInterface::class => 'thelia.command',
             ControllerInterface::class => 'controller.service_arguments',
             TaxTypeInterface::class => 'thelia.taxType',
+            CustomerPersonalDataProviderInterface::class => 'thelia.customer.personal_data_provider',
 
             QueryCollectionExtensionInterface::class => 'thelia.api.propel.query_extension.collection',
             QueryItemExtensionInterface::class => 'thelia.api.propel.query_extension.item',

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerAnonymizer.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerAnonymizer.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Customer\Service;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\CartAddressQuery;
+use Thelia\Model\CartQuery;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerVersionQuery;
+use Thelia\Model\Map\CustomerTableMap;
+use Thelia\Model\NewsletterQuery;
+use Thelia\Model\OrderAddressQuery;
+use Thelia\Model\OrderQuery;
+
+/**
+ * Erases the identifying data of a customer while keeping the accounting
+ * record of the orders intact.
+ *
+ * Orders stay attached to the (now anonymous) customer account, keep their
+ * reference, their invoice number and date, their amounts, their taxes, their
+ * coupons and their status history. What disappears is who placed them: the
+ * account identity, the address book, the identity frozen on the invoice and
+ * delivery order addresses, the carts and the newsletter subscription.
+ *
+ * The country and state of an order address are kept, because they justify
+ * the tax rate applied on the order.
+ *
+ * Modules add their own data to the operation by implementing
+ * CustomerPersonalDataProviderInterface.
+ */
+final readonly class CustomerAnonymizer
+{
+    public const ANONYMIZED_VALUE = 'anonymous';
+    public const ANONYMIZED_EMAIL_DOMAIN = 'anonymous.invalid';
+
+    /**
+     * @param iterable<CustomerPersonalDataProviderInterface> $personalDataProviders
+     */
+    public function __construct(
+        #[AutowireIterator('thelia.customer.personal_data_provider')]
+        private iterable $personalDataProviders = [],
+    ) {
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function anonymize(Customer $customer): void
+    {
+        $connection = Propel::getConnection(CustomerTableMap::DATABASE_NAME);
+        $connection->beginTransaction();
+
+        try {
+            $this->anonymizeOrderAddresses($customer, $connection);
+            $this->deleteCarts($customer, $connection);
+            $this->deleteAddresses($customer, $connection);
+            $this->deleteNewsletterSubscription($customer, $connection);
+            $this->anonymizeAccount($customer, $connection);
+
+            foreach ($this->personalDataProviders as $provider) {
+                $provider->anonymizePersonalData($customer);
+            }
+
+            $connection->commit();
+        } catch (\Throwable $throwable) {
+            $connection->rollBack();
+
+            throw $throwable;
+        }
+    }
+
+    /**
+     * The order addresses are frozen copies made at checkout: they are not
+     * shared with the address book, so they are neutralized in place rather
+     * than deleted, which would break the orders that reference them.
+     */
+    private function anonymizeOrderAddresses(Customer $customer, ConnectionInterface $connection): void
+    {
+        $orderAddressIds = [];
+
+        foreach (OrderQuery::create()->filterByCustomerId($customer->getId())->find($connection) as $order) {
+            $orderAddressIds[] = $order->getInvoiceOrderAddressId();
+            $orderAddressIds[] = $order->getDeliveryOrderAddressId();
+        }
+
+        $orderAddressIds = array_values(array_unique(array_filter($orderAddressIds)));
+
+        if ([] === $orderAddressIds) {
+            return;
+        }
+
+        $orderAddresses = OrderAddressQuery::create()
+            ->filterById($orderAddressIds)
+            ->find($connection);
+
+        foreach ($orderAddresses as $orderAddress) {
+            $orderAddress
+                ->setCustomerTitleId(null)
+                ->setCompany(null)
+                ->setFirstname(self::ANONYMIZED_VALUE)
+                ->setLastname(self::ANONYMIZED_VALUE)
+                ->setAddress1(self::ANONYMIZED_VALUE)
+                ->setAddress2(null)
+                ->setAddress3(null)
+                ->setZipcode(self::ANONYMIZED_VALUE)
+                ->setCity(self::ANONYMIZED_VALUE)
+                ->setPhone(null)
+                ->setCellphone(null)
+                ->save($connection);
+        }
+    }
+
+    /**
+     * A cart holds a copy of the delivery and invoice addresses, so the cart
+     * addresses are deleted along with the carts themselves.
+     */
+    private function deleteCarts(Customer $customer, ConnectionInterface $connection): void
+    {
+        $carts = CartQuery::create()->filterByCustomerId($customer->getId())->find($connection);
+
+        $cartAddressIds = [];
+
+        foreach ($carts as $cart) {
+            $cartAddressIds[] = $cart->getAddressDeliveryId();
+            $cartAddressIds[] = $cart->getAddressInvoiceId();
+            $cart->delete($connection);
+        }
+
+        $cartAddressIds = array_values(array_unique(array_filter($cartAddressIds)));
+
+        if ([] === $cartAddressIds) {
+            return;
+        }
+
+        CartAddressQuery::create()->filterById($cartAddressIds)->delete($connection);
+    }
+
+    private function deleteAddresses(Customer $customer, ConnectionInterface $connection): void
+    {
+        $addressIds = AddressQuery::create()
+            ->filterByCustomerId($customer->getId())
+            ->select('Id')
+            ->find($connection)
+            ->toArray();
+
+        if ([] === $addressIds) {
+            return;
+        }
+
+        // A cart address keeps a reference to the address book entry it was
+        // copied from, under a RESTRICT foreign key: clear it first.
+        $cartAddresses = CartAddressQuery::create()
+            ->filterByAddressId($addressIds)
+            ->find($connection);
+
+        foreach ($cartAddresses as $cartAddress) {
+            $cartAddress->setAddressId(null)->save($connection);
+        }
+
+        AddressQuery::create()->filterById($addressIds)->delete($connection);
+    }
+
+    private function deleteNewsletterSubscription(Customer $customer, ConnectionInterface $connection): void
+    {
+        $email = $customer->getEmail();
+
+        if (null === $email || '' === $email) {
+            return;
+        }
+
+        NewsletterQuery::create()->filterByEmail($email)->delete($connection);
+    }
+
+    private function anonymizeAccount(Customer $customer, ConnectionInterface $connection): void
+    {
+        $customer
+            ->setFirstname(self::ANONYMIZED_VALUE)
+            ->setLastname(self::ANONYMIZED_VALUE)
+            ->setEmail(\sprintf('%s-%d@%s', self::ANONYMIZED_VALUE, $customer->getId(), self::ANONYMIZED_EMAIL_DOMAIN))
+            ->setAlgo(null)
+            ->setSponsor(null)
+            ->setRememberMeToken(null)
+            ->setRememberMeSerial(null)
+            ->setConfirmationToken(null)
+            ->setConfirmationTokenExpiresAt(null)
+            ->setEnable(0);
+
+        $customer->erasePassword();
+        $customer->save($connection);
+
+        // The versionable behavior keeps a full copy of every past revision of
+        // the account, identity included. Anonymizing the row is pointless
+        // while that history is still readable.
+        CustomerVersionQuery::create()->filterById($customer->getId())->delete($connection);
+    }
+}

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataExporter.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataExporter.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Customer\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Thelia\Model\Address;
+use Thelia\Model\Cart;
+use Thelia\Model\Customer;
+use Thelia\Model\Newsletter;
+use Thelia\Model\NewsletterQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderAddress;
+
+/**
+ * Collects everything the shop knows about one person, as a nested array
+ * ready to be serialized — a data portability archive for a single customer,
+ * as opposed to the administrator bulk export of Export\Type\CustomerExport.
+ *
+ * Core contributes the sections listed in CORE_SECTION_NAMES; modules
+ * contribute theirs through CustomerPersonalDataProviderInterface.
+ */
+final readonly class CustomerPersonalDataExporter
+{
+    public const CORE_SECTION_NAMES = ['customer', 'addresses', 'orders', 'carts', 'newsletter'];
+
+    /**
+     * @param iterable<CustomerPersonalDataProviderInterface> $personalDataProviders
+     */
+    public function __construct(
+        #[AutowireIterator('thelia.customer.personal_data_provider')]
+        private iterable $personalDataProviders = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function export(Customer $customer): array
+    {
+        $personalData = [
+            'customer' => $this->exportAccount($customer),
+            'addresses' => $this->exportAddresses($customer),
+            'orders' => $this->exportOrders($customer),
+            'carts' => $this->exportCarts($customer),
+            'newsletter' => $this->exportNewsletterSubscription($customer),
+        ];
+
+        foreach ($this->personalDataProviders as $provider) {
+            $sectionName = $provider->getPersonalDataSectionName();
+
+            if (isset($personalData[$sectionName])) {
+                throw new \LogicException(\sprintf('The personal data section "%s" declared by %s is already used. Section names must be unique.', $sectionName, $provider::class));
+            }
+
+            $personalData[$sectionName] = $provider->exportPersonalData($customer);
+        }
+
+        return $personalData;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportAccount(Customer $customer): array
+    {
+        // Customer::getLocale() fatals when the account carries no language,
+        // which the schema allows.
+        $locale = $customer->getLangModel()?->getLocale();
+
+        return [
+            'reference' => $customer->getRef(),
+            'title' => null === $locale ? null : $customer->getCustomerTitle()?->setLocale($locale)->getLong(),
+            'firstname' => $customer->getFirstname(),
+            'lastname' => $customer->getLastname(),
+            'email' => $customer->getEmail(),
+            'locale' => $locale,
+            'reseller' => (bool) $customer->getReseller(),
+            'discount' => $customer->getDiscount(),
+            'sponsor' => $customer->getSponsor(),
+            'created_at' => $this->formatDate($customer->getCreatedAt()),
+            'updated_at' => $this->formatDate($customer->getUpdatedAt()),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function exportAddresses(Customer $customer): array
+    {
+        $addresses = [];
+
+        foreach ($customer->getAddresses() as $address) {
+            $addresses[] = $this->exportAddress($address);
+        }
+
+        return $addresses;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportAddress(Address $address): array
+    {
+        return [
+            'label' => $address->getLabel(),
+            'is_default' => (bool) $address->getIsDefault(),
+            'company' => $address->getCompany(),
+            'firstname' => $address->getFirstname(),
+            'lastname' => $address->getLastname(),
+            'address1' => $address->getAddress1(),
+            'address2' => $address->getAddress2(),
+            'address3' => $address->getAddress3(),
+            'zipcode' => $address->getZipcode(),
+            'city' => $address->getCity(),
+            'country' => $address->getCountry()?->getIsoalpha2(),
+            'phone' => $address->getPhone(),
+            'cellphone' => $address->getCellphone(),
+            'created_at' => $this->formatDate($address->getCreatedAt()),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function exportOrders(Customer $customer): array
+    {
+        $orders = [];
+
+        foreach ($customer->getOrders() as $order) {
+            $orders[] = $this->exportOrder($order);
+        }
+
+        return $orders;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportOrder(Order $order): array
+    {
+        return [
+            'reference' => $order->getRef(),
+            'status' => $order->getOrderStatus()?->getCode(),
+            'invoice_reference' => $order->getInvoiceRef(),
+            'invoice_date' => $this->formatDate($order->getInvoiceDate()),
+            'currency' => $order->getCurrency()?->getCode(),
+            'currency_rate' => $order->getCurrencyRate(),
+            'discount' => $order->getDiscount(),
+            'postage' => $order->getPostage(),
+            'postage_tax' => $order->getPostageTax(),
+            'transaction_reference' => $order->getTransactionRef(),
+            'delivery_reference' => $order->getDeliveryRef(),
+            'created_at' => $this->formatDate($order->getCreatedAt()),
+            'invoice_address' => $this->exportOrderAddress($order->getOrderAddressRelatedByInvoiceOrderAddressId()),
+            'delivery_address' => $this->exportOrderAddress($order->getOrderAddressRelatedByDeliveryOrderAddressId()),
+            'products' => $this->exportOrderProducts($order),
+            'coupons' => $this->exportOrderCoupons($order),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function exportOrderAddress(?OrderAddress $orderAddress): ?array
+    {
+        if (!$orderAddress instanceof OrderAddress) {
+            return null;
+        }
+
+        return [
+            'company' => $orderAddress->getCompany(),
+            'firstname' => $orderAddress->getFirstname(),
+            'lastname' => $orderAddress->getLastname(),
+            'address1' => $orderAddress->getAddress1(),
+            'address2' => $orderAddress->getAddress2(),
+            'address3' => $orderAddress->getAddress3(),
+            'zipcode' => $orderAddress->getZipcode(),
+            'city' => $orderAddress->getCity(),
+            'country' => $orderAddress->getCountry()?->getIsoalpha2(),
+            'phone' => $orderAddress->getPhone(),
+            'cellphone' => $orderAddress->getCellphone(),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function exportOrderProducts(Order $order): array
+    {
+        $products = [];
+
+        foreach ($order->getOrderProducts() as $orderProduct) {
+            $products[] = [
+                'product_reference' => $orderProduct->getProductRef(),
+                'title' => $orderProduct->getTitle(),
+                'quantity' => $orderProduct->getQuantity(),
+                'price' => $orderProduct->getPrice(),
+                'promo_price' => $orderProduct->getPromoPrice(),
+                'was_in_promo' => (bool) $orderProduct->getWasInPromo(),
+                'tax_rule_title' => $orderProduct->getTaxRuleTitle(),
+            ];
+        }
+
+        return $products;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function exportOrderCoupons(Order $order): array
+    {
+        $coupons = [];
+
+        foreach ($order->getOrderCoupons() as $orderCoupon) {
+            $coupons[] = [
+                'code' => $orderCoupon->getCode(),
+                'title' => $orderCoupon->getTitle(),
+                'type' => $orderCoupon->getType(),
+                'amount' => $orderCoupon->getAmount(),
+            ];
+        }
+
+        return $coupons;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function exportCarts(Customer $customer): array
+    {
+        $carts = [];
+
+        foreach ($customer->getCarts() as $cart) {
+            $carts[] = $this->exportCart($cart);
+        }
+
+        return $carts;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exportCart(Cart $cart): array
+    {
+        $items = [];
+
+        foreach ($cart->getCartItems() as $cartItem) {
+            $items[] = [
+                'product_reference' => $cartItem->getProduct()?->getRef(),
+                'quantity' => $cartItem->getQuantity(),
+                'price' => $cartItem->getPrice(),
+            ];
+        }
+
+        return [
+            'token' => $cart->getToken(),
+            'created_at' => $this->formatDate($cart->getCreatedAt()),
+            'updated_at' => $this->formatDate($cart->getUpdatedAt()),
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * The newsletter table has no foreign key on the customer: the two are
+     * only related by email address.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function exportNewsletterSubscription(Customer $customer): ?array
+    {
+        $email = $customer->getEmail();
+
+        if (null === $email || '' === $email) {
+            return null;
+        }
+
+        $newsletter = NewsletterQuery::create()->findOneByEmail($email);
+
+        if (!$newsletter instanceof Newsletter) {
+            return null;
+        }
+
+        return [
+            'email' => $newsletter->getEmail(),
+            'firstname' => $newsletter->getFirstname(),
+            'lastname' => $newsletter->getLastname(),
+            'locale' => $newsletter->getLocale(),
+            'unsubscribed' => $newsletter->getUnsubscribed(),
+            'created_at' => $this->formatDate($newsletter->getCreatedAt()),
+        ];
+    }
+
+    private function formatDate(mixed $date): ?string
+    {
+        return $date instanceof \DateTimeInterface ? $date->format(\DATE_ATOM) : null;
+    }
+}

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataProviderInterface.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataProviderInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Customer\Service;
+
+use Thelia\Model\Customer;
+
+/**
+ * Declares the personal data a module holds about a customer.
+ *
+ * Implementations are auto-registered: any service implementing this
+ * interface is tagged `thelia.customer.personal_data_provider` and is called
+ * by CustomerPersonalDataExporter when the data of a customer is exported,
+ * and by CustomerAnonymizer when that customer is anonymized.
+ *
+ * Core covers the customer account, its addresses, orders and their frozen
+ * order addresses, carts and newsletter subscriptions. Everything else — a
+ * loyalty balance, a support ticket, a stored payment token — belongs to the
+ * module that stores it, hence this interface.
+ */
+interface CustomerPersonalDataProviderInterface
+{
+    /**
+     * Key under which this provider appears in the exported data.
+     *
+     * It must not collide with a core section (customer, addresses, orders,
+     * carts, newsletter) nor with another provider: prefer the module code,
+     * for instance `loyalty` or `virtual_product_delivery`.
+     */
+    public function getPersonalDataSectionName(): string;
+
+    /**
+     * Personal data held about this customer, in a structure suitable for
+     * JSON serialization. Return an empty array when there is nothing.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function exportPersonalData(Customer $customer): array;
+
+    /**
+     * Neutralizes or deletes the personal data held about this customer.
+     *
+     * Runs inside the anonymization transaction: throwing rolls back the
+     * whole operation, including what core already anonymized.
+     */
+    public function anonymizePersonalData(Customer $customer): void;
+}

--- a/tests/Integration/Domain/Customer/CustomerAnonymizerTest.php
+++ b/tests/Integration/Domain/Customer/CustomerAnonymizerTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Customer;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Customer\CustomerAnonymizeEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Customer\Service\CustomerAnonymizer;
+use Thelia\Domain\Customer\Service\CustomerPersonalDataProviderInterface;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\CartQuery;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerQuery;
+use Thelia\Model\CustomerVersionQuery;
+use Thelia\Model\Newsletter;
+use Thelia\Model\NewsletterQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderAddressQuery;
+use Thelia\Model\OrderProduct;
+use Thelia\Model\OrderQuery;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+final class CustomerAnonymizerTest extends IntegrationTestCase
+{
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testAnonymizeKeepsTheOrderAndItsAmounts(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+        $order = $customer->getOrders()->getFirst();
+        self::assertInstanceOf(Order::class, $order);
+
+        $orderId = $order->getId();
+        $orderReference = $order->getRef();
+
+        $this->anonymize($customer);
+
+        $reloadedOrder = OrderQuery::create()->findPk($orderId);
+        self::assertNotNull($reloadedOrder, 'Anonymizing a customer must not delete the orders.');
+        self::assertSame($orderReference, $reloadedOrder->getRef());
+        self::assertSame($customer->getId(), $reloadedOrder->getCustomerId());
+        self::assertSame('12.500000', $reloadedOrder->getPostage());
+        self::assertSame('2.500000', $reloadedOrder->getPostageTax());
+
+        $orderProduct = $reloadedOrder->getOrderProducts()->getFirst();
+        self::assertNotNull($orderProduct);
+        self::assertSame('99.990000', $orderProduct->getPrice());
+        self::assertSame(2.0, $orderProduct->getQuantity());
+    }
+
+    public function testAnonymizeErasesTheAccountIdentity(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $this->anonymize($customer);
+
+        $reloaded = CustomerQuery::create()->findPk($customer->getId());
+        self::assertNotNull($reloaded);
+        self::assertSame(CustomerAnonymizer::ANONYMIZED_VALUE, $reloaded->getFirstname());
+        self::assertSame(CustomerAnonymizer::ANONYMIZED_VALUE, $reloaded->getLastname());
+        self::assertStringEndsWith('@'.CustomerAnonymizer::ANONYMIZED_EMAIL_DOMAIN, (string) $reloaded->getEmail());
+        self::assertSame('', $reloaded->getPassword());
+        self::assertNull($reloaded->getAlgo());
+        self::assertNull($reloaded->getRememberMeToken());
+        self::assertNull($reloaded->getRememberMeSerial());
+        self::assertNull($reloaded->getConfirmationToken());
+        self::assertSame(0, $reloaded->getEnable());
+    }
+
+    public function testAnonymizeLeavesNoIdentifyingDataBehind(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+        $customerId = $customer->getId();
+
+        $this->anonymize($customer);
+
+        self::assertSame(
+            0,
+            AddressQuery::create()->filterByCustomerId($customerId)->count(),
+            'The address book must be deleted.',
+        );
+        self::assertSame(
+            0,
+            CartQuery::create()->filterByCustomerId($customerId)->count(),
+            'The carts must be deleted.',
+        );
+        self::assertSame(
+            0,
+            NewsletterQuery::create()->filterByEmail('anonymizer-subject@test.com')->count(),
+            'The newsletter subscription must be deleted.',
+        );
+        self::assertSame(
+            0,
+            CustomerVersionQuery::create()->filterById($customerId)->count(),
+            'The versionable history keeps a readable copy of the identity and must be deleted.',
+        );
+
+        $order = OrderQuery::create()->filterByCustomerId($customerId)->findOne();
+        self::assertNotNull($order);
+
+        foreach ([$order->getInvoiceOrderAddressId(), $order->getDeliveryOrderAddressId()] as $orderAddressId) {
+            $orderAddress = OrderAddressQuery::create()->findPk($orderAddressId);
+            self::assertNotNull($orderAddress);
+            self::assertSame(CustomerAnonymizer::ANONYMIZED_VALUE, $orderAddress->getLastname());
+            self::assertSame(CustomerAnonymizer::ANONYMIZED_VALUE, $orderAddress->getAddress1());
+            self::assertNull($orderAddress->getPhone());
+            self::assertNull($orderAddress->getCompany());
+            self::assertNotNull(
+                $orderAddress->getCountryId(),
+                'The country justifies the tax rate applied on the order and must be kept.',
+            );
+        }
+    }
+
+    public function testAnonymizeCallsThePersonalDataProviders(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $provider = new class implements CustomerPersonalDataProviderInterface {
+            /** @var array<int, int> */
+            public array $anonymizedCustomerIds = [];
+
+            public function getPersonalDataSectionName(): string
+            {
+                return 'recording';
+            }
+
+            public function exportPersonalData(Customer $customer): array
+            {
+                return ['seen' => $customer->getId()];
+            }
+
+            public function anonymizePersonalData(Customer $customer): void
+            {
+                $this->anonymizedCustomerIds[] = $customer->getId();
+            }
+        };
+
+        (new CustomerAnonymizer([$provider]))->anonymize($customer);
+
+        self::assertSame([$customer->getId()], $provider->anonymizedCustomerIds);
+    }
+
+    /**
+     * Anonymization runs in a transaction, so a module that fails aborts the
+     * whole operation instead of leaving a half-erased account behind. Only
+     * the propagation is asserted here: this test itself runs inside the
+     * transaction opened by IntegrationTestCase, where the inner rollback is
+     * deferred to the outer one.
+     */
+    public function testAnonymizeStopsWhenAProviderFails(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $failingProvider = new class implements CustomerPersonalDataProviderInterface {
+            public function getPersonalDataSectionName(): string
+            {
+                return 'failing';
+            }
+
+            public function exportPersonalData(Customer $customer): array
+            {
+                return [];
+            }
+
+            public function anonymizePersonalData(Customer $customer): void
+            {
+                throw new \RuntimeException('module failure');
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('module failure');
+
+        (new CustomerAnonymizer([$failingProvider]))->anonymize($customer);
+    }
+
+    private function anonymize(Customer $customer): void
+    {
+        $this->getService(EventDispatcherInterface::class)->dispatch(
+            new CustomerAnonymizeEvent($customer),
+            TheliaEvents::CUSTOMER_ANONYMIZE,
+        );
+    }
+
+    /**
+     * A customer with everything core knows how to store about a person:
+     * an account, an address, a newsletter subscription, a cart and a paid
+     * order carrying a product line.
+     */
+    private function createCustomerWithHistory(): Customer
+    {
+        $customer = $this->factory->customer(
+            $this->factory->customerTitle(),
+            [
+                'firstname' => 'Anonymizer',
+                'lastname' => 'Subject',
+                'email' => 'anonymizer-subject@test.com',
+            ],
+        );
+
+        $this->factory->address($customer);
+
+        $newsletter = new Newsletter();
+        $newsletter
+            ->setEmail('anonymizer-subject@test.com')
+            ->setFirstname('Anonymizer')
+            ->setLastname('Subject')
+            ->save($this->getPropelConnection());
+
+        $order = $this->factory->order($customer, ['postage' => '12.5', 'postageTax' => '2.5']);
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('REF-ANONYMIZER')
+            ->setProductSaleElementsRef('REF-ANONYMIZER-PSE')
+            ->setTitle('Product')
+            ->setQuantity(2)
+            ->setPrice('99.99')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->save($this->getPropelConnection());
+
+        // The factory already created the cart backing the order; add one more
+        // so that a cart without an order is covered too.
+        $this->factory->cart($customer);
+
+        return $customer;
+    }
+}

--- a/tests/Integration/Domain/Customer/CustomerPersonalDataExporterTest.php
+++ b/tests/Integration/Domain/Customer/CustomerPersonalDataExporterTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Customer;
+
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Customer\CustomerPersonalDataExportEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Customer\Service\CustomerPersonalDataExporter;
+use Thelia\Domain\Customer\Service\CustomerPersonalDataProviderInterface;
+use Thelia\Model\Customer;
+use Thelia\Model\Newsletter;
+use Thelia\Model\OrderProduct;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+final class CustomerPersonalDataExporterTest extends IntegrationTestCase
+{
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testExportCollectsTheWholeCustomerFile(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $event = new CustomerPersonalDataExportEvent($customer);
+        $this->getService(EventDispatcherInterface::class)->dispatch(
+            $event,
+            TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT,
+        );
+
+        $personalData = $event->getPersonalData();
+
+        self::assertSame(CustomerPersonalDataExporter::CORE_SECTION_NAMES, array_keys($personalData));
+
+        self::assertSame('Exported', $personalData['customer']['firstname']);
+        self::assertSame('exporter-subject@test.com', $personalData['customer']['email']);
+        self::assertArrayNotHasKey('password', $personalData['customer']);
+
+        self::assertCount(1, $personalData['addresses']);
+        self::assertSame('Exported', $personalData['addresses'][0]['firstname']);
+
+        self::assertCount(1, $personalData['orders']);
+        $order = $personalData['orders'][0];
+        self::assertNotNull($order['reference']);
+        self::assertSame(12.5, (float) $order['postage']);
+        self::assertNotNull($order['invoice_address']);
+        self::assertNotNull($order['delivery_address']);
+        self::assertCount(1, $order['products']);
+        self::assertSame('REF-EXPORTER', $order['products'][0]['product_reference']);
+
+        self::assertNotEmpty($personalData['carts']);
+
+        self::assertNotNull($personalData['newsletter']);
+        self::assertSame('exporter-subject@test.com', $personalData['newsletter']['email']);
+    }
+
+    public function testExportIncludesTheSectionsDeclaredByModules(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $provider = new class implements CustomerPersonalDataProviderInterface {
+            public function getPersonalDataSectionName(): string
+            {
+                return 'loyalty';
+            }
+
+            public function exportPersonalData(Customer $customer): array
+            {
+                return ['points' => 120];
+            }
+
+            public function anonymizePersonalData(Customer $customer): void
+            {
+            }
+        };
+
+        $personalData = (new CustomerPersonalDataExporter([$provider]))->export($customer);
+
+        self::assertArrayHasKey('loyalty', $personalData);
+        self::assertSame(['points' => 120], $personalData['loyalty']);
+    }
+
+    public function testExportRejectsAProviderReusingACoreSectionName(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $provider = new class implements CustomerPersonalDataProviderInterface {
+            public function getPersonalDataSectionName(): string
+            {
+                return 'orders';
+            }
+
+            public function exportPersonalData(Customer $customer): array
+            {
+                return [];
+            }
+
+            public function anonymizePersonalData(Customer $customer): void
+            {
+            }
+        };
+
+        $this->expectException(\LogicException::class);
+
+        (new CustomerPersonalDataExporter([$provider]))->export($customer);
+    }
+
+    private function createCustomerWithHistory(): Customer
+    {
+        $customer = $this->factory->customer(
+            $this->factory->customerTitle(),
+            [
+                'firstname' => 'Exported',
+                'lastname' => 'Subject',
+                'email' => 'exporter-subject@test.com',
+            ],
+        );
+
+        $this->factory->address($customer, null, null, ['firstname' => 'Exported']);
+
+        $newsletter = new Newsletter();
+        $newsletter
+            ->setEmail('exporter-subject@test.com')
+            ->setFirstname('Exported')
+            ->setLastname('Subject')
+            ->save($this->getPropelConnection());
+
+        $order = $this->factory->order($customer, ['postage' => '12.5', 'postageTax' => '2.5']);
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('REF-EXPORTER')
+            ->setProductSaleElementsRef('REF-EXPORTER-PSE')
+            ->setTitle('Product')
+            ->setQuantity(1)
+            ->setPrice('99.99')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->save($this->getPropelConnection());
+
+        return $customer;
+    }
+}


### PR DESCRIPTION
Refs #2460.

## Why

A GDPR compliance module cannot be written against Thelia today, because the two operations it needs do not exist in core.

**No erasure.** `core/lib/Thelia/Action/Customer.php:202-211` refuses to delete a customer as soon as an order exists, which is the only possible behaviour: `fk_order_customer_id` is `ON DELETE RESTRICT` (`setup/thelia.sql:754-758`), and the orders must be kept for accounting anyway. So there is no way to honour a right-to-erasure request without destroying the books.

**No data-subject export.** The only customer export is an administrator bulk export of all customers, with one address and no orders: `core/lib/Thelia/Domain/DataTransfer/Export/Type/CustomerExport.php:32-50`.

**No seam for modules.** `grep -ri 'gdpr|rgpd|anonymi|personal data' core/lib` returns nothing, and no event lets a module declare the personal data it stores.

## What this adds

An anonymisation path that erases the identity while leaving the accounting record untouched, and a per-person export built on the same map of where personal data lives. Both are dispatchable events, both call the modules that hold personal data of their own.

**Two events** (`core/lib/Thelia/Core/Event/TheliaEvents.php`):

- `CUSTOMER_ANONYMIZE` with `CustomerAnonymizeEvent`
- `CUSTOMER_PERSONAL_DATA_EXPORT` with `CustomerPersonalDataExportEvent`

Both are handled by `Thelia\Action\CustomerPersonalData`, which delegates to two services.

**`Thelia\Domain\Customer\Service\CustomerAnonymizer`** — what it touches, and why:

| Data | Treatment |
|---|---|
| `customer` identity (`firstname`, `lastname`, `email`, `password`, `algo`, `sponsor`, remember-me and confirmation tokens) | replaced by a neutral value, account disabled |
| `customer_version` | deleted — the versionable behaviour keeps a full readable copy of every past revision, identity included |
| `address` | deleted, along with the `cart_address` rows that reference them |
| `cart` and its `cart_address` copies | deleted |
| `newsletter` (matched by email, no foreign key) | deleted |
| `order_address` (invoice and delivery, frozen at checkout) | names, company, street, zipcode, city and phones neutralised in place; **country and state kept**, they justify the tax rate applied on the order |
| `order`, `order_product`, `order_product_tax`, `order_coupon`, `order_status` | untouched — reference, invoice number and date, amounts, taxes, coupons and history stay exactly as they were, still attached to the (now anonymous) account |

The whole operation runs in one transaction: a module that fails aborts it rather than leaving a half-erased account.

**`Thelia\Domain\Customer\Service\CustomerPersonalDataExporter`** returns everything the shop knows about one person as a nested array ready to be serialised: account, addresses, orders (with their frozen addresses, product lines and coupons), carts and newsletter subscription. The password is never exported.

**The extension point** is `Thelia\Domain\Customer\Service\CustomerPersonalDataProviderInterface`. Any service implementing it is auto-tagged `thelia.customer.personal_data_provider` (`TheliaKernel::loadAutoConfigureInterfaces()`) and is called on both operations, so a module declares its personal data once:

```php
final readonly class LoyaltyPersonalDataProvider implements CustomerPersonalDataProviderInterface
{
    public function getPersonalDataSectionName(): string
    {
        return 'loyalty';
    }

    public function exportPersonalData(Customer $customer): array
    {
        return LoyaltyAccountQuery::create()->findByCustomerId($customer->getId())->toArray();
    }

    public function anonymizePersonalData(Customer $customer): void
    {
        LoyaltyAccountQuery::create()->filterByCustomerId($customer->getId())->delete();
    }
}
```

A section name colliding with a core one throws, so a module cannot silently overwrite the orders of the archive.

**Two commands** make the path usable without a module:

```
php Thelia customer:anonymize <email> [--force]
php Thelia customer:export-personal-data <email> [--output-file=archive.json]
```

## How to verify

```
php bin/test-prepare
vendor/bin/phpunit --testsuite integration --filter 'CustomerAnonymizerTest|CustomerPersonalDataExporterTest'
```

`tests/Integration/Domain/Customer/CustomerAnonymizerTest.php` builds a customer with an address, a newsletter subscription, a cart and an order carrying a product line, then asserts after anonymisation that the order still exists with the same reference, postage and product price, that the account, addresses, carts, newsletter row and version history no longer hold anything identifying, and that the order addresses keep only their country. `CustomerPersonalDataExporterTest` covers the archive and the module sections.

Neutralising the service bodies turns 7 of the 8 tests red; the eighth is the "orders survive" assertion, which a no-op passes by construction.

## Out of scope

No schema change: the anonymisation is designed to work with the existing columns. What is deliberately left out — a marker column recording that an account was anonymised, a retention job, back-office and front-office entry points, and the residual personal data in `admin_log.request` — is described in the follow-up issue.
