### PR TITLE
fix: index the tax factor cache on the order or cart it was computed for

### DIFF
--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
@@ -46,6 +46,20 @@ class Calculator implements TaxCalculatorInterface
     protected $country;
     protected $state;
 
+    /**
+     * Tax factors already computed in this process, indexed on the order or the
+     * cart they were computed for. A single request handles several of them —
+     * the back-office order list, for one — and each has its own tax rates.
+     *
+     * @var \WeakMap<Order, float>|null
+     */
+    private static ?\WeakMap $orderTaxFactors = null;
+
+    /**
+     * @var \WeakMap<Cart, array<string, float>>|null
+     */
+    private static ?\WeakMap $cartTaxFactors = null;
+
     public function __construct()
     {
         $this->taxRuleQuery = new TaxRuleQuery();
@@ -79,33 +93,32 @@ class Calculator implements TaxCalculatorInterface
      */
     public static function getOrderTaxFactor(Order $order): float
     {
-        // Cache the result in a local variable
-        static $orderTaxFactor;
-
-        if (null === $orderTaxFactor) {
-            if (0.0 === (float) $order->getDiscount()) {
-                return 1;
-            }
-
-            // Find the average Tax rate (see \Thelia\TaxEngine\Calculator::getCartTaxFactor())
-            $orderTaxFactors = [];
-
-            /** @var OrderProduct $orderProduct */
-            foreach ($order->getOrderProducts() as $orderProduct) {
-                /** @var \Thelia\Core\Template\Loop\OrderProductTax $orderProductTax */
-                foreach ($orderProduct->getOrderProductTaxes() as $orderProductTax) {
-                    $orderTaxFactors[] = 1 + $orderProductTax->getAmount() / $orderProduct->getPrice();
-                }
-            }
-
-            if (0 === $orderTaxfactorCount = \count($orderTaxFactors)) {
-                return 1;
-            }
-
-            $orderTaxFactor = array_sum($orderTaxFactors) / \count($orderTaxFactors);
+        if (0.0 === (float) $order->getDiscount()) {
+            return 1;
         }
 
-        return $orderTaxFactor;
+        self::$orderTaxFactors ??= new \WeakMap();
+
+        if (isset(self::$orderTaxFactors[$order])) {
+            return self::$orderTaxFactors[$order];
+        }
+
+        // Find the average Tax rate (see \Thelia\TaxEngine\Calculator::getCartTaxFactor())
+        $orderTaxFactors = [];
+
+        /** @var OrderProduct $orderProduct */
+        foreach ($order->getOrderProducts() as $orderProduct) {
+            /** @var \Thelia\Core\Template\Loop\OrderProductTax $orderProductTax */
+            foreach ($orderProduct->getOrderProductTaxes() as $orderProductTax) {
+                $orderTaxFactors[] = 1 + $orderProductTax->getAmount() / $orderProduct->getPrice();
+            }
+        }
+
+        if ([] === $orderTaxFactors) {
+            return 1;
+        }
+
+        return self::$orderTaxFactors[$order] = array_sum($orderTaxFactors) / \count($orderTaxFactors);
     }
 
     /**
@@ -113,31 +126,46 @@ class Calculator implements TaxCalculatorInterface
      */
     public static function getCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
     {
-        // Cache the result in a local variable
-        static $cartFactor;
-
-        if (null === $cartFactor) {
-            if (0.0 === (float) $cart->getDiscount()) {
-                return 1;
-            }
-
-            $cartItems = $cart->getCartItems();
-
-            // Get the average of tax factor to apply it to the discount
-            $cartTaxFactors = [];
-
-            /** @var CartItem $cartItem */
-            foreach ($cartItems as $cartItem) {
-                $taxRulesCollection = TaxRuleQuery::create()->getTaxCalculatorCollection($cartItem->getProduct()->getTaxRule(), $country, $state);
-
-                /** @var TaxRule $taxRule */
-                foreach ($taxRulesCollection as $taxRule) {
-                    $cartTaxFactors[] = 1 + $taxRule->getTypeInstance()->pricePercentRetriever();
-                }
-            }
-
-            $cartFactor = array_sum($cartTaxFactors) / \count($cartTaxFactors);
+        if (0.0 === (float) $cart->getDiscount()) {
+            return 1;
         }
+
+        $cartItems = $cart->getCartItems();
+
+        // The factor depends on the destination and on the products in the cart,
+        // both of which change while a request is being served.
+        $key = implode(':', [$country->getId(), $state?->getId()]);
+
+        /** @var CartItem $cartItem */
+        foreach ($cartItems as $cartItem) {
+            $key .= ':'.$cartItem->getProductId();
+        }
+
+        self::$cartTaxFactors ??= new \WeakMap();
+
+        $cartFactors = self::$cartTaxFactors[$cart] ?? [];
+
+        if (isset($cartFactors[$key])) {
+            return $cartFactors[$key];
+        }
+
+        // Get the average of tax factor to apply it to the discount
+        $cartTaxFactors = [];
+
+        /** @var CartItem $cartItem */
+        foreach ($cartItems as $cartItem) {
+            $taxRulesCollection = TaxRuleQuery::create()->getTaxCalculatorCollection($cartItem->getProduct()->getTaxRule(), $country, $state);
+
+            /** @var TaxRule $taxRule */
+            foreach ($taxRulesCollection as $taxRule) {
+                $cartTaxFactors[] = 1 + $taxRule->getTypeInstance()->pricePercentRetriever();
+            }
+        }
+
+        $cartFactor = array_sum($cartTaxFactors) / \count($cartTaxFactors);
+
+        $cartFactors[$key] = $cartFactor;
+        self::$cartTaxFactors[$cart] = $cartFactors;
 
         return $cartFactor;
     }

--- a/tests/Integration/Domain/Taxation/TaxFactorScopeTest.php
+++ b/tests/Integration/Domain/Taxation/TaxFactorScopeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Taxation;
+
+use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Model\Cart;
+use Thelia\Model\CartItem;
+use Thelia\Model\Country;
+use Thelia\Model\Order;
+use Thelia\Model\OrderProduct;
+use Thelia\Model\OrderProductTax;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleCountry;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The tax factor spreads a discount over the VAT rates of what is being bought,
+ * so it belongs to one order or one cart. A single request handles several of
+ * them — the back-office order list walks the whole page.
+ */
+final class TaxFactorScopeTest extends IntegrationTestCase
+{
+    public function testEachOrderKeepsItsOwnTaxFactor(): void
+    {
+        $standardRate = $this->createDiscountedOrder('20.000000');
+        $reducedRate = $this->createDiscountedOrder('5.500000');
+
+        self::assertEqualsWithDelta(1.2, Calculator::getOrderTaxFactor($standardRate), 0.0001);
+        self::assertEqualsWithDelta(
+            1.055,
+            Calculator::getOrderTaxFactor($reducedRate),
+            0.0001,
+            'The second order of the request must not inherit the first order tax factor.',
+        );
+
+        // 10 of discount on goods taxed at 5.5 % is 9.48 before tax, not 8.33.
+        self::assertEqualsWithDelta(
+            10 / 1.055,
+            Calculator::getUntaxedOrderDiscount($reducedRate),
+            0.0001,
+        );
+    }
+
+    public function testEachCartKeepsItsOwnTaxFactor(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+
+        $standardRate = $this->createDiscountedCart($country, '20');
+        $reducedRate = $this->createDiscountedCart($country, '5.5');
+
+        self::assertEqualsWithDelta(1.2, Calculator::getCartTaxFactor($standardRate, $country), 0.0001);
+        self::assertEqualsWithDelta(
+            1.055,
+            Calculator::getCartTaxFactor($reducedRate, $country),
+            0.0001,
+            'The second cart of the request must not inherit the first cart tax factor.',
+        );
+
+        self::assertEqualsWithDelta(
+            10 / 1.055,
+            Calculator::getUntaxedCartDiscount($reducedRate, $country),
+            0.0001,
+        );
+    }
+
+    private function createDiscountedOrder(string $taxAmount): Order
+    {
+        $order = $this->createFixtureFactory()->order();
+        $order->setDiscount('10.000000')->save($this->getPropelConnection());
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('taxed-ref')
+            ->setProductSaleElementsRef('taxed-pse-ref')
+            ->setTitle('Taxed product')
+            ->setQuantity(1.0)
+            ->setPrice('100.000000')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->save($this->getPropelConnection());
+
+        (new OrderProductTax())
+            ->setOrderProductId($orderProduct->getId())
+            ->setTitle('VAT')
+            ->setDescription('')
+            ->setAmount($taxAmount)
+            ->save($this->getPropelConnection());
+
+        return $order;
+    }
+
+    private function createDiscountedCart(Country $country, string $percent): Cart
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $this->createTaxRule($country, $percent), $factory->currency());
+
+        $cart = $factory->cart();
+        $cart->setDiscount('10.000000')->save($this->getPropelConnection());
+
+        (new CartItem())
+            ->setCart($cart)
+            ->setProduct($product)
+            ->setProductSaleElements($product->getDefaultSaleElements())
+            ->setQuantity(1)
+            ->setPrice('100')
+            ->setPromoPrice('100')
+            ->setPromo(0)
+            ->save($this->getPropelConnection());
+
+        return $cart;
+    }
+
+    private function createTaxRule(Country $country, string $percent): TaxRule
+    {
+        $factory = $this->createFixtureFactory();
+        // A non-empty override array forces a rule of its own instead of reusing the seeded one.
+        $taxRule = $factory->taxRule(['isDefault' => false]);
+        $tax = $factory->tax(['requirements' => ['percent' => $percent], 'title' => 'VAT '.$percent]);
+
+        (new TaxRuleCountry())
+            ->setTaxRuleId($taxRule->getId())
+            ->setCountryId($country->getId())
+            ->setTaxId($tax->getId())
+            ->setPosition(1)
+            ->save($this->getPropelConnection());
+
+        return $taxRule;
+    }
+}


### PR DESCRIPTION
## Symptom

The tax factor spreads an order or a cart discount over the VAT rates of the goods it applies to. As soon as a request handles more than one of them — the back-office order list walks a whole page of orders — every order after the first is charged the first order's rate. With a 20 % order processed first, a 10 € discount on goods taxed at 5.5 % is reported as 8.33 € before tax instead of 9.48 €, and the VAT total of that order is off by the difference.

## Cause

`core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php:83` and `:117` cached the result in a function-static variable:

```php
public static function getOrderTaxFactor(Order $order): float
{
    // Cache the result in a local variable
    static $orderTaxFactor;

    if (null === $orderTaxFactor) {
```

A function static lives for the whole process and is not tied to the `$order` argument, so the first factor computed answers every later call, whatever order or cart is passed.

The neighbouring `Order::getTotalAmount()` (`core/lib/Thelia/Model/Order.php:201`) already carries the right shape, and its comment names this exact situation: *"We have to use an array indexed on the order ID, as the cache is static and may cache results for several orders, for example in the order list in the back-office."* The tax factors never got the same treatment.

Callers reached more than once per request: `core/lib/Thelia/Core/Template/Loop/Order.php:338`, `core/lib/Thelia/Model/Order.php:265` and `core/lib/Thelia/Model/Cart.php:261`.

## Fix

Memoize in a `\WeakMap` keyed on the order or the cart the factor was computed for. The cart entry is keyed further on the destination (country, state) and on the products in the cart, since both change while a request is being served. The zero-discount shortcut stays outside the memo, so a coupon applied mid-request is still taken into account.

The static-versus-instance question these helpers also raise is untouched here: this changes the cache only.

## Verifying

`tests/Integration/Domain/Taxation/TaxFactorScopeTest.php` computes two orders and two carts at 20 % and 5.5 % in a single process and asserts each keeps its own factor. It is committed before the fix so it can be seen failing, and passes with the second commit.
