### PR TITLE
fix: enforce the declared import formats on the uploaded file

### DIFF
--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -571,6 +571,7 @@ return [
     'The detailed description.' => 'The detailed description.',
     'The email address "%mail" was not found.' => 'The email address "%mail" was not found.',
     'The extension "%extension" is not allowed' => 'The extension "%extension" is not allowed',
+    'The extension "%extension" is not allowed. Accepted formats: %formats' => 'The extension "%extension" is not allowed. Accepted formats: %formats',
     'The file %path has been successfully downloaded' => 'The file %path has been successfully downloaded',
     'The following columns are missing: %columns' => 'The following columns are missing: %columns',
     'The image which replaces an undefined country flag (%file) was not found. Please check unknown-flag-path configuration variable, and check that the image exists.' => 'The image which replaces an undefined country flag (%file) was not found. Please check unknown-flag-path configuration variable, and check that the image exists.',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -569,6 +569,7 @@ return [
     'The detailed description.' => 'La description détaillée.',
     'The email address "%mail" was not found.' => 'L\'adresse e-mail "%mail" n\'as pas été trouvée.',
     'The extension "%extension" is not allowed' => 'L\'extension "%extension" n\'est pas autorisée',
+    'The extension "%extension" is not allowed. Accepted formats: %formats' => 'L\'extension "%extension" n\'est pas autorisée. Formats acceptés : %formats',
     'The file %path has been successfully downloaded' => 'Le fichier %path a été téléchargé',
     'The following columns are missing: %columns' => 'Il manque les colonnes suivantes: %columns',
     'The image which replaces an undefined country flag (%file) was not found. Please check unknown-flag-path configuration variable, and check that the image exists.' => 'L\'image qui remplace un drapeau de pays manquant (%file) n\'a pas été trouvée. Merci de vérifier la variable de configuration unknown-flag-path.',

--- a/core/lib/Thelia/Core/File/FileConfiguration.php
+++ b/core/lib/Thelia/Core/File/FileConfiguration.php
@@ -64,6 +64,20 @@ class FileConfiguration
     ];
 
     /**
+     * Extensions a web server may be configured to execute. They are refused on
+     * every upload path, whatever the configuration above says, and whether they
+     * end the file name or sit in the middle of it ("shell.php.jpg"). Only
+     * extensions that never collide with a legitimate locale or type suffix are
+     * listed, to avoid false positives.
+     */
+    public const SERVER_EXECUTABLE_EXTENSIONS = [
+        'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
+        'phtml', 'phtm', 'pht', 'phps', 'phpt', 'phar',
+        'shtml', 'shtm', 'stm',
+        'htaccess', 'htpasswd',
+    ];
+
+    /**
      * Extensions a mime type is allowed to carry, so that a PNG named ".jpg"
      * is rejected. A mime type absent from this table is matched on the mime
      * type alone, which lets a shop add a new one without a core change.
@@ -124,6 +138,25 @@ class FileConfiguration
             'document' => self::getDocumentConfig(),
             default => ['objectType' => $objectType, 'validMimeTypes' => [], 'extBlackList' => []],
         };
+    }
+
+    /**
+     * Returns the first server-executable extension segment found in the file name
+     * (terminal or not), or null when the name is safe.
+     */
+    public static function findExecutableExtension(string $fileName): ?string
+    {
+        $segments = explode('.', strtolower($fileName));
+        // Drop the base name; only extension segments are relevant.
+        array_shift($segments);
+
+        foreach ($segments as $segment) {
+            if (\in_array($segment, self::SERVER_EXECUTABLE_EXTENSIONS, true)) {
+                return $segment;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/core/lib/Thelia/Core/File/Service/FileProcessorService.php
+++ b/core/lib/Thelia/Core/File/Service/FileProcessorService.php
@@ -156,7 +156,7 @@ readonly class FileProcessorService
         // Defense in depth against double-extension bypasses (e.g. "shell.php.jpg"):
         // reject any file whose name contains a server-executable segment, not just the
         // terminal one. Applies to every upload, regardless of the caller's configuration.
-        if (null === $message && null !== ($dangerousExtension = $this->findExecutableExtension($realFileName))) {
+        if (null === $message && null !== ($dangerousExtension = FileConfiguration::findExecutableExtension($realFileName))) {
             $message = $this->translator->trans(
                 'Files with the following extension are not allowed: %extension, please do an archive of the file if you want to upload it',
                 [
@@ -179,33 +179,6 @@ readonly class FileProcessorService
     public function sanitizeUpload(UploadedFile $fileBeingUploaded): void
     {
         $this->sanitizeSvgUpload($fileBeingUploaded);
-    }
-
-    /**
-     * Returns the first server-executable extension segment found in the file name
-     * (terminal or not), or null when the name is safe. Only extensions that never
-     * collide with legitimate locale/type suffixes are listed, to avoid false positives.
-     */
-    private function findExecutableExtension(string $fileName): ?string
-    {
-        static $dangerous = [
-            'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
-            'phtml', 'phtm', 'pht', 'phps', 'phpt', 'phar',
-            'shtml', 'shtm', 'stm',
-            'htaccess', 'htpasswd',
-        ];
-
-        $segments = explode('.', strtolower($fileName));
-        // Drop the base name; only extension segments are relevant.
-        array_shift($segments);
-
-        foreach ($segments as $segment) {
-            if (\in_array($segment, $dangerous, true)) {
-                return $segment;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/core/lib/Thelia/Domain/DataTransfer/ImportHandler.php
+++ b/core/lib/Thelia/Domain/DataTransfer/ImportHandler.php
@@ -21,6 +21,7 @@ use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\Archiver\ArchiverManager;
 use Thelia\Core\Event\ImportEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\File\FileConfiguration;
 use Thelia\Core\Serializer\AbstractSerializer;
 use Thelia\Core\Serializer\SerializerInterface;
 use Thelia\Core\Serializer\SerializerManager;
@@ -128,11 +129,77 @@ class ImportHandler
         return $event;
     }
 
+    /**
+     * Extensions the registered serializers and archivers are able to read. This is
+     * what the back office may accept, and what it advertises to the administrator.
+     *
+     * @return list<string>
+     */
+    public function getAcceptedExtensions(): array
+    {
+        $extensions = [];
+
+        foreach ($this->serializerManager->getSerializers() as $serializer) {
+            $extensions[] = strtolower($serializer->getExtension());
+        }
+
+        foreach ($this->archiverManager->getArchivers(true) as $archiver) {
+            $extensions[] = strtolower($archiver->getExtension());
+        }
+
+        return array_values(array_unique($extensions));
+    }
+
+    /**
+     * Mime types matching getAcceptedExtensions(), for the file input "accept" hint.
+     *
+     * @return list<string>
+     */
+    public function getAcceptedMimeTypes(): array
+    {
+        $mimeTypes = [];
+
+        foreach ($this->serializerManager->getSerializers() as $serializer) {
+            $mimeTypes[] = $serializer->getMimeType();
+        }
+
+        foreach ($this->archiverManager->getArchivers(true) as $archiver) {
+            $mimeTypes[] = $archiver->getMimeType();
+        }
+
+        return array_values(array_unique($mimeTypes));
+    }
+
+    /**
+     * Checks an uploaded file name against the formats the import handlers declare,
+     * before anything is written to disk. Callers get the same policy the back office
+     * displays, so the promise made by the interface is the one that is enforced.
+     *
+     * @throws FormValidationException when the file may not be imported
+     */
+    public function validateUpload(string $fileName): void
+    {
+        $dangerousExtension = FileConfiguration::findExecutableExtension($fileName);
+
+        if (null !== $dangerousExtension) {
+            throw new FormValidationException(Translator::getInstance()->trans('The extension "%extension" is not allowed', ['%extension' => $dangerousExtension]));
+        }
+
+        $extension = strtolower(pathinfo($fileName, \PATHINFO_EXTENSION));
+        $acceptedExtensions = $this->getAcceptedExtensions();
+
+        if (!\in_array($extension, $acceptedExtensions, true)) {
+            throw new FormValidationException(Translator::getInstance()->trans('The extension "%extension" is not allowed. Accepted formats: %formats', ['%extension' => $extension, '%formats' => implode(', ', $acceptedExtensions)]));
+        }
+    }
+
     public function matchArchiverByExtension(string $fileName): ?AbstractArchiver
     {
+        $extension = pathinfo($fileName, \PATHINFO_EXTENSION);
+
         /** @var AbstractArchiver $archiver */
         foreach ($this->archiverManager->getArchivers(true) as $archiver) {
-            if (false !== stripos($fileName, '.'.$archiver->getExtension())) {
+            if (0 === strcasecmp($extension, $archiver->getExtension())) {
                 return $archiver;
             }
         }
@@ -142,9 +209,11 @@ class ImportHandler
 
     public function matchSerializerByExtension($fileName): ?AbstractSerializer
     {
+        $extension = pathinfo((string) $fileName, \PATHINFO_EXTENSION);
+
         /** @var AbstractSerializer $serializer */
         foreach ($this->serializerManager->getSerializers() as $serializer) {
-            if (false !== stripos((string) $fileName, '.'.$serializer->getExtension())) {
+            if (0 === strcasecmp($extension, $serializer->getExtension())) {
                 return $serializer;
             }
         }

--- a/tests/Integration/Domain/DataTransfer/ImportHandlerTest.php
+++ b/tests/Integration/Domain/DataTransfer/ImportHandlerTest.php
@@ -77,11 +77,10 @@ final class ImportHandlerTest extends IntegrationTestCase
     {
         $handler = $this->importHandler();
 
+        // Each call throws when the file is refused.
         $handler->validateUpload('products.csv');
         $handler->validateUpload('68ab1c2d.12345678-products.CSV');
         $handler->validateUpload('catalogue.zip');
-
-        $this->expectNotToPerformAssertions();
     }
 
     public function testASerializerIsOnlyMatchedOnTheActualExtension(): void

--- a/tests/Integration/Domain/DataTransfer/ImportHandlerTest.php
+++ b/tests/Integration/Domain/DataTransfer/ImportHandlerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\DataTransfer;
+
+use Thelia\Domain\DataTransfer\ImportHandler;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The back office advertises the formats the import handlers can read. Nothing
+ * used to enforce that promise: any file was moved to the import cache directory
+ * and handed over to a serializer matched on a substring of its name.
+ */
+final class ImportHandlerTest extends IntegrationTestCase
+{
+    public function testAcceptedExtensionsAreDerivedFromTheRegisteredHandlers(): void
+    {
+        $extensions = $this->importHandler()->getAcceptedExtensions();
+
+        self::assertContains('csv', $extensions);
+        self::assertContains('json', $extensions);
+        self::assertContains('xml', $extensions);
+        self::assertContains('yaml', $extensions);
+        self::assertContains('zip', $extensions);
+        self::assertNotContains('exe', $extensions);
+    }
+
+    public function testAcceptedMimeTypesAreDerivedFromTheRegisteredHandlers(): void
+    {
+        $mimeTypes = $this->importHandler()->getAcceptedMimeTypes();
+
+        self::assertContains('text/csv', $mimeTypes);
+        self::assertContains('application/zip', $mimeTypes);
+    }
+
+    public function testAFileFormatNoHandlerCanReadIsRefused(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->importHandler()->validateUpload('payload.exe');
+    }
+
+    public function testAFileWithoutExtensionIsRefused(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->importHandler()->validateUpload('payload');
+    }
+
+    public function testAnExecutableExtensionIsRefusedEvenBehindAnAcceptedOne(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->importHandler()->validateUpload('products.php.csv');
+    }
+
+    public function testAnAcceptedExtensionDoesNotWhitewashAnExecutableSuffix(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->importHandler()->validateUpload('products.csv.php');
+    }
+
+    public function testALegitimateImportFileIsAccepted(): void
+    {
+        $handler = $this->importHandler();
+
+        $handler->validateUpload('products.csv');
+        $handler->validateUpload('68ab1c2d.12345678-products.CSV');
+        $handler->validateUpload('catalogue.zip');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testASerializerIsOnlyMatchedOnTheActualExtension(): void
+    {
+        $handler = $this->importHandler();
+
+        self::assertNotNull($handler->matchSerializerByExtension('products.csv'));
+        // "products.csv.php" used to be matched as a CSV file, because the lookup
+        // searched ".csv" anywhere in the name.
+        self::assertNull($handler->matchSerializerByExtension('products.csv.php'));
+        self::assertNull($handler->matchSerializerByExtension('csv.php'));
+    }
+
+    public function testAnArchiverIsOnlyMatchedOnTheActualExtension(): void
+    {
+        $handler = $this->importHandler();
+
+        self::assertNotNull($handler->matchArchiverByExtension('catalogue.zip'));
+        self::assertNull($handler->matchArchiverByExtension('catalogue.zip.php'));
+    }
+
+    private function importHandler(): ImportHandler
+    {
+        $handler = $this->getService(ImportHandler::class);
+
+        self::assertInstanceOf(ImportHandler::class, $handler);
+
+        return $handler;
+    }
+}


### PR DESCRIPTION
Fixes #3592 — core half. The two back offices are updated in `thelia-templates/default-twig` and `thelia-templates/back`, and both depend on this one.

## Symptom

The back office import page advertises the formats it accepts ("Accepted formats: csv, json, xml, yaml, zip, tar, tgz, bz2") and then accepts anything. Both back offices move the uploaded file into `THELIA_CACHE_DIR/import/<date>/` under its original name before a single check has run.

## Cause

Nothing between the request and the disk knew what an import may be.

- The Twig back office reads the file straight from the request and moves it: `thelia-templates/default-twig`, `src/Controller/ExportImportController.php:329-346`. It builds the advertised extension and mime type lists a few lines above (`:300-312`) purely for display.
- The Smarty back office carries a single `NotNull` on the field: `thelia-templates/back`, `Form/ImportForm.php:33-40`, and duplicates the same display-only lists in `Controller/Admin/ImportController.php:150-163`.
- Once on disk, `ImportHandler::matchSerializerByExtension()` looked its extension up with `stripos($fileName, '.'.$extension)` (`core/lib/Thelia/Domain/DataTransfer/ImportHandler.php:147` before this change), a substring search anywhere in the name. `products.csv.php` therefore resolved to the CSV serializer, and `matchArchiverByExtension()` (`:135`) had the same hole.

So the knowledge of what may be imported existed — every serializer and archiver declares its extension and mime type — and it was used for the label, never for the check.

## Fix

The constraint is derived from the registered handlers, not restated in a controller.

`ImportHandler` gains three public methods:

- `getAcceptedExtensions()` and `getAcceptedMimeTypes()`, built from `SerializerManager` and the *available* archivers. A module registering a serializer widens the accepted set by itself, with no extra configuration variable and no change anywhere else.
- `validateUpload(string $fileName)`, which throws the usual `FormValidationException` when the name does not end with an accepted extension. Both back offices call it before moving the file.

The server-executable extension floor introduced by #3582 is reused rather than restated: its list and lookup move from `FileProcessorService` into `FileConfiguration::SERVER_EXECUTABLE_EXTENSIONS` / `FileConfiguration::findExecutableExtension()`, so image uploads, document uploads and imports share one definition. `products.php.csv` is refused even though `csv` is accepted.

Finally the two extension lookups are anchored on the actual extension (`pathinfo(..., PATHINFO_EXTENSION)`) instead of a substring search, which closes the `products.csv.php` case for the CLI import as well.

No new configuration variable, so nothing to insert in the database: the accepted set is the set of registered handlers.

## Behaviour change worth knowing

A file named `catalogue.tar.gz` used to be handed to the plain tar archiver because `.tar` appeared in its name. It is now refused, with a message listing the accepted formats. The gzip archiver declares `tgz`, which is what Thelia's own exports produce and what the page advertises.

## How to verify

```
composer test:integration -- --filter ImportHandlerTest
```

`tests/Integration/Domain/DataTransfer/ImportHandlerTest.php` fails on `main` and passes here: `testASerializerIsOnlyMatchedOnTheActualExtension` shows `products.csv.php` resolving to the CSV serializer before the change, and the `validateUpload()` cases have nothing to call at all.

Manually, once the two theme pull requests are in: back office → Tools → Import → pick any import → upload `payload.exe`, or a text file renamed `products.csv.php`. Both are refused with "The extension … is not allowed", and nothing is written to `var/cache/<env>/import/`.
