### PR TITLE
feat: let a module declare the position of its hooks

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -153,6 +153,8 @@ class RegisterHookListenersPass implements CompilerPassInterface
         $attributes['templates'] = isset($attributes['templates']) ? (string) ($attributes['templates']) : '';
         $attributes['type'] = (isset($attributes['type'])) ? $this->getHookType($attributes['type']) : TemplateDefinition::FRONT_OFFICE;
 
+        $declaredPosition = $this->getDeclaredPosition($attributes, $class);
+
         if (null === $hook = $this->getHook($attributes['event'], $attributes['type'])) {
             return;
         }
@@ -210,7 +212,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
                     ->setActive($savedConfiguration['active'] ?? $active)
                     ->setHookActive(true)
                     ->setModuleActive(true)
-                    ->setPosition($savedConfiguration['position'] ?? ModuleHook::MAX_POSITION);
+                    ->setPosition($savedConfiguration['position'] ?? $declaredPosition ?? ModuleHook::MAX_POSITION);
 
                 if (isset($attributes['templates'])) {
                     $moduleHook->setTemplates($attributes['templates']);
@@ -244,6 +246,39 @@ class RegisterHookListenersPass implements CompilerPassInterface
                 $moduleHook->save();
             }
         }
+    }
+
+    /**
+     * A module may declare the position it wants for one of its hooks. The value is read only when the
+     * module_hook row is created: once the row exists, the position belongs to the back office and the
+     * declaration must not overwrite it.
+     *
+     * @param array  $attributes the hook attributes
+     * @param string $class      the namespace of the class
+     */
+    protected function getDeclaredPosition(array $attributes, string $class): ?int
+    {
+        if (!isset($attributes['position']) || '' === $attributes['position']) {
+            return null;
+        }
+
+        $position = (int) $attributes['position'];
+
+        if ($position < 1 || $position >= ModuleHook::MAX_POSITION) {
+            $this->logAlertMessage(
+                sprintf(
+                    'Hook class [%s] declares position [%s], which is out of the allowed range [1, %d]. The hook is appended at the end of the queue instead.',
+                    $class,
+                    $attributes['position'],
+                    ModuleHook::MAX_POSITION - 1
+                ),
+                true
+            );
+
+            return null;
+        }
+
+        return $position;
     }
 
     /**

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd
@@ -210,7 +210,15 @@
         <xsd:attribute name="type" type="hook_type" />
         <xsd:attribute name="active" type="hook_active" />
         <xsd:attribute name="templates" type="xsd:string" />
+        <xsd:attribute name="position" type="hook_position" />
     </xsd:complexType>
+
+    <xsd:simpleType name="hook_position">
+        <xsd:restriction base="xsd:integer">
+            <xsd:minInclusive value="1" />
+            <xsd:maxInclusive value="999" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="hook_type">
         <xsd:restriction base="xsd:string">

--- a/core/lib/Thelia/Core/Hook/BaseHook.php
+++ b/core/lib/Thelia/Core/Hook/BaseHook.php
@@ -474,11 +474,16 @@ abstract class BaseHook implements BaseHookInterface
      *          ],
      *          [
      *              type => "front",
-     *              method => "displaySomething"
+     *              method => "displaySomething",
+     *              position => 10
      *          ],
      *      ],
      *      'another.hook' => [[...]]
      *  ]
+     *
+     *  The optional position, between 1 and 999, states where the module wants to be rendered among the
+     *  listeners of that hook: the lower the position, the earlier the render. It is applied when the hook
+     *  is registered, and never afterwards: an order set in the back office always wins.
      *
      * @return array
      */

--- a/tests/Functional/Core/DependencyInjection/RegisterHookListenersPassTest.php
+++ b/tests/Functional/Core/DependencyInjection/RegisterHookListenersPassTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Functional\Core\DependencyInjection;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Thelia\Core\DependencyInjection\Compiler\RegisterHookListenersPass;
+use Thelia\Core\Hook\DefaultHook;
+use Thelia\Core\Hook\ModuleHookConfigurationStore;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Model\Hook;
+use Thelia\Model\HookQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
+use Thelia\Model\ModuleQuery;
+
+/**
+ * The order in which the listeners of a hook are rendered is frozen at container build time, from the
+ * module_hook.position column. These tests cover the position a module declares in its hook declaration,
+ * which is the only order a module can express before an administrator reorders the hooks.
+ */
+class RegisterHookListenersPassTest extends KernelTestCase
+{
+    private const HOOK_CODE_PREFIX = 'test.hook.position.';
+
+    private const HOOK_METHOD = 'insertTemplate';
+
+    private const FIRST_SERVICE_ID = 'test.hook.position.first';
+
+    private const SECOND_SERVICE_ID = 'test.hook.position.second';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        ModuleHookConfigurationStore::discard();
+        $this->deleteTestHooks();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTestHooks();
+
+        parent::tearDown();
+    }
+
+    public function testDeclaredPositionIsUsedWhenTheHookIsRegistered(): void
+    {
+        $hook = $this->createHook(self::HOOK_CODE_PREFIX.'declared');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, 3);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(3, $moduleHook->getPosition());
+    }
+
+    public function testHookWithoutDeclaredPositionIsAppendedAtTheEndOfTheQueue(): void
+    {
+        $hook = $this->createHook(self::HOOK_CODE_PREFIX.'undeclared');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, null);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(ModuleHook::MAX_POSITION, $moduleHook->getPosition());
+    }
+
+    public function testOutOfRangeDeclaredPositionIsIgnored(): void
+    {
+        $hook = $this->createHook(self::HOOK_CODE_PREFIX.'out-of-range');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, 0);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        self::assertSame(ModuleHook::MAX_POSITION, $moduleHook->getPosition());
+    }
+
+    public function testPositionSetInTheBackOfficeWinsOverTheDeclaredOne(): void
+    {
+        $module = $this->getModule('Cheque');
+        $hook = $this->createHook(self::HOOK_CODE_PREFIX.'back-office');
+
+        $this->registerHook($module, self::FIRST_SERVICE_ID, $hook, 3);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertNotNull($moduleHook);
+        $moduleHook->setPosition(9)->save();
+
+        $this->registerHook($module, self::FIRST_SERVICE_ID, $hook, 3);
+
+        $moduleHook = ModuleHookQuery::create()->filterByHookId($hook->getId())->findOne();
+        self::assertSame(9, $moduleHook->getPosition());
+    }
+
+    /**
+     * A module loaded after another one can no longer be forced to render after it: the declared
+     * position, not the module load order, decides.
+     */
+    public function testDeclaredPositionOrdersTheListenersOfAHook(): void
+    {
+        $hook = $this->createHook(self::HOOK_CODE_PREFIX.'ordering');
+
+        $this->registerHook($this->getModule('Cheque'), self::FIRST_SERVICE_ID, $hook, 20);
+        $this->registerHook($this->getModule('FreeOrder'), self::SECOND_SERVICE_ID, $hook, 10);
+
+        $listeners = $this->compileListenersOf($hook);
+
+        self::assertSame([self::SECOND_SERVICE_ID, self::FIRST_SERVICE_ID], array_keys($listeners));
+        self::assertGreaterThan($listeners[self::FIRST_SERVICE_ID], $listeners[self::SECOND_SERVICE_ID]);
+    }
+
+    private function getModule(string $code): Module
+    {
+        $module = ModuleQuery::create()->findOneByCode($code);
+        self::assertNotNull($module, sprintf('%s module must be registered by thelia:install', $code));
+
+        return $module;
+    }
+
+    private function createHook(string $code): Hook
+    {
+        $hook = new Hook();
+        $hook
+            ->setCode($code)
+            ->setType(TemplateDefinition::FRONT_OFFICE)
+            ->setNative(false)
+            ->setActivate(true)
+            ->setBlock(false)
+            ->setByModule(false);
+        $hook
+            ->setLocale('en_US')
+            ->setTitle('Hook '.$code);
+        $hook->save();
+
+        return $hook;
+    }
+
+    private function registerHook(Module $module, string $serviceId, Hook $hook, ?int $position): void
+    {
+        $attributes = ['event' => $hook->getCode(), 'type' => 'front', 'method' => self::HOOK_METHOD];
+
+        if (null !== $position) {
+            $attributes['position'] = $position;
+        }
+
+        (new \ReflectionMethod(RegisterHookListenersPass::class, 'registerHook'))->invoke(
+            new RegisterHookListenersPass(),
+            DefaultHook::class,
+            $module,
+            $serviceId,
+            $attributes
+        );
+    }
+
+    /**
+     * Runs the part of the compiler pass that turns module_hook rows into event dispatcher listeners,
+     * and returns the priority given to each of the hook's listeners, in registration order.
+     *
+     * @return array<string, int>
+     */
+    private function compileListenersOf(Hook $hook): array
+    {
+        $container = new ContainerBuilder();
+        $container->register(self::FIRST_SERVICE_ID, DefaultHook::class);
+        $container->register(self::SECOND_SERVICE_ID, DefaultHook::class);
+
+        $dispatcher = new Definition();
+
+        (new \ReflectionMethod(RegisterHookListenersPass::class, 'addHooksMethodCall'))->invoke(
+            new RegisterHookListenersPass(),
+            $container,
+            $dispatcher
+        );
+
+        $eventName = sprintf('hook.%s.%s', $hook->getType(), $hook->getCode());
+        $priorities = [];
+
+        foreach ($dispatcher->getMethodCalls() as [$method, $arguments]) {
+            if ('addListener' !== $method || $eventName !== $arguments[0]) {
+                continue;
+            }
+
+            $priorities[(string) $arguments[1][0]->getValues()[0]] = $arguments[2];
+        }
+
+        return $priorities;
+    }
+
+    private function deleteTestHooks(): void
+    {
+        $hookIds = HookQuery::create()
+            ->filterByCode(self::HOOK_CODE_PREFIX.'%', Criteria::LIKE)
+            ->select('Id')
+            ->find()
+            ->getData();
+
+        if ([] === $hookIds) {
+            return;
+        }
+
+        ModuleHookQuery::create()->filterByHookId($hookIds, Criteria::IN)->delete();
+        HookQuery::create()->filterById($hookIds, Criteria::IN)->delete();
+    }
+}


### PR DESCRIPTION
Ports the declared hook position to the 2.6 line.

## What a module can now declare

A module states the position it wants for one of its hooks, either in XML:

```xml
<tag name="hook.event_listener" event="main.body.top" type="front" method="onMainBodyTop" position="10" />
```

or from `getSubscribedHooks()`:

```php
return [
    'main.body.top' => [['type' => 'front', 'method' => 'onMainBodyTop', 'position' => 10]],
];
```

The lower the position, the earlier the render. Until now every hook was created at `ModuleHook::MAX_POSITION`, so the render order came down to the order in which modules happened to be registered, and a module had no way to ask for anything else.

## Scope of the value

The position seeds the `module_hook` row when it is created, and is never read again: an order set in the back office always wins, and so does a position restored by `hook:clean`. Allowed range is 1 to 999; anything else is refused with an alert in the log and the hook falls back to the end of the queue.

## Changes

- `core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterHookListenersPass.php`: `getDeclaredPosition()` reads and validates the attribute, `registerHook()` uses it as the middle term of `$savedConfiguration['position'] ?? $declaredPosition ?? ModuleHook::MAX_POSITION`.
- `core/lib/Thelia/Core/DependencyInjection/Loader/schema/dic/config/thelia-1.0.xsd`: `position` attribute on `hook_tag`, restricted to 1-999 so a bad value is caught when the module configuration is loaded.
- `core/lib/Thelia/Core/Hook/BaseHook.php`: documents the attribute on `getSubscribedHooks()`.

The out-of-range alert is raised in fail-safe mode, so a mistyped position never breaks the container build in debug: it is logged and ignored, as the XSD already rejects it earlier for XML declarations.

## Verifying

`tests/Functional/Core/DependencyInjection/RegisterHookListenersPassTest.php` covers the five behaviours: the declared position is used, no declaration still lands at the end of the queue, an out-of-range value is ignored, a back-office order wins over the declaration, and two modules declaring 10 and 20 are dispatched in that order regardless of registration order. It is committed before the change so it can be seen failing, and passes with the second commit.
