### PR TITLE
fix: keep the Propel schema when a cache clear cannot have changed it

### DIFF
--- a/core/lib/Thelia/Action/Cache.php
+++ b/core/lib/Thelia/Action/Cache.php
@@ -54,6 +54,12 @@ class Cache extends BaseAction implements EventSubscriberInterface
 
         foreach ($this->onTerminateCacheClearEvents as $cacheEvent) {
             if ($cacheEvent->getDir() === $event->getDir()) {
+                // Events are deduplicated per directory, so the one that is kept must
+                // carry the schema invalidation as soon as any of them asks for it.
+                if ($event->invalidatesPropelSchema()) {
+                    $cacheEvent->setInvalidatePropelSchema(true);
+                }
+
                 $findDir = true;
                 break;
             }
@@ -75,10 +81,12 @@ class Cache extends BaseAction implements EventSubscriberInterface
     {
         $this->adapter->clear();
 
-        $dir = $event->getDir();
-
         $fs = new Filesystem();
-        $fs->remove($dir);
+        $fs->remove($event->getDir());
+
+        if (!$event->invalidatesPropelSchema()) {
+            return;
+        }
 
         // Invalidate the Propel combined schema so it is recombined on next boot
         // (picks up activated/deactivated modules). Models are only rebuilt if the

--- a/core/lib/Thelia/Action/Hook.php
+++ b/core/lib/Thelia/Action/Hook.php
@@ -149,7 +149,9 @@ class Hook extends BaseAction implements EventSubscriberInterface
 
     protected function cacheClear(): void
     {
-        $cacheEvent = new CacheEvent($this->cacheDir);
+        // Hooks are database rows and container listeners; none of this reaches a
+        // schema.xml, so the Propel schema does not need recombining.
+        $cacheEvent = new CacheEvent($this->cacheDir, invalidatePropelSchema: false);
 
         $this->dispatcher->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);
     }

--- a/core/lib/Thelia/Action/ModuleHook.php
+++ b/core/lib/Thelia/Action/ModuleHook.php
@@ -222,7 +222,10 @@ class ModuleHook extends BaseAction implements EventSubscriberInterface
 
     protected function cacheClear(): void
     {
-        $cacheEvent = new CacheEvent($this->cacheDir);
+        // Listener order and activation are frozen into the compiled container, so the
+        // container has to go. Binding a module to a hook, moving it or switching it
+        // off touches no schema.xml, so the Propel schema is left alone.
+        $cacheEvent = new CacheEvent($this->cacheDir, invalidatePropelSchema: false);
 
         $this->dispatcher->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);
     }

--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -340,8 +340,10 @@ class Translation extends BaseAction implements EventSubscriberInterface
 
     protected function cacheClear(EventDispatcherInterface $dispatcher): void
     {
+        // Only translation files were written; the database schema cannot have moved.
         $cacheEvent = new CacheEvent(
             $this->container->getParameter('kernel.cache_dir'),
+            invalidatePropelSchema: false,
         );
 
         $dispatcher->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);

--- a/core/lib/Thelia/Command/HookCleanCommand.php
+++ b/core/lib/Thelia/Command/HookCleanCommand.php
@@ -187,7 +187,8 @@ class HookCleanCommand extends ContainerAwareCommand
     {
         try {
             $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
-            $cacheEvent = new CacheEvent($cacheDir);
+            // Hook rows only: no schema.xml is involved.
+            $cacheEvent = new CacheEvent($cacheDir, invalidatePropelSchema: false);
             $this->getDispatcher()->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);
         } catch (\Exception $exception) {
             throw new \Exception(\sprintf('Error during clearing of cache : %s', $exception->getMessage()), $exception->getCode(), $exception);

--- a/core/lib/Thelia/Command/I18nPruneOverridesCommand.php
+++ b/core/lib/Thelia/Command/I18nPruneOverridesCommand.php
@@ -120,7 +120,11 @@ class I18nPruneOverridesCommand extends ContainerAwareCommand
 
         if ($force) {
             $this->getDispatcher()->dispatch(
-                new CacheEvent($this->getContainer()->getParameter('kernel.cache_dir')),
+                // Translation overrides only: the database schema cannot have moved.
+                new CacheEvent(
+                    $this->getContainer()->getParameter('kernel.cache_dir'),
+                    invalidatePropelSchema: false,
+                ),
                 TheliaEvents::CACHE_CLEAR,
             );
             $io->success(\sprintf('Pruned %d orphaned override(s).', $totalPruned));

--- a/core/lib/Thelia/Core/Event/Cache/CacheEvent.php
+++ b/core/lib/Thelia/Core/Event/Cache/CacheEvent.php
@@ -30,6 +30,13 @@ class CacheEvent extends ActionEvent
          */
         protected string $dir,
         protected bool $onKernelTerminate = true,
+        /**
+         * The combined Propel schema depends only on which modules are active and on
+         * the content of their schema.xml. It is dropped by default, because most
+         * clears follow a change that may have touched either; pass false when the
+         * caller knows the database schema cannot have moved.
+         */
+        protected bool $invalidatePropelSchema = true,
     ) {
     }
 
@@ -53,6 +60,18 @@ class CacheEvent extends ActionEvent
     public function setOnKernelTerminate(bool $onKernelTerminate): self
     {
         $this->onKernelTerminate = $onKernelTerminate;
+
+        return $this;
+    }
+
+    public function invalidatesPropelSchema(): bool
+    {
+        return $this->invalidatePropelSchema;
+    }
+
+    public function setInvalidatePropelSchema(bool $invalidatePropelSchema): self
+    {
+        $this->invalidatePropelSchema = $invalidatePropelSchema;
 
         return $this;
     }

--- a/tests/Integration/Action/ModuleHookActionTest.php
+++ b/tests/Integration/Action/ModuleHookActionTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Action;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+use Thelia\Core\Event\Cache\CacheEvent;
 use Thelia\Core\Event\Hook\HookCreateEvent;
 use Thelia\Core\Event\Hook\ModuleHookCreateEvent;
 use Thelia\Core\Event\Hook\ModuleHookDeleteEvent;
@@ -253,6 +255,37 @@ final class ModuleHookActionTest extends ActionIntegrationTestCase
         self::assertSame(
             3,
             ModuleHookQuery::create()->findPk($mh1->getId())->getPosition(),
+        );
+    }
+
+    public function testUpdatePositionDoesNotInvalidateThePropelSchema(): void
+    {
+        $hook = $this->createTestHook('test.mh.pos.cache');
+        $moduleId = $this->getActiveModuleId();
+        $moduleHook = $this->createModuleHookBinding($moduleId, $hook->getId(), 'method1');
+
+        $captured = [];
+        $listener = static function (CacheEvent $event) use (&$captured): void {
+            $captured[] = $event;
+        };
+
+        /** @var SymfonyEventDispatcherInterface $dispatcher */
+        $dispatcher = $this->dispatcher;
+        $dispatcher->addListener(TheliaEvents::CACHE_CLEAR, $listener, 255);
+
+        try {
+            $this->dispatch(
+                new UpdatePositionEvent($moduleHook->getId(), UpdatePositionEvent::POSITION_ABSOLUTE, 1),
+                TheliaEvents::MODULE_HOOK_UPDATE_POSITION,
+            );
+        } finally {
+            $dispatcher->removeListener(TheliaEvents::CACHE_CLEAR, $listener);
+        }
+
+        self::assertCount(1, $captured, 'Reordering a hook still invalidates the container.');
+        self::assertFalse(
+            $captured[0]->invalidatesPropelSchema(),
+            'A display position has no effect on the database schema.',
         );
     }
 

--- a/tests/Unit/Action/CacheTest.php
+++ b/tests/Unit/Action/CacheTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Action;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Action\Cache;
+use Thelia\Core\Event\Cache\CacheEvent;
+
+/**
+ * The combined Propel schema depends on the active modules and on their
+ * schema.xml. A clear that follows something else — a hook reordering, a
+ * translation — has to leave it in place, or the boot that follows recombines
+ * the schema and resets the opcode cache for nothing.
+ */
+final class CacheTest extends TestCase
+{
+    private const ENVIRONMENT = 'cache-action-test';
+
+    private Filesystem $filesystem;
+    private string $propelSchemaDir;
+    private string $clearedDir;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->propelSchemaDir = THELIA_ROOT.'var'.\DIRECTORY_SEPARATOR.'propel'
+            .\DIRECTORY_SEPARATOR.self::ENVIRONMENT.\DIRECTORY_SEPARATOR.'schema';
+        $this->clearedDir = sys_get_temp_dir().'/thelia_cache_action_'.uniqid();
+
+        $this->filesystem->dumpFile(
+            $this->propelSchemaDir.\DIRECTORY_SEPARATOR.'TheliaMain.schema.xml',
+            '<database/>',
+        );
+        $this->filesystem->mkdir($this->clearedDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove([
+            THELIA_ROOT.'var'.\DIRECTORY_SEPARATOR.'propel'.\DIRECTORY_SEPARATOR.self::ENVIRONMENT,
+            $this->clearedDir,
+        ]);
+    }
+
+    public function testClearInvalidatesThePropelSchemaByDefault(): void
+    {
+        $this->action()->cacheClear(new CacheEvent($this->clearedDir, false));
+
+        self::assertDirectoryDoesNotExist($this->clearedDir);
+        self::assertDirectoryDoesNotExist($this->propelSchemaDir);
+    }
+
+    public function testClearKeepsThePropelSchemaWhenTheCallerRulesItOut(): void
+    {
+        $this->action()->cacheClear(new CacheEvent($this->clearedDir, false, false));
+
+        self::assertDirectoryDoesNotExist($this->clearedDir);
+        self::assertDirectoryExists($this->propelSchemaDir);
+    }
+
+    public function testDeferredClearsKeepTheSchemaInvalidationOfAnyDeduplicatedEvent(): void
+    {
+        $action = $this->action();
+
+        // Same directory, so the second event is dropped: the invalidation it
+        // carries has to survive on the event that is kept.
+        $action->cacheClear(new CacheEvent($this->clearedDir, true, false));
+        $action->cacheClear(new CacheEvent($this->clearedDir, true, true));
+
+        self::assertDirectoryExists($this->propelSchemaDir);
+
+        $action->onTerminate();
+
+        self::assertDirectoryDoesNotExist($this->clearedDir);
+        self::assertDirectoryDoesNotExist($this->propelSchemaDir);
+    }
+
+    private function action(): Cache
+    {
+        return new Cache(new NullAdapter(), self::ENVIRONMENT);
+    }
+}


### PR DESCRIPTION
Fixes #3591

## Symptom

Moving a hook one position in the back office makes the next `/admin` request pay for a full cache rebuild. Measured on a demo install (DDEV, PHP 8.3, `dev`, Twig back office), 3 runs:

| Request | Before | After |
|---|---|---|
| warm `/admin` | 0.10 s | 0.11 s |
| `/admin` right after the reordering click | 5.03 s | 4.55 s |
| the one after | **0.69 s** | **0.17 s** |
| steady state again | 0.12 s | 0.14 s |

## Cause

`Thelia\Action\Cache::execCacheClear()` (`core/lib/Thelia/Action/Cache.php:74-87`) removed `var/propel/<env>/schema` on **every** `CACHE_CLEAR`, whatever the caller and whatever directory the event targeted. Reordering a hook goes through `Thelia\Action\ModuleHook::updateModuleHookPosition()` (`core/lib/Thelia/Action/ModuleHook.php:188-194`), which dispatches such an event.

Two things follow from removing that directory, measured by clearing each half separately:

- `PropelInitService::buildPropelGlobalSchema()` recombines every module schema — about 0.06 s;
- `isCacheComplete()` (`core/lib/Thelia/Core/Propel/PropelInitService.php:327-337`) then returns false, so `init()` takes the build branch and ends on `opcache_reset()` (`:280-283`). That flush costs the **following** request another 0.52 s, and on a busy server every concurrent request pays it, not just one.

The models themselves were *not* regenerated: `buildPropelModels()` compares the recombined schema hash with the model hash and returns early. Verified on the demo install: `var/propel/dev/model` keeps its mtime and its 740 files across a reordering. So the wasted work is the recombination plus the opcode flush, not a model build.

Rebuilding the container is legitimate here: listener order is frozen into Symfony priorities at compile time. Its scope was not.

## Fix

`CacheEvent` gains an `invalidatePropelSchema` flag. It **defaults to true**, so every caller that invalidates today — module activation and deactivation, module install and update, `template:set`, the back-office "flush application cache" button, third-party modules — keeps exactly the behaviour it has. Only the callers whose events provably cannot move a `schema.xml` opt out:

- `Action\ModuleHook` — hook bindings, positions, activation;
- `Action\Hook` — hook rows;
- `Action\Translation` and `I18nPruneOverridesCommand` — translation files;
- `HookCleanCommand`.

Opt-out rather than opt-in was chosen deliberately: the risk worth avoiding is a Propel cache left stale after a real schema change, and opt-out makes that impossible by construction — nothing that invalidates today stops invalidating.

`Cache::cacheClear()` deduplicates deferred events per directory, so the event that is kept now inherits the invalidation of any duplicate that asked for it.

## Verifying

```
php Thelia cache:clear                      # warm
# reorder a hook in Configuration > Hooks, then reload /admin
ls var/propel/dev/schema                    # still there
# Configuration > Advanced > flush application cache
ls var/propel/dev/schema                    # gone, rebuilt on next boot
```

Both were checked on the demo install: after a reordering the schema directory survives; after the back-office cache flush it disappears and is rebuilt.

Tests: `tests/Unit/Action/CacheTest.php` covers the three branches of the action (default invalidates, opt-out preserves, deduplicated events keep the invalidation), and `ModuleHookActionTest::testUpdatePositionDoesNotInvalidateThePropelSchema` pins the reported path. Both fail on the current behaviour and pass with the fix.

Local run: 5 suites green (259 + 392 + 187 with 1 skip + 11 + 11), `cs-diff` 0/1761, PHPStan 0 errors.

## Noted while investigating, not changed here

- The deferred `CACHE_CLEAR` never runs under `php Thelia`: `module:deactivate` leaves both `var/cache/<env>` and the Propel schema untouched. Same on the current `main`, so it is not a consequence of this change, but it means CLI module operations do not invalidate anything.
- `Thelia\Command\CacheClear` (`cache:clear`, "Invalidate all caches") is shadowed by the FrameworkBundle command of the same name, so it is unreachable.
- The back-office image, document and asset cache flushes also drop the Propel schema for nothing. They live in the theme repositories and can pass `invalidatePropelSchema: false` once this is released.
