### PR TITLE
fix: index the category child id cache on the depth it was walked with

### DIFF
--- a/core/lib/Thelia/Model/CategoryQuery.php
+++ b/core/lib/Thelia/Model/CategoryQuery.php
@@ -83,6 +83,10 @@ class CategoryQuery extends BaseCategoryQuery
      */
     public static function findAllChildId(int|array $categoryId, int $depth = 0, int $currentPos = 0): array
     {
+        // Cache the tree walk. The cache is static, so it lives for the whole
+        // process and holds the answers of every call made during it: it has to
+        // be indexed on all three arguments, since the same category walked with
+        // another depth has another answer.
         static $cache = [];
 
         $result = [];
@@ -91,30 +95,34 @@ class CategoryQuery extends BaseCategoryQuery
             foreach ($categoryId as $categorySingleId) {
                 $result = array_merge($result, self::findAllChildId($categorySingleId, $depth, $currentPos));
             }
-        } elseif (!isset($cache[$categoryId])) {
-            ++$currentPos;
 
-            if ($depth === $currentPos && 0 !== $depth) {
-                return [];
-            }
-
-            $subCategories = self::create()
-                ->filterByParent($categoryId)
-                ->select(['id'])
-                ->find()
-                ->getData();
-
-            foreach ($subCategories as $subCategoryId) {
-                $result[] = $subCategoryId;
-                $result = array_merge($result, self::findAllChildId($subCategoryId, $depth, $currentPos));
-            }
-
-            $cache[$categoryId] = $result;
-        } else {
-            $result = $cache[$categoryId];
+            return $result;
         }
 
-        return $result;
+        $cacheKey = $categoryId.':'.$depth.':'.$currentPos;
+
+        if (isset($cache[$cacheKey])) {
+            return $cache[$cacheKey];
+        }
+
+        ++$currentPos;
+
+        if ($depth === $currentPos && 0 !== $depth) {
+            return [];
+        }
+
+        $subCategories = self::create()
+            ->filterByParent($categoryId)
+            ->select(['id'])
+            ->find()
+            ->getData();
+
+        foreach ($subCategories as $subCategoryId) {
+            $result[] = $subCategoryId;
+            $result = array_merge($result, self::findAllChildId($subCategoryId, $depth, $currentPos));
+        }
+
+        return $cache[$cacheKey] = $result;
     }
 
     /**

--- a/tests/Integration/Model/CategoryChildIdDepthTest.php
+++ b/tests/Integration/Model/CategoryChildIdDepthTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Model\Category;
+use Thelia\Model\CategoryQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * CategoryQuery::findAllChildId() memoises its tree walk in a function static,
+ * which lives for the whole process: the same category walked with another depth
+ * must not be served the answer of an earlier call.
+ */
+final class CategoryChildIdDepthTest extends IntegrationTestCase
+{
+    public function testAnUnlimitedWalkIsNotServedTheAnswerOfADepthLimitedOne(): void
+    {
+        [$root, $child, $grandChild] = $this->createThreeLevelTree();
+
+        self::assertSame([$child->getId()], CategoryQuery::findAllChildId($root->getId(), 2));
+
+        self::assertSame(
+            [$child->getId(), $grandChild->getId()],
+            CategoryQuery::findAllChildId($root->getId()),
+            'The whole tree is expected, not the two levels the previous call asked for.',
+        );
+    }
+
+    public function testADepthLimitedWalkIsNotServedTheAnswerOfAnUnlimitedOne(): void
+    {
+        [$root, $child, $grandChild] = $this->createThreeLevelTree();
+
+        self::assertSame(
+            [$child->getId(), $grandChild->getId()],
+            CategoryQuery::findAllChildId($root->getId()),
+        );
+
+        self::assertSame(
+            [$child->getId()],
+            CategoryQuery::findAllChildId($root->getId(), 2),
+            'The depth limit still applies once the tree has been walked without one.',
+        );
+    }
+
+    /**
+     * @return array{Category, Category, Category}
+     */
+    private function createThreeLevelTree(): array
+    {
+        $factory = $this->createFixtureFactory();
+
+        $root = $factory->category();
+        $child = $factory->category(['parent' => $root->getId()]);
+        $grandChild = $factory->category(['parent' => $child->getId()]);
+
+        return [$root, $child, $grandChild];
+    }
+}


### PR DESCRIPTION
`CategoryQuery::findAllChildId()` memoises its tree walk in a function static keyed on the category id alone (`core/lib/Thelia/Model/CategoryQuery.php:86`), while the answer also depends on `$depth` and `$currentPos` (written line 112, read line 114). A function static lives for the whole process, so the first walk of a category answers for every later walk of it, whatever depth is asked for.

Reproduced on a database, on a `root -> child -> grandChild` tree:

```
findAllChildId($root, 2)      [201]        correct
findAllChildId($root)         [201]        wrong, expected [201, 202]
```

The other way round, the depth limit is ignored entirely once the tree has been walked without one:

```
findAllChildId($root)         [204, 205]   correct
findAllChildId($root, 2)      [204, 205]   wrong, expected [204]
```

The memo is kept — repeated walks of the same tree in one request are what it is for — and indexed on the three arguments the result depends on, the way `Order::getTotalAmount()` indexes its own static on the order id.

`tests/Integration/Model/CategoryChildIdDepthTest.php` covers both orders. It is committed on its own first, so it can be seen failing before the fix lands: https://github.com/thelia/thelia/actions/runs/31583906612 (two failures, both on the arrays above, on PHP 8.3 and 8.4). The fix commit turns the five suites green: https://github.com/thelia/thelia/actions/runs/31584198540.

Fixes #3604
