### PR TITLE
fix: leave a cart discount untouched when nothing in the cart is taxable

### DIFF
--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
@@ -162,6 +162,13 @@ class Calculator implements TaxCalculatorInterface
             }
         }
 
+        // Nothing taxable to spread the discount over: a cart still carrying the
+        // discount of a coupon after its last item was removed, or a destination
+        // no tax rule applies to. Leave the discount as it is, like an order does.
+        if ([] === $cartTaxFactors) {
+            return 1;
+        }
+
         $cartFactor = array_sum($cartTaxFactors) / \count($cartTaxFactors);
 
         $cartFactors[$key] = $cartFactor;

--- a/tests/Integration/Domain/Taxation/CartTaxFactorWithoutTaxableItemTest.php
+++ b/tests/Integration/Domain/Taxation/CartTaxFactorWithoutTaxableItemTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Taxation;
+
+use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Model\Cart;
+use Thelia\Model\CartItem;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The tax factor spreads a cart discount over the VAT rates of what is being
+ * bought. A discounted cart with nothing taxable in it has no rate to average,
+ * and must be left with its discount as it is rather than divided by zero.
+ */
+final class CartTaxFactorWithoutTaxableItemTest extends IntegrationTestCase
+{
+    public function testACartWhoseItemsWereAllRemovedKeepsItsDiscount(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+
+        // A coupon was applied, then the last item was removed from the cart.
+        $cart = $this->createDiscountedCart();
+
+        self::assertCount(0, $cart->getCartItems());
+        self::assertSame(1.0, Calculator::getCartTaxFactor($cart, $country));
+        self::assertEqualsWithDelta(10.0, Calculator::getUntaxedCartDiscount($cart, $country), 0.0001);
+    }
+
+    public function testACartShippedWhereNoTaxRuleAppliesKeepsItsDiscount(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $country = $factory->country();
+
+        // A tax rule of its own, with no tax declared for the delivery country.
+        $product = $factory->product(
+            $factory->category(),
+            $factory->taxRule(['isDefault' => false]),
+            $factory->currency(),
+        );
+
+        $cart = $this->createDiscountedCart();
+
+        (new CartItem())
+            ->setCart($cart)
+            ->setProduct($product)
+            ->setProductSaleElements($product->getDefaultSaleElements())
+            ->setQuantity(1)
+            ->setPrice('100')
+            ->setPromoPrice('100')
+            ->setPromo(0)
+            ->save($this->getPropelConnection());
+
+        self::assertSame(1.0, Calculator::getCartTaxFactor($cart, $country));
+        self::assertEqualsWithDelta(10.0, Calculator::getUntaxedCartDiscount($cart, $country), 0.0001);
+    }
+
+    private function createDiscountedCart(): Cart
+    {
+        $cart = $this->createFixtureFactory()->cart();
+        $cart->setDiscount('10.000000')->save($this->getPropelConnection());
+
+        return $cart;
+    }
+}


### PR DESCRIPTION
`Calculator::getCartTaxFactor()` averages the tax rates of the cart items in order to spread a cart discount over them, and divides by `\count($cartTaxFactors)` without guarding the empty set (`core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php:165`). Its order counterpart returns 1 in that case (same file, line 117).

Two cart states reach that division, both with a discount still on the cart:

- a coupon was applied and every item was then removed;
- the cart is shipped to a destination the product tax rule declares no tax for.

Both raise `DivisionByZeroError` at `Calculator.php:165` on a real database. The front office reaches it on every checkout summary render: the Flexy `Checkout/Summary` component reads the `discount` cart attribute, which goes through `Cart::getCalculatedDiscount(false, …)` (`core/lib/Thelia/Model/Cart.php:261`).

The fix returns 1 on an empty set, like `getOrderTaxFactor()` already does, which leaves the discount as it is.

`tests/Integration/Domain/Taxation/CartTaxFactorWithoutTaxableItemTest.php` covers both cart states. It is committed on its own first, so it can be seen erroring before the fix lands: https://github.com/thelia/thelia/actions/runs/31583914933 (`DivisionByZeroError` at `Calculator.php:165` for both, on PHP 8.3 and 8.4). The fix commit turns the five suites green: https://github.com/thelia/thelia/actions/runs/31584232070.

Fixes #3605
