### PR TITLE
fix: roll back the transaction when a non-Exception error escapes an action

### DIFF
--- a/core/lib/Thelia/Action/Address.php
+++ b/core/lib/Thelia/Action/Address.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Thelia\Action;
 
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -102,10 +101,10 @@ class Address extends BaseAction implements EventSubscriberInterface
 
             $event->setAddress($addressModel);
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollback();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Action/BaseCachedFile.php
+++ b/core/lib/Thelia/Action/BaseCachedFile.php
@@ -223,7 +223,7 @@ abstract class BaseCachedFile extends BaseAction
 
             $event->setUploadedFile($newUploadedFile);
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Action/Category.php
+++ b/core/lib/Thelia/Action/Category.php
@@ -129,7 +129,7 @@ class Category extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
 
             throw $e;

--- a/core/lib/Thelia/Action/Content.php
+++ b/core/lib/Thelia/Action/Content.php
@@ -85,7 +85,7 @@ class Content extends BaseAction implements EventSubscriberInterface
 
             $event->setContent($content);
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;
@@ -164,7 +164,7 @@ class Content extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
 
             throw $e;

--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -329,7 +329,7 @@ class Coupon extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception  $ex) {
+        } catch (\Throwable $ex) {
             $con->rollBack();
 
             throw $ex;

--- a/core/lib/Thelia/Action/CustomerTitle.php
+++ b/core/lib/Thelia/Action/CustomerTitle.php
@@ -60,7 +60,7 @@ class CustomerTitle extends BaseAction implements EventSubscriberInterface
             $event->getCustomerTitle()->delete();
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;
@@ -96,7 +96,7 @@ class CustomerTitle extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Action/Folder.php
+++ b/core/lib/Thelia/Action/Folder.php
@@ -98,7 +98,7 @@ class Folder extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
 
                 throw $e;

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -313,7 +313,7 @@ class Module extends BaseAction implements EventSubscriberInterface
 
             $event->setModule($module);
             $this->cacheClear($dispatcher);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -246,11 +246,13 @@ class Module extends BaseAction implements EventSubscriberInterface
     public function delete(ModuleDeleteEvent $event, $eventName, EventDispatcherInterface $dispatcher): void
     {
         $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
-        $con->beginTransaction();
 
         if (null === $module = ModuleQuery::create()->findPk($event->getModuleId(), $con)) {
             return;
         }
+
+        $con->beginTransaction();
+
         try {
             if (null === $module->getFullNamespace()) {
                 throw new \LogicException(Translator::getInstance()->trans('Cannot instantiate module "%name%": the namespace is null. Maybe the model is not loaded ?', ['%name%' => $module->getCode()]));
@@ -310,14 +312,16 @@ class Module extends BaseAction implements EventSubscriberInterface
             $module->delete($con);
 
             $con->commit();
-
-            $event->setModule($module);
-            $this->cacheClear($dispatcher);
         } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;
         }
+
+        // Outside the try: these two run once the deletion is committed, so a
+        // failure there no longer reaches a rollback of a closed transaction.
+        $event->setModule($module);
+        $this->cacheClear($dispatcher);
     }
 
     public function update(ModuleEvent $event, $eventName, EventDispatcherInterface $dispatcher): void

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -257,7 +257,7 @@ class Order extends BaseAction implements EventSubscriberInterface
             $event->setOrder($order);
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -164,7 +164,7 @@ class Product extends BaseAction implements EventSubscriberInterface
             $this->eventDispatcher->dispatch($event, TheliaEvents::PSE_CLONE);
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;
@@ -370,7 +370,7 @@ class Product extends BaseAction implements EventSubscriberInterface
 
             $event->setProduct($product);
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;
@@ -463,7 +463,7 @@ class Product extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;
@@ -671,7 +671,7 @@ class Product extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -103,7 +103,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;
@@ -198,7 +198,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;
@@ -251,7 +251,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
                 // Store all the stuff !
                 $con->commit();
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
                 $con->rollback();
 
                 throw $ex;
@@ -304,7 +304,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;

--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -196,7 +196,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
 
             throw $e;
@@ -307,7 +307,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
 
                 throw $e;
@@ -342,10 +342,10 @@ class Sale extends BaseAction implements EventSubscriberInterface
             $event->setSale($sale);
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollback();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 
@@ -378,7 +378,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 $event->setSale($sale);
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
 
                 throw $e;
@@ -408,10 +408,10 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 ->update(['Promo' => 0], $con);
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollback();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 
@@ -465,10 +465,10 @@ class Sale extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollback();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Action/Template.php
+++ b/core/lib/Thelia/Action/Template.php
@@ -146,7 +146,7 @@ class Template extends BaseAction implements EventSubscriberInterface
                         ->update(['DefaultTemplateId' => null], $con);
 
                     $con->commit();
-                } catch (\Exception $ex) {
+                } catch (\Throwable $ex) {
                     $con->rollback();
 
                     throw $ex;

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
@@ -77,7 +77,7 @@ readonly class PropelPersistProcessor implements ProcessorInterface
             $propelModel->reload();
 
             $data->setId($propelModel->getId());
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $connection->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelRemoveProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelRemoveProcessor.php
@@ -52,7 +52,7 @@ readonly class PropelRemoveProcessor implements ProcessorInterface
             }
 
             $connection->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $connection->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
@@ -410,6 +410,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($exception->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -483,6 +489,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($exception->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -526,6 +538,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($exception->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -599,6 +617,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($exception->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -250,6 +250,16 @@ class Update
             $ex->setVersion($version);
 
             throw $ex;
+        } catch (\Throwable $throwable) {
+            // An Error is not turned into an UpdateException — the installer keeps
+            // seeing it as it is today — but the update transaction is closed.
+            // The guard matters here: $this->connection is the raw PDO handle
+            // (see __construct()), whose rollBack() throws when no transaction is open.
+            if ($this->connection->inTransaction()) {
+                $this->connection->rollBack();
+            }
+
+            throw $throwable;
         }
 
         $this->log('debug', 'end of update processing');

--- a/core/lib/Thelia/Model/Content.php
+++ b/core/lib/Thelia/Model/Content.php
@@ -137,7 +137,7 @@ class Content extends BaseContent implements FileModelParentInterface
             $this->setDefaultFolder($defaultFolderId)->save($con);
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -100,10 +100,10 @@ class Country extends BaseCountry
                 ->save($con);
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollBack();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Model/Coupon.php
+++ b/core/lib/Thelia/Model/Coupon.php
@@ -137,7 +137,7 @@ class Coupon extends BaseCoupon
             }
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -123,10 +123,10 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
             $this->save($con);
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollBack();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Model/CustomerTitle.php
+++ b/core/lib/Thelia/Model/CustomerTitle.php
@@ -36,7 +36,7 @@ class CustomerTitle extends BaseCustomerTitle
             $this->setByDefault(1)->save();
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Model/Lang.php
+++ b/core/lib/Thelia/Model/Lang.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Thelia\Model\Base\Lang as BaseLang;
 use Thelia\Model\Map\LangTableMap;
@@ -73,10 +72,10 @@ class Lang extends BaseLang
                 ->save($con);
 
             $con->commit();
-        } catch (PropelException $propelException) {
+        } catch (\Throwable $throwable) {
             $con->rollBack();
 
-            throw $propelException;
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Model/Product.php
+++ b/core/lib/Thelia/Model/Product.php
@@ -184,7 +184,7 @@ class Product extends BaseProduct implements FileModelParentInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $con->rollback();
 
             throw $exception;

--- a/core/lib/Thelia/Model/Tools/PositionManagementTrait.php
+++ b/core/lib/Thelia/Model/Tools/PositionManagementTrait.php
@@ -114,6 +114,12 @@ trait PositionManagementTrait
                 $cnx->commit();
             } catch (\Exception) {
                 $cnx->rollback();
+            } catch (\Throwable $throwable) {
+                // A position swap is best-effort, but an Error is not: it keeps
+                // propagating as before, only without leaving the transaction open.
+                $cnx->rollback();
+
+                throw $throwable;
             }
         }
     }
@@ -177,6 +183,12 @@ trait PositionManagementTrait
                 $cnx->commit();
             } catch (\Exception) {
                 $cnx->rollback();
+            } catch (\Throwable $throwable) {
+                // Same as changeRelativePosition(): an Error still propagates,
+                // it just no longer leaves an open transaction behind.
+                $cnx->rollback();
+
+                throw $throwable;
             }
         }
     }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -144,6 +144,11 @@ class BaseModule implements BaseModuleInterface
                     $this->postDeactivation($con);
 
                     $con->commit();
+                } else {
+                    // A module refusing its own deactivation is a normal outcome:
+                    // discard whatever preDeactivation() wrote instead of leaving
+                    // the transaction — and its locks — open.
+                    $con->rollBack();
                 }
             } catch (\Throwable $e) {
                 $con->rollBack();
@@ -280,46 +285,52 @@ class BaseModule implements BaseModuleInterface
                 if (Image::isImage($filePath)) {
                     $con->beginTransaction();
 
-                    $image = new ModuleImage();
-                    $image->setModuleId($module->getId());
-                    $image->setPosition($imagePosition);
-                    $image->setFile('');
-                    $image->save($con);
+                    try {
+                        $image = new ModuleImage();
+                        $image->setModuleId($module->getId());
+                        $image->setPosition($imagePosition);
+                        $image->setFile('');
+                        $image->save($con);
 
-                    $imageDirectory = \sprintf('%s/media/images/module', THELIA_LOCAL_DIR);
-                    $imageFileName = \sprintf('%s-%d-%s', $module->getCode(), $image->getId(), $fileName);
+                        $imageDirectory = \sprintf('%s/media/images/module', THELIA_LOCAL_DIR);
+                        $imageFileName = \sprintf('%s-%d-%s', $module->getCode(), $image->getId(), $fileName);
 
-                    $increment = 0;
+                        $increment = 0;
 
-                    while (file_exists($imageDirectory.'/'.$imageFileName)) {
-                        $imageFileName = \sprintf(
-                            '%s-%d-%d-%s',
-                            $module->getCode(),
-                            $image->getId(),
-                            $increment,
-                            $fileName,
-                        );
-                        ++$increment;
-                    }
+                        while (file_exists($imageDirectory.'/'.$imageFileName)) {
+                            $imageFileName = \sprintf(
+                                '%s-%d-%d-%s',
+                                $module->getCode(),
+                                $image->getId(),
+                                $increment,
+                                $fileName,
+                            );
+                            ++$increment;
+                        }
 
-                    $imagePath = \sprintf('%s/%s', $imageDirectory, $imageFileName);
+                        $imagePath = \sprintf('%s/%s', $imageDirectory, $imageFileName);
 
-                    if (!is_dir($imageDirectory) && !mkdir($imageDirectory, 0o777, true) && !is_dir($imageDirectory)) {
+                        if (!is_dir($imageDirectory) && !mkdir($imageDirectory, 0o777, true) && !is_dir($imageDirectory)) {
+                            throw new ModuleException(\sprintf('Cannot create directory : %s', $imageDirectory), ModuleException::CODE_NOT_FOUND);
+                        }
+
+                        if (!@copy($filePath, $imagePath)) {
+                            throw new ModuleException(\sprintf('Cannot copy file : %s to : %s', $filePath, $imagePath), ModuleException::CODE_NOT_FOUND);
+                        }
+
+                        $image->setFile($imageFileName);
+                        $image->save($con);
+
+                        $con->commit();
+                    } catch (\Throwable $throwable) {
+                        // The two ModuleException paths used to roll back by hand; a
+                        // failing save() did not, and left the transaction open for
+                        // the rest of the install.
                         $con->rollBack();
 
-                        throw new ModuleException(\sprintf('Cannot create directory : %s', $imageDirectory), ModuleException::CODE_NOT_FOUND);
+                        throw $throwable;
                     }
 
-                    if (!@copy($filePath, $imagePath)) {
-                        $con->rollBack();
-
-                        throw new ModuleException(\sprintf('Cannot copy file : %s to : %s', $filePath, $imagePath), ModuleException::CODE_NOT_FOUND);
-                    }
-
-                    $image->setFile($imageFileName);
-                    $image->save($con);
-
-                    $con->commit();
                     ++$imagePosition;
                 }
             }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -113,7 +113,7 @@ class BaseModule implements BaseModuleInterface
 
                 $this->postActivation($con);
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 if ($con->inTransaction()) {
                     $con->rollBack();
                 }
@@ -145,7 +145,7 @@ class BaseModule implements BaseModuleInterface
 
                     $con->commit();
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
 
                 throw $e;

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -168,7 +168,7 @@ class ModuleManagement
             }
 
             $con->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             Tlog::getInstance()->addError('Failed to update module '.$module->getCode(), $exception);
 
             $con->rollBack();

--- a/tests/Integration/Action/TransactionRollbackOnErrorTest.php
+++ b/tests/Integration/Action/TransactionRollbackOnErrorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Propel;
+use Thelia\Action\Address as AddressAction;
+use Thelia\Core\Event\Address\AddressCreateOrUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Customer\Service\CustomerTitleService;
+use Thelia\Model\CustomerTitle;
+use Thelia\Model\Map\AddressTableMap;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * The actions wrap their writes in a Propel transaction and roll it back from a
+ * catch block. When that catch was narrower than \Throwable, an Error thrown by
+ * the code inside the try (a TypeError, a call on null, a module listener
+ * blowing up) escaped with the transaction still open: the connection kept its
+ * row and metadata locks, and every later write on the same tables waited for
+ * the lock timeout.
+ *
+ * The nesting counter of the Propel connection is what makes this observable.
+ * IntegrationTestCase opens one transaction per test, so the counter sits at 1
+ * when the action is called; the action's own beginTransaction() takes it to 2.
+ * If the counter is still 2 once the error has propagated, the transaction
+ * leaked.
+ */
+final class TransactionRollbackOnErrorTest extends ActionIntegrationTestCase
+{
+    public function testAddressCreateRollsBackWhenANonPropelErrorEscapes(): void
+    {
+        $title = $this->factory->customerTitle();
+        $customer = $this->factory->customer($title);
+        $country = $this->factory->country();
+
+        $connection = Propel::getWriteConnection(AddressTableMap::DATABASE_NAME);
+        self::assertInstanceOf(ConnectionWrapper::class, $connection);
+
+        $nestingBeforeTheAction = $connection->getNestedTransactionCount();
+
+        // The event carries no title, so the action asks the service for the
+        // default one — from inside its transaction. A service blowing up with
+        // an Error stands for any non-Exception failure in that block.
+        $action = new AddressAction(new class extends CustomerTitleService {
+            public function __construct()
+            {
+            }
+
+            public function getDefaultCustomerTitle(): ?CustomerTitle
+            {
+                throw new \Error('Error raised inside the action transaction');
+            }
+        });
+
+        $event = new AddressCreateOrUpdateEvent(
+            label: 'Home',
+            title: null,
+            firstname: 'John',
+            lastname: 'Doe',
+            address1: '10 rue de la Paix',
+            address2: '',
+            address3: '',
+            zipcode: '75002',
+            city: 'Paris',
+            country: $country->getId(),
+            cellphone: '',
+            phone: '',
+            company: null,
+        );
+        $event->setCustomer($customer);
+
+        try {
+            $action->create($event, TheliaEvents::ADDRESS_CREATE, $this->dispatcher);
+
+            self::fail('The Error raised by the service should have propagated out of the action.');
+        } catch (\Error $error) {
+            // The error must still reach the caller unchanged: the fix only adds
+            // the rollback, it does not swallow anything.
+            self::assertSame('Error raised inside the action transaction', $error->getMessage());
+        }
+
+        self::assertSame(
+            $nestingBeforeTheAction,
+            $connection->getNestedTransactionCount(),
+            'The action left its transaction open: every later write on address will now wait for the lock timeout.',
+        );
+    }
+}


### PR DESCRIPTION
## Symptom

An action opens a Propel transaction and rolls it back from a `catch` block. When that
`catch` is narrower than `\Throwable`, an `Error` raised by the code inside the `try` —
a `TypeError`, a call on null, a module listener blowing up — escapes with the
transaction still open. The connection keeps its row and metadata locks, and every
later write on the same tables waits until the lock timeout.

The defect hides itself: in production the request dies anyway, and the leaked
transaction only surfaces later as unexplained lock waits on unrelated requests. It was
found while reviving the legacy test suite, where it turned one failure into six by
poisoning the following tests with 50-second lock waits.

## Cause

`core/lib/Thelia/Action/Address.php:105` (before this change):

```php
$con->beginTransaction();

try {
    // ...
    $con->commit();
} catch (PropelException $propelException) {
    $con->rollback();

    throw $propelException;
}
```

`PropelException` extends `\Exception`, so `\Error` never matches. The same shape is
used at 46 transaction sites in `core/lib/`: 11 catch `PropelException`, 28 catch
`\Exception` (which also lets `\Error` through), 3 are already `\Throwable`, and 4 close
the transaction on some exit paths only.

Sites that leaked on a normal, non-exception path:

- `core/lib/Thelia/Action/Module.php:249` — `beginTransaction()` ran before the
  "module not found" early return at 251-253, which returned without commit or rollback.
- `core/lib/Thelia/Module/BaseModule.php:141` — `deActivate()` committed only when
  `preDeactivation()` returned true; a module refusing its own deactivation left the
  transaction open.
- `core/lib/Thelia/Module/BaseModule.php:281` — `deployImageFolder()` opened a
  transaction per image with no `try` at all; only two of its failure paths rolled back
  by hand, a failing `save()` leaked.

## Fix

Two rules, applied site by site rather than uniformly, because a `catch` that swallows
or replaces an exception cannot be widened without changing what the caller sees:

1. **The handler rethrows the same object** → the caught type is widened to
   `\Throwable`. The exception still propagates unchanged; only the rollback now also
   happens for an `\Error`. This covers the 39 rollback-and-rethrow handlers in
   `Action/`, `Model/`, `Api/Bridge/Propel/State/`, `Module/`.
2. **The handler swallows or replaces the exception** → it is left untouched and a
   `catch (\Throwable $throwable) { rollBack(); throw $throwable; }` is appended after
   it. An `\Error` keeps propagating exactly as it does today, it is simply no longer
   preceded by a leaked transaction. This covers `XmlFileLoader` (logs the error and
   continues), `PositionManagementTrait` (a best-effort position swap, swallowed), and
   `Core/Install/Update.php` (wraps into `UpdateException`).

`Core/Install/Update.php` also keeps its `inTransaction()` guard: unlike everywhere
else, `$this->connection` there is the raw PDO handle unwrapped in the constructor, and
PDO's `rollBack()` throws when no transaction is open. Propel's `ConnectionWrapper`
guards its own `rollBack()` with `$opcount > 0 && inTransaction()`, so the wrapped
connections are safe on an already-closed transaction.

`Action\Module::delete()` had a second rollback hazard: `$event->setModule()` and
`cacheClear()` ran inside the `try`, after `commit()`, so a failure there reached a
rollback of a committed transaction. They are moved out of the `try`.

One behaviour extension is deliberate: `BaseModule::activate()` now also resets the
module to `IS_NOT_ACTIVATED` when an `\Error` interrupts activation, as it already did
for an `\Exception`. Leaving a module flagged active after a fatal in `postActivation()`
is the inconsistency that handler exists to prevent, and the method already declares
`@throws \Throwable`.

## Verifying

`tests/Integration/Action/TransactionRollbackOnErrorTest.php` drives
`Action\Address::create()` with a `CustomerTitleService` that raises an `\Error` from
inside the action's transaction, then asserts the transaction was closed. The state is
observed, not assumed, through Propel's nesting counter: `IntegrationTestCase` opens one
transaction per test, so the counter is 1 when the action is called and 2 once the
action has begun its own.

Without the fix:

```
The action left its transaction open: every later write on address will now wait for the lock timeout.
Failed asserting that 2 is identical to 1.
```

With it, `OK (1 test, 3 assertions)`. The test also asserts the `\Error` still reaches
the caller with its message intact, so a handler that started swallowing would fail too.

Full local run on an isolated database: unit 259, integration 468, api 188 (1 skip),
http-flexy 11, http-backoffice 11 — all green; `cs-diff` 0/1792; PHPStan no errors.

Fixes #3609
