### PR TITLE
fix: enforce the declared import formats on the uploaded file

### DIFF
--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -569,6 +569,7 @@ return [
     'The detailed description.' => 'The detailed description.',
     'The email address "%mail" was not found.' => 'The email address "%mail" was not found.',
     'The extension "%extension" is not allowed' => 'The extension "%extension" is not allowed',
+    'The extension "%extension" is not allowed. Accepted formats: %formats' => 'The extension "%extension" is not allowed. Accepted formats: %formats',
     'The file %path has been successfully downloaded' => 'The file %path has been successfully downloaded',
     'The file your customer will download once the order is paid. Only the documents of this product which are not visible can be selected, so that they cannot be downloaded for free. Leave empty if this virtual product has nothing to download.' => 'The file your customer will download once the order is paid. Only the documents of this product which are not visible can be selected, so that they cannot be downloaded for free. Leave empty if this virtual product has nothing to download.',
     'The following columns are missing: %columns' => 'The following columns are missing: %columns',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -567,6 +567,7 @@ return [
     'The detailed description.' => 'La description détaillée.',
     'The email address "%mail" was not found.' => 'L\'adresse e-mail "%mail" n\'as pas été trouvée.',
     'The extension "%extension" is not allowed' => 'L\'extension "%extension" n\'est pas autorisée',
+    'The extension "%extension" is not allowed. Accepted formats: %formats' => 'L\'extension "%extension" n\'est pas autorisée. Formats acceptés : %formats',
     'The file %path has been successfully downloaded' => 'Le fichier %path a été téléchargé',
     'The file your customer will download once the order is paid. Only the documents of this product which are not visible can be selected, so that they cannot be downloaded for free. Leave empty if this virtual product has nothing to download.' => 'Le fichier que votre client téléchargera une fois la commande payée. Seuls les documents non visibles de ce produit peuvent être sélectionnés, afin qu\'ils ne soient pas téléchargeables gratuitement. Laissez vide si ce produit virtuel n\'a rien à télécharger.',
     'The following columns are missing: %columns' => 'Il manque les colonnes suivantes: %columns',

--- a/core/lib/Thelia/Controller/Admin/ImportController.php
+++ b/core/lib/Thelia/Controller/Admin/ImportController.php
@@ -13,8 +13,6 @@
 namespace Thelia\Controller\Admin;
 
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Thelia\Core\DependencyInjection\Compiler\RegisterArchiverPass;
-use Thelia\Core\DependencyInjection\Compiler\RegisterSerializerPass;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Security\AccessManager;
@@ -141,20 +139,10 @@ class ImportController extends BaseAdminController
             return $this->pageNotFound();
         }
 
-        $extensions = [];
-        $mimeTypes = [];
-
-        /** @var \Thelia\Core\Serializer\AbstractSerializer $serializer */
-        foreach ($this->container->get(RegisterSerializerPass::MANAGER_SERVICE_ID)->getSerializers() as $serializer) {
-            $extensions[] = $serializer->getExtension();
-            $mimeTypes[] = $serializer->getMimeType();
-        }
-
-        /** @var \Thelia\Core\Archiver\AbstractArchiver $archiver */
-        foreach ($this->container->get(RegisterArchiverPass::MANAGER_SERVICE_ID)->getArchivers(true) as $archiver) {
-            $extensions[] = $archiver->getExtension();
-            $mimeTypes[] = $archiver->getMimeType();
-        }
+        // Advertise exactly what the import handlers accept, so that the page and the
+        // constraint enforced by ImportForm cannot drift apart.
+        $extensions = $importHandler->getAcceptedExtensions();
+        $mimeTypes = $importHandler->getAcceptedMimeTypes();
 
         // Render standard view or ajax one
         $templateName = 'import-page';

--- a/core/lib/Thelia/Files/FileConfiguration.php
+++ b/core/lib/Thelia/Files/FileConfiguration.php
@@ -19,6 +19,38 @@ namespace Thelia\Files;
  */
 class FileConfiguration
 {
+    /**
+     * Extensions a web server may be configured to execute. They are refused whatever
+     * the upload path allows otherwise, and whether they end the file name or sit in
+     * the middle of it ("shell.php.jpg"). Only extensions that never collide with a
+     * legitimate locale or type suffix are listed, to avoid false positives.
+     */
+    public const SERVER_EXECUTABLE_EXTENSIONS = [
+        'php', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8',
+        'phtml', 'phtm', 'pht', 'phps', 'phpt', 'phar',
+        'shtml', 'shtm', 'stm',
+        'htaccess', 'htpasswd',
+    ];
+
+    /**
+     * Returns the first server-executable extension segment found in the file name
+     * (terminal or not), or null when the name is safe.
+     */
+    public static function findExecutableExtension(string $fileName): ?string
+    {
+        $segments = explode('.', strtolower($fileName));
+        // Drop the base name; only extension segments are relevant.
+        array_shift($segments);
+
+        foreach ($segments as $segment) {
+            if (\in_array($segment, self::SERVER_EXECUTABLE_EXTENSIONS, true)) {
+                return $segment;
+            }
+        }
+
+        return null;
+    }
+
     public static function getImageConfig()
     {
         return [

--- a/core/lib/Thelia/Form/ImportForm.php
+++ b/core/lib/Thelia/Form/ImportForm.php
@@ -14,8 +14,11 @@ namespace Thelia\Form;
 
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Handler\ImportHandler;
 use Thelia\Model\LangQuery;
 
 /**
@@ -25,6 +28,11 @@ use Thelia\Model\LangQuery;
  */
 class ImportForm extends BaseForm
 {
+    public function __construct(
+        private readonly ImportHandler $importHandler,
+    ) {
+    }
+
     protected function buildForm(): void
     {
         $this->formBuilder
@@ -34,6 +42,9 @@ class ImportForm extends BaseForm
             'required' => true,
                 'constraints' => [
                     new Assert\NotNull(),
+                    new Assert\Callback(
+                        [$this, 'checkFileFormat']
+                    ),
                 ],
             ])
             ->add('language', IntegerType::class, [
@@ -55,6 +66,23 @@ class ImportForm extends BaseForm
     public static function getName()
     {
         return 'thelia_import';
+    }
+
+    /**
+     * The page advertises the formats the import handlers can read; only a NotNull
+     * used to stand between the request and the import cache directory.
+     */
+    public function checkFileFormat($value, ExecutionContextInterface $context): void
+    {
+        if (!$value instanceof UploadedFile) {
+            return;
+        }
+
+        try {
+            $this->importHandler->validateUpload($value->getClientOriginalName());
+        } catch (FormValidationException $exception) {
+            $context->addViolation($exception->getMessage());
+        }
     }
 
     public function checkLanguage($value, ExecutionContextInterface $context): void

--- a/core/lib/Thelia/Handler/ImportHandler.php
+++ b/core/lib/Thelia/Handler/ImportHandler.php
@@ -21,6 +21,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Serializer\SerializerInterface;
 use Thelia\Core\Serializer\SerializerManager;
 use Thelia\Core\Translation\Translator;
+use Thelia\Files\FileConfiguration;
 use Thelia\Form\Exception\FormValidationException;
 use Thelia\ImportExport\Import\AbstractImport;
 use Thelia\Model\Import;
@@ -35,6 +36,17 @@ use Thelia\Model\Lang;
  */
 class ImportHandler
 {
+    /**
+     * Compound extensions the archivers read but do not declare. Thelia used to accept
+     * them by accident, through a substring lookup on the file name, and "tar czf"
+     * produces them, so they stay accepted. Each maps to the extension of the archiver
+     * that reads it, so an unavailable archiver does not advertise its compound form.
+     */
+    public const COMPOUND_ARCHIVE_EXTENSIONS = [
+        'tar.gz' => 'tgz',
+        'tar.bz2' => 'bz2',
+    ];
+
     /**
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface An event dispatcher interface
      */
@@ -206,6 +218,89 @@ class ImportHandler
     }
 
     /**
+     * Extensions the registered serializers and archivers are able to read. This is
+     * what the back office may accept, and what it advertises to the administrator.
+     *
+     * @return array<int, string>
+     */
+    public function getAcceptedExtensions()
+    {
+        $extensions = [];
+
+        /** @var \Thelia\Core\Serializer\AbstractSerializer $serializer */
+        foreach ($this->serializerManager->getSerializers() as $serializer) {
+            $extensions[] = strtolower($serializer->getExtension());
+        }
+
+        $extensions = array_merge($extensions, $this->getAcceptedArchiveExtensions());
+
+        return array_values(array_unique($extensions));
+    }
+
+    /**
+     * Mime types matching getAcceptedExtensions(), for the file input "accept" hint.
+     *
+     * @return array<int, string>
+     */
+    public function getAcceptedMimeTypes()
+    {
+        $mimeTypes = [];
+
+        /** @var \Thelia\Core\Serializer\AbstractSerializer $serializer */
+        foreach ($this->serializerManager->getSerializers() as $serializer) {
+            $mimeTypes[] = $serializer->getMimeType();
+        }
+
+        /** @var \Thelia\Core\Archiver\AbstractArchiver $archiver */
+        foreach ($this->archiverManager->getArchivers(true) as $archiver) {
+            $mimeTypes[] = $archiver->getMimeType();
+        }
+
+        return array_values(array_unique($mimeTypes));
+    }
+
+    /**
+     * Checks an uploaded file name against the formats the import handlers declare,
+     * before anything is written to disk. Callers get the same policy the back office
+     * displays, so the promise made by the interface is the one that is enforced.
+     *
+     * @param string $fileName File name
+     *
+     * @throws \Thelia\Form\Exception\FormValidationException when the file may not be imported
+     */
+    public function validateUpload($fileName): void
+    {
+        $fileName = (string) $fileName;
+
+        $dangerousExtension = FileConfiguration::findExecutableExtension($fileName);
+
+        if ($dangerousExtension !== null) {
+            throw new FormValidationException(
+                Translator::getInstance()->trans(
+                    'The extension "%extension" is not allowed',
+                    [
+                        '%extension' => $dangerousExtension,
+                    ]
+                )
+            );
+        }
+
+        $acceptedExtensions = $this->getAcceptedExtensions();
+
+        if ($this->matchExtension($fileName, $acceptedExtensions) === null) {
+            throw new FormValidationException(
+                Translator::getInstance()->trans(
+                    'The extension "%extension" is not allowed. Accepted formats: %formats',
+                    [
+                        '%extension' => pathinfo($fileName, \PATHINFO_EXTENSION),
+                        '%formats' => implode(', ', $acceptedExtensions),
+                    ]
+                )
+            );
+        }
+    }
+
+    /**
      * Match archiver relative to file name.
      *
      * @param string $fileName File name
@@ -214,9 +309,17 @@ class ImportHandler
      */
     public function matchArchiverByExtension($fileName)
     {
+        $extension = $this->matchExtension((string) $fileName, $this->getAcceptedArchiveExtensions());
+
+        if ($extension === null) {
+            return null;
+        }
+
+        $extension = self::COMPOUND_ARCHIVE_EXTENSIONS[$extension] ?? $extension;
+
         /** @var \Thelia\Core\Archiver\AbstractArchiver $archiver */
         foreach ($this->archiverManager->getArchivers(true) as $archiver) {
-            if (stripos($fileName, '.'.$archiver->getExtension()) !== false) {
+            if (strcasecmp($extension, $archiver->getExtension()) === 0) {
                 return $archiver;
             }
         }
@@ -233,14 +336,66 @@ class ImportHandler
      */
     public function matchSerializerByExtension($fileName)
     {
+        $extension = pathinfo((string) $fileName, \PATHINFO_EXTENSION);
+
         /** @var \Thelia\Core\Serializer\AbstractSerializer $serializer */
         foreach ($this->serializerManager->getSerializers() as $serializer) {
-            if (stripos($fileName, '.'.$serializer->getExtension()) !== false) {
+            if (strcasecmp($extension, $serializer->getExtension()) === 0) {
                 return $serializer;
             }
         }
 
         return null;
+    }
+
+    /**
+     * Extensions of the available archivers, plus the compound forms they can read
+     * without declaring them.
+     *
+     * @return array<int, string>
+     */
+    protected function getAcceptedArchiveExtensions()
+    {
+        $extensions = [];
+
+        /** @var \Thelia\Core\Archiver\AbstractArchiver $archiver */
+        foreach ($this->archiverManager->getArchivers(true) as $archiver) {
+            $extensions[] = strtolower($archiver->getExtension());
+        }
+
+        foreach (self::COMPOUND_ARCHIVE_EXTENSIONS as $compoundExtension => $archiverExtension) {
+            if (\in_array($archiverExtension, $extensions, true)) {
+                $extensions[] = $compoundExtension;
+            }
+        }
+
+        return array_values(array_unique($extensions));
+    }
+
+    /**
+     * Returns the longest of the given extensions the file name ends with, so that
+     * "catalogue.tar.gz" resolves to "tar.gz" and not to "gz".
+     *
+     * @param array<int, string> $extensions
+     */
+    protected function matchExtension(string $fileName, array $extensions): ?string
+    {
+        $fileName = strtolower($fileName);
+        $match = null;
+
+        foreach ($extensions as $extension) {
+            $extension = strtolower($extension);
+
+            if (!str_ends_with($fileName, '.'.$extension)) {
+                continue;
+            }
+
+            if ($match === null || \strlen($extension) > \strlen($match)) {
+                $match = $extension;
+            }
+        }
+
+        return $match;
     }
 
     /**

--- a/tests/Unit/Handler/ImportHandlerTest.php
+++ b/tests/Unit/Handler/ImportHandlerTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Core\Archiver\Archiver\TarArchiver;
+use Thelia\Core\Archiver\Archiver\TarBz2Archiver;
+use Thelia\Core\Archiver\Archiver\TarGzArchiver;
+use Thelia\Core\Archiver\Archiver\ZipArchiver;
+use Thelia\Core\Archiver\ArchiverManager;
+use Thelia\Core\Serializer\Serializer\CSVSerializer;
+use Thelia\Core\Serializer\Serializer\JSONSerializer;
+use Thelia\Core\Serializer\Serializer\XMLSerializer;
+use Thelia\Core\Serializer\Serializer\YAMLSerializer;
+use Thelia\Core\Serializer\SerializerManager;
+use Thelia\Core\Translation\Translator;
+use Thelia\Form\Exception\FormValidationException;
+use Thelia\Handler\ImportHandler;
+
+/**
+ * The import page advertises the formats the serializers and archivers can read.
+ * Nothing used to enforce that promise: the file was moved to the import cache
+ * directory and handed to a serializer matched on a substring of its name, so
+ * "products.csv.php" was read as a CSV file.
+ *
+ * The archivers are subclassed here to pin their availability, which depends on
+ * the php extensions of the host and is not what these tests are about.
+ */
+final class ImportHandlerTest extends TestCase
+{
+    private ?Translator $previousTranslator = null;
+
+    protected function setUp(): void
+    {
+        $this->previousTranslator = $this->translatorInstance()->getValue();
+
+        // validateUpload() builds its message through the singleton.
+        new Translator(new RequestStack());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->translatorInstance()->setValue(null, $this->previousTranslator);
+    }
+
+    public function testAcceptedExtensionsAreDerivedFromTheRegisteredHandlers(): void
+    {
+        $extensions = $this->createImportHandler()->getAcceptedExtensions();
+
+        self::assertContains('csv', $extensions);
+        self::assertContains('json', $extensions);
+        self::assertContains('xml', $extensions);
+        self::assertContains('yaml', $extensions);
+        self::assertContains('tar', $extensions);
+        self::assertContains('tgz', $extensions);
+        self::assertContains('bz2', $extensions);
+        self::assertContains('zip', $extensions);
+        self::assertNotContains('exe', $extensions);
+        self::assertNotContains('php', $extensions);
+    }
+
+    public function testAcceptedMimeTypesAreDerivedFromTheRegisteredHandlers(): void
+    {
+        $mimeTypes = $this->createImportHandler()->getAcceptedMimeTypes();
+
+        self::assertContains('text/csv', $mimeTypes);
+        self::assertContains('application/zip', $mimeTypes);
+    }
+
+    public function testAFileFormatNoHandlerCanReadIsRefused(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->createImportHandler()->validateUpload('payload.exe');
+    }
+
+    public function testAFileWithoutExtensionIsRefused(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->createImportHandler()->validateUpload('payload');
+    }
+
+    public function testAnAcceptedExtensionDoesNotWhitewashATrailingExecutableOne(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->createImportHandler()->validateUpload('products.csv.php');
+    }
+
+    public function testAnExecutableExtensionIsRefusedEvenBehindAnAcceptedOne(): void
+    {
+        $this->expectException(FormValidationException::class);
+
+        $this->createImportHandler()->validateUpload('products.php.csv');
+    }
+
+    public function testTheRefusalMessageListsTheAcceptedFormats(): void
+    {
+        try {
+            $this->createImportHandler()->validateUpload('payload.exe');
+        } catch (FormValidationException $exception) {
+            self::assertStringContainsString('exe', $exception->getMessage());
+            self::assertStringContainsString('csv', $exception->getMessage());
+
+            return;
+        }
+
+        self::fail('"payload.exe" should not be an acceptable import file');
+    }
+
+    /**
+     * @dataProvider acceptedFileNameProvider
+     */
+    public function testALegitimateImportFileIsAccepted(string $fileName): void
+    {
+        $handler = $this->createImportHandler();
+
+        $handler->validateUpload($fileName);
+
+        // validateUpload() throws when the file is refused, so the file name having
+        // survived the call is the assertion.
+        self::assertNotNull($handler->matchSerializerByExtension($fileName) ?? $handler->matchArchiverByExtension($fileName));
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function acceptedFileNameProvider(): array
+    {
+        return [
+            ['products.csv'],
+            // Every export file carries the date and a uniqid before its name.
+            ['20260812-68ab1c2d-products.csv'],
+            ['products.CSV'],
+            ['catalogue.zip'],
+            // What an archived export of the back office is downloaded as.
+            ['catalogue.tgz'],
+            ['catalogue.tar'],
+            ['catalogue.bz2'],
+            // What "tar czf" produces, and what the substring lookup used to accept.
+            ['catalogue.tar.gz'],
+            ['catalogue.tar.bz2'],
+            // What an export archive is actually named on disk.
+            ['20260812-68ab1c2d-products.csv.tgz'],
+        ];
+    }
+
+    public function testASerializerIsOnlyMatchedOnTheActualExtension(): void
+    {
+        $handler = $this->createImportHandler();
+
+        self::assertInstanceOf(CSVSerializer::class, $handler->matchSerializerByExtension('products.csv'));
+        // "products.csv.php" used to resolve to the CSV serializer, because the lookup
+        // searched ".csv" anywhere in the name.
+        self::assertNull($handler->matchSerializerByExtension('products.csv.php'));
+        self::assertNull($handler->matchSerializerByExtension('csv.php'));
+        self::assertNull($handler->matchSerializerByExtension('products.php'));
+    }
+
+    public function testAnArchiverIsOnlyMatchedOnTheActualExtension(): void
+    {
+        $handler = $this->createImportHandler();
+
+        self::assertInstanceOf(ZipArchiver::class, $handler->matchArchiverByExtension('catalogue.zip'));
+        self::assertNull($handler->matchArchiverByExtension('catalogue.zip.php'));
+        self::assertNull($handler->matchArchiverByExtension('products.csv'));
+    }
+
+    public function testACompoundArchiveExtensionResolvesToItsCompressedArchiver(): void
+    {
+        $handler = $this->createImportHandler();
+
+        // "catalogue.tar.gz" used to be swallowed by the plain tar archiver, which
+        // happened to work because PharData reads a compressed tar anyway. Those files
+        // stay importable, on the archiver that owns the compression.
+        self::assertInstanceOf(TarGzArchiver::class, $handler->matchArchiverByExtension('catalogue.tar.gz'));
+        self::assertInstanceOf(TarBz2Archiver::class, $handler->matchArchiverByExtension('catalogue.tar.bz2'));
+        self::assertInstanceOf(TarGzArchiver::class, $handler->matchArchiverByExtension('catalogue.tgz'));
+        self::assertInstanceOf(TarArchiver::class, $handler->matchArchiverByExtension('catalogue.tar'));
+    }
+
+    public function testAnUnavailableArchiverIsNeitherAdvertisedNorMatched(): void
+    {
+        $handler = $this->createImportHandler(
+            (new ArchiverManager())->setArchivers([$this->zipArchiver(), $this->unavailableTarGzArchiver()])
+        );
+
+        $extensions = $handler->getAcceptedExtensions();
+
+        self::assertContains('zip', $extensions);
+        self::assertNotContains('tgz', $extensions);
+        self::assertNotContains('tar.gz', $extensions);
+        self::assertNull($handler->matchArchiverByExtension('catalogue.tar.gz'));
+    }
+
+    private function createImportHandler(ArchiverManager $archiverManager = null): ImportHandler
+    {
+        $serializerManager = (new SerializerManager())->setSerializers([
+            new CSVSerializer(),
+            new JSONSerializer(),
+            new XMLSerializer(),
+            new YAMLSerializer(),
+        ]);
+
+        $archiverManager ??= (new ArchiverManager())->setArchivers([
+            $this->tarArchiver(),
+            $this->tarBz2Archiver(),
+            $this->tarGzArchiver(),
+            $this->zipArchiver(),
+        ]);
+
+        return new ImportHandler(new EventDispatcher(), $serializerManager, $archiverManager);
+    }
+
+    private function tarArchiver(): TarArchiver
+    {
+        return new class() extends TarArchiver {
+            public function isAvailable()
+            {
+                return true;
+            }
+        };
+    }
+
+    private function tarGzArchiver(): TarGzArchiver
+    {
+        return new class() extends TarGzArchiver {
+            public function isAvailable()
+            {
+                return true;
+            }
+        };
+    }
+
+    private function unavailableTarGzArchiver(): TarGzArchiver
+    {
+        return new class() extends TarGzArchiver {
+            public function isAvailable()
+            {
+                return false;
+            }
+        };
+    }
+
+    private function tarBz2Archiver(): TarBz2Archiver
+    {
+        return new class() extends TarBz2Archiver {
+            public function isAvailable()
+            {
+                return true;
+            }
+        };
+    }
+
+    private function zipArchiver(): ZipArchiver
+    {
+        return new class() extends ZipArchiver {
+            public function isAvailable()
+            {
+                return true;
+            }
+        };
+    }
+
+    private function translatorInstance(): \ReflectionProperty
+    {
+        $instance = new \ReflectionProperty(Translator::class, 'instance');
+        $instance->setAccessible(true);
+
+        return $instance;
+    }
+}


### PR DESCRIPTION
Refs #3601 — the 2.6 counterpart of #3597, plus the slice of #3582 it needs. `Fixes` keywords only auto-close from the default branch, so the issue stays open after this merge.

## Symptom

The import page advertises the formats it accepts ("Accepted formats: csv, json, xml, yaml, tar, bz2, tgz, zip") and then accepts anything. A file named `products.csv.php` is read as a CSV file, and lands in `var/cache/import/<date>/` under a name ending in `.php` before a single check has run.

## Cause

The knowledge of what may be imported existed — every serializer and archiver declares its extension and mime type — and it was used for the label, never for the check.

- `core/lib/Thelia/Controller/Admin/ImportController.php:144-171` built the advertised extension and mime type lists purely for display, then `:199-202` moved the uploaded file to the import cache directory under its original name.
- `core/lib/Thelia/Form/ImportForm.php:35-37` carried a single `NotNull` on the file field, so nothing validated the upload server-side.
- `core/lib/Thelia/Handler/ImportHandler.php:219` and `:238` resolved the archiver and the serializer with `stripos($fileName, '.'.$extension)`, a substring search anywhere in the name. `products.csv.php` therefore resolved to the CSV serializer, for the back office and for `php Thelia import` alike.

## Fix

The constraint is derived from the registered handlers, not restated in a controller.

`ImportHandler` gains three public methods:

- `getAcceptedExtensions()` and `getAcceptedMimeTypes()`, built from `SerializerManager` and the *available* archivers. A module registering a serializer widens the accepted set by itself, with no extra configuration variable and no change anywhere else.
- `validateUpload(string $fileName)`, which throws the usual `FormValidationException` when the name does not end with an accepted extension. `ImportForm` calls it from an `Assert\Callback`, so the file is refused before it reaches the disk.

`ImportController::configureAction()` now advertises `getAcceptedExtensions()` / `getAcceptedMimeTypes()`, so the page and the enforced constraint cannot drift apart.

The server-executable extension floor is ported from #3582 into `FileConfiguration::SERVER_EXECUTABLE_EXTENSIONS` / `FileConfiguration::findExecutableExtension()`. It applies whether the segment ends the name or sits in the middle of it, so `products.php.csv` is refused even though `csv` is accepted.

Finally the two extension lookups are anchored on the actual extension instead of a substring search, which closes the `products.csv.php` case for the CLI import as well.

No new configuration variable and no schema change: the accepted set is the set of registered handlers.

Only that slice of #3582 is ported. The rest of it — the per-shop upload policy, `FileConfiguration` as the single source of truth for image and document uploads — is a behaviour change for every upload path and does not belong on a maintenance branch; the document upload blacklist of this branch is left as it is.

## Compound archive extensions

`catalogue.tar.gz` used to reach the plain tar archiver because `.tar` appeared in its name, and it worked, because `PharData` reads a compressed tar transparently. An anchored lookup would have refused it, since the gzip archiver declares `tgz`. Rather than block a case that works today, `tar.gz` and `tar.bz2` are accepted explicitly and mapped to the archiver that owns the compression, so they are advertised only when that archiver is available. The page now lists `csv, json, xml, yaml, tar, bz2, tgz, zip, tar.gz, tar.bz2`.

## How to verify

```
composer test-unit
```

`tests/Unit/Handler/ImportHandlerTest.php` fails on `2.6` and passes here. `testASerializerIsOnlyMatchedOnTheActualExtension` shows `products.csv.php` resolving to the CSV serializer before the change, `testACompoundArchiveExtensionResolvesToItsCompressedArchiver` shows `catalogue.tar.gz` resolving to the plain tar archiver, and the `validateUpload()` cases have nothing to call at all.

Manually: back office → Tools → Import → pick any import → upload `payload.exe`, or a CSV file renamed `products.csv.php` or `products.php.csv`. All three are refused, with the accepted formats listed, and nothing is written to `var/cache/import/`. A plain `products.csv` still imports.

Round trip checked on an install with the demo data: the four archived flavours of an export (`tgz`, `bz2`, `tar`, `zip`), under the name they are downloaded as and under the name they carry on disk, plus a `tar.gz` built with `tar czf`, are all still accepted and still import.
