### PR TITLE
feat: let a template declare the views the front office must not serve as pages

### DIFF
--- a/core/lib/Thelia/Core/Template/InternalViewsDeclaration.php
+++ b/core/lib/Thelia/Core/Template/InternalViewsDeclaration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Template;
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+use Thelia\Core\Template\Exception\TemplateException;
+
+/**
+ * Reads the list of internal views a template declares in `config/views.yaml`:
+ *
+ *     internal:
+ *         - checkout-delivery
+ *         - checkout-payment
+ *
+ * Internal views are root templates a controller renders with the context it prepares.
+ * They are not pages, so they must not answer on a URL made of their own name.
+ *
+ * The file is optional: a template that ships none declares nothing, and every one of its
+ * root templates stays reachable by name, as it always was. A file that is there but
+ * unreadable is a template packaging error and is reported as such.
+ */
+final class InternalViewsDeclaration
+{
+    public const FILE_NAME = 'config/views.yaml';
+
+    /**
+     * @param string $templateDirectory absolute path of the template directory
+     *
+     * @return list<string>|null the declared view names, or null when the template declares nothing
+     *
+     * @throws TemplateException when the declaration is present but cannot be read
+     */
+    public static function readFrom(string $templateDirectory): ?array
+    {
+        $file = rtrim($templateDirectory, '/\\').\DIRECTORY_SEPARATOR.self::FILE_NAME;
+
+        if (!is_file($file)) {
+            return null;
+        }
+
+        try {
+            $declaration = Yaml::parseFile($file);
+        } catch (ParseException $e) {
+            throw new TemplateException(\sprintf('%s is not a valid YAML file: %s', $file, $e->getMessage()));
+        }
+
+        if (!\is_array($declaration) || !\array_key_exists('internal', $declaration)) {
+            return null;
+        }
+
+        if (!\is_array($declaration['internal'])) {
+            throw self::invalidList($file);
+        }
+
+        $views = [];
+        foreach ($declaration['internal'] as $view) {
+            if (!\is_string($view) || '' === trim($view)) {
+                throw self::invalidList($file);
+            }
+
+            $views[] = trim($view);
+        }
+
+        return $views;
+    }
+
+    private static function invalidList(string $file): TemplateException
+    {
+        return new TemplateException(\sprintf('The "internal" key of %s must contain a list of view names.', $file));
+    }
+}

--- a/core/lib/Thelia/Core/Template/TemplateDefinition.php
+++ b/core/lib/Thelia/Core/Template/TemplateDefinition.php
@@ -50,6 +50,9 @@ class TemplateDefinition
     ];
     protected ?array $parentList = null;
 
+    /** @var list<string>|null */
+    protected ?array $internalViews = null;
+
     /**
      * @param string $name the template name (= directory name)
      * @param int    $type the remplate type (see $standardTemplatesSubdirs)
@@ -99,6 +102,36 @@ class TemplateDefinition
         }
 
         return $this->parentList;
+    }
+
+    /**
+     * The views this template declares as internal, i.e. rendered by a controller and not
+     * reachable on a URL made of their own name.
+     *
+     * The declaration is optional (see InternalViewsDeclaration): a template that ships no
+     * declaration keeps exposing all of its root templates. The nearest declaration wins —
+     * an inherited list only applies while the template declares nothing itself.
+     *
+     * @return list<string>
+     */
+    public function getInternalViews(): array
+    {
+        if (null !== $this->internalViews) {
+            return $this->internalViews;
+        }
+
+        $templateList = array_merge([$this], array_values($this->getParentList() ?? []));
+
+        /** @var self $templateDefinition */
+        foreach ($templateList as $templateDefinition) {
+            $declaredViews = InternalViewsDeclaration::readFrom($templateDefinition->getAbsolutePath());
+
+            if (null !== $declaredViews) {
+                return $this->internalViews = $declaredViews;
+            }
+        }
+
+        return $this->internalViews = [];
     }
 
     public function getTemplateFilePath(string $templateName): string

--- a/core/lib/Thelia/Core/View/ViewRenderer.php
+++ b/core/lib/Thelia/Core/View/ViewRenderer.php
@@ -63,6 +63,14 @@ readonly class ViewRenderer
                 throw new NotFoundHttpException();
             }
 
+            // A view reached here was named by the request, either through the catch-all
+            // route of the front-office or through a rewritten URL. A template the active
+            // template declares as internal is not a page: it only renders with the context
+            // its controller prepares, so serving it here can only fail.
+            if (\in_array($view, $parser->getTemplateDefinition()?->getInternalViews() ?? [], true)) {
+                throw new NotFoundHttpException();
+            }
+
             $viewId = $request->attributes->get($view.'_id');
             $this->eventDispatcher->dispatch(new ViewCheckEvent($view, $viewId), TheliaEvents::VIEW_CHECK);
 

--- a/tests/Unit/Core/Template/InternalViewsDeclarationTest.php
+++ b/tests/Unit/Core/Template/InternalViewsDeclarationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Template;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\Template\Exception\TemplateException;
+use Thelia\Core\Template\InternalViewsDeclaration;
+
+/**
+ * A template declares the views it does not want served on a URL of their own name.
+ *
+ * Reading that declaration must tell "declares nothing" (null, so the caller keeps the
+ * historical behaviour and exposes everything) apart from "declares an empty list".
+ */
+final class InternalViewsDeclarationTest extends TestCase
+{
+    private string $templateDirectory;
+
+    protected function setUp(): void
+    {
+        $this->templateDirectory = sys_get_temp_dir().'/thelia-internal-views-'.uniqid('', true);
+
+        (new Filesystem())->mkdir($this->templateDirectory.'/config');
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->templateDirectory);
+    }
+
+    public function testATemplateWithoutTheFileDeclaresNothing(): void
+    {
+        (new Filesystem())->remove($this->templateDirectory.'/config');
+
+        self::assertNull(InternalViewsDeclaration::readFrom($this->templateDirectory));
+    }
+
+    public function testDeclaredViewsAreReturnedInOrder(): void
+    {
+        $this->writeDeclaration("internal:\n    - checkout-delivery\n    - checkout-payment\n");
+
+        self::assertSame(
+            ['checkout-delivery', 'checkout-payment'],
+            InternalViewsDeclaration::readFrom($this->templateDirectory),
+        );
+    }
+
+    public function testAnEmptyListIsADeclaration(): void
+    {
+        $this->writeDeclaration("internal: []\n");
+
+        self::assertSame([], InternalViewsDeclaration::readFrom($this->templateDirectory));
+    }
+
+    public function testViewNamesAreTrimmed(): void
+    {
+        $this->writeDeclaration("internal:\n    - '  address  '\n");
+
+        self::assertSame(['address'], InternalViewsDeclaration::readFrom($this->templateDirectory));
+    }
+
+    public function testAFileWithoutTheInternalKeyDeclaresNothing(): void
+    {
+        $this->writeDeclaration("public:\n    - index\n");
+
+        self::assertNull(InternalViewsDeclaration::readFrom($this->templateDirectory));
+    }
+
+    public function testAFileThatIsNotValidYamlIsReported(): void
+    {
+        $this->writeDeclaration("internal:\n  - unclosed: [\n");
+
+        $this->expectException(TemplateException::class);
+        $this->expectExceptionMessageMatches('/is not a valid YAML file/');
+
+        InternalViewsDeclaration::readFrom($this->templateDirectory);
+    }
+
+    public function testAListOfSomethingElseThanViewNamesIsReported(): void
+    {
+        $this->writeDeclaration("internal:\n    - address\n    - { view: category }\n");
+
+        $this->expectException(TemplateException::class);
+        $this->expectExceptionMessageMatches('/must contain a list of view names/');
+
+        InternalViewsDeclaration::readFrom($this->templateDirectory);
+    }
+
+    public function testAnInternalKeyThatIsNotAListIsReported(): void
+    {
+        $this->writeDeclaration("internal: address\n");
+
+        $this->expectException(TemplateException::class);
+
+        InternalViewsDeclaration::readFrom($this->templateDirectory);
+    }
+
+    private function writeDeclaration(string $content): void
+    {
+        (new Filesystem())->dumpFile(
+            $this->templateDirectory.'/'.InternalViewsDeclaration::FILE_NAME,
+            $content,
+        );
+    }
+}


### PR DESCRIPTION
The front office answers on `/{view}` for every root template of the active template: the Front module catch-all route (`Front/Config/front.xml`, `<route id="default" path="/{_view}">`) maps the URL segment to `_view`, and `Thelia\Core\View\ViewRenderer::render()` renders `<view>.html.twig`. The set of public URLs of a shop is therefore the file listing of the template's root directory, which is not what a template author is publishing on purpose. Root templates that only render with the context their controller prepares answer on their own URL and fail there. On a stock Flexy install with the demo data, eight of them returned a 500 (`/account-order`, `/address`, `/address-update`, `/checkout-delivery`, `/checkout-payment`, `/customer-activation`, `/customer-informations`, `/reset_password`), of the shape `Call to a member function getId() on null`.

This adds a way for a template to say which of its root templates are not pages, and makes the front office answer 404 for them.

## What a template declares

An optional `config/views.yaml` in the template directory:

```yaml
internal:
    - checkout-delivery
    - checkout-payment
```

- `Thelia\Core\Template\InternalViewsDeclaration` reads the file. No file, or no `internal` key, means the template declares nothing.
- `TemplateDefinition::getInternalViews()` exposes the list, falling back to the parent template while the template itself declares nothing (nearest declaration wins, so a child template can replace an inherited list).
- `ViewRenderer::render()` throws `NotFoundHttpException` for a declared view.

A declared view is refused wherever the request names it — the catch-all route, a rewritten URL, or a route default that carries the view name. A controller that renders the template itself is untouched: it returns its own `Response`, so `kernel.view` and `ViewRenderer` never run.

## Compatibility

A template that ships no `config/views.yaml` behaves exactly as before. Measured on a fresh install of `main` with the demo data and the Flexy theme: with this commit applied and no declaration in the theme, the HTTP status of all 38 root templates is unchanged, the eight 500s included.

The declaration is deliberately a list of what is *not* a page rather than a list of pages. The reachable set is not the template's to enumerate: the Twig loader also serves root templates from the parent template (`<parent>` in `template.xml`) and from the `templates/frontOffice/<template>/` directory of every activated module (`TheliaKernel::getModuleTemplateDirs()`, `TwigParser::addModulesTemplatesDirectories()`). A template listing its own pages would make module-contributed and inherited pages unreachable.

An unreadable declaration (invalid YAML, `internal` holding something else than a list of names) raises a `TemplateException`, as a broken `template.xml` already does. It is a packaging error of the template, and silently ignoring it would leave the pages it means to hide exposed.

## Verification

On a fresh install of `main` (PHP 8.3, demo data, Flexy), with the theme declaring the eight broken views plus its two layout templates: the ten answer 404, the 28 other root templates keep their previous status, and the pages that render those same templates from their controller still answer 200 (`/account/address/new`, `/account/address/{id}`).

`tests/Unit/Core/Template/InternalViewsDeclarationTest.php` covers the reading of the declaration: declared list, empty list, absent file, file without the key, and the three unreadable shapes.

`composer cs-diff` 0/1771, `composer phpstan` no errors, `composer test` green on the five suites (264 + 430 + 188/1 skip + 11 + 11).

Follow-up worth documenting once this is in: the convention belongs in the templating chapter of the documentation.

Fixes #3603
