### PR TITLE
fix: expose the folder parent id instead of a boolean in the API

### DIFF
--- a/core/lib/Thelia/Api/Resource/Folder.php
+++ b/core/lib/Thelia/Api/Resource/Folder.php
@@ -150,6 +150,11 @@ class Folder extends AbstractTranslatableResource
         return $this;
     }
 
+    public function getParent(): int
+    {
+        return $this->parent;
+    }
+
     public function isParent(): bool
     {
         return 0 !== $this->parent;

--- a/tests/Integration/Api/FolderParentSerializationTest.php
+++ b/tests/Integration/Api/FolderParentSerializationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\DataAccessService;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The Folder resource must expose which folder a folder belongs to.
+ *
+ * Symfony's PropertyAccessor resolves a property through its accessor methods before the
+ * public property itself, and tries an `is` accessor among them. Folder declared only
+ * isParent(): bool, so `parent` was serialized as "does it have a parent" instead of the
+ * parent id, and a client could not rebuild a folder tree from a collection response.
+ * Category exposes the same property through getParent(): int and was unaffected.
+ */
+final class FolderParentSerializationTest extends IntegrationTestCase
+{
+    public function testFrontFolderExposesItsParentIdRatherThanABoolean(): void
+    {
+        $factory = $this->createFixtureFactory();
+
+        $parent = $factory->folder();
+        $factory->folder($parent->getId());
+
+        $folders = static::getContainer()->get(DataAccessService::class)->resources(
+            '/api/front/folders',
+            ['parent' => $parent->getId(), 'visible' => true],
+        );
+
+        self::assertIsArray($folders);
+        self::assertCount(1, $folders);
+        self::assertSame($parent->getId(), $folders[0]['parent']);
+    }
+}


### PR DESCRIPTION
## Problem

`GET /api/front/folders` and `GET /api/admin/folders` return `"parent": false` for every folder instead of the id of the folder it belongs to. A consumer cannot tell which folder a folder sits under, so a folder tree cannot be rebuilt from a collection response — the only way left is one request per parent.

`GET /api/front/categories` returns `"parent": 0` for the same field, so the two resources disagree on a shape that looks identical from the outside.

## Root cause

`Thelia\Api\Resource\Folder` declares `public int $parent;` but exposes it only through `isParent(): bool` (`core/lib/Thelia/Api/Resource/Folder.php:153`), which returns `0 !== $this->parent`.

Symfony's `PropertyAccessor` resolves a property through its accessor methods before reaching the public property, and an `is` accessor is among the methods it tries. `isParent()` therefore wins, and the serializer publishes *whether* the folder has a parent where the property value is expected.

`Category` declares the same property and exposes it through `getParent(): int`, which is why it is unaffected. Scanning the 105 resources under `core/lib/Thelia/Api/Resource/`, `Folder::isParent()` is the only `is` accessor whose matching property is not a boolean.

## Why this change is needed

The parent id is the only link between two folders in a collection response. Without it, anything rendering a folder hierarchy — a navigation menu, a sitemap, a back-office tree — has to issue one request per node instead of reading a relation it already received.

The field is declared, typed, and filterable (`SearchFilter` on `parent`), so callers reasonably expect to read back what they are allowed to filter on. Today the filter works while the read does not.

It also cannot be worked around by the caller: the value is lost during normalization, so no client-side handling can recover it.

## Fix

Add `getParent(): int`. `PropertyAccessor` tries `getParent()` before `isParent()`, so the property value is serialized again.

`isParent()` is left untouched, since it is public API. It has no caller in this repository, and its name reads as "is a parent" while it answers "has a parent", so maintainers may want to rename or remove it — deliberately kept out of scope here.

## How to reproduce

`tests/Integration/Api/FolderParentSerializationTest` creates a parent folder and a child folder, fetches `/api/front/folders` filtered on the parent, and asserts the child reports the parent id.

Without the patch it fails with `Failed asserting that true is identical to 63`.

## Compatibility

`parent` changes from `bool` to `int` on `/api/front/folders` and `/api/admin/folders` reads. The current value carries no usable information — `false` for a root, `true` for anything else — so no consumer can meaningfully depend on it.

No method is removed or has its signature changed. Writes go through `setParent(int)` and are unaffected.
