### PR TITLE
fix: run deferred cache clears from the console, and make Thelia's own cache command reachable

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -61,8 +61,8 @@ Note:
 Once the update is done successfully, you have to clear all caches :  
 
 - clear all caches in all environment :
-    - ```php Thelia cache:clear```
-    - ```php Thelia cache:clear --env=prod```
+    - ```php Thelia thelia:cache:clear```
+    - ```php Thelia thelia:cache:clear --env=prod```
     
 If the command fails, you can do it manually. Just delete the content of 
 the ```cache``` and ```web/cache``` directories. 

--- a/core/lib/Thelia/Action/Cache.php
+++ b/core/lib/Thelia/Action/Cache.php
@@ -30,6 +30,14 @@ use Thelia\Core\Event\TheliaEvents;
  */
 class Cache extends BaseAction implements EventSubscriberInterface
 {
+    /**
+     * Removing the cache directory takes the compiled container's lazy service
+     * files with it, so any listener still waiting to be loaded from the
+     * container would fail to load. The deferred clear therefore runs after
+     * every other terminate listener.
+     */
+    private const TERMINATE_PRIORITY = \PHP_INT_MIN;
+
     /** @var CacheEvent[] */
     protected array $onTerminateCacheClearEvents = [];
 
@@ -98,8 +106,8 @@ class Cache extends BaseAction implements EventSubscriberInterface
     {
         return [
             TheliaEvents::CACHE_CLEAR => ['cacheClear', 128],
-            KernelEvents::TERMINATE => ['onTerminate', 128],
-            ConsoleEvents::TERMINATE => ['onTerminate', 128],
+            KernelEvents::TERMINATE => ['onTerminate', self::TERMINATE_PRIORITY],
+            ConsoleEvents::TERMINATE => ['onTerminate', self::TERMINATE_PRIORITY],
         ];
     }
 }

--- a/core/lib/Thelia/Command/CacheClear.php
+++ b/core/lib/Thelia/Command/CacheClear.php
@@ -28,9 +28,13 @@ use Thelia\Model\ConfigQuery;
  *
  * Class CacheClear
  *
+ * The name is namespaced: `cache:clear` belongs to FrameworkBundle, which also
+ * warms the container up, and registering a second command under that name only
+ * makes one of the two reachable.
+ *
  * @author Manuel Raynaud <manu@raynaud.io>
  */
-#[AsCommand(name: 'cache:clear', description: 'Invalidate all caches')]
+#[AsCommand(name: 'thelia:cache:clear', description: 'Invalidate the application, assets, image and document caches')]
 class CacheClear extends ContainerAwareCommand
 {
     protected function configure(): void
@@ -91,10 +95,14 @@ class CacheClear extends ContainerAwareCommand
 
     protected function clearCache(string $dir, OutputInterface $output): void
     {
-        $output->writeln(\sprintf('Clearing cache in <info>%s</info> directory', $dir));
+        $output->writeln(\sprintf('Invalidating cache in <info>%s</info> directory', $dir));
 
         try {
-            $cacheEvent = new CacheEvent($dir, false);
+            // Deferred: removing the container directory while the command is
+            // still running takes the services it has not loaded yet with it.
+            // The removal happens once the command is over, like every other
+            // caller of CACHE_CLEAR.
+            $cacheEvent = new CacheEvent($dir);
             $this->getDispatcher()->dispatch($cacheEvent, TheliaEvents::CACHE_CLEAR);
         } catch (\UnexpectedValueException $e) {
             // throws same exception code for does not exist and permission denied ...
@@ -108,7 +116,5 @@ class CacheClear extends ContainerAwareCommand
         } catch (IOException $e) {
             $output->writeln(\sprintf('Error during clearing of cache : %s', $e->getMessage()));
         }
-
-        $output->writeln(\sprintf('<info>%s cache directory cleared successfully</info>', $dir));
     }
 }

--- a/core/lib/Thelia/Core/Application.php
+++ b/core/lib/Thelia/Core/Application.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Command\Install;
 
 /**
@@ -55,6 +56,19 @@ class Application extends BaseApplication
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
         $this->registerCommands();
+
+        // Without a dispatcher, Symfony's console runs the command and returns
+        // without emitting console.command, console.error or console.terminate.
+        // Whatever the application defers to the end of the process then never
+        // runs: a cache clear queued by a module activation, for one, so the
+        // command reports success while leaving a container that still
+        // describes the previous state.
+        $container = $this->kernel->getContainer();
+        $dispatcher = $container->has('event_dispatcher') ? $container->get('event_dispatcher') : null;
+
+        if ($dispatcher instanceof EventDispatcherInterface) {
+            $this->setDispatcher($dispatcher);
+        }
 
         return parent::doRun($input, $output);
     }

--- a/setup/update.php
+++ b/setup/update.php
@@ -249,7 +249,7 @@ foreach ($finder as $file) {
 
 if (true === $hasDeleteError) {
     cliOutput('The cache has not been cleared properly. Try to run the command manually : '.
-        '(sudo) php Thelia cache:clear (--env=prod).');
+        '(sudo) php Thelia thelia:cache:clear (--env=prod).');
 }
 
 cliOutput('Update process finished.', 'info');

--- a/tests/Unit/Action/CacheTest.php
+++ b/tests/Unit/Action/CacheTest.php
@@ -16,9 +16,13 @@ namespace Thelia\Tests\Unit\Action;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\EventDispatcher\Event;
 use Thelia\Action\Cache;
 use Thelia\Core\Event\Cache\CacheEvent;
+use Thelia\Core\Event\TheliaEvents;
 
 /**
  * The combined Propel schema depends on the active modules and on their
@@ -87,6 +91,37 @@ final class CacheTest extends TestCase
 
         self::assertDirectoryDoesNotExist($this->clearedDir);
         self::assertDirectoryDoesNotExist($this->propelSchemaDir);
+    }
+
+    /**
+     * Removing the cache directory takes the compiled container's lazy service
+     * files with it. Outside debug mode listeners are loaded from the container
+     * one at a time, as they are called, so a listener that has not run yet
+     * would fail to load.
+     */
+    public function testTheDeferredClearRunsAfterTheOtherTerminateListeners(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($this->action());
+
+        $clearedDirWasStillThere = null;
+        $dispatcher->addListener(
+            ConsoleEvents::TERMINATE,
+            function () use (&$clearedDirWasStillThere): void {
+                $clearedDirWasStillThere = is_dir($this->clearedDir);
+            },
+            // Symfony's own lowest priority on that event (the console profiler).
+            -4096,
+        );
+
+        $dispatcher->dispatch(new CacheEvent($this->clearedDir, true, false), TheliaEvents::CACHE_CLEAR);
+
+        self::assertDirectoryExists($this->clearedDir);
+
+        $dispatcher->dispatch(new Event(), ConsoleEvents::TERMINATE);
+
+        self::assertTrue($clearedDirWasStillThere, 'The cache directory must outlive every other terminate listener.');
+        self::assertDirectoryDoesNotExist($this->clearedDir);
     }
 
     private function action(): Cache

--- a/tests/Unit/Core/ApplicationTest.php
+++ b/tests/Unit/Core/ApplicationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Thelia\Core\Application;
+
+/**
+ * Work the application defers to the end of the process — a cache clear queued
+ * by a module activation, for instance — only runs if the console emits
+ * console.terminate, which Symfony does only when a dispatcher is attached.
+ */
+final class ApplicationTest extends TestCase
+{
+    public function testTheConsoleEmitsTheTerminateEvent(): void
+    {
+        $terminated = 0;
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            ConsoleEvents::TERMINATE,
+            static function () use (&$terminated): void { ++$terminated; },
+        );
+
+        $application = new Application($this->kernelWith($dispatcher));
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $exitCode = $application->run(new ArrayInput(['command' => 'list']), new NullOutput());
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(1, $terminated);
+    }
+
+    private function kernelWith(EventDispatcher $dispatcher): KernelInterface
+    {
+        $container = new Container();
+        $container->setParameter('command.definition', []);
+        $container->set('event_dispatcher', $dispatcher);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        $kernel->method('getEnvironment')->willReturn('test');
+
+        return $kernel;
+    }
+}


### PR DESCRIPTION
Fixes #3607

## Symptom

`php Thelia module:deactivate <module>` reports success and leaves `var/cache/<env>` and the Propel schema directory untouched, so the next HTTP request serves a container that still describes the previous state. Reproduced on a demo install (DDEV, PHP 8.3):

```
php Thelia cache:clear                        # warm
php Thelia module:deactivate HookAdminHome    # exit 0, no output at all
du -sh var/cache/dev                          # 91M, unchanged
stat -c %Y var/propel/dev/schema              # unchanged
php Thelia module:list | grep HookAdminHome   # No  → the database did change
```

The reverse direction shows the consequence: after `php Thelia module:activate Tinymce`, `php Thelia debug:container --raw | grep -ci tinymce` still returns `0`.

## Cause

`Thelia\Action\Cache` subscribes to both `kernel.terminate` and `console.terminate` (`core/lib/Thelia/Action/Cache.php:97-104`), and module activation and deactivation queue their `CACHE_CLEAR` for that moment (`core/lib/Thelia/Action/Module.php:446-453`, default `onKernelTerminate: true`).

`Thelia\Core\Application` never attaches an event dispatcher. `Symfony\Component\Console\Application::doRunCommand()` therefore takes its dispatcher-less branch (`vendor/symfony/console/Application.php:1092-1100`) and emits no `console.command`, `console.error` or `console.terminate` at all — visible in any stack trace from `php Thelia`, which goes through `Application.php:1094`. The queue is never drained.

`bin/console` uses `Symfony\Bundle\FrameworkBundle\Console\Application`, which does attach the dispatcher, so the deferred clear did run there — and broke:

```
php bin/console module:activate Tinymce
Warning: require(var/cache/dev/ContainerSLnBsmr/getConsole_ErrorListenerService.php):
         Failed to open stream: No such file or directory        # exit 1
```

The clear ran at priority `128`, ahead of every other terminate listener, and outside debug mode listeners are loaded from the container one at a time as they are called (`EventDispatcher::optimizeListeners()`, `vendor/symfony/event-dispatcher/EventDispatcher.php:232-250`). Removing the cache directory takes the dumped service files of the listeners that have not run yet. `bin/install:326-334` already carries a `set_error_handler` to swallow exactly those warnings.

## Fix

- `Thelia\Core\Application::doRun()` attaches the container's dispatcher, like FrameworkBundle's console application does. `php Thelia` now emits the standard console events, so anything the application defers to the end of the process runs, and third-party `ConsoleEvents` subscribers work.
- `Thelia\Action\Cache` runs its deferred clear after every other terminate listener instead of before. Nothing then needs to be loaded from the container once the directory is gone. This is what makes the `bin/console` path above work as well.
- `Thelia\Command\CacheClear` was registered as `cache:clear`, the name FrameworkBundle already uses, so it was unreachable: `php Thelia cache:clear --help` shows the Symfony options. It becomes **`thelia:cache:clear`**, in line with the other `thelia:*` commands. It also stops clearing synchronously — deleting the container directory mid-command is what broke it once reachable — and queues its directories like every other caller. `setup/update.php` and `UPDATE.md` are updated.

`cache:clear` keeps its FrameworkBundle meaning (clear plus warmup). `thelia:cache:clear` is the one that also invalidates the Propel combined schema, the assets, and optionally the image and document caches.

## Verifying

On a demo install, in `dev` and in `prod`, through both entry points:

```
for BIN in "php Thelia" "php bin/console"; do for E in dev prod; do
  php bin/console cache:clear --env=$E
  $BIN module:deactivate Tinymce --env=$E && du -sh var/cache/$E
  php bin/console cache:clear --env=$E
  $BIN module:activate   Tinymce --env=$E && du -sh var/cache/$E
done; done
```

All eight combinations exit 0 and the cache directory is gone afterwards; before this change `bin/console` failed in both environments and `php Thelia` invalidated nothing. `php Thelia thelia:cache:clear` exits 0 in both environments and removes both `var/cache/<env>` and `var/propel/<env>/schema`; the same command was fatal in `prod` with the previous priority. The HTTP cycle still drains the queue on `kernel.terminate` (checked by dispatching a deferred `CacheEvent` and calling `Kernel::terminate()`).

Tests: `tests/Unit/Core/ApplicationTest.php` pins that the console emits `console.terminate`, and `CacheTest::testTheDeferredClearRunsAfterTheOtherTerminateListeners` pins the ordering against a listener registered at Symfony's own lowest priority on that event. Both fail on the current behaviour and pass with the fix.

Local run: `unit` 261, `api` 188 with 1 skip, `http-flexy` 11, `http-backoffice` 11 — all green; `integration` 467 with 4 errors and 3 failures in `FileProcessorServiceTest`, identical with and without this change (pre-existing in that environment). `cs-diff` 0/1792, PHPStan 0 errors.

## Noted while investigating, not changed here

- `Application::registerCommands()` uses `Symfony\Component\Console\Application::add()`, deprecated since symfony/console 7.4 in favour of `addCommand()`. Now that the console logs, the deprecation shows up on every `php Thelia` invocation in `prod`.
- `bin/install` can drop the `set_error_handler` and the `catch (\Error)` that hide the mid-process cache removal, once this is released.
- The documentation states that `php Thelia cache:clear` purges more completely than `php bin/console cache:clear` (`reference/cli/index.md`), which was not true while the command was shadowed. It needs the new name.
