### PR TITLE
fix: hand back the stored rewritten url, 404 the url of a deleted object, and keep the source image locale when cloning

### DIFF
--- a/core/lib/Thelia/Action/File.php
+++ b/core/lib/Thelia/Action/File.php
@@ -128,6 +128,12 @@ class File extends BaseAction implements EventSubscriberInterface
                 ->setVisible($originalProductFile->getVisible())
                 ->setPosition($originalProductFile->getPosition());
 
+            // The image file name is translated, so every active language is cloned in turn.
+            // Reading one moves the source model to that locale, and the caller still holds
+            // that model: Propel pools its instances, so even a fresh query hands it back on
+            // the last language walked, where the file name is usually empty.
+            $sourceLocale = $originalProductFile->getLocale();
+
             foreach (LangQuery::create()->findByActive(1) as $lang) {
                 $locale = $lang->getLocale();
                 $srcPath = $originalProductFile->getUploadDir().DS.$originalProductFile->setLocale($locale)->getFile();
@@ -180,6 +186,8 @@ class File extends BaseAction implements EventSubscriberInterface
                 // Set a temporary source file as the original one
                 rename($srcTmp, $srcPath);
             }
+
+            $originalProductFile->setLocale($sourceLocale);
         }
     }
 

--- a/core/lib/Thelia/Core/Routing/RewritingRouter.php
+++ b/core/lib/Thelia/Core/Routing/RewritingRouter.php
@@ -175,6 +175,15 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
                 }
             }
 
+            // Deleting an object does not delete its rewritten urls: Product::postDelete() and
+            // its siblings move them to the obsolete view instead. The object is gone, so there
+            // is no page left to serve and no current url to redirect to: such an url must answer
+            // 404, like any unknown one. An url that was merely replaced is a different case,
+            // kept with its "redirected" target, and still answered with a 301 further down.
+            if (ConfigQuery::getObsoleteRewrittenUrlView() == $rewrittenUrlData->view) {
+                throw new ResourceNotFoundException();
+            }
+
             // If we have a "lang" parameter, whe have to check if the found URL has the proper locale
             // If it's not the case, find the rewritten URL with the requested locale, and redirect to it.
             if (null == !$requestedLocale = $request->get('lang')) {

--- a/core/lib/Thelia/Model/Tools/UrlRewritingTrait.php
+++ b/core/lib/Thelia/Model/Tools/UrlRewritingTrait.php
@@ -104,6 +104,12 @@ trait UrlRewritingTrait
                 ->setViewLocale($locale)
                 ->save()
             ;
+
+            // RewritingUrl::preInsert() sanitizes the url before storing it: accents are
+            // folded, the ".html" extension is dropped, and the object id is prefixed when
+            // the result is already taken. Only the stored url resolves, so that is the one
+            // the caller must get back.
+            return $rewritingUrl->getUrl();
         }
 
         return $urlFilePart;

--- a/tests/Legacy/Action/ProductTest.php
+++ b/tests/Legacy/Action/ProductTest.php
@@ -861,10 +861,9 @@ class ProductTest extends TestCaseWithURLToolSetup
             // Check each file
             /** @var ProductDocument $originalProductFile */
             foreach ($originalProductFiles as $originalProductFile) {
-                // Thelia\Action\File::cloneImage() walks every active language and
-                // leaves the source model on the last one, where the file name is
-                // usually empty. Read it back in the default language instead.
-                $originalProductFile->setLocale(Lang::getDefaultLanguage()->getLocale());
+                // The source models come back from the Propel instance pool, so cloning
+                // must have left them on the locale they were read with.
+                $this->assertEquals(Lang::getDefaultLanguage()->getLocale(), $originalProductFile->getLocale());
 
                 $srcPath = $originalProductFile->getUploadDir().DS.$originalProductFile->getFile();
 

--- a/tests/Legacy/Core/Routing/RewritingRouterTest.php
+++ b/tests/Legacy/Core/Routing/RewritingRouterTest.php
@@ -19,6 +19,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Routing\RewritingRouter;
+use Thelia\Model\Category;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\LangQuery;
 use Thelia\Model\ProductQuery;
@@ -80,11 +81,53 @@ class RewritingRouterTest extends TestCase
     {
         ConfigQuery::write('rewriting_enable', 1);
         // A random path: any url left in the rewriting_url table by another test
-        // would be matched, obsolete ones included.
+        // would be matched.
         $request = Request::create('http://test.com/'.uniqid('no-such-url-', false));
         // Without a session the router falls back on a native PHP session, and
         // session_start() warns as soon as anything has been written to stdout.
         $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $rewritingRouter = new RewritingRouter();
+
+        $this->expectException(\Symfony\Component\Routing\Exception\ResourceNotFoundException::class);
+        $rewritingRouter->matchRequest($request);
+    }
+
+    /**
+     * covers RewritingRouter::matchRequest.
+     */
+    public function testMatchRequestWithObsoleteUrl(): void
+    {
+        ConfigQuery::write('rewriting_enable', 1);
+        ConfigQuery::write('one_domain_foreach_lang', 0);
+
+        $defaultLang = LangQuery::create()->findOneByByDefault(1);
+
+        $category = new Category();
+        $category->setVisible(1)
+            ->setPosition(1)
+            ->setLocale($defaultLang->getLocale())
+            ->setTitle('Obsolete rewritten url '.uniqid('', false))
+            ->save();
+
+        $obsoleteUrl = $category->getRewrittenUrl($defaultLang->getLocale());
+
+        // Deleting the object keeps its urls, moved to the obsolete view.
+        $category->delete();
+
+        $this->assertEquals(
+            ConfigQuery::getObsoleteRewrittenUrlView(),
+            RewritingUrlQuery::create()->findOneByUrl($obsoleteUrl)->getView()
+        );
+
+        $request = Request::create('http://test.com/'.$obsoleteUrl);
+        $session = new Session(new MockArraySessionStorage());
+        $session->setLang($defaultLang);
+        $request->setSession($session);
+        $url = new URL();
+        $requestContext = new RequestContext();
+        $requestContext->fromRequest($request);
+        $url->setRequestContext($requestContext);
 
         $rewritingRouter = new RewritingRouter();
 

--- a/tests/Legacy/Rewriting/BaseRewritingObject.php
+++ b/tests/Legacy/Rewriting/BaseRewritingObject.php
@@ -14,6 +14,7 @@ namespace Thelia\Tests\Rewriting;
 
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Propel;
+use Thelia\Model\RewritingUrlQuery;
 use Thelia\Model\Tools\UrlRewritingTrait;
 
 /**
@@ -56,10 +57,9 @@ abstract class BaseRewritingObject extends TestCase
         $con = Propel::getConnection();
         $rewrittenUrl = $object->generateRewrittenUrl('fr_FR', $con);
         $this->assertNotNull($rewrittenUrl, 'rewritten url can not be null');
-        // generateRewrittenUrl() returns the url it built from the title, before
-        // RewritingUrl::preInsert() sanitized it. The stored one is what the
-        // front office resolves, so check that one.
-        $this->assertMatchesRegularExpression(self::FRENCH_URL_PATTERN, $object->getRewrittenUrl('fr_FR'));
+        // The returned url is the one that was stored: only that one resolves.
+        $this->assertMatchesRegularExpression(self::FRENCH_URL_PATTERN, $rewrittenUrl);
+        $this->assertNotNull(RewritingUrlQuery::create()->findOneByUrl($rewrittenUrl));
 
         $object->delete();
     }
@@ -82,7 +82,8 @@ abstract class BaseRewritingObject extends TestCase
         $con = Propel::getConnection();
         $rewrittenUrl = $object->generateRewrittenUrl('en_US', $con);
         $this->assertNotNull($rewrittenUrl, 'rewritten url can not be null');
-        $this->assertMatchesRegularExpression(self::ENGLISH_URL_PATTERN, $object->getRewrittenUrl('en_US'));
+        $this->assertMatchesRegularExpression(self::ENGLISH_URL_PATTERN, $rewrittenUrl);
+        $this->assertNotNull(RewritingUrlQuery::create()->findOneByUrl($rewrittenUrl));
 
         $object->delete();
     }


### PR DESCRIPTION
The three rewritten-url behaviours reported in #3610, in one commit each. The first two are also fixed on `main` by #3615; the third one is specific to this line, where the image file name is an i18n column.

The legacy suite is the one that exposed them: three of its tests were written around the current behaviour when it was revived in #3606, and this branch puts them back on the behaviour that is expected.

## 1. `generateRewrittenUrl()` returned an url that does not exist

`RewritingUrl::preInsert()` (`core/lib/Thelia/Model/RewritingUrl.php:41-49`) sanitizes the url before storing it: accents are folded, `.html` is dropped unless `admin.url.sanitizer.remove.html` says otherwise, and `unifyUrl()` prefixes the object id as long as the result is taken. `UrlRewritingTrait::generateRewrittenUrl()` stored that row but returned `$urlFilePart`, the candidate built from the title before the model touched it (`core/lib/Thelia/Model/Tools/UrlRewritingTrait.php:109`, before this change).

With a category titled `Mon super titre en français`, it returned `mon-super-titre-en-français.html` while the table held `mon-super-titre-en-francais`. A caller that redirects to the returned value, or prints it as a link, hands out a 404. The method now returns the url of the row it saved.

Test update: `tests/Legacy/Rewriting/BaseRewritingObject.php` asserted the stored url instead of the returned one, precisely because the returned one did not match. It asserts the returned value again, and that the value exists in `rewriting_url`.

## 2. The rewritten url of a deleted object still matched

Deleting a product, category, content, folder or brand does not delete its rewritten urls: `postDelete()` moves them to the obsolete view (`UrlRewritingTrait::markRewrittenUrlObsolete()`), which is the only place that view is ever set. `RewritingRouter::matchRequest()` matched those rows like any other and answered with `DefaultController::noAction`, so the request reached the view stage with `_view = obsolete-rewritten-url` and only ended up as a 404 because no template happens to be named after that view. Asked in another language, the same url answered a **301 to an unrelated page**: every deleted object of every type shares the single obsolete view name, so `URL::retrieve('obsolete-rewritten-url', <id>, <locale>)` returns the url of whichever deleted object had the same id.

301 or 404? The 301 already exists for the case it belongs to: an url that was *replaced* keeps a `redirected` target and is answered with a 301 to the current url. That path is untouched. The obsolete view is the other case: it is set from `postDelete()` only, so the object is gone by construction and there is no current url to point to. Nothing to redirect to means 404, raised by the router instead of depending on a missing template.

Impact on an existing shop: urls of deleted objects already answered 404 in the default flow, so their status code does not change; what changes is that the wrong 301 disappears and the 404 no longer depends on the theme. Urls that were merely replaced keep their 301.

Test update: `testMatchRequestWithNonExistingUrl` had to randomize its path to avoid matching an obsolete url left by another test — that comment no longer applies to obsolete urls. `testMatchRequestWithObsoleteUrl` covers the new behaviour.

## 3. Cloning a product left the source image on the last language

`Action\File::cloneImage()` walks every active language, and reads the translated file name with `$originalProductFile->setLocale($locale)->getFile()` (`core/lib/Thelia/Action/File.php:133`). Nothing puts the source model back afterwards, so it is left on the last active language — `nl_NL` on a demo install — where the file name is usually empty and `getUploadDir().DS.getFile()` points at the upload directory itself. Propel pools its instances, so even a caller that re-queries the row gets that mutated model back. The source locale is now restored after the language loop.

Test update: `ProductTest::testCloneFile` worked around it by forcing the source model back to the default language before reading the file name; it now asserts that cloning left it alone.

## Checks

Local install mirroring the CI steps (install, `composer demo-database`, module activations), each fix checked failing without it and passing with it:

* legacy suite: 583 tests before, 584 after with the added router test, no failure (24 skipped, 11 risky — same as before the branch);
* unit suite: 22 tests, green;
* `PHP_CS_FIXER_IGNORE_ENV=1 composer cs-diff` with the pinned php-cs-fixer 3.41: 0 of 1955 files.
