### PR TITLE
fix: roll back the transaction when a non-Exception error escapes an action

### DIFF
--- a/core/lib/Thelia/Action/Address.php
+++ b/core/lib/Thelia/Action/Address.php
@@ -12,7 +12,6 @@
 
 namespace Thelia\Action;
 
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -86,7 +85,7 @@ class Address extends BaseAction implements EventSubscriberInterface
 
             $event->setAddress($addressModel);
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
             throw $e;
         }

--- a/core/lib/Thelia/Action/BaseCachedFile.php
+++ b/core/lib/Thelia/Action/BaseCachedFile.php
@@ -234,7 +234,7 @@ abstract class BaseCachedFile extends BaseAction
 
             $event->setUploadedFile($newUploadedFile);
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;

--- a/core/lib/Thelia/Action/Category.php
+++ b/core/lib/Thelia/Action/Category.php
@@ -127,7 +127,7 @@ class Category extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }

--- a/core/lib/Thelia/Action/Content.php
+++ b/core/lib/Thelia/Action/Content.php
@@ -82,7 +82,7 @@ class Content extends BaseAction implements EventSubscriberInterface
 
                 $event->setContent($content);
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }
@@ -158,7 +158,7 @@ class Content extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }

--- a/core/lib/Thelia/Action/Coupon.php
+++ b/core/lib/Thelia/Action/Coupon.php
@@ -342,7 +342,7 @@ class Coupon extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception  $ex) {
+            } catch (\Throwable $ex) {
                 $con->rollBack();
 
                 throw $ex;

--- a/core/lib/Thelia/Action/CustomerTitle.php
+++ b/core/lib/Thelia/Action/CustomerTitle.php
@@ -49,7 +49,7 @@ class CustomerTitle extends BaseAction implements EventSubscriberInterface
             $event->getCustomerTitle()->delete();
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;
@@ -88,7 +88,7 @@ class CustomerTitle extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;

--- a/core/lib/Thelia/Action/Folder.php
+++ b/core/lib/Thelia/Action/Folder.php
@@ -98,7 +98,7 @@ class Folder extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -282,7 +282,7 @@ class Module extends BaseAction implements EventSubscriberInterface
 
                 $event->setModule($module);
                 $this->cacheClear($dispatcher);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -202,9 +202,10 @@ class Module extends BaseAction implements EventSubscriberInterface
     public function delete(ModuleDeleteEvent $event, $eventName, EventDispatcherInterface $dispatcher): void
     {
         $con = Propel::getWriteConnection(ModuleTableMap::DATABASE_NAME);
-        $con->beginTransaction();
 
         if (null !== $module = ModuleQuery::create()->findPk($event->getModuleId(), $con)) {
+            $con->beginTransaction();
+
             try {
                 if (null === $module->getFullNamespace()) {
                     throw new \LogicException(
@@ -279,13 +280,15 @@ class Module extends BaseAction implements EventSubscriberInterface
                 $module->delete($con);
 
                 $con->commit();
-
-                $event->setModule($module);
-                $this->cacheClear($dispatcher);
             } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }
+
+            // Outside the try: these two run once the deletion is committed, so a
+            // failure there no longer reaches a rollback of a closed transaction.
+            $event->setModule($module);
+            $this->cacheClear($dispatcher);
         }
     }
 

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -157,209 +157,217 @@ class Order extends BaseAction implements EventSubscriberInterface
 
         $con->beginTransaction();
 
-        $placedOrder = $sessionOrder->copy();
+        try {
+            $placedOrder = $sessionOrder->copy();
 
-        // Be sure to create a brand new order, as copy raises the modified flag for all fields
-        // and will also copy order reference and id.
-        $placedOrder->setId(null)->setRef(null)->setNew(true);
+            // Be sure to create a brand new order, as copy raises the modified flag for all fields
+            // and will also copy order reference and id.
+            $placedOrder->setId(null)->setRef(null)->setNew(true);
 
-        // Dates should be marked as not updated so that Propel will update them.
-        $placedOrder->resetModified(OrderTableMap::COL_CREATED_AT);
-        $placedOrder->resetModified(OrderTableMap::COL_UPDATED_AT);
-        $placedOrder->resetModified(OrderTableMap::COL_VERSION_CREATED_AT);
+            // Dates should be marked as not updated so that Propel will update them.
+            $placedOrder->resetModified(OrderTableMap::COL_CREATED_AT);
+            $placedOrder->resetModified(OrderTableMap::COL_UPDATED_AT);
+            $placedOrder->resetModified(OrderTableMap::COL_VERSION_CREATED_AT);
 
-        $cartItems = $cart->getCartItems();
+            $cartItems = $cart->getCartItems();
 
-        /* fulfill order */
-        $placedOrder->setCustomerId($customer->getId());
-        $placedOrder->setCurrencyId($currency->getId());
-        $placedOrder->setCurrencyRate($currency->getRate());
-        $placedOrder->setLangId($lang->getId());
+            /* fulfill order */
+            $placedOrder->setCustomerId($customer->getId());
+            $placedOrder->setCurrencyId($currency->getId());
+            $placedOrder->setCurrencyRate($currency->getRate());
+            $placedOrder->setLangId($lang->getId());
 
-        if ($useOrderDefinedAddresses) {
-            $taxCountry =
-                OrderAddressQuery::create()
-                    ->findPk($placedOrder->getDeliveryOrderAddressId())
-                    ->getCountry()
-            ;
-        } else {
-            $deliveryAddress = AddressQuery::create()->findPk($sessionOrder->getChoosenDeliveryAddress());
-            $invoiceAddress = AddressQuery::create()->findPk($sessionOrder->getChoosenInvoiceAddress());
+            if ($useOrderDefinedAddresses) {
+                $taxCountry =
+                    OrderAddressQuery::create()
+                        ->findPk($placedOrder->getDeliveryOrderAddressId())
+                        ->getCountry()
+                ;
+            } else {
+                $deliveryAddress = AddressQuery::create()->findPk($sessionOrder->getChoosenDeliveryAddress());
+                $invoiceAddress = AddressQuery::create()->findPk($sessionOrder->getChoosenInvoiceAddress());
 
-            /* hard save the delivery and invoice addresses */
-            $deliveryOrderAddress = new OrderAddress();
-            $deliveryOrderAddress
-                ->setCustomerTitleId($deliveryAddress->getTitleId())
-                ->setCompany($deliveryAddress->getCompany())
-                ->setFirstname($deliveryAddress->getFirstname())
-                ->setLastname($deliveryAddress->getLastname())
-                ->setAddress1($deliveryAddress->getAddress1())
-                ->setAddress2($deliveryAddress->getAddress2())
-                ->setAddress3($deliveryAddress->getAddress3())
-                ->setZipcode($deliveryAddress->getZipcode())
-                ->setCity($deliveryAddress->getCity())
-                ->setPhone($deliveryAddress->getPhone())
-                ->setCellphone($deliveryAddress->getCellphone())
-                ->setCountryId($deliveryAddress->getCountryId())
-                ->setStateId($deliveryAddress->getStateId())
-                ->save($con);
+                /* hard save the delivery and invoice addresses */
+                $deliveryOrderAddress = new OrderAddress();
+                $deliveryOrderAddress
+                    ->setCustomerTitleId($deliveryAddress->getTitleId())
+                    ->setCompany($deliveryAddress->getCompany())
+                    ->setFirstname($deliveryAddress->getFirstname())
+                    ->setLastname($deliveryAddress->getLastname())
+                    ->setAddress1($deliveryAddress->getAddress1())
+                    ->setAddress2($deliveryAddress->getAddress2())
+                    ->setAddress3($deliveryAddress->getAddress3())
+                    ->setZipcode($deliveryAddress->getZipcode())
+                    ->setCity($deliveryAddress->getCity())
+                    ->setPhone($deliveryAddress->getPhone())
+                    ->setCellphone($deliveryAddress->getCellphone())
+                    ->setCountryId($deliveryAddress->getCountryId())
+                    ->setStateId($deliveryAddress->getStateId())
+                    ->save($con);
 
-            $invoiceOrderAddress = new OrderAddress();
-            $invoiceOrderAddress
-                ->setCustomerTitleId($invoiceAddress->getTitleId())
-                ->setCompany($invoiceAddress->getCompany())
-                ->setFirstname($invoiceAddress->getFirstname())
-                ->setLastname($invoiceAddress->getLastname())
-                ->setAddress1($invoiceAddress->getAddress1())
-                ->setAddress2($invoiceAddress->getAddress2())
-                ->setAddress3($invoiceAddress->getAddress3())
-                ->setZipcode($invoiceAddress->getZipcode())
-                ->setCity($invoiceAddress->getCity())
-                ->setPhone($invoiceAddress->getPhone())
-                ->setCellphone($invoiceAddress->getCellphone())
-                ->setCountryId($invoiceAddress->getCountryId())
-                ->setStateId($deliveryAddress->getStateId())
-                ->save($con);
+                $invoiceOrderAddress = new OrderAddress();
+                $invoiceOrderAddress
+                    ->setCustomerTitleId($invoiceAddress->getTitleId())
+                    ->setCompany($invoiceAddress->getCompany())
+                    ->setFirstname($invoiceAddress->getFirstname())
+                    ->setLastname($invoiceAddress->getLastname())
+                    ->setAddress1($invoiceAddress->getAddress1())
+                    ->setAddress2($invoiceAddress->getAddress2())
+                    ->setAddress3($invoiceAddress->getAddress3())
+                    ->setZipcode($invoiceAddress->getZipcode())
+                    ->setCity($invoiceAddress->getCity())
+                    ->setPhone($invoiceAddress->getPhone())
+                    ->setCellphone($invoiceAddress->getCellphone())
+                    ->setCountryId($invoiceAddress->getCountryId())
+                    ->setStateId($deliveryAddress->getStateId())
+                    ->save($con);
 
-            $placedOrder->setDeliveryOrderAddressId($deliveryOrderAddress->getId());
-            $placedOrder->setInvoiceOrderAddressId($invoiceOrderAddress->getId());
+                $placedOrder->setDeliveryOrderAddressId($deliveryOrderAddress->getId());
+                $placedOrder->setInvoiceOrderAddressId($invoiceOrderAddress->getId());
 
-            $taxCountry = $deliveryAddress->getCountry();
-        }
-
-        $placedOrder->setStatusId(
-            OrderStatusQuery::getNotPaidStatus()->getId()
-        );
-
-        $placedOrder->setCartId($cart->getId());
-
-        /* memorize discount */
-        $placedOrder->setDiscount(
-            $cart->getDiscount()
-        );
-
-        $placedOrder->save($con);
-
-        $manageStock = $placedOrder->isStockManagedOnOrderCreation($dispatcher);
-
-        /* fulfill order_products and decrease stock */
-
-        foreach ($cartItems as $cartItem) {
-            $product = $cartItem->getProduct();
-
-            /* get translation */
-            /** @var ProductI18n $productI18n */
-            $productI18n = I18n::forceI18nRetrieving($lang->getLocale(), 'Product', $product->getId());
-
-            $pse = $cartItem->getProductSaleElements();
-
-            // get the virtual document path
-            $virtualDocumentEvent = new VirtualProductOrderHandleEvent($placedOrder, $pse->getId());
-            // essentially used for virtual product. modules that handles virtual product can
-            // allow the use of stock even for virtual products
-            $useStock = true;
-            $virtual = 0;
-
-            // if the product is virtual, dispatch an event to collect information
-            if ($product->getVirtual() === 1) {
-                $dispatcher->dispatch($virtualDocumentEvent, TheliaEvents::VIRTUAL_PRODUCT_ORDER_HANDLE);
-                $useStock = $virtualDocumentEvent->isUseStock();
-                $virtual = $virtualDocumentEvent->isVirtual() ? 1 : 0;
+                $taxCountry = $deliveryAddress->getCountry();
             }
 
-            /* check still in stock */
-            if ($cartItem->getQuantity() > $pse->getQuantity()
-                && true === ConfigQuery::checkAvailableStock()
-                && $useStock) {
-                throw new TheliaProcessException('Not enough stock', TheliaProcessException::CART_ITEM_NOT_ENOUGH_STOCK, $cartItem);
-            }
-
-            if ($useStock && $manageStock) {
-                /* decrease stock for non virtual product */
-                $allowNegativeStock = (int) ConfigQuery::read('allow_negative_stock', 0);
-                $newStock = $pse->getQuantity() - $cartItem->getQuantity();
-                // Forbid negative stock
-                if ($newStock < 0 && 0 === $allowNegativeStock) {
-                    $newStock = 0;
-                }
-                $pse->setQuantity(
-                    $newStock
-                );
-
-                $pse->save($con);
-            }
-
-            /* get tax */
-            /** @var TaxRuleI18n $taxRuleI18n */
-            $taxRuleI18n = I18n::forceI18nRetrieving($lang->getLocale(), 'TaxRule', $product->getTaxRuleId());
-
-            $taxDetail = $product->getTaxRule()->getTaxDetail(
-                $product,
-                $taxCountry,
-                $cartItem->getPrice(),
-                $cartItem->getPromoPrice(),
-                $lang->getLocale()
+            $placedOrder->setStatusId(
+                OrderStatusQuery::getNotPaidStatus()->getId()
             );
 
-            $orderProduct = new OrderProduct();
-            $orderProduct
-                ->setOrderId($placedOrder->getId())
-                ->setProductRef($product->getRef())
-                ->setProductSaleElementsRef($pse->getRef())
-                ->setProductSaleElementsId($pse->getId())
-                ->setTitle($productI18n->getTitle())
-                ->setChapo($productI18n->getChapo())
-                ->setDescription($productI18n->getDescription())
-                ->setPostscriptum($productI18n->getPostscriptum())
-                ->setVirtual($virtual)
-                ->setVirtualDocument($virtualDocumentEvent->getPath())
-                ->setQuantity($cartItem->getQuantity())
-                ->setPrice($cartItem->getPrice())
-                ->setPromoPrice($cartItem->getPromoPrice())
-                ->setWasNew($pse->getNewness())
-                ->setWasInPromo($cartItem->getPromo())
-                ->setWeight($pse->getWeight())
-                ->setTaxRuleTitle($taxRuleI18n->getTitle())
-                ->setTaxRuleDescription($taxRuleI18n->getDescription())
-                ->setEanCode($pse->getEanCode())
-                ->setCartItemId($cartItem->getId())
+            $placedOrder->setCartId($cart->getId());
 
-                ->save($con)
-            ;
+            /* memorize discount */
+            $placedOrder->setDiscount(
+                $cart->getDiscount()
+            );
 
-            /* fulfill order_product_tax */
-            /** @var OrderProductTax $tax */
-            foreach ($taxDetail as $tax) {
-                $tax->setOrderProductId($orderProduct->getId());
-                $tax->save($con);
+            $placedOrder->save($con);
+
+            $manageStock = $placedOrder->isStockManagedOnOrderCreation($dispatcher);
+
+            /* fulfill order_products and decrease stock */
+
+            foreach ($cartItems as $cartItem) {
+                $product = $cartItem->getProduct();
+
+                /* get translation */
+                /** @var ProductI18n $productI18n */
+                $productI18n = I18n::forceI18nRetrieving($lang->getLocale(), 'Product', $product->getId());
+
+                $pse = $cartItem->getProductSaleElements();
+
+                // get the virtual document path
+                $virtualDocumentEvent = new VirtualProductOrderHandleEvent($placedOrder, $pse->getId());
+                // essentially used for virtual product. modules that handles virtual product can
+                // allow the use of stock even for virtual products
+                $useStock = true;
+                $virtual = 0;
+
+                // if the product is virtual, dispatch an event to collect information
+                if ($product->getVirtual() === 1) {
+                    $dispatcher->dispatch($virtualDocumentEvent, TheliaEvents::VIRTUAL_PRODUCT_ORDER_HANDLE);
+                    $useStock = $virtualDocumentEvent->isUseStock();
+                    $virtual = $virtualDocumentEvent->isVirtual() ? 1 : 0;
+                }
+
+                /* check still in stock */
+                if ($cartItem->getQuantity() > $pse->getQuantity()
+                    && true === ConfigQuery::checkAvailableStock()
+                    && $useStock) {
+                    throw new TheliaProcessException('Not enough stock', TheliaProcessException::CART_ITEM_NOT_ENOUGH_STOCK, $cartItem);
+                }
+
+                if ($useStock && $manageStock) {
+                    /* decrease stock for non virtual product */
+                    $allowNegativeStock = (int) ConfigQuery::read('allow_negative_stock', 0);
+                    $newStock = $pse->getQuantity() - $cartItem->getQuantity();
+                    // Forbid negative stock
+                    if ($newStock < 0 && 0 === $allowNegativeStock) {
+                        $newStock = 0;
+                    }
+                    $pse->setQuantity(
+                        $newStock
+                    );
+
+                    $pse->save($con);
+                }
+
+                /* get tax */
+                /** @var TaxRuleI18n $taxRuleI18n */
+                $taxRuleI18n = I18n::forceI18nRetrieving($lang->getLocale(), 'TaxRule', $product->getTaxRuleId());
+
+                $taxDetail = $product->getTaxRule()->getTaxDetail(
+                    $product,
+                    $taxCountry,
+                    $cartItem->getPrice(),
+                    $cartItem->getPromoPrice(),
+                    $lang->getLocale()
+                );
+
+                $orderProduct = new OrderProduct();
+                $orderProduct
+                    ->setOrderId($placedOrder->getId())
+                    ->setProductRef($product->getRef())
+                    ->setProductSaleElementsRef($pse->getRef())
+                    ->setProductSaleElementsId($pse->getId())
+                    ->setTitle($productI18n->getTitle())
+                    ->setChapo($productI18n->getChapo())
+                    ->setDescription($productI18n->getDescription())
+                    ->setPostscriptum($productI18n->getPostscriptum())
+                    ->setVirtual($virtual)
+                    ->setVirtualDocument($virtualDocumentEvent->getPath())
+                    ->setQuantity($cartItem->getQuantity())
+                    ->setPrice($cartItem->getPrice())
+                    ->setPromoPrice($cartItem->getPromoPrice())
+                    ->setWasNew($pse->getNewness())
+                    ->setWasInPromo($cartItem->getPromo())
+                    ->setWeight($pse->getWeight())
+                    ->setTaxRuleTitle($taxRuleI18n->getTitle())
+                    ->setTaxRuleDescription($taxRuleI18n->getDescription())
+                    ->setEanCode($pse->getEanCode())
+                    ->setCartItemId($cartItem->getId())
+
+                    ->save($con)
+                ;
+
+                /* fulfill order_product_tax */
+                /** @var OrderProductTax $tax */
+                foreach ($taxDetail as $tax) {
+                    $tax->setOrderProductId($orderProduct->getId());
+                    $tax->save($con);
+                }
+
+                /* fulfill order_attribute_combination and decrease stock */
+                foreach ($pse->getAttributeCombinations() as $attributeCombination) {
+                    /** @var \Thelia\Model\Attribute $attribute */
+                    $attribute = I18n::forceI18nRetrieving($lang->getLocale(), 'Attribute', $attributeCombination->getAttributeId());
+
+                    /** @var \Thelia\Model\AttributeAv $attributeAv */
+                    $attributeAv = I18n::forceI18nRetrieving($lang->getLocale(), 'AttributeAv', $attributeCombination->getAttributeAvId());
+
+                    $orderAttributeCombination = new OrderProductAttributeCombination();
+                    $orderAttributeCombination
+                        ->setOrderProductId($orderProduct->getId())
+                        ->setAttributeTitle($attribute->getTitle())
+                        ->setAttributeChapo($attribute->getChapo())
+                        ->setAttributeDescription($attribute->getDescription())
+                        ->setAttributePostscriptum($attribute->getPostscriptum())
+                        ->setAttributeAvTitle($attributeAv->getTitle())
+                        ->setAttributeAvChapo($attributeAv->getChapo())
+                        ->setAttributeAvDescription($attributeAv->getDescription())
+                        ->setAttributeAvPostscriptum($attributeAv->getPostscriptum())
+                        ->save($con);
+                }
             }
 
-            /* fulfill order_attribute_combination and decrease stock */
-            foreach ($pse->getAttributeCombinations() as $attributeCombination) {
-                /** @var \Thelia\Model\Attribute $attribute */
-                $attribute = I18n::forceI18nRetrieving($lang->getLocale(), 'Attribute', $attributeCombination->getAttributeId());
+            $con->commit();
 
-                /** @var \Thelia\Model\AttributeAv $attributeAv */
-                $attributeAv = I18n::forceI18nRetrieving($lang->getLocale(), 'AttributeAv', $attributeCombination->getAttributeAvId());
+            return $placedOrder;
+        } catch (\Throwable $throwable) {
+            // Placing an order writes to a dozen tables; a failure anywhere in
+            // between used to leave the transaction — and its locks — open.
+            $con->rollBack();
 
-                $orderAttributeCombination = new OrderProductAttributeCombination();
-                $orderAttributeCombination
-                    ->setOrderProductId($orderProduct->getId())
-                    ->setAttributeTitle($attribute->getTitle())
-                    ->setAttributeChapo($attribute->getChapo())
-                    ->setAttributeDescription($attribute->getDescription())
-                    ->setAttributePostscriptum($attribute->getPostscriptum())
-                    ->setAttributeAvTitle($attributeAv->getTitle())
-                    ->setAttributeAvChapo($attributeAv->getChapo())
-                    ->setAttributeAvDescription($attributeAv->getDescription())
-                    ->setAttributeAvPostscriptum($attributeAv->getPostscriptum())
-                    ->save($con);
-            }
+            throw $throwable;
         }
-
-        $con->commit();
-
-        return $placedOrder;
     }
 
     /**

--- a/core/lib/Thelia/Action/Order.php
+++ b/core/lib/Thelia/Action/Order.php
@@ -499,7 +499,7 @@ class Order extends BaseAction implements EventSubscriberInterface
             $event->setOrder($order);
 
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollBack();
 
             throw $ex;

--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -168,7 +168,7 @@ class Product extends BaseAction implements EventSubscriberInterface
             $this->eventDispatcher->dispatch($event, TheliaEvents::PSE_CLONE);
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
             throw $e;
         }
@@ -372,7 +372,7 @@ class Product extends BaseAction implements EventSubscriberInterface
 
                 $event->setProduct($product);
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }
@@ -423,7 +423,7 @@ class Product extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }
@@ -635,7 +635,7 @@ class Product extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollBack();
 
             throw $ex;

--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -102,7 +102,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;
@@ -204,7 +204,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;
@@ -256,7 +256,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
                 // Store all the stuff !
                 $con->commit();
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
                 $con->rollback();
 
                 throw $ex;
@@ -305,7 +305,7 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;

--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -189,7 +189,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }
@@ -305,7 +305,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 }
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }
@@ -339,7 +339,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
             $event->setSale($sale);
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
             throw $e;
         }
@@ -374,7 +374,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
                 $event->setSale($sale);
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollback();
                 throw $e;
             }
@@ -405,7 +405,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
             ;
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
             throw $e;
         }
@@ -461,7 +461,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
             }
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollback();
             throw $e;
         }

--- a/core/lib/Thelia/Action/Template.php
+++ b/core/lib/Thelia/Action/Template.php
@@ -145,7 +145,7 @@ class Template extends BaseAction implements EventSubscriberInterface
                         ->update(['DefaultTemplateId' => null], $con);
 
                     $con->commit();
-                } catch (\Exception $ex) {
+                } catch (\Throwable $ex) {
                     $con->rollback();
 
                     throw $ex;

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
@@ -69,7 +69,7 @@ readonly class PropelPersistProcessor implements ProcessorInterface
             $propelModel->reload();
 
             $data->setId($propelModel->getId());
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $connection->rollBack();
             throw $exception;
         }

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelRemoveProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelRemoveProcessor.php
@@ -47,7 +47,7 @@ readonly class PropelRemoveProcessor implements ProcessorInterface
             }
 
             $connection->commit();
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $connection->rollBack();
 
             throw $exception;

--- a/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Loader/XmlFileLoader.php
@@ -408,6 +408,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($e->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -488,6 +494,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($e->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -532,6 +544,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($e->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 
@@ -612,6 +630,12 @@ class XmlFileLoader extends FileLoader
             $con->rollBack();
 
             Tlog::getInstance()->error($e->getMessage());
+        } catch (\Throwable $throwable) {
+            // A malformed config entry is logged and skipped, but an Error keeps
+            // propagating as before: only the rollback is new.
+            $con->rollBack();
+
+            throw $throwable;
         }
     }
 

--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -257,13 +257,27 @@ class Update
             $this->connection->commit();
             $this->log('debug', 'update successfully');
         } catch (\Exception $e) {
-            $this->connection->rollBack();
+            // The guard matters here: $this->connection is the raw PDO handle
+            // unwrapped in the constructor, and its rollBack() throws when no
+            // transaction is open — which happens when the failure comes from the
+            // logging that follows commit().
+            if ($this->connection->inTransaction()) {
+                $this->connection->rollBack();
+            }
 
             $this->log('error', sprintf('error during update process with message : %s', $e->getMessage()));
 
             $ex = new UpdateException($e->getMessage(), $e->getCode(), $e->getPrevious());
             $ex->setVersion($version);
             throw $ex;
+        } catch (\Throwable $throwable) {
+            // An Error is not turned into an UpdateException — the installer keeps
+            // seeing it as it is today — but the update transaction is closed.
+            if ($this->connection->inTransaction()) {
+                $this->connection->rollBack();
+            }
+
+            throw $throwable;
         }
         $this->log('debug', 'end of update processing');
 

--- a/core/lib/Thelia/Model/Content.php
+++ b/core/lib/Thelia/Model/Content.php
@@ -144,7 +144,7 @@ class Content extends BaseContent implements FileModelParentInterface
             $this->setDefaultFolder($defaultFolderId)->save($con);
 
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -100,7 +100,7 @@ class Country extends BaseCountry
                 ->save($con);
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
             throw $e;
         }

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -13,7 +13,6 @@
 namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\Base\Country as BaseCountry;

--- a/core/lib/Thelia/Model/Coupon.php
+++ b/core/lib/Thelia/Model/Coupon.php
@@ -133,7 +133,7 @@ class Coupon extends BaseCoupon
             }
 
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -150,7 +150,7 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
             $this->save($con);
 
             $con->commit();
-        } catch (PropelException $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
             throw $e;
         }

--- a/core/lib/Thelia/Model/CustomerTitle.php
+++ b/core/lib/Thelia/Model/CustomerTitle.php
@@ -35,7 +35,7 @@ class CustomerTitle extends BaseCustomerTitle
             $this->setByDefault(1)->save();
 
             $con->commit();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $con->rollBack();
 
             throw $e;

--- a/core/lib/Thelia/Model/Lang.php
+++ b/core/lib/Thelia/Model/Lang.php
@@ -13,7 +13,6 @@
 namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Thelia\Model\Base\Lang as BaseLang;
 use Thelia\Model\Map\LangTableMap;
@@ -64,7 +63,7 @@ class Lang extends BaseLang
                     ->save($con);
 
                 $con->commit();
-            } catch (PropelException $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }

--- a/core/lib/Thelia/Model/Product.php
+++ b/core/lib/Thelia/Model/Product.php
@@ -186,7 +186,7 @@ class Product extends BaseProduct implements FileModelParentInterface
 
             // Store all the stuff !
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $con->rollback();
 
             throw $ex;

--- a/core/lib/Thelia/Model/Tools/PositionManagementTrait.php
+++ b/core/lib/Thelia/Model/Tools/PositionManagementTrait.php
@@ -113,6 +113,12 @@ trait PositionManagementTrait
                 $cnx->commit();
             } catch (\Exception $e) {
                 $cnx->rollback();
+            } catch (\Throwable $throwable) {
+                // A position swap is best-effort, but an Error is not: it keeps
+                // propagating as before, only without leaving the transaction open.
+                $cnx->rollback();
+
+                throw $throwable;
             }
         }
     }
@@ -177,6 +183,12 @@ trait PositionManagementTrait
                 $cnx->commit();
             } catch (\Exception $e) {
                 $cnx->rollback();
+            } catch (\Throwable $throwable) {
+                // A position swap is best-effort, but an Error is not: it keeps
+                // propagating as before, only without leaving the transaction open.
+                $cnx->rollback();
+
+                throw $throwable;
             }
         }
     }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -101,7 +101,7 @@ class BaseModule implements BaseModuleInterface
                 $this->initializeCoreI18n();
                 $this->postActivation($con);
                 $con->commit();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 $moduleModel->setActivate(self::IS_NOT_ACTIVATED);
                 $moduleModel->save();
@@ -128,7 +128,7 @@ class BaseModule implements BaseModuleInterface
 
                     $con->commit();
                 }
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $con->rollBack();
                 throw $e;
             }

--- a/core/lib/Thelia/Module/BaseModule.php
+++ b/core/lib/Thelia/Module/BaseModule.php
@@ -127,6 +127,11 @@ class BaseModule implements BaseModuleInterface
                     $this->postDeactivation($con);
 
                     $con->commit();
+                } else {
+                    // A module refusing its own deactivation is a normal outcome:
+                    // discard whatever preDeactivation() wrote instead of leaving
+                    // the transaction — and its locks — open.
+                    $con->rollBack();
                 }
             } catch (\Throwable $e) {
                 $con->rollBack();
@@ -269,50 +274,58 @@ class BaseModule implements BaseModuleInterface
                 if (Image::isImage($filePath)) {
                     $con->beginTransaction();
 
-                    $image = new ModuleImage();
-                    $image->setModuleId($module->getId());
-                    $image->setPosition($imagePosition);
-                    $image->save($con);
+                    try {
+                        $image = new ModuleImage();
+                        $image->setModuleId($module->getId());
+                        $image->setPosition($imagePosition);
+                        $image->save($con);
 
-                    $imageDirectory = sprintf('%s/media/images/module', THELIA_LOCAL_DIR);
-                    $imageFileName = sprintf('%s-%d-%s', $module->getCode(), $image->getId(), $fileName);
+                        $imageDirectory = sprintf('%s/media/images/module', THELIA_LOCAL_DIR);
+                        $imageFileName = sprintf('%s-%d-%s', $module->getCode(), $image->getId(), $fileName);
 
-                    $increment = 0;
-                    while (file_exists($imageDirectory.'/'.$imageFileName)) {
-                        $imageFileName = sprintf(
-                            '%s-%d-%d-%s',
-                            $module->getCode(),
-                            $image->getId(),
-                            $increment,
-                            $fileName
-                        );
-                        ++$increment;
-                    }
+                        $increment = 0;
+                        while (file_exists($imageDirectory.'/'.$imageFileName)) {
+                            $imageFileName = sprintf(
+                                '%s-%d-%d-%s',
+                                $module->getCode(),
+                                $image->getId(),
+                                $increment,
+                                $fileName
+                            );
+                            ++$increment;
+                        }
 
-                    $imagePath = sprintf('%s/%s', $imageDirectory, $imageFileName);
+                        $imagePath = sprintf('%s/%s', $imageDirectory, $imageFileName);
 
-                    if (!is_dir($imageDirectory)) {
-                        if (!@mkdir($imageDirectory, 0777, true)) {
-                            $con->rollBack();
+                        if (!is_dir($imageDirectory)) {
+                            if (!@mkdir($imageDirectory, 0777, true)) {
+                                throw new ModuleException(
+                                    sprintf('Cannot create directory : %s', $imageDirectory),
+                                    ModuleException::CODE_NOT_FOUND
+                                );
+                            }
+                        }
+
+                        if (!@copy($filePath, $imagePath)) {
                             throw new ModuleException(
-                                sprintf('Cannot create directory : %s', $imageDirectory),
+                                sprintf('Cannot copy file : %s to : %s', $filePath, $imagePath),
                                 ModuleException::CODE_NOT_FOUND
                             );
                         }
-                    }
 
-                    if (!@copy($filePath, $imagePath)) {
+                        $image->setFile($imageFileName);
+                        $image->save($con);
+
+                        $con->commit();
+                    } catch (\Throwable $throwable) {
+                        // The two ModuleException paths used to roll back by hand; a
+                        // failing save() did not, and left the transaction open for
+                        // the rest of the install.
                         $con->rollBack();
-                        throw new ModuleException(
-                            sprintf('Cannot copy file : %s to : %s', $filePath, $imagePath),
-                            ModuleException::CODE_NOT_FOUND
-                        );
+
+                        throw $throwable;
                     }
 
-                    $image->setFile($imageFileName);
-                    $image->save($con);
-
-                    $con->commit();
                     ++$imagePosition;
                 }
             }

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -160,7 +160,7 @@ class ModuleManagement
             }
 
             $con->commit();
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             Tlog::getInstance()->addError('Failed to update module '.$module->getCode(), $ex);
 
             $con->rollBack();

--- a/tests/Legacy/Action/TransactionRollbackOnErrorTest.php
+++ b/tests/Legacy/Action/TransactionRollbackOnErrorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Action;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Propel;
+use Thelia\Action\Address;
+use Thelia\Core\Event\Address\AddressCreateOrUpdateEvent;
+use Thelia\Model\Address as AddressModel;
+use Thelia\Model\CustomerQuery;
+use Thelia\Model\Map\AddressTableMap;
+
+/**
+ * The actions wrap their writes in a Propel transaction and roll it back from a
+ * catch block. When that catch was narrower than \Throwable, an Error thrown by
+ * the code inside the try (a TypeError, a call on null, a module listener
+ * blowing up) escaped with the transaction still open: the connection kept its
+ * row and metadata locks, and every later write on the same tables waited for
+ * the lock timeout. That is how a single failure in this suite turned into six.
+ *
+ * The nesting counter of the Propel connection is what makes this observable:
+ * it goes back to its starting value once the transaction has been closed, and
+ * stays one level above it when the transaction leaked.
+ */
+class TransactionRollbackOnErrorTest extends BaseAction
+{
+    public function testAddressUpdateRollsBackWhenANonPropelErrorEscapes(): void
+    {
+        $customer = CustomerQuery::create()->findOne();
+        $address = $customer->getAddresses()->getFirst();
+
+        $connection = Propel::getWriteConnection(AddressTableMap::DATABASE_NAME);
+        self::assertInstanceOf(ConnectionWrapper::class, $connection);
+
+        $nestingBeforeTheAction = $connection->getNestedTransactionCount();
+
+        // A model whose save() raises an Error stands for any non-Exception
+        // failure happening inside the action's transaction.
+        $failingAddress = new class() extends AddressModel {
+            public function save(ConnectionInterface $con = null): void
+            {
+                throw new \Error('Error raised inside the action transaction');
+            }
+        };
+        $failingAddress->setId($address->getId());
+        $failingAddress->setCustomerId($customer->getId());
+        $failingAddress->setNew(false);
+
+        $event = new AddressCreateOrUpdateEvent(
+            'test address',
+            1,
+            'Thelia',
+            'Thelia',
+            '5 rue rochon',
+            '',
+            '',
+            '63000',
+            'clermont-ferrand',
+            64,
+            '0102030405',
+            '',
+            ''
+        );
+        $event->setAddress($failingAddress);
+
+        try {
+            (new Address())->update($event, null, $this->getMockEventDispatcher());
+
+            self::fail('The Error raised by save() should have propagated out of the action.');
+        } catch (\Error $error) {
+            // The error must still reach the caller unchanged: the fix only adds
+            // the rollback, it does not swallow anything.
+            self::assertSame('Error raised inside the action transaction', $error->getMessage());
+        }
+
+        self::assertSame(
+            $nestingBeforeTheAction,
+            $connection->getNestedTransactionCount(),
+            'The action left its transaction open: every later write on address will now wait for the lock timeout.'
+        );
+    }
+}


### PR DESCRIPTION
The `2.6` counterpart of #3613. This is where the defect was observed: it turned one
failure of the legacy suite into six by poisoning the following tests with 50-second lock
waits.

## Symptom

An action opens a Propel transaction and rolls it back from a `catch` block. When that
`catch` is narrower than `\Throwable`, an `Error` raised by the code inside the `try` —
a `TypeError`, a call on null, a module listener blowing up — escapes with the
transaction still open. The connection keeps its row and metadata locks, and every
later write on the same tables waits until the lock timeout.

In production the defect hides itself: the request dies anyway, and the leaked
transaction only surfaces later as unexplained lock waits on unrelated requests.

## Cause

`core/lib/Thelia/Action/Address.php:89` (before this change):

```php
$con->beginTransaction();
try {
    // ...
    $con->commit();
} catch (PropelException $e) {
    $con->rollback();
    throw $e;
}
```

`PropelException` extends `\Exception`, so `\Error` never matches. The same shape is
used at 44 transaction sites in `core/lib/`: 11 catch `PropelException`, 27 catch
`\Exception` (which also lets `\Error` through), and 4 close the transaction on some
exit paths only.

The exit paths that never closed the transaction:

- `core/lib/Thelia/Action/Order.php:158` — `createOrder()` opened a transaction and
  committed it 200 lines later with **no `try` at all**. Any failure while placing an
  order left the transaction, and its locks on `order`, `order_product`, `order_address`
  and the stock columns, open. This is the front-office checkout path.
- `core/lib/Thelia/Action/Module.php:205` — `beginTransaction()` ran before the
  `if (null !== $module = ...)` guard, so a delete request for an unknown module id
  returned with the transaction open.
- `core/lib/Thelia/Module/BaseModule.php:122` — `deActivate()` committed only when
  `preDeactivation()` returned true; a module refusing its own deactivation left the
  transaction open.
- `core/lib/Thelia/Module/BaseModule.php:270` — `deployImageFolder()` opened a
  transaction per image with no `try`; only two of its failure paths rolled back by
  hand, a failing `save()` leaked.

## Fix

Two rules, applied site by site rather than uniformly, because a `catch` that swallows
or replaces an exception cannot be widened without changing what the caller sees:

1. **The handler rethrows the same object** → the caught type is widened to
   `\Throwable`. The exception still propagates unchanged; only the rollback now also
   happens for an `\Error`. 38 sites in `Action/`, `Model/`,
   `Api/Bridge/Propel/State/`, `Module/`.
2. **The handler swallows or replaces the exception** → it is left untouched and a
   `catch (\Throwable $throwable) { rollBack(); throw $throwable; }` is appended after
   it. An `\Error` keeps propagating exactly as it does today, it is simply no longer
   preceded by a leaked transaction. `XmlFileLoader` (logs the error and continues),
   `PositionManagementTrait` (a best-effort position swap, swallowed) and
   `Install/Update.php` (wraps into `UpdateException`) fall here.

`Install/Update.php` also gains an `inTransaction()` guard around its rollback. Unlike
everywhere else, `$this->connection` there is the raw PDO handle unwrapped in the
constructor, and PDO's `rollBack()` throws when no transaction is open — which is
reachable today, because the `$this->log('debug', 'update successfully')` that follows
`commit()` sits inside the `try`. Propel's `ConnectionWrapper` guards its own
`rollBack()` with `$opcount > 0 && inTransaction()`, so the wrapped connections used
everywhere else are already safe on an already-closed transaction.

`Action\Module::delete()` had the same hazard: `$event->setModule()` and `cacheClear()`
ran inside the `try`, after `commit()`. They are moved out of it.

The two `Order::createOrder()` and `deployImageFolder()` wraps are indentation only
around the existing code — `git diff -w` shows just the added `try`/`catch`.

## Verifying

`tests/Legacy/Action/TransactionRollbackOnErrorTest.php` drives `Action\Address::update()`
with an address model whose `save()` raises an `\Error`, then asserts the transaction was
closed. The state is observed, not assumed, through Propel's nesting counter, which goes
back to its starting value once the transaction is closed and stays one level above it
when it leaked.

Without the fix:

```
The action left its transaction open: every later write on address will now wait for the lock timeout.
Failed asserting that 1 is identical to 0.
```

With it, `OK (1 test, 3 assertions)`. The test also asserts the `\Error` still reaches
the caller with its message intact, so a handler that started swallowing would fail too.

Full local `composer ci` on an isolated database: `cs-diff` 0/1956, unit 22, functional
81, legacy 584 (24 skipped, 11 risky) — all green.

Refs #3609
