### PR TITLE
fix: keep the generated Propel models when the kernel cache is cleared

### DIFF
--- a/core/lib/Thelia/Action/Cache.php
+++ b/core/lib/Thelia/Action/Cache.php
@@ -28,8 +28,20 @@ use Thelia\Core\Event\TheliaEvents;
  */
 class Cache extends BaseAction implements EventSubscriberInterface
 {
+    /**
+     * Entries of the Propel cache a kernel cache clear keeps: the generated
+     * models, the database map they rely on, its loader script, and the schema
+     * hash they were built from. The hash is what makes keeping them safe —
+     * PropelInitService::buildPropelModels() rebuilds everything as soon as the
+     * schema recombined on the next boot no longer matches it.
+     */
+    private const PRESERVED_PROPEL_ENTRIES = ['model', 'database', 'loader', 'hash'];
+
     /** @var AdapterInterface */
     protected $adapter;
+
+    /** @var string */
+    protected $kernelCacheDir;
 
     /**
      * @var CacheEvent[]
@@ -39,9 +51,10 @@ class Cache extends BaseAction implements EventSubscriberInterface
     /**
      * CacheListener constructor.
      */
-    public function __construct(AdapterInterface $adapter)
+    public function __construct(AdapterInterface $adapter, string $kernelCacheDir)
     {
         $this->adapter = $adapter;
+        $this->kernelCacheDir = $kernelCacheDir;
     }
 
     public function cacheClear(CacheEvent $event): void
@@ -77,9 +90,49 @@ class Cache extends BaseAction implements EventSubscriberInterface
         $this->adapter->clear();
 
         $dir = $event->getDir();
+        $propelDir = rtrim($dir, DS).DS.'propel';
 
         $fs = new Filesystem();
-        $fs->remove($dir);
+
+        if (!$this->isKernelCacheDir($dir) || !is_dir($propelDir)) {
+            $fs->remove($dir);
+
+            return;
+        }
+
+        // PropelInitService keeps its cache inside the kernel cache, so removing
+        // the whole directory used to take the generated models with it and
+        // rebuild all of them on the next boot. Everything else still goes,
+        // including the combined schema: it is recombined on the next boot, and
+        // the models are rebuilt only if that changes the hash.
+        foreach ($this->childrenOf($dir) as $entry) {
+            if ('propel' !== $entry) {
+                $fs->remove(rtrim($dir, DS).DS.$entry);
+
+                continue;
+            }
+
+            foreach ($this->childrenOf($propelDir) as $propelEntry) {
+                if (\in_array($propelEntry, self::PRESERVED_PROPEL_ENTRIES, true)) {
+                    continue;
+                }
+
+                $fs->remove($propelDir.DS.$propelEntry);
+            }
+        }
+    }
+
+    private function isKernelCacheDir(string $dir): bool
+    {
+        return rtrim($dir, DS) === rtrim($this->kernelCacheDir, DS);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function childrenOf(string $dir): array
+    {
+        return array_diff((array) scandir($dir), ['.', '..']);
     }
 
     public static function getSubscribedEvents(): array

--- a/tests/Legacy/Action/CacheTest.php
+++ b/tests/Legacy/Action/CacheTest.php
@@ -44,7 +44,7 @@ class CacheTest extends TestCase
         $event = new CacheEvent($this->dir, false);
 
         $adapter = new ArrayAdapter();
-        $action = new Cache($adapter);
+        $action = new Cache($adapter, __DIR__.'/kernel-cache');
         $action->cacheClear($event);
 
         $fs = new Filesystem();
@@ -56,7 +56,7 @@ class CacheTest extends TestCase
         $event = new CacheEvent($this->dir2);
 
         $adapter = new ArrayAdapter();
-        $action = new Cache($adapter);
+        $action = new Cache($adapter, __DIR__.'/kernel-cache');
         $action->cacheClear($event);
 
         $fs = new Filesystem();

--- a/tests/Unit/Action/CacheTest.php
+++ b/tests/Unit/Action/CacheTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Action;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Action\Cache;
+use Thelia\Core\Event\Cache\CacheEvent;
+
+/**
+ * PropelInitService keeps its cache inside the kernel cache, so clearing the
+ * kernel cache used to take the generated Propel models with it and rebuild all
+ * of them on the next boot. What has to survive is exactly what the schema hash
+ * guards; everything else, the combined schema included, still goes.
+ */
+final class CacheTest extends TestCase
+{
+    private Filesystem $filesystem;
+    private string $kernelCacheDir;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->kernelCacheDir = sys_get_temp_dir().'/thelia_cache_action_'.uniqid();
+
+        foreach ([
+            'ContainerAbc123/Thelia_KernelDevDebugContainer.php',
+            'propel/model/Thelia/Model/Base/Product.php',
+            'propel/model/hash',
+            'propel/database/TheliaMain/TheliaMainDatabase.php',
+            'propel/loader/loadDatabase.php',
+            'propel/hash',
+            'propel/config/propel.yml',
+            'propel/schema/TheliaMain.schema.xml',
+        ] as $file) {
+            $this->filesystem->dumpFile($this->kernelCacheDir.'/'.$file, 'x');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->kernelCacheDir);
+    }
+
+    public function testClearingTheKernelCacheKeepsTheGeneratedPropelModels(): void
+    {
+        $this->action()->cacheClear(new CacheEvent($this->kernelCacheDir, false));
+
+        self::assertDirectoryDoesNotExist($this->kernelCacheDir.'/ContainerAbc123');
+        self::assertFileExists($this->kernelCacheDir.'/propel/model/Thelia/Model/Base/Product.php');
+        self::assertFileExists($this->kernelCacheDir.'/propel/model/hash');
+        self::assertFileExists($this->kernelCacheDir.'/propel/database/TheliaMain/TheliaMainDatabase.php');
+        self::assertFileExists($this->kernelCacheDir.'/propel/loader/loadDatabase.php');
+        self::assertFileExists($this->kernelCacheDir.'/propel/hash');
+    }
+
+    public function testClearingTheKernelCacheStillInvalidatesTheCombinedSchema(): void
+    {
+        $this->action()->cacheClear(new CacheEvent($this->kernelCacheDir, false));
+
+        // Recombined on the next boot, which is what makes keeping the models
+        // safe: a schema that really moved no longer matches their hash.
+        self::assertDirectoryDoesNotExist($this->kernelCacheDir.'/propel/schema');
+        self::assertDirectoryDoesNotExist($this->kernelCacheDir.'/propel/config');
+    }
+
+    public function testClearingAnyOtherDirectoryRemovesItEntirely(): void
+    {
+        $assetsDir = sys_get_temp_dir().'/thelia_cache_action_assets_'.uniqid();
+        $this->filesystem->dumpFile($assetsDir.'/propel/model/keep-nothing', 'x');
+
+        $this->action()->cacheClear(new CacheEvent($assetsDir, false));
+
+        self::assertDirectoryDoesNotExist($assetsDir);
+    }
+
+    private function action(): Cache
+    {
+        return new Cache(new NullAdapter(), $this->kernelCacheDir);
+    }
+}


### PR DESCRIPTION
Fixes #3608

## Symptom

On `2.6`, clearing the cache regenerates all 616 generated Propel model files — 25 MB — even though no schema changed. Every `CACHE_CLEAR` pays for it: the back-office "flush application cache" button, module install, activation and deactivation, moving a hook one position, saving a translation.

Measured on a demo install (DDEV, PHP 8.2, `dev`, front page, 5 runs, medians):

| Request | Current | Sparing the models |
|---|---|---|
| the one that rebuilds | 3.75 s | **2.96 s** |
| the one after | 0.49 s | **0.18 s** |
| steady state | 0.15 s | 0.15 s |
| `propel/model` mtime | rewritten every time | untouched |

About 1.1 s per cache clear. The second request matters as much as the first: 616 model files rewritten have no opcode-cache entry any more, so every PHP-FPM worker recompiles them, not just the one that did the rebuild.

## Cause

`PropelInitService::getPropelCacheDir()` returns `THELIA_CACHE_DIR.<env>/propel/` (`core/lib/Thelia/Core/PropelInitService.php:100-103`), a subdirectory of the kernel cache. `Action\Cache::execCacheClear()` removed the whole target directory (`core/lib/Thelia/Action/Cache.php:77-85`), so the combined schema, the generated models, the database map and **both hash files** went with it. With `propel/model/hash` gone, the guard in `buildPropelModels()` (`:316-319`) can no longer tell that the schema is unchanged, and rebuilds everything.

This is why #3591 believed Thelia 3 regenerated its models: on `main` the Propel cache moved out of the kernel cache in #3410, so only the schema was ever dropped there.

## Fix

When the directory being cleared is the kernel cache directory, remove its contents but keep the four Propel entries that the schema hash guards: `model`, `database`, `loader`, `hash`. Everything else still goes — the compiled container, and inside `propel/` the combined `schema/` and the `config/` derived from the database credentials.

Nothing else about the clear changes. In particular the combined schema is still recombined on the next boot, so `PropelInitService::init()` still reports a cache refresh and `Thelia::boot()` still runs `ModuleManagement::updateModules()` (`core/lib/Thelia/Core/Thelia.php:303-306`). Only the model rebuild is skipped, and only when the recombined schema still matches the hash the models were built from.

Any other directory — `web/assets`, the image and document caches — is removed exactly as before.

## Why this rather than moving the Propel cache out of the kernel cache

Moving it, as `main` did, is a larger change on a maintenance branch and it takes the invalidation of `propel/config` with it: the Propel configuration is a `ConfigCache` written without resources, so once it exists it is fresh forever. Today a cache clear is what re-reads the database credentials from the environment. Keeping the Propel cache where it is preserves that.

## The stale-model risk, ruled out

The models survive a clear, so the question is whether a real schema change can leave them stale. It cannot: the clear still drops `propel/schema`, the next boot recombines it and writes `propel/hash`, and `buildPropelModels()` compares that hash with `propel/model/hash`.

Checked on the demo install, adding a column to a module schema (`local/modules/Carousel/Config/schema.xml`):

```
# clear, no schema change
propel/model mtime unchanged, propel/hash rewritten

# add <column name="stale_probe" .../>, clear again
propel/model mtime updated
grep -c stale_probe var/cache/dev/propel/model/Carousel/Model/Base/Carousel.php  ->  13

# revert the column, clear again
grep -c stale_probe ...  ->  0
```

## Verifying

```
php Thelia thelia:config ...            # anything that warms the cache
stat -c %Y var/cache/dev/propel/model
# back office > Configuration > Advanced > flush application cache, then reload the front
stat -c %Y var/cache/dev/propel/model   # unchanged
ls var/cache/dev/propel/schema          # gone, recombined on the next boot
```

Tests: `tests/Unit/Action/CacheTest.php` covers the three branches — the kernel cache keeps the model artefacts, still loses the combined schema and the Propel config, and any other directory is removed whole. The first fails on the current behaviour and passes with the fix. `tests/Legacy/Action/CacheTest.php` follows the new constructor signature.

Local run: `cs-diff` 0 of 1957, `test-unit` 46 green, `test-legacy` 583 green (24 skipped, 11 risky), `test-functional` 81 with 2 errors and 1 failure — identical with and without this change, and caused by the shared database that environment reuses across suites.

## Upgrading

`Action\Cache` takes the kernel cache directory as a second constructor argument, autowired through the existing `$kernelCacheDir` binding. The compiled container has to be rebuilt, which the update process already does; a container left over from an earlier version fails with `Too few arguments to Thelia\Action\Cache::__construct()`.

## Noted while investigating, not changed here

- `php bin/console cache:clear` removes `var/cache/<env>` itself, so it still takes the Propel cache with it. Unchanged, and it is a developer command.
- An in-process `CACHE_CLEAR` breaks the rest of the process: the removed container directory takes with it the service files that have not been loaded yet. Pre-existing, and the same defect as #3607 on `main`.
- `Thelia\Command\CacheClear` is registered as `cache:clear` here too, so FrameworkBundle's command shadows it and Thelia's own invalidation is unreachable from the console. Same as #3607 on `main`.
