### PR TITLE
fix: index the tax factor cache on the order or cart it was computed for

### DIFF
--- a/core/lib/Thelia/TaxEngine/Calculator.php
+++ b/core/lib/Thelia/TaxEngine/Calculator.php
@@ -49,6 +49,20 @@ class Calculator
     protected $country;
     protected $state;
 
+    /**
+     * Tax factors already computed in this process, indexed on the order or the
+     * cart they were computed for. A single request handles several of them —
+     * the back-office order list, for one — and each has its own tax rates.
+     *
+     * @var \WeakMap<Order, float>|null
+     */
+    private static $orderTaxFactors;
+
+    /**
+     * @var \WeakMap<Cart, array<string, float>>|null
+     */
+    private static $cartTaxFactors;
+
     public function __construct()
     {
         $this->taxRuleQuery = new TaxRuleQuery();
@@ -87,33 +101,32 @@ class Calculator
      */
     public static function getOrderTaxFactor(Order $order)
     {
-        // Cache the result in a local variable
-        static $orderTaxFactor;
-
-        if (null === $orderTaxFactor) {
-            if ((float) $order->getDiscount() === 0.0) {
-                return 1;
-            }
-
-            // Find the average Tax rate (see \Thelia\TaxEngine\Calculator::getCartTaxFactor())
-            $orderTaxFactors = [];
-
-            /** @var \Thelia\Model\OrderProduct $orderProduct */
-            foreach ($order->getOrderProducts() as $orderProduct) {
-                /** @var \Thelia\Core\Template\Loop\OrderProductTax $orderProductTax */
-                foreach ($orderProduct->getOrderProductTaxes() as $orderProductTax) {
-                    $orderTaxFactors[] = 1 + $orderProductTax->getAmount() / $orderProduct->getPrice();
-                }
-            }
-
-            if (0 === $orderTaxfactorCount = \count($orderTaxFactors)) {
-                return 1;
-            }
-
-            $orderTaxFactor = array_sum($orderTaxFactors) / \count($orderTaxFactors);
+        if ((float) $order->getDiscount() === 0.0) {
+            return 1;
         }
 
-        return $orderTaxFactor;
+        self::$orderTaxFactors = self::$orderTaxFactors ?? new \WeakMap();
+
+        if (isset(self::$orderTaxFactors[$order])) {
+            return self::$orderTaxFactors[$order];
+        }
+
+        // Find the average Tax rate (see \Thelia\TaxEngine\Calculator::getCartTaxFactor())
+        $orderTaxFactors = [];
+
+        /** @var \Thelia\Model\OrderProduct $orderProduct */
+        foreach ($order->getOrderProducts() as $orderProduct) {
+            /** @var \Thelia\Core\Template\Loop\OrderProductTax $orderProductTax */
+            foreach ($orderProduct->getOrderProductTaxes() as $orderProductTax) {
+                $orderTaxFactors[] = 1 + $orderProductTax->getAmount() / $orderProduct->getPrice();
+            }
+        }
+
+        if ([] === $orderTaxFactors) {
+            return 1;
+        }
+
+        return self::$orderTaxFactors[$order] = array_sum($orderTaxFactors) / \count($orderTaxFactors);
     }
 
     /**
@@ -123,30 +136,45 @@ class Calculator
      */
     public static function getCartTaxFactor(Cart $cart, Country $country, State $state = null)
     {
-        // Cache the result in a local variable
-        static $cartFactor;
-
-        if (null === $cartFactor) {
-            if ((float) $cart->getDiscount() === 0.0) {
-                return 1;
-            }
-
-            $cartItems = $cart->getCartItems();
-
-            // Get the average of tax factor to apply it to the discount
-            $cartTaxFactors = [];
-
-            /** @var CartItem $cartItem */
-            foreach ($cartItems as $cartItem) {
-                $taxRulesCollection = TaxRuleQuery::create()->getTaxCalculatorCollection($cartItem->getProduct()->getTaxRule(), $country, $state);
-                /** @var TaxRule $taxRule */
-                foreach ($taxRulesCollection as $taxRule) {
-                    $cartTaxFactors[] = 1 + $taxRule->getTypeInstance()->pricePercentRetriever();
-                }
-            }
-
-            $cartFactor = array_sum($cartTaxFactors) / \count($cartTaxFactors);
+        if ((float) $cart->getDiscount() === 0.0) {
+            return 1;
         }
+
+        $cartItems = $cart->getCartItems();
+
+        // The factor depends on the destination and on the products in the cart,
+        // both of which change while a request is being served.
+        $key = implode(':', [$country->getId(), $state !== null ? $state->getId() : null]);
+
+        /** @var CartItem $cartItem */
+        foreach ($cartItems as $cartItem) {
+            $key .= ':'.$cartItem->getProductId();
+        }
+
+        self::$cartTaxFactors = self::$cartTaxFactors ?? new \WeakMap();
+
+        $cartFactors = self::$cartTaxFactors[$cart] ?? [];
+
+        if (isset($cartFactors[$key])) {
+            return $cartFactors[$key];
+        }
+
+        // Get the average of tax factor to apply it to the discount
+        $cartTaxFactors = [];
+
+        /** @var CartItem $cartItem */
+        foreach ($cartItems as $cartItem) {
+            $taxRulesCollection = TaxRuleQuery::create()->getTaxCalculatorCollection($cartItem->getProduct()->getTaxRule(), $country, $state);
+            /** @var TaxRule $taxRule */
+            foreach ($taxRulesCollection as $taxRule) {
+                $cartTaxFactors[] = 1 + $taxRule->getTypeInstance()->pricePercentRetriever();
+            }
+        }
+
+        $cartFactor = array_sum($cartTaxFactors) / \count($cartTaxFactors);
+
+        $cartFactors[$key] = $cartFactor;
+        self::$cartTaxFactors[$cart] = $cartFactors;
 
         return $cartFactor;
     }

--- a/tests/Legacy/TaxEngine/TaxFactorScopeTest.php
+++ b/tests/Legacy/TaxEngine/TaxFactorScopeTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\TaxEngine;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Model\Cart;
+use Thelia\Model\CartItem;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderProduct;
+use Thelia\Model\OrderProductTax;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\Tax;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleCountry;
+use Thelia\TaxEngine\Calculator;
+
+/**
+ * The tax factor spreads a discount over the VAT rates of what is being bought,
+ * so it belongs to one order or one cart. A single request handles several of
+ * them: the back-office order list walks a whole page.
+ */
+class TaxFactorScopeTest extends TestCase
+{
+    /**
+     * @var array<\Thelia\Model\Tax|\Thelia\Model\TaxRule|\Thelia\Model\TaxRuleCountry>
+     */
+    private $createdRows = [];
+
+    protected function tearDown(): void
+    {
+        // Reverse creation order: the link row references both the rule and the tax.
+        foreach (array_reverse($this->createdRows) as $row) {
+            $row->delete();
+        }
+
+        $this->createdRows = [];
+    }
+
+    public function testEachOrderKeepsItsOwnTaxFactor(): void
+    {
+        $standardRate = $this->createDiscountedOrder('20.000000');
+        $reducedRate = $this->createDiscountedOrder('5.500000');
+
+        $this->assertEqualsWithDelta(1.2, Calculator::getOrderTaxFactor($standardRate), 0.0001);
+        $this->assertEqualsWithDelta(
+            1.055,
+            Calculator::getOrderTaxFactor($reducedRate),
+            0.0001,
+            'The second order of the request must not inherit the first order tax factor.'
+        );
+
+        // 10 of discount on goods taxed at 5.5 % is 9.48 before tax, not 8.33.
+        $this->assertEqualsWithDelta(
+            10 / 1.055,
+            Calculator::getUntaxedOrderDiscount($reducedRate),
+            0.0001
+        );
+    }
+
+    public function testEachCartKeepsItsOwnTaxFactor(): void
+    {
+        $country = CountryQuery::create()->findOne();
+        $products = ProductQuery::create()->limit(2)->find();
+
+        if ($country === null || \count($products) < 2) {
+            $this->markTestSkipped('Needs a country and two products to build two carts.');
+        }
+
+        $standardRate = $this->createDiscountedCart($products[0], $this->createTaxRule($country, '20'));
+        $reducedRate = $this->createDiscountedCart($products[1], $this->createTaxRule($country, '5.5'));
+
+        $this->assertEqualsWithDelta(1.2, Calculator::getCartTaxFactor($standardRate, $country), 0.0001);
+        $this->assertEqualsWithDelta(
+            1.055,
+            Calculator::getCartTaxFactor($reducedRate, $country),
+            0.0001,
+            'The second cart of the request must not inherit the first cart tax factor.'
+        );
+
+        $this->assertEqualsWithDelta(
+            10 / 1.055,
+            Calculator::getUntaxedCartDiscount($reducedRate, $country),
+            0.0001
+        );
+    }
+
+    /**
+     * An order and its lines are never saved: the factor is read off the object graph.
+     */
+    private function createDiscountedOrder(string $taxAmount): Order
+    {
+        $orderProductTax = new OrderProductTax();
+        $orderProductTax
+            ->setTitle('VAT')
+            ->setDescription('')
+            ->setAmount($taxAmount);
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setProductRef('taxed-ref')
+            ->setProductSaleElementsRef('taxed-pse-ref')
+            ->setTitle('Taxed product')
+            ->setQuantity(1.0)
+            ->setPrice('100.000000')
+            ->addOrderProductTax($orderProductTax);
+
+        $order = new Order();
+        $order
+            ->setDiscount('10.000000')
+            ->addOrderProduct($orderProduct);
+
+        return $order;
+    }
+
+    /**
+     * The cart is not saved either. The product comes from the database because the
+     * factor reads its tax rule, but the rule assigned here stays in memory.
+     */
+    private function createDiscountedCart($product, TaxRule $taxRule): Cart
+    {
+        $product->setTaxRule($taxRule);
+
+        $cartItem = new CartItem();
+        $cartItem
+            ->setProduct($product)
+            ->setQuantity(1)
+            ->setPrice('100')
+            ->setPromoPrice('100')
+            ->setPromo(0);
+
+        $cart = new Cart();
+        $cart
+            ->setDiscount('10.000000')
+            ->addCartItem($cartItem);
+
+        return $cart;
+    }
+
+    private function createTaxRule(Country $country, string $percent): TaxRule
+    {
+        $tax = new Tax();
+        $tax
+            ->setType('Thelia\TaxEngine\TaxType\PricePercentTaxType')
+            ->setRequirements(['percent' => $percent])
+            ->setLocale('en_US')
+            ->setTitle('VAT '.$percent)
+            ->setDescription('')
+            ->save();
+
+        $taxRule = new TaxRule();
+        $taxRule
+            ->setIsDefault(false)
+            ->setLocale('en_US')
+            ->setTitle('Tax rule '.$percent)
+            ->setDescription('')
+            ->save();
+
+        $taxRuleCountry = new TaxRuleCountry();
+        $taxRuleCountry
+            ->setTaxRuleId($taxRule->getId())
+            ->setCountryId($country->getId())
+            ->setTaxId($tax->getId())
+            ->setPosition(1)
+            ->save();
+
+        array_push($this->createdRows, $tax, $taxRule, $taxRuleCountry);
+
+        return $taxRule;
+    }
+}


### PR DESCRIPTION
## Symptom

The tax factor spreads an order or a cart discount over the VAT rates of the goods it applies to. As soon as one request handles more than one of them — the back-office order list walks a whole page of orders — every order after the first is charged the first order's rate, so its VAT base is wrong on the invoice.

Measured on `2.6` before this change, two orders of 100 with a 10 discount, one taxed at 20 % and one at 5.5 %, in a single process:

```
order #1 (20%)   factor=1.2000  untaxed discount=8.3333
order #2 (5.5%)  factor=1.2000  untaxed discount=8.3333   <- expected 1.0550 / 9.4787
```

1.15 of error on the second order's tax base. Two carts behave the same way.

## Cause

`core/lib/Thelia/TaxEngine/Calculator.php:91` and `:127` cached the result in a function-static variable:

```php
public static function getOrderTaxFactor(Order $order)
{
    // Cache the result in a local variable
    static $orderTaxFactor;

    if (null === $orderTaxFactor) {
```

A function static lives for the whole process and is not tied to the `$order` argument, so the first factor computed answers every later call whatever order or cart is passed.

The neighbouring `Order::getTotalAmount()` (`core/lib/Thelia/Model/Order.php:146`) already carries the right shape, and its comment at line 153 names this exact situation: the cache is static and has to be indexed on the order id, because a single request handles several orders, the back-office order list for one. The tax factors never got the same treatment.

Callers reached more than once per request: `core/lib/Thelia/Core/Template/Loop/Order.php:328`, `core/lib/Thelia/Model/Order.php:225` and `core/lib/Thelia/Model/Cart.php:280`.

## Fix

Memoize in a `\WeakMap` keyed on the order or the cart the factor was computed for. The cart entry is keyed further on the destination (country, state) and on the products in the cart, since both change while a request is being served. The zero-discount shortcut stays outside the memo, so a coupon applied mid-request is still taken into account.

`$orderTaxfactorCount`, assigned and never read since the count guard was written, is gone with it.

This is the same shape as #3596 on `main`, transposed to the `Thelia\TaxEngine` namespace and to the untyped signatures of this branch. The static-versus-instance question these helpers also raise is untouched here: this changes the cache only.

## Verifying

`tests/Legacy/TaxEngine/TaxFactorScopeTest.php` computes two orders and two carts at 20 % and 5.5 % in a single process and asserts each keeps its own factor. Without the fix both tests fail with `Failed asserting that 1.2 matches expected 1.055`; with it they pass.

The orders are built in memory. The carts need a tax rule in the database to read a rate from, so the test creates one rule per rate and removes it in `tearDown()`.