### PR TITLE
fix: never redirect a rewritten url to itself when the language domain is missing

### DIFF
--- a/core/lib/Thelia/Core/Routing/RewritingRouter.php
+++ b/core/lib/Thelia/Core/Routing/RewritingRouter.php
@@ -204,16 +204,49 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
 
         $currentLang = $request->getSession()->getLang();
 
-        if ($lang->getLocale() !== $currentLang?->getLocale()) {
-            if (ConfigQuery::isMultiDomainActivated()) {
-                $this->redirect(
-                    \sprintf('%s/%s', $lang->getUrl(), $resolver->rewrittenUrl),
-                    301,
-                );
-            } else {
-                $this->langService->setLang($lang);
+        if ($lang->getLocale() === $currentLang?->getLocale()) {
+            return;
+        }
+
+        if (ConfigQuery::isMultiDomainActivated()) {
+            $domainUrl = rtrim((string) $lang->getUrl(), '/');
+            $targetUrl = $domainUrl.'/'.$resolver->rewrittenUrl;
+
+            // An empty lang.url - the state of a fresh install until the per language domains
+            // are filled in - or a domain equal to the one being browsed makes that redirect
+            // point at the url that was just asked for, and a browser follows it until it gives
+            // up. Switch the session language and serve the page, as in single domain mode.
+            if ('' !== $domainUrl && !$this->isCurrentUrl($request, $targetUrl)) {
+                $this->redirect($targetUrl, 301);
             }
         }
+
+        $this->langService->setLang($lang);
+    }
+
+    /**
+     * A redirect to the url being served is never a useful answer: it only tells the browser
+     * to ask the same question again. Queries are ignored on purpose, since dropping them
+     * still lands on the same page, and so still loops.
+     */
+    private function isCurrentUrl(TheliaRequest $request, string $url): bool
+    {
+        $target = parse_url($url);
+
+        if (false === $target) {
+            return false;
+        }
+
+        // A host-less target is relative to the host being browsed.
+        $sameHost = !isset($target['host'])
+            || (
+                $target['host'] === $request->getHost()
+                && ($target['scheme'] ?? $request->getScheme()) === $request->getScheme()
+                && ($target['port'] ?? $request->getPort()) === $request->getPort()
+            );
+
+        return $sameHost
+            && trim($target['path'] ?? '', '/') === trim($request->getRealPathInfo(), '/');
     }
 
     private function defaultRouteParams(): array

--- a/tests/Integration/Core/Routing/RewritingRouterTest.php
+++ b/tests/Integration/Core/Routing/RewritingRouterTest.php
@@ -22,6 +22,7 @@ use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Routing\RewritingRouter;
 use Thelia\Model\Category;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\LangQuery;
 use Thelia\Test\IntegrationTestCase;
 
 final class RewritingRouterTest extends IntegrationTestCase
@@ -62,6 +63,31 @@ final class RewritingRouterTest extends IntegrationTestCase
         return $request;
     }
 
+    /**
+     * A request whose session language differs from the language of the url being asked for,
+     * which is what makes the router look at the per language domains.
+     */
+    private function requestInFrench(string $url): Request
+    {
+        $request = $this->request($url);
+        $request->getSession()->setLang(LangQuery::create()->findOneByLocale('fr_FR'));
+
+        return $request;
+    }
+
+    private function langUrl(string $locale, string $url): void
+    {
+        LangQuery::create()->findOneByLocale($locale)->setActive(true)->setUrl($url)->save();
+    }
+
+    /**
+     * The language is switched on the main request, the one LangService works with.
+     */
+    private function mainRequestLocale(): ?string
+    {
+        return $this->getService('request_stack')->getMainRequest()?->getSession()->getLang(false)?->getLocale();
+    }
+
     public function testMatchRequestResolvesALiveUrl(): void
     {
         $category = $this->createCategory('Live category');
@@ -95,6 +121,69 @@ final class RewritingRouterTest extends IntegrationTestCase
         // unrelated object that happened to have the same id.
         $this->expectException(ResourceNotFoundException::class);
         $this->router->matchRequest($this->request($url, ['lang' => 'fr_FR']));
+    }
+
+    public function testMatchRequestDoesNotRedirectToItselfWhenTheLanguageHasNoDomain(): void
+    {
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+        $this->langUrl('en_US', '');
+
+        $category = $this->createCategory('Category of a language without domain');
+        $request = $this->requestInFrench($category->getRewrittenUrl('en_US'));
+
+        // Every lang.url is empty on a fresh install: the redirect target used to be the
+        // very url being asked for, and a browser follows it until it gives up.
+        $parameters = $this->router->matchRequest($request);
+
+        self::assertTrue($parameters['_rewritten']);
+        self::assertSame('en_US', $this->mainRequestLocale());
+    }
+
+    public function testMatchRequestDoesNotRedirectToItselfWhenTheLanguageDomainIsTheCurrentOne(): void
+    {
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+        $this->langUrl('en_US', 'http://localhost');
+
+        $category = $this->createCategory('Category of a language on the current domain');
+        $request = $this->requestInFrench($category->getRewrittenUrl('en_US'));
+
+        $parameters = $this->router->matchRequest($request);
+
+        self::assertTrue($parameters['_rewritten']);
+        self::assertSame('en_US', $this->mainRequestLocale());
+    }
+
+    public function testMatchRequestRedirectsToTheLanguageDomainWhenItDiffers(): void
+    {
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+        $this->langUrl('en_US', 'http://en.example.com');
+
+        $category = $this->createCategory('Category of a language on its own domain');
+        $url = $category->getRewrittenUrl('en_US');
+
+        try {
+            $this->router->matchRequest($this->requestInFrench($url));
+            self::fail('An url of another language domain must redirect to that domain.');
+        } catch (RedirectException $redirectException) {
+            self::assertSame(301, $redirectException->getStatusCode());
+            self::assertSame('http://en.example.com/'.$url, $redirectException->getUrl());
+        }
+    }
+
+    public function testMatchRequestRedirectsToALanguageDomainWrittenWithATrailingSlash(): void
+    {
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+        $this->langUrl('en_US', 'http://en.example.com/');
+
+        $category = $this->createCategory('Category of a language on its own slashed domain');
+        $url = $category->getRewrittenUrl('en_US');
+
+        try {
+            $this->router->matchRequest($this->requestInFrench($url));
+            self::fail('An url of another language domain must redirect to that domain.');
+        } catch (RedirectException $redirectException) {
+            self::assertSame('http://en.example.com/'.$url, $redirectException->getUrl());
+        }
     }
 
     public function testMatchRequestRedirectsAReplacedUrlToTheCurrentOne(): void


### PR DESCRIPTION
With `one_domain_foreach_lang=1`, any url whose locale differs from the session locale answered `301` to itself, and a browser follows that until it gives up: an infinite redirect loop on a public url.

`RewritingRouter::manageLocale()` (`core/lib/Thelia/Core/Routing/RewritingRouter.php:207-216`) built its redirect target as `sprintf('%s/%s', $lang->getUrl(), $resolver->rewrittenUrl)`. Two configurations make that target the url being served:

- `lang.url` empty — the state of a fresh install until the per-language domains are filled in. The target becomes `/the-page.html`, the path just requested. Nothing switched the session language, so the next request took the same branch again.
- `lang.url` equal to the domain being browsed, for instance while languages are being moved to their own domains one at a time.

Reproduced on a demo install with `one_domain_foreach_lang=1` and every `lang.url` empty: `GET /horatio-46.html` (an `en_US` url, session in `fr_FR`) answered `301 Location: http://<host>/horatio-46.html`, and `curl -L` gave up after its redirect limit. With a `lang.url` filled in but pointing at the domain being browsed, same loop.

The redirect is now issued only when it leads somewhere else. When the language has no domain, or when its domain is the one being browsed, the session language is switched and the page is served, exactly as in single-domain mode — the page is already the one the visitor asked for, in that language. A language domain written with a trailing slash no longer produces a doubled slash in the target.

Redirects to a different language domain are unchanged.

Four tests in `tests/Integration/Core/Routing/RewritingRouterTest.php` cover it: the two self-redirecting configurations (red before this change: `RedirectException` to the requested url), the legitimate cross-domain redirect, and the trailing-slash form.

Fixes #3626
