### PR TITLE
fix: never redirect a rewritten url to itself when the language domain is missing

### DIFF
--- a/core/lib/Thelia/Core/Routing/RewritingRouter.php
+++ b/core/lib/Thelia/Core/Routing/RewritingRouter.php
@@ -268,16 +268,49 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
 
         $langSession = $request->getSession()->getLang();
 
-        if ($lang->getLocale() !== $langSession->getLocale()) {
-            if (ConfigQuery::isMultiDomainActivated()) {
-                $this->redirect(
-                    sprintf('%s/%s', $lang->getUrl(), $rewrittenUrlData->rewrittenUrl),
-                    301
-                );
-            } else {
-                $request->getSession()->setLang($lang);
+        if ($lang->getLocale() === $langSession->getLocale()) {
+            return;
+        }
+
+        if (ConfigQuery::isMultiDomainActivated()) {
+            $domainUrl = rtrim((string) $lang->getUrl(), '/');
+            $targetUrl = $domainUrl.'/'.$rewrittenUrlData->rewrittenUrl;
+
+            // An empty lang.url - the state of a fresh install until the per language domains
+            // are filled in - or a domain equal to the one being browsed makes that redirect
+            // point at the url that was just asked for, and a browser follows it until it gives
+            // up. Switch the session language and serve the page, as in single domain mode.
+            if ('' !== $domainUrl && !$this->isCurrentUrl($request, $targetUrl)) {
+                $this->redirect($targetUrl, 301);
             }
         }
+
+        $request->getSession()->setLang($lang);
+    }
+
+    /**
+     * A redirect to the url being served is never a useful answer: it only tells the browser
+     * to ask the same question again. Queries are ignored on purpose, since dropping them
+     * still lands on the same page, and so still loops.
+     */
+    private function isCurrentUrl(TheliaRequest $request, string $url): bool
+    {
+        $target = parse_url($url);
+
+        if (false === $target) {
+            return false;
+        }
+
+        // A host-less target is relative to the host being browsed.
+        $sameHost = !isset($target['host'])
+            || (
+                $target['host'] === $request->getHost()
+                && ($target['scheme'] ?? $request->getScheme()) === $request->getScheme()
+                && ($target['port'] ?? $request->getPort()) === $request->getPort()
+            );
+
+        return $sameHost
+            && trim($target['path'] ?? '', '/') === trim($request->getRealPathInfo(), '/');
     }
 
     protected function redirect($url, $status = 302): void


### PR DESCRIPTION
With `one_domain_foreach_lang=1`, any url whose locale differs from the session locale answered `301` to itself, and a browser follows that until it gives up: an infinite redirect loop on a public url.

`RewritingRouter::manageLocale()` (`core/lib/Thelia/Core/Routing/RewritingRouter.php:262-271`) built its redirect target as `sprintf('%s/%s', $lang->getUrl(), $rewrittenUrlData->rewrittenUrl)`. Two configurations make that target the url being served:

- `lang.url` empty — the state of a fresh install until the per-language domains are filled in. The target becomes `/the-page.html`, the path just requested. Nothing switched the session language, so the next request took the same branch again.
- `lang.url` equal to the domain being browsed, for instance while languages are being moved to their own domains one at a time.

The redirect is now issued only when it leads somewhere else. When the language has no domain, or when its domain is the one being browsed, the session language is switched and the page is served, exactly as in single-domain mode — the page is already the one the visitor asked for, in that language. A language domain written with a trailing slash no longer produces a doubled slash in the target.

Redirects to a different language domain are unchanged.

Same change as #3630 on `main`, where it is covered by four integration tests on the router (the 2.6 test suites have no coverage of url rewriting). The loop was reproduced on a demo install of the 3.0 branch, which carries the same code: `GET /horatio-46.html` (an `en_US` url, session in `fr_FR`) answered `301 Location: http://<host>/horatio-46.html`, and `curl -L` gave up after its redirect limit.

See #3626
