### PR TITLE
test: compare cloned product prices as numbers, not as DECIMAL strings

### DIFF
--- a/tests/Legacy/Action/ProductTest.php
+++ b/tests/Legacy/Action/ProductTest.php
@@ -81,6 +81,22 @@ class ProductTest extends TestCaseWithURLToolSetup
             ->delete();
     }
 
+    /**
+     * A DECIMAL column has two representations in one process: the string the
+     * database hands back ('10.000000'), and whatever a setter left in memory
+     * ('10') when Propel's instance pool still holds the object. Prices are
+     * therefore compared as numbers, at the scale the column is declared with,
+     * and never as strings.
+     */
+    private function assertSameDecimal($expected, $actual, string $message): void
+    {
+        $this->assertSame(
+            number_format((float) $expected, 6, '.', ''),
+            number_format((float) $actual, 6, '.', ''),
+            $message
+        );
+    }
+
     public function testCreate()
     {
         $event = new ProductCreateEvent();
@@ -485,8 +501,8 @@ class ProductTest extends TestCaseWithURLToolSetup
 
         $this->assertEquals($oldProductSaleElements->getWeight(), $newProductSaleElements->getWeight(), sprintf('->testSetProductTemplate new PSE weight must be %s', $oldProductSaleElements->getWeight()));
 
-        $this->assertEquals($oldProductPrice->getPrice(), $productPrice->getPrice(), sprintf('->testSetProductTemplate price must be %s', $oldProductPrice->getPrice()));
-        $this->assertEquals($oldProductPrice->getPromoPrice(), $productPrice->getPromoPrice(), sprintf('->testSetProductTemplate promo price must be %s', $oldProductPrice->getPromoPrice()));
+        $this->assertSameDecimal($oldProductPrice->getPrice(), $productPrice->getPrice(), sprintf('->testSetProductTemplate price must be %s', $oldProductPrice->getPrice()));
+        $this->assertSameDecimal($oldProductPrice->getPromoPrice(), $productPrice->getPromoPrice(), sprintf('->testSetProductTemplate promo price must be %s', $oldProductPrice->getPromoPrice()));
         $this->assertEquals($oldProductPrice->getCurrencyId(), $productPrice->getCurrencyId(), sprintf('->testSetProductTemplate currency_id must be %s', $oldProductPrice->getCurrencyId()));
 
         return $updatedProduct;
@@ -561,7 +577,7 @@ class ProductTest extends TestCaseWithURLToolSetup
 
         $clonedProductPrice = $clonedDefaultPSE->getProductPrices()->getFirst();
 
-        $this->assertEquals($originalProductDefaultPrice->getPrice(), $clonedProductPrice->getPrice(), 'Default price must be equal');
+        $this->assertSameDecimal($originalProductDefaultPrice->getPrice(), $clonedProductPrice->getPrice(), 'Default price must be equal');
         $this->assertEquals($originalProductDefaultPrice->getCurrencyId(), $clonedProductPrice->getCurrencyId(), 'Currency IDs must be equal');
 
         return $event;
@@ -1054,8 +1070,8 @@ class ProductTest extends TestCaseWithURLToolSetup
             'Instance of clone product price must be Thelia\Model\ProductPrice'
         );
         $this->assertEquals($originalProductPrice->getCurrencyId(), $cloneProductPrice->getCurrencyId(), 'CurrencyID must be equal');
-        $this->assertEquals($originalProductPrice->getPrice(), $cloneProductPrice->getPrice(), 'Price must be equal');
-        $this->assertEquals($originalProductPrice->getPromoPrice(), $cloneProductPrice->getPromoPrice(), 'Promo price must be equal');
+        $this->assertSameDecimal($originalProductPrice->getPrice(), $cloneProductPrice->getPrice(), 'Price must be equal');
+        $this->assertSameDecimal($originalProductPrice->getPromoPrice(), $cloneProductPrice->getPromoPrice(), 'Promo price must be equal');
         $this->assertEquals(0, $cloneProductPrice->getFromDefaultCurrency(), 'From default currency must be equal to 0');
 
         return [


### PR DESCRIPTION
## Symptom

`tests/Legacy/Action/ProductTest.php` fails at random, roughly once in a handful of full legacy runs:

```
1) Thelia\Tests\Action\ProductTest::testUpdateClonePSE
Price must be equal
Failed asserting that two strings are equal.
-'10.000000'
+'10'
```

The legacy suite runs in CI on `2.6` since #3583 and #3606, so this turns the branch red for no reason.

## Cause

Two things combine.

**The comparison is a string comparison.** `tests/Legacy/Action/ProductTest.php:1057` asserts

```php
$this->assertEquals($originalProductPrice->getPrice(), $cloneProductPrice->getPrice(), 'Price must be equal');
```

`product_price.price` is `DECIMAL(16,6)` (`local/config/schema.xml:1155`), and it has two representations inside one process. Propel hydrates it from the database as the string `'10.000000'`, while an object whose price went through the setter holds what the setter left there — `'10'` when `ProductCreateEvent::setBasePrice(10)` was given an int. When PHPUnit compares two strings it compares them strictly, so the two spellings of ten do not match. Same family as #3534.

**Which spelling each side gets depends on what ran before.** `tests/Legacy/Action/ProductTest.php:522` picks the product to clone at random:

```php
$originalProduct = ProductQuery::create()->addAscendingOrderByColumn('RAND()')->findOne();
```

The failing draw is the one that lands on a product created earlier in the same run — `testCreateWithOptionalParametersAction` (`:154`) creates one with `setBasePrice(10)` and never removes it. Its `product_price` row is then still in Propel's instance pool, so the clone written from it keeps `'10'` in memory while the original, re-read from the database by the test, comes back as `'10.000000'`.

Replacing that `RAND()` draw with `filterByRef('testCreateWithOptionalParameters%', Criteria::LIKE)->orderById(Criteria::DESC)` reproduces the reported failure on demand, verbatim.

The same draw explains the assertion-count drift reported in #3625: the clone tests loop over the drawn product's attributes, features, images, documents and accessories, so a run's assertion count follows whichever product was drawn. Eight consecutive runs of the suite on this branch: 587 tests every time, 1764, 1764, 1805, 1833, 1805, 1805, 1805 and 1813 assertions. The suite also never removes what it creates, so the pool of candidate products grows with every run — runs were observed cloning `testClone-*` products left behind by earlier runs.

## Fix

Compare prices as numbers at the scale the column is declared with, through one helper used by the five price assertions in the file (`testSetProductTemplate`, `testCreateClone`, `testUpdateClonePSE`). `weight` and `quantity` are `FLOAT`, not `DECIMAL`, and are not exposed to this.

The `RAND()` fixtures and the rows the suite leaves behind are left alone here: that is the suite's own design and changing it is not a one-line job. This PR removes the failure mode, not the randomness.

## Verifying

With the deterministic draw described above, the assertion fails before this change (`'10.000000'` vs `'10'`) and passes after it.

With the draw left random, the full legacy suite was run eight times in a row: 587 tests, green every time.
