### PR TITLE
fix: run an export without a date range instead of dying on it

### DIFF
--- a/core/lib/Thelia/Handler/ExportHandler.php
+++ b/core/lib/Thelia/Handler/ExportHandler.php
@@ -171,30 +171,34 @@ class ExportHandler
             }
         }
 
-        if ($rangeDate['start'] && !($rangeDate['start'] instanceof \DateTime)) {
-            $startYear = $rangeDate['start']['year'] !== '' ? $rangeDate['start']['year'] : (new \DateTime())->format('Y');
-            $startMonth = $rangeDate['start']['month'] !== '' ? $rangeDate['start']['month'] : (new \DateTime())->format('m');
-            $rangeDate['start'] = \DateTime::createFromFormat(
-                'Y-m-d H:i:s',
-                $startYear.'-'.$startMonth.'-1 00:00:00'
-            );
-        }
-        if ($rangeDate['end'] && !($rangeDate['end'] instanceof \DateTime)) {
-            $endYear = $rangeDate['end']['year'] !== '' ? $rangeDate['end']['year'] : (new \DateTime())->format('Y');
-            $endMonth = $rangeDate['end']['month'] !== '' ? $rangeDate['end']['month'] : (new \DateTime())->format('m');
-            $rangeDate['end'] = \DateTime::createFromFormat(
-                'Y-m-d H:i:s',
-                $endYear.'-'.$endMonth.'-1 23:59:59'
-            );
-
-            if ($rangeDate['end'] instanceof \DateTime) {
-                $rangeDate['end']
-                    ->add(new \DateInterval('P1M'))
-                    ->sub(new \DateInterval('P1D'));
+        // An export is not bounded by dates unless the caller asks for it: the command
+        // never does, and the back-office form only does for the exports that offer it.
+        if ($rangeDate !== null) {
+            if ($rangeDate['start'] && !($rangeDate['start'] instanceof \DateTime)) {
+                $startYear = $rangeDate['start']['year'] !== '' ? $rangeDate['start']['year'] : (new \DateTime())->format('Y');
+                $startMonth = $rangeDate['start']['month'] !== '' ? $rangeDate['start']['month'] : (new \DateTime())->format('m');
+                $rangeDate['start'] = \DateTime::createFromFormat(
+                    'Y-m-d H:i:s',
+                    $startYear.'-'.$startMonth.'-1 00:00:00'
+                );
             }
-        }
+            if ($rangeDate['end'] && !($rangeDate['end'] instanceof \DateTime)) {
+                $endYear = $rangeDate['end']['year'] !== '' ? $rangeDate['end']['year'] : (new \DateTime())->format('Y');
+                $endMonth = $rangeDate['end']['month'] !== '' ? $rangeDate['end']['month'] : (new \DateTime())->format('m');
+                $rangeDate['end'] = \DateTime::createFromFormat(
+                    'Y-m-d H:i:s',
+                    $endYear.'-'.$endMonth.'-1 23:59:59'
+                );
 
-        $instance->setRangeDate($rangeDate);
+                if ($rangeDate['end'] instanceof \DateTime) {
+                    $rangeDate['end']
+                        ->add(new \DateInterval('P1M'))
+                        ->sub(new \DateInterval('P1D'));
+                }
+            }
+
+            $instance->setRangeDate($rangeDate);
+        }
 
         // Process export
         $event = new ExportEvent($instance, $serializer, $archiver);

--- a/tests/Legacy/Handler/ExportHandlerTest.php
+++ b/tests/Legacy/Handler/ExportHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Thelia\Core\Event\ExportEvent;
+use Thelia\Core\Serializer\Serializer\CSVSerializer;
+use Thelia\Handler\ExportHandler;
+use Thelia\Model\ExportQuery;
+use Thelia\Model\Lang;
+
+/**
+ * A date range is optional. `php Thelia export` never supplies one, and the
+ * back-office form only does for the exports that offer the field.
+ */
+class ExportHandlerTest extends TestCase
+{
+    /**
+     * @var array<int, string>
+     */
+    private $writtenFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->writtenFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        $this->writtenFiles = [];
+    }
+
+    public function testAnExportRunsWithoutADateRange(): void
+    {
+        $event = $this->runExport(null);
+
+        $this->assertFileExists($event->getFilePath());
+        $this->assertNull($event->getExport()->getRangeDate());
+    }
+
+    public function testASuppliedDateRangeIsTurnedIntoBoundaryDates(): void
+    {
+        $event = $this->runExport([
+            'start' => ['year' => '2026', 'month' => '02'],
+            'end' => ['year' => '2026', 'month' => '02'],
+        ]);
+
+        $rangeDate = $event->getExport()->getRangeDate();
+
+        $this->assertSame('2026-02-01 00:00:00', $rangeDate['start']->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-02-28 23:59:59', $rangeDate['end']->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @param array|null $rangeDate
+     */
+    private function runExport($rangeDate): ExportEvent
+    {
+        // Product prices: an export every install has, over rows the demo data provides.
+        $export = ExportQuery::create()->findOneByRef('thelia.export.prices');
+
+        $this->assertNotNull($export, 'The product prices export is part of every install.');
+
+        $event = (new ExportHandler(new EventDispatcher()))->export(
+            $export,
+            new CSVSerializer(),
+            null,
+            Lang::getDefaultLanguage(),
+            false,
+            false,
+            $rangeDate
+        );
+
+        $this->writtenFiles[] = $event->getFilePath();
+
+        return $event;
+    }
+}


### PR DESCRIPTION
## Symptom

`php Thelia export <ref> <serializer>` dies before exporting anything:

```
In ExportHandler.php line 174:
  [ErrorException]
  Warning: Trying to access array offset on value of type null

  at core/lib/Thelia/Handler/ExportHandler.php:174
 Thelia\Handler\ExportHandler->export() at core/lib/Thelia/Command/ExportCommand.php:133
```

Every invocation is affected, so the command is unusable as documented.

## Cause

`core/lib/Thelia/Handler/ExportHandler.php:174` normalises the date range without first checking that there is one:

```php
if ($rangeDate['start'] && !($rangeDate['start'] instanceof \DateTime)) {
```

The parameter is declared `$rangeDate = null` (`:156`) and documented `@param array|null` (`:145`), and `core/lib/Thelia/Command/ExportCommand.php:133` calls `export()` with four arguments, so the range is always null on the command line.

The back-office is unaffected: `core/lib/Thelia/Controller/Admin/ExportController.php:200` builds the range from two `DateType` fields configured with `'input' => 'array'` and `'widget' => 'choice'` (`core/lib/Thelia/Form/ExportForm.php:94`), which always submit an array, empty strings included — that is what the `!== ''` tests on the next lines are for. Only the command reaches the handler with null.

## Fix

Skip the normalisation, and the `setRangeDate()` call it feeds, when no range was given. `AbstractExport::$rangeDate` is already null by default (`core/lib/Thelia/ImportExport/Export/AbstractExport.php:102`), so not calling the setter leaves the instance in the same state.

This is the shape `main` already has at `core/lib/Thelia/Domain/DataTransfer/ExportHandler.php:105`, which is why that branch does not show the bug.

## Verifying

`tests/Legacy/Handler/ExportHandlerTest.php` runs the product prices export through the handler twice: once with no range, once with a February 2026 range whose boundaries it checks (`2026-02-01 00:00:00` to `2026-02-28 23:59:59`, the end date being derived by the month arithmetic in the block). The first test errors with the warning above before this change and passes after it; the second passes either way and pins the behaviour the guard now wraps.

End to end on a demo install, seven of the eight built-in exports go from failing to producing a file:

```
$ php Thelia export thelia.export.prices thelia.csv
  Export finish
Export available at path:
var/cache/export/20260812-...-product_price.csv
```

`thelia.export.mailing` reports `No data found for your export` on an install with no newsletter subscriber, which is its normal behaviour.

## Left out

`thelia.export.orders` still fails, on a different line and for a different reason: `core/lib/Thelia/ImportExport/Export/Type/OrderExport.php:166` dereferences `$this->rangeDate['start']` unconditionally, and it is the only export declaring `USE_RANGE_DATE = true` while the command offers no way to pass a range. `main` carries the same code at `core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php:166`. Deciding what a range-less order export should mean — every order, or a clear refusal — is a separate question from this warning, and it needs the same answer on both branches, so it is not settled here.
