### PR TITLE
fix: let the API file upload endpoints receive their parent item

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ItemFileResourceService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ItemFileResourceService.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
+use Thelia\Action\Image as ImageAction;
 use Thelia\Core\Event\File\FileCreateOrUpdateEvent;
 use Thelia\Core\Event\Image\ImageEvent;
 use Thelia\Core\Event\TheliaEvents;
@@ -46,18 +47,25 @@ readonly class ItemFileResourceService
             throw new FileException($file->getErrorMessage());
         }
 
+        // The Propel setters are natively typed, so the raw strings of a multipart
+        // body have to be converted before they reach the model.
         $fileModel->setParentId($parentId)
-            ->setVisible(filter_var($request->request->get('visible'), \FILTER_VALIDATE_BOOLEAN))
-            ->setPosition($request->request->get('position'));
+            ->setVisible((int) filter_var($request->request->get('visible', '1'), \FILTER_VALIDATE_BOOLEAN));
 
-        $i18ns = json_decode((string) $request->request->get('i18ns'), true);
+        $position = $request->request->get('position');
 
-        foreach ($i18ns as $locale => $i18n) {
+        if (null !== $position && '' !== $position) {
+            $fileModel->setPosition((int) $position);
+        }
+
+        $i18ns = json_decode((string) $request->request->get('i18ns', '{}'), true);
+
+        foreach (\is_array($i18ns) ? $i18ns : [] as $locale => $i18n) {
             $fileModel->setLocale($locale)
-                ->setTitle($i18n['title'] ?? null)
-                ->setDescription($i18n['description'])
-                ->setChapo($i18n['chapo'])
-                ->setPostscriptum($i18n['postscriptum']);
+                ->setTitle($i18n['title'] ?? '')
+                ->setDescription($i18n['description'] ?? '')
+                ->setChapo($i18n['chapo'] ?? '')
+                ->setPostscriptum($i18n['postscriptum'] ?? '');
         }
 
         $fileEvent = new FileCreateOrUpdateEvent($parentId);
@@ -66,7 +74,7 @@ readonly class ItemFileResourceService
 
         $file = $this->eventDispatcher->dispatch(
             $fileEvent,
-            TheliaEvents::DOCUMENT_SAVE,
+            'image' === $fileType ? TheliaEvents::IMAGE_SAVE : TheliaEvents::DOCUMENT_SAVE,
         );
 
         if ('image' !== $fileType) {
@@ -95,7 +103,7 @@ readonly class ItemFileResourceService
         $event->setHeight(100);
         $event->setWidth(200);
         $event->setRotation(0);
-        $event->setResizeMode(1);
+        $event->setResizeMode((string) ImageAction::EXACT_RATIO_WITH_BORDERS);
 
         $this->eventDispatcher->dispatch($event, TheliaEvents::IMAGE_PROCESS);
     }

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
@@ -53,6 +53,8 @@ readonly class PropelPersistProcessor implements ProcessorInterface
             $propelModel->setId($uriVariables['id']);
         }
 
+        $resourceAddons = [];
+
         $connection = Propel::getWriteConnection(DatabaseConfiguration::THELIA_CONNECTION_NAME);
         $connection->beginTransaction();
 

--- a/core/lib/Thelia/Api/Controller/Admin/PostItemFileController.php
+++ b/core/lib/Thelia/Api/Controller/Admin/PostItemFileController.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\Post;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 use Thelia\Api\Bridge\Propel\Service\ItemFileResourceService;
@@ -40,8 +41,11 @@ class PostItemFileController
             throw new \Exception('Resource must implements ItemFileResourceInterface to use the PostItemFileController');
         }
 
-        /** @var UploadedFile $file */
         $file = $request->files->get('fileToUpload');
+
+        if (!$file instanceof UploadedFile) {
+            throw new UnprocessableEntityHttpException('The "fileToUpload" file part is required.');
+        }
 
         $constraints = $itemDocumentResourceService->getPropertyFileConstraints($resourceClass, 'fileToUpload');
         $violations = $validator->validate($file, $constraints);
@@ -53,12 +57,12 @@ class PostItemFileController
                 $errors[] = $violation->getMessage();
             }
 
-            throw new \Exception('Validation error: '.implode(', ', $errors));
+            throw new UnprocessableEntityHttpException('Validation error: '.implode(', ', $errors));
         }
 
         $itemType = $resourceClass::getItemType();
         $fileType = $resourceClass::getFileType();
-        $itemId = $request->attributes->get($itemType);
+        $itemId = self::resolveItemId($request, $itemType);
         $modelTableMap = $resourceClass::getPropelRelatedTableMap();
         $modelClassName = $modelTableMap->getClassName();
         $propelModel = new $modelClassName();
@@ -76,7 +80,37 @@ class PostItemFileController
         return $apiResourceService->modelToResource(
             $resourceClass,
             $propelModel,
-            $operation->getDenormalizationContext(),
+            $operation->getNormalizationContext(),
         );
+    }
+
+    /**
+     * Which item the uploaded file belongs to.
+     *
+     * A route placeholder wins, so an operation may put the item in its uri
+     * template. Otherwise the multipart body carries it under the item type
+     * ("product", "category", …), as a plain identifier or as an IRI, the two
+     * forms every other relation of this API accepts.
+     */
+    private static function resolveItemId(Request $request, string $itemType): int
+    {
+        $raw = $request->attributes->get($itemType) ?? $request->request->get($itemType);
+
+        if (\is_int($raw)) {
+            return $raw;
+        }
+
+        if (\is_string($raw)) {
+            if (ctype_digit($raw)) {
+                return (int) $raw;
+            }
+
+            // An IRI, for instance /api/admin/products/42
+            if (1 === preg_match('#/(\d+)/?$#', $raw, $matches)) {
+                return (int) $matches[1];
+            }
+        }
+
+        throw new UnprocessableEntityHttpException(\sprintf('The "%s" field is required and must be an id or an IRI: it tells which %s the file belongs to.', $itemType, $itemType));
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
 
 		-
-			message: '#^Variable \$resourceAddons might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
-
-		-
 			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Brand\:\:getLocale\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/tests/Api/Admin/ItemFileUploadApiTest.php
+++ b/tests/Api/Admin/ItemFileUploadApiTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Model\Product;
+use Thelia\Model\ProductDocumentQuery;
+use Thelia\Model\ProductImageQuery;
+use Thelia\Test\ApiTestCase;
+use Thelia\Tests\Support\Trait\CreatesTestFiles;
+
+/**
+ * The documented way to attach a file to an item over the API.
+ *
+ * The item the file belongs to is not part of any uri template, so it travels in
+ * the multipart body. Reading it from the route attributes only made every one of
+ * these endpoints answer 500 whatever the client sent.
+ */
+final class ItemFileUploadApiTest extends ApiTestCase
+{
+    use CreatesTestFiles;
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpTestFiles();
+        parent::tearDown();
+    }
+
+    public function testUploadADocumentWithThePlainProductId(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_documents',
+            ['product' => (string) $product->getId(), 'i18ns' => '{}'],
+            $this->createTestTextFile('%PDF-1.4 placeholder'),
+            'manual.pdf',
+            'application/pdf',
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
+
+        $document = ProductDocumentQuery::create()->filterByProductId($product->getId())->findOne();
+        self::assertNotNull($document);
+        self::assertSame(1, (int) $document->getVisible());
+
+        $path = $document->getUploadDir().\DIRECTORY_SEPARATOR.$document->getFile();
+        $this->trackFileForCleanup($path);
+        self::assertFileExists($path);
+    }
+
+    public function testUploadADocumentWithTheProductIri(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_documents',
+            ['product' => '/api/admin/products/'.$product->getId()],
+            $this->createTestTextFile('plain notes'),
+            'notes.txt',
+            'text/plain',
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
+
+        $document = ProductDocumentQuery::create()->filterByProductId($product->getId())->findOne();
+        self::assertNotNull($document);
+        $this->trackFileForCleanup($document->getUploadDir().\DIRECTORY_SEPARATOR.$document->getFile());
+    }
+
+    public function testUploadAnImage(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_images',
+            ['product' => (string) $product->getId()],
+            $this->createTestPng(),
+            'kitten.png',
+            'image/png',
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
+
+        $image = ProductImageQuery::create()->filterByProductId($product->getId())->findOne();
+        self::assertNotNull($image);
+        $this->trackFileForCleanup($image->getUploadDir().\DIRECTORY_SEPARATOR.$image->getFile());
+    }
+
+    public function testAnUploadWithoutItsItemIsRefused(): void
+    {
+        $response = $this->upload(
+            '/api/admin/product_documents',
+            [],
+            $this->createTestTextFile('orphan'),
+            'orphan.txt',
+            'text/plain',
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode(), (string) $response->getContent());
+    }
+
+    private function createProduct(): Product
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->product(
+            $factory->category(),
+            $factory->taxRule(),
+            $factory->currency(),
+        );
+    }
+
+    /**
+     * @param array<string, string> $fields
+     */
+    private function upload(
+        string $uri,
+        array $fields,
+        string $path,
+        string $fileName,
+        string $mimeType,
+    ): Response {
+        $this->client->request(
+            'POST',
+            $uri,
+            parameters: $fields,
+            files: ['fileToUpload' => $this->createUploadedFile($path, $fileName, $mimeType)],
+            server: [
+                'CONTENT_TYPE' => 'multipart/form-data',
+                'HTTP_ACCEPT' => 'application/ld+json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->authenticateAsAdmin(),
+            ],
+        );
+
+        return $this->client->getResponse();
+    }
+}


### PR DESCRIPTION
Refs #3593. Groundwork: the upload constraints cannot be enforced on a path that
answers 500 before it reaches the disk. The policy itself follows in a second pull
request, and the read-only publication in a third.

## Symptom

Every documented file upload of the API answers `500`, whatever the client sends:

```
POST /api/admin/product_documents        (multipart/form-data)
{"@type":"hydra:Error","status":500,
 "detail":"ItemFileResourceService::createItemFile(): Argument #1 ($parentId)
           must be of type int, null given"}
```

`product_images`, `product_documents`, `category_*`, `content_*`, `folder_*`,
`brand_*` and `module_images` all share the controller, so none of them can attach
a file. Verified against a running install, with the item passed as a body field,
as a query parameter and as an IRI.

## Cause

Five separate defects on the same path, each of which alone is enough to fatal.

1. **The item can never arrive.** `PostItemFileController.php:62` read it with
   `$request->attributes->get($itemType)`, and no `Post` operation carries the item
   in its uri template (`Api/Resource/ProductDocument.php:41`), so the attribute is
   always `null`. This regressed in two steps: #3426 replaced `$request->get()`
   — which did find the multipart field — with `$request->attributes->get()`, and
   #3333 added `declare(strict_types=1)`, turning the resulting `null` into a
   `TypeError` instead of a silent `0`.
2. **`setVisible()` received a bool.** `ItemFileResourceService.php:50` passed the
   result of `filter_var(..., FILTER_VALIDATE_BOOLEAN)` to a natively typed
   `setVisible(?int)`, and `setPosition()` the raw string of the body.
3. **`i18ns` was mandatory in practice.** `json_decode('')` returns `null` and
   `:55` iterated over it; `$i18n['description']` and its two siblings were read
   without a default.
4. **`setResizeMode(1)`** (`:98`) on `setResizeMode(string)`, so the image branch
   fataled after the row had been written.
5. **Two PHP warnings per successful upload.** `PropelPersistProcessor.php:72`
   only assigns `$resourceAddons` for a non-file resource, and `:97` iterates over
   it unconditionally.

Nothing in the test suite covered these endpoints, which is why five stacked
regressions went unnoticed.

## Fix

- The item is read from the route attributes first — so an operation may still put
  it in its uri template — then from the multipart body under the item type, as a
  plain identifier or as an IRI, the two forms every other relation of this API
  already accepts (`PlainIdentifierDenormalizer`). A missing or unusable value now
  answers `422` with a message naming the field, instead of `500`.
- The body values are converted before they reach the natively typed Propel
  setters; `position` is left untouched when absent, `i18ns` defaults to `{}` and
  each translated field to an empty string.
- `visible` defaults to `1`. A client that does not mention it uploaded a file to
  publish it, and silently storing an invisible image is the kind of trap that
  costs an afternoon.
- An image upload dispatches `IMAGE_SAVE` rather than `DOCUMENT_SAVE`. Both reach
  `BaseCachedFile::saveFile()`, so this changes no behaviour of the core, but a
  module listening on the image event was never called.
- The `201` body is built with the operation's normalization context. The
  denormalization context was used, which hydrates the write groups, so the
  response would have carried none of `id`, `file`, `fileUrl` or `createdAt` that
  the operation declares.
- A validation violation and a missing file part answer `422` instead of the
  previous uncaught `\Exception`, that is `500`.

## How to verify

```
composer test:api -- --filter ItemFileUploadApiTest
```

`tests/Api/Admin/ItemFileUploadApiTest.php` uploads a document with a plain id,
the same with an IRI, an image, and checks that an upload without its item is
refused with `422`.

Checked on `main` with only the test file added: the four cases error out with the
`TypeError` above. With this change: `OK (4 tests, 9 assertions)`, and no PHP
warning. Full local run: unit 269, api 192 (1 legitimate skip), flexy 11,
back office 11, integration green apart from `FileProcessorServiceTest`, which
needs the Twig back office wired to keep `FileProcessorService` out of the
inliner and is unrelated to this change.

## Out of scope, worth a look

- A nonexistent item id still reaches the database and surfaces as a foreign key
  error. Checking it needs a per-item-type lookup; `getParentFileModel()` returns
  a blank model (`Model/ProductDocument.php:84`) and cannot serve.
- `ImageEvent::setResizeMode()` takes a string while `Action/Image.php:68-70`
  defines its modes as `int` constants, so callers keep casting in both
  directions.
