### PR TITLE
fix: apply the shop upload policy to the API file uploads

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ItemFileResourceService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ItemFileResourceService.php
@@ -24,12 +24,14 @@ use Thelia\Core\Event\File\FileCreateOrUpdateEvent;
 use Thelia\Core\Event\Image\ImageEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\File\FileModelInterface;
+use Thelia\Core\File\Service\FileProcessorService;
 use Thelia\Model\ConfigQuery;
 
 readonly class ItemFileResourceService
 {
     public function __construct(
         private EventDispatcherInterface $eventDispatcher,
+        private FileProcessorService $fileProcessorService,
     ) {
     }
 
@@ -46,6 +48,12 @@ readonly class ItemFileResourceService
         if (!$file->isValid()) {
             throw new FileException($file->getErrorMessage());
         }
+
+        // The shop upload policy, the one the back office applies (FileConfiguration).
+        // The API used to carry its own copy as per-resource constraints, which said
+        // something else and covered images only.
+        $this->fileProcessorService->validateUpload($file, $fileType);
+        $this->fileProcessorService->sanitizeUpload($file);
 
         // The Propel setters are natively typed, so the raw strings of a multipart
         // body have to be converted before they reach the model.

--- a/core/lib/Thelia/Api/Controller/Admin/PostItemFileController.php
+++ b/core/lib/Thelia/Api/Controller/Admin/PostItemFileController.php
@@ -17,13 +17,16 @@ namespace Thelia\Api\Controller\Admin;
 use ApiPlatform\Metadata\Post;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 use Thelia\Api\Bridge\Propel\Service\ItemFileResourceService;
 use Thelia\Api\Resource\ItemFileResourceInterface;
 use Thelia\Api\Resource\PropelResourceInterface;
+use Thelia\Core\File\Exception\ProcessFileException;
 
 #[AsController]
 class PostItemFileController
@@ -66,13 +69,20 @@ class PostItemFileController
         $modelTableMap = $resourceClass::getPropelRelatedTableMap();
         $modelClassName = $modelTableMap->getClassName();
         $propelModel = new $modelClassName();
-        $itemDocumentResourceService->createItemFile(
-            $itemId,
-            $propelModel,
-            $itemType,
-            $fileType,
-            $request,
-        );
+
+        try {
+            $itemDocumentResourceService->createItemFile(
+                $itemId,
+                $propelModel,
+                $itemType,
+                $fileType,
+                $request,
+            );
+        } catch (ProcessFileException $exception) {
+            // The upload policy speaks in HTTP terms already: 415 for a type that is
+            // not accepted, 403 for a file above the server limit.
+            throw new HttpException($exception->getCode() >= 400 && $exception->getCode() < 600 ? $exception->getCode() : Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $exception->getMessage(), $exception);
+        }
 
         /** @var Post $operation */
         $operation = $request->attributes->get('_api_operation');

--- a/core/lib/Thelia/Api/Resource/BrandImage.php
+++ b/core/lib/Thelia/Api/Resource/BrandImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
@@ -142,17 +141,6 @@ class BrandImage extends AbstractTranslatableResource implements ItemFileResourc
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Api/Resource/CategoryImage.php
+++ b/core/lib/Thelia/Api/Resource/CategoryImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
@@ -142,17 +141,6 @@ class CategoryImage extends AbstractTranslatableResource implements ItemFileReso
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Api/Resource/ContentImage.php
+++ b/core/lib/Thelia/Api/Resource/ContentImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
@@ -142,17 +141,6 @@ class ContentImage extends AbstractTranslatableResource implements ItemFileResou
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Api/Resource/FolderImage.php
+++ b/core/lib/Thelia/Api/Resource/FolderImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
@@ -120,17 +119,6 @@ class FolderImage extends AbstractTranslatableResource implements ItemFileResour
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Api/Resource/ModuleImage.php
+++ b/core/lib/Thelia/Api/Resource/ModuleImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
@@ -143,17 +142,6 @@ class ModuleImage extends AbstractTranslatableResource implements ItemFileResour
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Api/Resource/ProductImage.php
+++ b/core/lib/Thelia/Api/Resource/ProductImage.php
@@ -28,7 +28,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use Propel\Runtime\Map\TableMap;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\NotInFilter;
@@ -161,17 +160,6 @@ class ProductImage extends AbstractTranslatableResource implements ItemFileResou
         openapiContext: [
             'type' => 'string',
             'format' => 'binary',
-        ],
-    )]
-    #[Assert\Image(
-        mimeTypes: [
-            'image/bmp',
-            'image/gif',
-            'image/jpeg',
-            'image/png',
-            'image/vnd.wap.wbmp',
-            'image/webp',
-            'image/xbm',
         ],
     )]
     public UploadedFile $fileToUpload;

--- a/core/lib/Thelia/Core/Translation/Translator.php
+++ b/core/lib/Thelia/Core/Translation/Translator.php
@@ -50,14 +50,24 @@ class Translator extends BaseTranslator
         return self::$instance;
     }
 
+    /**
+     * The locale of the shop session, when there is one.
+     *
+     * An API request carries no session, and neither does the console, so the
+     * session is checked before it is read: getSession() throws when it is
+     * absent, which turned any translated message of an API request into a
+     * "Session has not been set." error.
+     */
     public function getLocale(): string
     {
         $currentRequest = $this->requestStack->getMainRequest();
 
-        if ($currentRequest instanceof Request) {
-            $session = $currentRequest->getSession();
+        if ($currentRequest instanceof Request && $currentRequest->hasSession()) {
+            $lang = $currentRequest->getSession()->getLang();
 
-            return $session->getLang()->getLocale();
+            if (null !== $lang) {
+                return $lang->getLocale();
+            }
         }
 
         return parent::getLocale();

--- a/tests/Api/Admin/ItemFileUploadPolicyApiTest.php
+++ b/tests/Api/Admin/ItemFileUploadPolicyApiTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Core\File\FileConfiguration;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductDocumentQuery;
+use Thelia\Model\ProductImageQuery;
+use Thelia\Test\ApiTestCase;
+use Thelia\Tests\Support\Trait\CreatesTestFiles;
+
+/**
+ * The API has to apply the same upload policy as the rest of the shop.
+ *
+ * The document resources declared no constraint at all, so any extension went
+ * through; the image resources declared their own mime type list, which neither
+ * matched FileConfiguration nor followed the shop configuration.
+ */
+final class ItemFileUploadPolicyApiTest extends ApiTestCase
+{
+    use CreatesTestFiles;
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpTestFiles();
+        // The database changes are rolled back, the static config cache is not.
+        ConfigQuery::resetCache();
+        parent::tearDown();
+    }
+
+    public function testAServerExecutableDocumentIsRefused(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_documents',
+            $product,
+            $this->createTestTextFile('<?php echo 1;'),
+            'shell.php',
+        );
+
+        self::assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), (string) $response->getContent());
+        self::assertNull(ProductDocumentQuery::create()->filterByProductId($product->getId())->findOne());
+    }
+
+    public function testABlacklistedDocumentExtensionIsRefused(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_documents',
+            $product,
+            $this->createTestTextFile('MZ'),
+            'payload.exe',
+        );
+
+        self::assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), (string) $response->getContent());
+        self::assertNull(ProductDocumentQuery::create()->filterByProductId($product->getId())->findOne());
+    }
+
+    public function testANonImageIsRefusedAsAnImage(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_images',
+            $product,
+            $this->createTestTextFile('not an image'),
+            'kitten.png',
+        );
+
+        self::assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), (string) $response->getContent());
+        self::assertNull(ProductImageQuery::create()->filterByProductId($product->getId())->findOne());
+    }
+
+    /**
+     * The list is the shop's, not the resource's: narrowing it in the
+     * configuration has to reach the API.
+     */
+    public function testTheShopConfigurationNarrowsTheAcceptedImageMimeTypes(): void
+    {
+        ConfigQuery::write(FileConfiguration::IMAGE_MIME_TYPES_VARIABLE, 'image/png');
+
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_images',
+            $product,
+            $this->createTestTextFile('GIF89a'.str_repeat("\x00", 16)),
+            'kitten.gif',
+        );
+
+        self::assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), (string) $response->getContent());
+    }
+
+    public function testALegitimateUploadStillGoesThrough(): void
+    {
+        $product = $this->createProduct();
+
+        $response = $this->upload(
+            '/api/admin/product_images',
+            $product,
+            $this->createTestPng(),
+            'kitten.png',
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), (string) $response->getContent());
+
+        $image = ProductImageQuery::create()->filterByProductId($product->getId())->findOne();
+        self::assertNotNull($image);
+        $this->trackFileForCleanup($image->getUploadDir().\DIRECTORY_SEPARATOR.$image->getFile());
+    }
+
+    private function createProduct(): Product
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->product(
+            $factory->category(),
+            $factory->taxRule(),
+            $factory->currency(),
+        );
+    }
+
+    private function upload(string $uri, Product $product, string $path, string $fileName): Response
+    {
+        $this->client->request(
+            'POST',
+            $uri,
+            parameters: ['product' => (string) $product->getId()],
+            // The mime type the client claims is deliberately not the one the file
+            // holds: the policy sniffs the content, it does not trust the request.
+            files: ['fileToUpload' => $this->createUploadedFile($path, $fileName, 'image/png')],
+            server: [
+                'CONTENT_TYPE' => 'multipart/form-data',
+                'HTTP_ACCEPT' => 'application/ld+json',
+                'HTTP_AUTHORIZATION' => 'Bearer '.$this->authenticateAsAdmin(),
+            ],
+        );
+
+        return $this->client->getResponse();
+    }
+}


### PR DESCRIPTION
Fixes #3593 — first half: one source of truth, enforced. Based on #3636, which
makes these endpoints reachable at all; GitHub retargets this one to `main` once
#3636 is merged.

## Symptom

An administrator token can upload a server-executable file through the API. On
`main` plus #3636:

```
POST /api/admin/product_documents      (fileToUpload=shell.php)
201 Created
{"file":"payload-10.exe",
 "fileUrl":"http://localhost/cache/documents/product/payload-10.exe"}
```

`Document::processDocument()` symlinks the stored document into
`web/cache/documents/`, so the uploaded file ends up served from the shop origin
under its own extension. The Twig back office refused both since #3582; the API
did not.

For images the API did check something, but not what the shop applies: it accepted
`image/bmp`, `image/vnd.wap.wbmp` and `image/xbm`, which
`FileConfiguration::DEFAULT_IMAGE_MIME_TYPES` does not, refused `image/svg+xml`,
which it does, and ignored `image_upload_allowed_mime_types` entirely. A client
reading the API was told one policy while the server enforced another.

## Cause

The API never went through the upload policy.

- The constraints were restated per resource as PHP attributes:
  `Api/Resource/ProductImage.php:158-176` and the five other `*Image` resources.
  `ItemFileResourceService::getPropertyFileConstraints()` reads them and
  `PostItemFileController.php:53-64` validates against them.
- The five `*Document` resources declare **no** constraint at all
  (`Api/Resource/ProductDocument.php:139-147`), so `$constraints` is `[]`,
  `$validator->validate($file, [])` reports nothing, and every extension passes.
- `ItemFileResourceService::createItemFile()` dispatches the save event directly.
  It never calls `FileProcessorService`, which is where `validateUpload()` and the
  SVG sanitisation live, so an SVG uploaded over the API kept its scripts too.

## Fix

`createItemFile()` asks `FileProcessorService` for the shop policy of the object
type it is handling — `image` or `document`, which is exactly what
`ItemFileResourceInterface::getFileType()` returns — and sanitises the file:

```php
$this->fileProcessorService->validateUpload($file, $fileType);
$this->fileProcessorService->sanitizeUpload($file);
```

The six hardcoded mime type lists are removed with it. `FileConfiguration` is now
the only place that says what may be uploaded, for the two back offices, the
imports and the API alike, and the two shop variables reach all of them.

`getPropertyFileConstraints()` stays: a module exposing its own file resource can
still add an `Assert\File` or `Assert\Image` of its own on top of the shop policy.
Only the core duplicates are gone.

A refused upload answers `415 Unsupported Media Type` with the policy message,
`403` when the file is over the server limit — the statuses `ProcessFileException`
already carries — instead of an uncaught `RuntimeException`.

### Enabling fix: the translator required a session

`Translator::getLocale()` called `$request->getSession()` unguarded
(`Core/Translation/Translator.php:58`). An API request carries no session — no
`Set-Cookie` on any `/api` response — so the first translated message of a request
threw `SessionNotFoundException`, which API Platform renders as
`400 Session has not been set.`. Every upload refusal hit it, and so does any
other core message translated while serving the API.

The check now follows the pattern the rest of the core already uses
(`SecurityContext.php:43`, `MailerFactory.php:189`, `LangService.php:44`): read the
session only when there is one, otherwise fall back to the translator's own locale.

## Behaviour changes worth knowing

- `image/bmp`, `image/vnd.wap.wbmp` and `image/xbm` are no longer accepted by the
  API unless `image_upload_allowed_mime_types` lists them. They were never accepted
  by either back office.
- `image/svg+xml` is now accepted, and sanitised on the way in.
- No serialized field is added, removed or retyped: the change is in the attributes
  and the upload path, not in the resource shape.

## How to verify

```
composer test:api -- --filter ItemFileUploadPolicyApiTest
```

`tests/Api/Admin/ItemFileUploadPolicyApiTest.php` posts `shell.php` and
`payload.exe` as product documents, a text file named `kitten.png` as a product
image, and a GIF against a configuration narrowed to `image/png`. Each must answer
`415` and leave no row behind; a real PNG must still answer `201`.

Checked on the parent branch with only the test file added: the two document cases
answer `201` and the file is written to `web/cache/documents/`, the image case
answers `422` with the resource's own list, and the configuration case answers
`500`. All five pass here.

Full local run of the five suites: unit 269, integration 478, api 197 (1 legitimate
skip), flexy 11, back office 11. `cs-diff` 0/1801, PHPStan 0 errors.

## Not in this pull request

Publishing the constraints read-only on the file resources — the second half of
#3593 — follows separately.
