### PR TITLE
fix: register console commands with addCommand() instead of the deprecated add()

### DIFF
--- a/core/lib/Thelia/Core/Application.php
+++ b/core/lib/Thelia/Core/Application.php
@@ -76,7 +76,7 @@ class Application extends BaseApplication
     protected function registerCommands(): void
     {
         if (!TheliaKernel::isInstalled()) {
-            $this->add(new Install($this->kernel->getEnvironment()));
+            $this->addCommand(new Install($this->kernel->getEnvironment()));
 
             return;
         }
@@ -103,7 +103,7 @@ class Application extends BaseApplication
                 throw new \LogicException(\sprintf('The command "%s" must be an instance of "%s".', $commandId, Command::class));
             }
 
-            $this->add($command);
+            $this->addCommand($command);
         }
     }
 }


### PR DESCRIPTION
Fixes #3628

## Symptom

Every `php Thelia` invocation logs:

```
User Deprecated: Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()"
method is deprecated and will be removed in Symfony 8.0, use
"Symfony\Component\Console\Application::addCommand()" instead.
```

## Cause

`core/lib/Thelia/Core/Application.php:65` and `:100` call `Application::add()`. `vendor/symfony/console/Application.php:556` triggers the deprecation and forwards to `addCommand()`, added in 7.4. `core/composer.json` pins `symfony/console` to `7.4.*`, so `addCommand()` is available on every supported version.

## Fix

Both call sites now use `addCommand()`. Nothing else changes: `add()` was already a one-line forward to it.

## Verified

On a disposable bench (worktree at `origin/main`, DDEV):

- before: `php Thelia list` emits the deprecation once
- after: no deprecation, and the command list is identical (101 entries, both the installed and the not-yet-installed code path)
- `composer cs-diff` → 0 of 1800, `composer phpstan` → no errors

## Modules

Swept the 162 working copies in `_modules-t3/` and the 22 installed modules in `vendor/thelia/modules/`: no module calls `add()` on the console application, none extends `Symfony\Component\Console\Application` and none overrides `registerCommands()`. The only `->add($command)` hits are in the Propel2 fork working copy (`_modules-t3/Propel2-fix/`, its own bin and tests), which is a library, not a Thelia module. Nothing to follow up on that side.
