### PR TITLE
fix: keep Thelia services reachable from the test container

### DIFF
--- a/core/lib/Thelia/Core/Bundle/TheliaBundle.php
+++ b/core/lib/Thelia/Core/Bundle/TheliaBundle.php
@@ -34,6 +34,7 @@ use Thelia\Core\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterRouterPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterSerializerPass;
 use Thelia\Core\DependencyInjection\Compiler\RegisterTemplateTranslationsPass;
+use Thelia\Core\DependencyInjection\Compiler\TestPublicServicesPass;
 use Thelia\Core\DependencyInjection\Compiler\TranslatorPass;
 
 /**
@@ -72,6 +73,10 @@ class TheliaBundle extends Bundle
             ->addCompilerPass(new RegisterCommandPass())
             ->addCompilerPass(new RegisterFormPass())
             ->addCompilerPass(new RegisterApiResourceAddonPass());
+
+        if ('test' === $container->getParameter('kernel.environment')) {
+            $container->addCompilerPass(new TestPublicServicesPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        }
     }
 
     public function boot(): void

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/TestPublicServicesPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/TestPublicServicesPass.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Keeps Thelia's own services reachable from the test container.
+ *
+ * Symfony exposes a private service to the test container only as long as
+ * something else in the compiled container still references it: a private
+ * service nothing uses is removed, and one used exactly once is inlined into
+ * its single consumer. Either way it disappears from the container the test
+ * suite talks to.
+ *
+ * The suite fetches more than twenty private services, so whether a test can
+ * reach the service it exercises depends on what else happens to be installed:
+ * FileProcessorService, for one, only survives because a back office template
+ * bundle injects it into a controller. Install a shop without that bundle and
+ * the very same commit turns the test red, which is how the suite came to pass
+ * in CI and fail on a plain checkout.
+ *
+ * Making Thelia's services public in the test environment removes that
+ * dependency. Nothing changes for dev and prod, where the removal and inlining
+ * passes keep working as before.
+ */
+class TestPublicServicesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!str_starts_with($id, 'Thelia\\')) {
+                continue;
+            }
+
+            if ($definition->isPublic() || $definition->isAbstract() || $definition->hasErrors()) {
+                continue;
+            }
+
+            $definition->setPublic(true);
+        }
+    }
+}

--- a/core/lib/Thelia/Test/IntegrationTestCase.php
+++ b/core/lib/Thelia/Test/IntegrationTestCase.php
@@ -19,6 +19,7 @@ use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Propel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Thelia\Core\DependencyInjection\Compiler\TestPublicServicesPass;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\TheliaKernel;
@@ -125,7 +126,17 @@ abstract class IntegrationTestCase extends KernelTestCase
      */
     protected function getService(string $id): object
     {
-        return static::getContainer()->get($id);
+        $container = static::getContainer();
+
+        // Symfony drops a private service nothing else references, and the
+        // message it then answers with ("removed or inlined when the container
+        // was compiled") reads like a broken environment. It is not: the
+        // service simply has no declared way in. Say so, and say what to do.
+        if (!$container->has($id)) {
+            throw new \LogicException(\sprintf('The "%s" service cannot be fetched from the test container: it is private and nothing in the compiled container references it. Make it public for the test environment (see %s) or reach it through a service that is.', $id, TestPublicServicesPass::class));
+        }
+
+        return $container->get($id);
     }
 
     protected function getPropelConnection(): ConnectionInterface


### PR DESCRIPTION
Fixes #3627

## Symptom

`tests/Integration/Core/File/FileProcessorServiceTest.php` (shipped by #3582) produces 4 errors and 3 failures on a checkout of `main`, while the CI of the same commit is green:

```
The "Thelia\Core\File\Service\FileProcessorService" service or alias has been removed
or inlined when the container was compiled.
```

## Cause

`Thelia\Core\File\Service\FileProcessorService` is **private** in the compiled container. `core/lib/Thelia/Config/Resources/services/handlers/file_manager.php:33` declares it `->public()`, but the prototype registration in `core/lib/Thelia/Config/Resources/services.php:55` (`load('Thelia\\', THELIA_LIB)`, private by default) overwrites that definition — the compiled test container holds the autowired, private, two-argument version, not the public three-argument one declared in `file_manager.php`. That precedence problem is left alone here: it silently affects the six services of `file_manager.php` and deserves its own ticket.

Symfony exposes a private service to the test container (`test.private_services_locator`) only as long as **something else in the compiled container still references it**: a private service nothing uses is removed, and one used exactly once is inlined into its single consumer. Either way it is gone from the container the suite talks to.

What keeps that reference is not core code, it is the installed back office template:

- `templates/backOffice/default/BackOfficeDefaultBundle.php:32` registers `Thelia\Controller\Admin\`, whose `FileController` receives `FileProcessorService` as an action argument, so the controller argument locator holds a real reference;
- the Twig back office does the same through its own `FileController` constructor.

And **neither bundle is in the tracked `config/bundles.php`**: they are added there by the Flex recipes of `thelia/backoffice-default-template` and `thelia/backoffice-default-twig-template` when `composer install` runs. CI checks out, installs, and never restores that file — so CI always has them. A bench where the recipes did not run, or where a `git checkout` / `git restore` put the tracked file back, does not. Same commit, different container, and a test that looks like "an environment thing".

`composer install` mutates three tracked files this way: `config/bundles.php`, `.env` (adds `ACTIVE_ADMIN_TEMPLATE` / `ACTIVE_FRONT_TEMPLATE`) and `phpunit.xml.dist`.

### Reproduced both ways

Disposable bench, worktree at `origin/main` (0fbb720), DDEV, own database, `composer install` then `composer test:prepare`:

| `config/bundles.php` | `FileProcessorServiceTest` |
|---|---|
| as written by `composer install` (what CI has) | `OK (7 tests)` |
| the tracked file, restored with `git show origin/main:config/bundles.php` | `Tests: 7, Errors: 4, Failures: 3` — the message above |
| tracked file + `BackOfficeDefaultBundle` alone | `OK (7 tests)` |
| tracked file + `BackOfficeDefaultTwigBundle` alone | `OK (7 tests)` |

## The family

The suite fetches 29 distinct ids from the test container. Seven are genuinely public (`LoopExecutor`, `FormatService`, `request_stack`, `translator`, `thelia.facade`, `thelia.translator`, `thelia.url.manager`); the other 22 are private and reachable only as a side effect of the removal pass. Comparing the reachability set of the two containers above (public ids plus the ids in `test.private_services_locator`), **two of them disappear when the template bundles are not enabled**:

- `Thelia\Core\File\Service\FileProcessorService` — `tests/Integration/Core/File/FileProcessorServiceTest.php` (4 errors, 3 failures)
- `Thelia\Api\Service\DataAccess\AttributeAccessService` — `tests/Integration/Api/AttributeAccessServiceTest.php` (2 errors, same message, verified on the same bench)

The remaining 20 hold today because two or more services reference them, which is luck rather than a contract: dropping one consumer inlines the service and breaks the test the same way.

## Fix

`TestPublicServicesPass` makes Thelia's own services public **in the test environment only** (registered from `TheliaBundle::build()` at `TYPE_BEFORE_REMOVING`, so it precedes the removal and inlining passes). Dev and prod containers are untouched, so nothing becomes reachable in production that was not before.

`IntegrationTestCase::getService()` now answers with what actually happened and what to do about it, instead of Symfony's "removed or inlined" message, which reads like a broken environment.

## Verified

On the disposable bench, both configurations:

- template bundles enabled (CI-equivalent): `composer test` → 5 suites green, 957 tests (unit 269, integration 478, api 188 with 1 skip, http-flexy 11, http-backoffice 11)
- tracked `config/bundles.php` restored: `FileProcessorServiceTest` **and** `AttributeAccessServiceTest` → `OK (9 tests)`, where both were red before the fix
- `composer cs-diff` → 0 of 1800, `composer phpstan` → no errors