### PR TITLE
feat: publish the upload constraints read-only on the API file resources

### DIFF
--- a/core/lib/Thelia/Api/Resource/BrandDocument.php
+++ b/core/lib/Thelia/Api/Resource/BrandDocument.php
@@ -284,6 +284,27 @@ class BrandDocument extends AbstractTranslatableResource implements ItemFileReso
         return BrandDocumentI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'brand';

--- a/core/lib/Thelia/Api/Resource/BrandImage.php
+++ b/core/lib/Thelia/Api/Resource/BrandImage.php
@@ -279,6 +279,27 @@ class BrandImage extends AbstractTranslatableResource implements ItemFileResourc
         return BrandImageI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'brand';

--- a/core/lib/Thelia/Api/Resource/CategoryDocument.php
+++ b/core/lib/Thelia/Api/Resource/CategoryDocument.php
@@ -274,6 +274,27 @@ class CategoryDocument extends AbstractTranslatableResource implements ItemFileR
         return $this;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'category';

--- a/core/lib/Thelia/Api/Resource/CategoryImage.php
+++ b/core/lib/Thelia/Api/Resource/CategoryImage.php
@@ -284,6 +284,27 @@ class CategoryImage extends AbstractTranslatableResource implements ItemFileReso
         return CategoryImageI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'category';

--- a/core/lib/Thelia/Api/Resource/ContentDocument.php
+++ b/core/lib/Thelia/Api/Resource/ContentDocument.php
@@ -284,6 +284,27 @@ class ContentDocument extends AbstractTranslatableResource implements ItemFileRe
         return $this;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'content';

--- a/core/lib/Thelia/Api/Resource/ContentImage.php
+++ b/core/lib/Thelia/Api/Resource/ContentImage.php
@@ -284,6 +284,27 @@ class ContentImage extends AbstractTranslatableResource implements ItemFileResou
         return ContentImageI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'content';

--- a/core/lib/Thelia/Api/Resource/FileUploadConstraints.php
+++ b/core/lib/Thelia/Api/Resource/FileUploadConstraints.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Resource;
+
+use Thelia\Core\File\FileConfiguration;
+
+/**
+ * What the shop accepts on an upload, as the server enforces it.
+ *
+ * Published read only on every file resource, so that an integrator building an
+ * upload form does not restate the lists and drift away from them. It follows the
+ * two shop variables of FileConfiguration when they are set.
+ *
+ * The value is returned as an array rather than as an object on purpose: the
+ * serialization groups of the file resources do not apply to a nested class, which
+ * would be normalized as an empty object.
+ */
+final class FileUploadConstraints
+{
+    /**
+     * Constraints applied to an upload of the given file type ("image", "document").
+     *
+     * - allowedMimeTypes: accepted mime types; empty means any mime type is accepted
+     * - allowedExtensions: extensions those mime types may carry, ready for an
+     *   "accept" attribute; empty means the extension is not what is checked
+     * - forbiddenExtensions: extensions always refused, whatever the configuration says
+     *
+     * @return array{allowedMimeTypes: list<string>, allowedExtensions: list<string>, forbiddenExtensions: list<string>}
+     */
+    public static function forFileType(string $fileType): array
+    {
+        $policy = FileConfiguration::getConfig($fileType);
+
+        $extensions = [];
+
+        foreach ($policy['validMimeTypes'] as $mimeTypeExtensions) {
+            foreach ($mimeTypeExtensions as $extension) {
+                $extensions[] = $extension;
+            }
+        }
+
+        return [
+            'allowedMimeTypes' => array_keys($policy['validMimeTypes']),
+            'allowedExtensions' => array_values(array_unique($extensions)),
+            'forbiddenExtensions' => array_values(array_unique(
+                [...$policy['extBlackList'], ...FileConfiguration::SERVER_EXECUTABLE_EXTENSIONS],
+            )),
+        ];
+    }
+}

--- a/core/lib/Thelia/Api/Resource/FolderDocument.php
+++ b/core/lib/Thelia/Api/Resource/FolderDocument.php
@@ -262,6 +262,27 @@ class FolderDocument extends AbstractTranslatableResource implements ItemFileRes
         return FolderDocumentI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'folder';

--- a/core/lib/Thelia/Api/Resource/FolderImage.php
+++ b/core/lib/Thelia/Api/Resource/FolderImage.php
@@ -262,6 +262,27 @@ class FolderImage extends AbstractTranslatableResource implements ItemFileResour
         return FolderImageI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'folder';

--- a/core/lib/Thelia/Api/Resource/ModuleImage.php
+++ b/core/lib/Thelia/Api/Resource/ModuleImage.php
@@ -285,6 +285,27 @@ class ModuleImage extends AbstractTranslatableResource implements ItemFileResour
         return ModuleImageI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'module';

--- a/core/lib/Thelia/Api/Resource/ProductDocument.php
+++ b/core/lib/Thelia/Api/Resource/ProductDocument.php
@@ -285,6 +285,27 @@ class ProductDocument extends AbstractTranslatableResource implements ItemFileRe
         return ProductDocumentI18n::class;
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'product';

--- a/core/lib/Thelia/Api/Resource/ProductImage.php
+++ b/core/lib/Thelia/Api/Resource/ProductImage.php
@@ -298,6 +298,27 @@ class ProductImage extends AbstractTranslatableResource implements ItemFileResou
         return new ProductImageTableMap();
     }
 
+    /**
+     * What this shop accepts on an upload, so that a client can build its form
+     * without restating the lists. Read only: the constraints belong to the shop
+     * configuration, not to the file.
+     */
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'object',
+            'properties' => [
+                'allowedMimeTypes' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'allowedExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+                'forbiddenExtensions' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ],
+    )]
+    public function getUploadConstraints(): array
+    {
+        return FileUploadConstraints::forFileType(self::getFileType());
+    }
+
     public static function getItemType(): string
     {
         return 'product';

--- a/tests/Api/Admin/FileUploadConstraintsApiTest.php
+++ b/tests/Api/Admin/FileUploadConstraintsApiTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Thelia\Core\File\FileConfiguration;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\ProductDocument;
+use Thelia\Model\ProductImage;
+use Thelia\Test\ApiTestCase;
+use Thelia\Tests\Support\Trait\CreatesTestFiles;
+
+/**
+ * A client building an upload form has to be able to ask what the shop accepts,
+ * rather than restate the lists and drift away from what the server enforces.
+ */
+final class FileUploadConstraintsApiTest extends ApiTestCase
+{
+    use CreatesTestFiles;
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpTestFiles();
+        // The database changes are rolled back, the static config cache is not.
+        ConfigQuery::resetCache();
+        parent::tearDown();
+    }
+
+    public function testAnImageResourcePublishesTheAcceptedMimeTypes(): void
+    {
+        $constraints = $this->readConstraints($this->createImage());
+
+        self::assertSame(FileConfiguration::DEFAULT_IMAGE_MIME_TYPES, $constraints['allowedMimeTypes']);
+        self::assertContains('jpg', $constraints['allowedExtensions']);
+        self::assertContains('svg', $constraints['allowedExtensions']);
+        // The executable floor applies to images too, whatever the configuration says.
+        self::assertContains('php', $constraints['forbiddenExtensions']);
+    }
+
+    public function testADocumentResourcePublishesTheForbiddenExtensions(): void
+    {
+        $constraints = $this->readConstraints($this->createDocument());
+
+        // A document is constrained by extension, not by mime type.
+        self::assertSame([], $constraints['allowedMimeTypes']);
+        self::assertSame([], $constraints['allowedExtensions']);
+        self::assertContains('exe', $constraints['forbiddenExtensions']);
+        self::assertContains('php', $constraints['forbiddenExtensions']);
+    }
+
+    public function testWhatIsPublishedFollowsTheShopConfiguration(): void
+    {
+        ConfigQuery::write(FileConfiguration::IMAGE_MIME_TYPES_VARIABLE, 'image/png, image/avif');
+
+        $constraints = $this->readConstraints($this->createImage());
+
+        self::assertSame(['image/png', 'image/avif'], $constraints['allowedMimeTypes']);
+        self::assertSame(['png', 'avif'], $constraints['allowedExtensions']);
+    }
+
+    /**
+     * @return array{allowedMimeTypes: list<string>, allowedExtensions: list<string>, forbiddenExtensions: list<string>}
+     */
+    private function readConstraints(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri, token: $this->authenticateAsAdmin());
+
+        self::assertJsonResponseSuccessful($response);
+
+        $data = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('uploadConstraints', $data, (string) $response->getContent());
+
+        return $data['uploadConstraints'];
+    }
+
+    private function createImage(): string
+    {
+        $image = new ProductImage();
+        $image
+            ->setProductId($this->createProductId())
+            ->setFile('constraints-test.png')
+            ->setVisible(1)
+            ->setPosition(1)
+            ->save();
+
+        $this->storeMediaFile($image->getUploadDir(), 'constraints-test.png', $this->onePixelPng());
+
+        return '/api/admin/product_images/'.$image->getId();
+    }
+
+    private function createDocument(): string
+    {
+        $document = new ProductDocument();
+        $document
+            ->setProductId($this->createProductId())
+            ->setFile('constraints-test.pdf')
+            ->setVisible(1)
+            ->setPosition(1)
+            ->save();
+
+        $this->storeMediaFile($document->getUploadDir(), 'constraints-test.pdf', '%PDF-1.4');
+
+        return '/api/admin/product_documents/'.$document->getId();
+    }
+
+    private function createProductId(): int
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->product(
+            $factory->category(),
+            $factory->taxRule(),
+            $factory->currency(),
+        )->getId();
+    }
+
+    /**
+     * The resource carries a file url, which is computed by processing the stored
+     * file, so that file has to be on disk.
+     */
+    private function storeMediaFile(string $directory, string $fileName, string $content): void
+    {
+        if (!is_dir($directory)) {
+            mkdir($directory, 0o775, true);
+        }
+
+        $path = $directory.\DIRECTORY_SEPARATOR.$fileName;
+        file_put_contents($path, $content);
+        $this->trackFileForCleanup($path);
+    }
+
+    private function onePixelPng(): string
+    {
+        return (string) base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+            true,
+        );
+    }
+}


### PR DESCRIPTION
Closes #3593 — second half. Based on #3637, which makes `FileConfiguration` the
only source of the API upload policy; GitHub retargets this one to `main` once the
parent is merged.

## Why

An integrator writing an upload form has nowhere to ask what the shop accepts. The
lists live in `FileConfiguration`, follow two shop variables
(`image_upload_allowed_mime_types`, `document_upload_forbidden_extensions`) and are
not exposed anywhere, so a client either hardcodes them — and drifts the day the
shop widens its policy — or discovers them by getting a `415`.

## What is published

Every file resource gains a read-only `uploadConstraints`, in its
`GROUP_ADMIN_READ_SINGLE` group, so it appears on `GET /admin/product_images/{id}`
and on the `201` of an upload, and never on a collection where the same shop-wide
value would be repeated for every row:

```json
"uploadConstraints": {
  "allowedMimeTypes": ["image/jpeg","image/png","image/gif","image/webp","image/svg+xml"],
  "allowedExtensions": ["jpg","jpeg","png","gif","webp","svg"],
  "forbiddenExtensions": ["php","php3","phtml","phar","htaccess", "…"]
}
```

A document resource answers with an empty `allowedMimeTypes` — a document is
constrained by extension, not by type — and the shop blacklist plus the executable
floor in `forbiddenExtensions`.

`allowedExtensions` is there because it is what an `accept` attribute needs, and it
is derived from the same mime type table the server matches on, so the two cannot
disagree.

## How

`Api/Resource/FileUploadConstraints::forFileType()` reads `FileConfiguration` and
returns the three lists. The resources expose it through a getter carrying the read
group, which is how API Platform states "readable, not writable": there is no
setter, nothing to send, and the value is the shop configuration read at the moment
of the request rather than a stored field.

The value is an array and not a small object on purpose. A nested class holds no
serialization group of its own, and with `groups` in the context the serializer
normalizes it as `{}` — checked, that is what the first attempt produced.

## Compatibility

Additive only. No existing field is renamed, retyped or removed; the payload of the
same resource before this change is in the test output of the run below. `Get` on a
collection is untouched.

## How to verify

```
composer test:api -- --filter FileUploadConstraintsApiTest
```

`tests/Api/Admin/FileUploadConstraintsApiTest.php` reads the constraints from a
product image and a product document, and checks that narrowing
`image_upload_allowed_mime_types` to `image/png, image/avif` changes both published
lists.

Checked on the parent branch with only the test file added: the three cases fail on
`Failed asserting that an array has the key 'uploadConstraints'`. All three pass
here.

Five suites: unit 269, integration 478, api 200 (1 legitimate skip), flexy 11, back
office 11. `cs-diff` 0/1803, PHPStan 0 errors.
