### PR TITLE
feat: make the tax discount helpers replaceable, deprecating their statics

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/Order.php
+++ b/core/lib/Thelia/Core/Template/Loop/Order.php
@@ -24,7 +24,7 @@ use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\CustomerQuery;
 use Thelia\Model\Map\CustomerTableMap;
@@ -57,6 +57,8 @@ use Thelia\Type\TypeCollection;
  */
 class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInterface
 {
+    use TaxCalculatorResolverTrait;
+
     protected $countable = true;
     protected $timestampable = true;
     protected $versionable = false;
@@ -335,7 +337,7 @@ class Order extends BaseLoop implements SearchLoopInterface, PropelSearchLoopInt
             if ($order->getId() <= $lastLegacyOrderId) {
                 $discountWithoutTax = $order->getDiscount();
             } else {
-                $discountWithoutTax = Calculator::getUntaxedOrderDiscount($order);
+                $discountWithoutTax = $this->createTaxCalculator()->computeUntaxedOrderDiscount($order);
             }
 
             $hasVirtualDownload = $order->hasVirtualProductWithDocument();

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php
@@ -66,32 +66,78 @@ class Calculator implements TaxCalculatorInterface
     }
 
     /**
-     * @return float
+     * @deprecated since 3.0, use {@see computeUntaxedCartDiscount()} on the calculator
+     *             handed out by TaxCalculatorFactoryInterface. A static cannot be replaced,
+     *             so a custom tax engine never gets a say in this result.
      *
      * @throws PropelException
      */
     public static function getUntaxedCartDiscount(Cart $cart, Country $country, ?State $state = null): int|float
     {
-        return $cart->getDiscount() / self::getCartTaxFactor($cart, $country, $state);
+        trigger_deprecation('thelia/core', '3.0', 'Calculator::getUntaxedCartDiscount() is deprecated, ask a TaxCalculatorFactoryInterface for a calculator and call computeUntaxedCartDiscount() on it.');
+
+        return (new self())->computeUntaxedCartDiscount($cart, $country, $state);
     }
 
     /**
-     * @throws PropelException
-     */
-    /**
-     * @return float
+     * @deprecated since 3.0, use {@see computeUntaxedOrderDiscount()} on the calculator
+     *             handed out by TaxCalculatorFactoryInterface
      *
      * @throws PropelException
      */
     public static function getUntaxedOrderDiscount(Order $order): int|float
     {
-        return $order->getDiscount() / self::getOrderTaxFactor($order);
+        trigger_deprecation('thelia/core', '3.0', 'Calculator::getUntaxedOrderDiscount() is deprecated, ask a TaxCalculatorFactoryInterface for a calculator and call computeUntaxedOrderDiscount() on it.');
+
+        return (new self())->computeUntaxedOrderDiscount($order);
+    }
+
+    /**
+     * @deprecated since 3.0, use {@see computeOrderTaxFactor()} on the calculator
+     *             handed out by TaxCalculatorFactoryInterface
+     *
+     * @throws PropelException
+     */
+    public static function getOrderTaxFactor(Order $order): float
+    {
+        trigger_deprecation('thelia/core', '3.0', 'Calculator::getOrderTaxFactor() is deprecated, ask a TaxCalculatorFactoryInterface for a calculator and call computeOrderTaxFactor() on it.');
+
+        return (new self())->computeOrderTaxFactor($order);
+    }
+
+    /**
+     * @deprecated since 3.0, use {@see computeCartTaxFactor()} on the calculator
+     *             handed out by TaxCalculatorFactoryInterface
+     *
+     * @throws PropelException
+     */
+    public static function getCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
+    {
+        trigger_deprecation('thelia/core', '3.0', 'Calculator::getCartTaxFactor() is deprecated, ask a TaxCalculatorFactoryInterface for a calculator and call computeCartTaxFactor() on it.');
+
+        return (new self())->computeCartTaxFactor($cart, $country, $state);
     }
 
     /**
      * @throws PropelException
      */
-    public static function getOrderTaxFactor(Order $order): float
+    public function computeUntaxedCartDiscount(Cart $cart, Country $country, ?State $state = null): int|float
+    {
+        return $cart->getDiscount() / $this->computeCartTaxFactor($cart, $country, $state);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function computeUntaxedOrderDiscount(Order $order): int|float
+    {
+        return $order->getDiscount() / $this->computeOrderTaxFactor($order);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function computeOrderTaxFactor(Order $order): float
     {
         if (0.0 === (float) $order->getDiscount()) {
             return 1;
@@ -103,7 +149,7 @@ class Calculator implements TaxCalculatorInterface
             return self::$orderTaxFactors[$order];
         }
 
-        // Find the average Tax rate (see \Thelia\TaxEngine\Calculator::getCartTaxFactor())
+        // Find the average Tax rate (see computeCartTaxFactor())
         $orderTaxFactors = [];
 
         /** @var OrderProduct $orderProduct */
@@ -124,7 +170,7 @@ class Calculator implements TaxCalculatorInterface
     /**
      * @throws PropelException
      */
-    public static function getCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
+    public function computeCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
     {
         if (0.0 === (float) $cart->getDiscount()) {
             return 1;

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorInterface.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxCalculatorInterface.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 
 namespace Thelia\Domain\Taxation\TaxEngine;
 
+use Thelia\Model\Cart;
 use Thelia\Model\Country;
+use Thelia\Model\Order;
 use Thelia\Model\Product;
 use Thelia\Model\State;
 use Thelia\Model\TaxRule;
@@ -43,4 +45,23 @@ interface TaxCalculatorInterface
     public function getTaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null, ?string $askedLocale = null): int|float;
 
     public function getUntaxedPrice($taxedPrice): int|float;
+
+    /**
+     * The share of a cart discount that is not tax, so that a shop can spread a
+     * coupon over its lines the way its accounting requires.
+     *
+     * These four do not depend on a load*() call: they take the cart or the order
+     * they work on as an argument. They replace the four statics of the same
+     * purpose on Calculator, which are deprecated and cannot be substituted.
+     */
+    public function computeUntaxedCartDiscount(Cart $cart, Country $country, ?State $state = null): int|float;
+
+    public function computeUntaxedOrderDiscount(Order $order): int|float;
+
+    /**
+     * The average tax factor of the cart, the divisor applied to its discount.
+     */
+    public function computeCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float;
+
+    public function computeOrderTaxFactor(Order $order): float;
 }

--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -20,11 +20,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Cart\CartDuplicationEvent;
 use Thelia\Core\Event\Cart\CartItemDuplicationItem;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Base\Cart as BaseCart;
 
 class Cart extends BaseCart
 {
+    use TaxCalculatorResolverTrait;
+
     /**
      * Duplicate the current existing cart. Only the token is changed.
      *
@@ -258,7 +260,7 @@ class Cart extends BaseCart
             return (float) $this->getDiscount();
         }
 
-        return round(Calculator::getUntaxedCartDiscount($this, $country, $state), 2);
+        return round($this->createTaxCalculator()->computeUntaxedCartDiscount($this, $country, $state), 2);
     }
 
     public function getTaxedPostage(): float

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -23,7 +23,7 @@ use Thelia\Core\Event\Payment\ManageStockOnCreationEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Domain\Order\Service\SequenceOrderRefGenerator;
 use Thelia\Domain\Sequence\GaplessSequenceGenerator;
-use Thelia\Domain\Taxation\TaxEngine\Calculator;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Exception\TheliaProcessException;
 use Thelia\Model\Base\Order as BaseOrder;
 use Thelia\Model\Map\OrderProductTableMap;
@@ -34,6 +34,8 @@ use Thelia\Module\PaymentModuleInterface;
 
 class Order extends BaseOrder
 {
+    use TaxCalculatorResolverTrait;
+
     protected ?int $choosenDeliveryAddress = null;
 
     protected ?int $choosenInvoiceAddress = null;
@@ -262,7 +264,7 @@ class Order extends BaseOrder
 
         if (true === $includeDiscount) {
             $total -= $this->getDiscount();
-            $tax -= $this->getDiscount() - Calculator::getUntaxedOrderDiscount($this);
+            $tax -= $this->getDiscount() - $this->createTaxCalculator()->computeUntaxedOrderDiscount($this);
 
             if ($total < 0) {
                 $total = 0;

--- a/tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php
+++ b/tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php
@@ -20,8 +20,10 @@ use Thelia\Domain\Taxation\TaxEngine\Calculator;
 use Thelia\Domain\Taxation\TaxEngine\OrderProductTaxCollection;
 use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
 use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\Cart;
 use Thelia\Model\CartItem;
 use Thelia\Model\Country;
+use Thelia\Model\Order;
 use Thelia\Model\OrderProductTax;
 use Thelia\Model\Product;
 use Thelia\Model\State;
@@ -35,6 +37,12 @@ use Thelia\Test\IntegrationTestCase;
 final class TaxCalculatorReplacementTest extends IntegrationTestCase
 {
     public const SUBSTITUTED_TAXED_PRICE = 133.7;
+
+    /**
+     * What the substitute answers when asked to split a discount, whatever the
+     * discount actually is.
+     */
+    public const SUBSTITUTED_UNTAXED_DISCOUNT = 42.42;
 
     private ?\Closure $listener = null;
 
@@ -111,6 +119,61 @@ final class TaxCalculatorReplacementTest extends IntegrationTestCase
         self::assertSame('substituted', $taxDetail->getKey(0)->getTitle());
     }
 
+    /**
+     * The discount split used to be four statics, which no module could replace.
+     */
+    public function testCartDiscountSplitGoesThroughTheReplacedCalculator(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $cart = $factory->cart();
+        $cart->setDiscount('10')->save($this->getPropelConnection());
+        $country = $factory->country();
+
+        self::assertSame(
+            10.0,
+            $cart->getCalculatedDiscount(false, $country),
+            'Nothing taxable in the cart: the shipped calculator leaves the discount alone.',
+        );
+
+        $this->replaceCalculator();
+
+        self::assertSame(
+            self::SUBSTITUTED_UNTAXED_DISCOUNT,
+            $cart->getCalculatedDiscount(false, $country),
+        );
+    }
+
+    public function testOrderDiscountSplitGoesThroughTheReplacedCalculator(): void
+    {
+        $order = $this->createFixtureFactory()->order();
+        $order->setDiscount('10')->save($this->getPropelConnection());
+
+        $tax = 0.0;
+        $order->getTotalAmount($tax);
+        self::assertSame(0.0, $tax, 'No order product, so no tax to take the discount out of.');
+
+        $this->replaceCalculator();
+
+        $tax = 0.0;
+        $order->getTotalAmount($tax);
+
+        // getTotalAmount() subtracts (discount - untaxed discount) from the tax.
+        self::assertSame(self::SUBSTITUTED_UNTAXED_DISCOUNT - 10.0, $tax);
+    }
+
+    public function testTheDeprecatedStaticsStillAnswer(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $cart = $factory->cart();
+        $cart->setDiscount('10')->save($this->getPropelConnection());
+        $order = $factory->order();
+
+        self::assertSame(1.0, Calculator::getCartTaxFactor($cart, $factory->country()));
+        self::assertSame(10.0, (float) Calculator::getUntaxedCartDiscount($cart, $factory->country()));
+        self::assertSame(1.0, Calculator::getOrderTaxFactor($order));
+        self::assertSame(0.0, (float) Calculator::getUntaxedOrderDiscount($order));
+    }
+
     public function testFactoryIsAliasedAndHandsOutAFreshInstanceEveryTime(): void
     {
         $factory = $this->getService(TaxCalculatorFactoryInterface::class);
@@ -178,6 +241,26 @@ final class TaxCalculatorReplacementTest extends IntegrationTestCase
                 public function getUntaxedPrice($taxedPrice): int|float
                 {
                     return $taxedPrice;
+                }
+
+                public function computeUntaxedCartDiscount(Cart $cart, Country $country, ?State $state = null): int|float
+                {
+                    return TaxCalculatorReplacementTest::SUBSTITUTED_UNTAXED_DISCOUNT;
+                }
+
+                public function computeUntaxedOrderDiscount(Order $order): int|float
+                {
+                    return TaxCalculatorReplacementTest::SUBSTITUTED_UNTAXED_DISCOUNT;
+                }
+
+                public function computeCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
+                {
+                    return 2.0;
+                }
+
+                public function computeOrderTaxFactor(Order $order): float
+                {
+                    return 2.0;
                 }
             });
         };


### PR DESCRIPTION
Closes #3594. The compatibility question the issue asks to settle is answered by a
census: nothing outside the core calls these four statics, and they are kept working
anyway.

## The census that decided it

`getUntaxedCartDiscount()`, `getUntaxedOrderDiscount()`, `getCartTaxFactor()` and
`getOrderTaxFactor()`, searched across the 162 Thelia 3 modules, the four template
repositories, the `thelia-modules` organisation and public code:

| Caller | Kind |
|---|---|
| `core/lib/Thelia/Model/Cart.php:261` | core |
| `core/lib/Thelia/Model/Order.php:265` | core |
| `core/lib/Thelia/Core/Template/Loop/Order.php:338` | core |
| `core/lib/Thelia/Domain/Taxation/TaxEngine/Calculator.php:61`, `:74` | core, internal |
| `SOBIO-BCB/lgpb-drive/override/Thelia/Model/Cart.php` | a project overriding `Model\Cart` |

No module, no theme. The one caller outside the core is a copy of `Model\Cart` in a
shop project, which is exactly the kind of consumer a silent rename would break
weeks later, so the statics stay.

## What changes

Four instance methods on `TaxCalculatorInterface`, which is what makes them
replaceable:

```
computeUntaxedCartDiscount(Cart, Country, ?State)
computeUntaxedOrderDiscount(Order)
computeCartTaxFactor(Cart, Country, ?State)
computeOrderTaxFactor(Order)
```

They carry the bodies; the four statics are now one-line delegates marked
`@deprecated` and raising `trigger_deprecation('thelia/core', '3.0', …)`, the way
#3585 handles `routing.xml`. Old code keeps working and keeps the behaviour it has
today, and there is a single implementation, so the two paths cannot drift.

The three core call sites go through `TaxCalculatorResolverTrait`, the route #3587
already established for the places with no container: `Model\Cart`, `Model\Order` and
the order loop ask for a calculator through `TheliaEvents::TAX_GET_CALCULATOR`, so a
module replacing the engine finally has a say in how a discount is split between tax
and untaxed amount.

```php
$services->set(MyTaxCalculatorFactory::class)->autowire();
$services->alias(TaxCalculatorFactoryInterface::class, MyTaxCalculatorFactory::class);
```

Naming: `compute*` rather than `get*` because PHP forbids an instance method next to
a static of the same name, and because these four do not depend on a `load*()` call —
they take the cart or the order they work on as an argument, unlike the rest of the
calculator.

## Compatibility

- The four statics keep their signature and their result. Nothing is removed.
- `TaxCalculatorInterface` gains four methods, which an implementation must add. The
  interface was introduced in #3587 and has not shipped in a release yet, so this is
  the cheap moment to widen it; the only implementations today are `Calculator` and
  the test double, both updated here.
- The static memoisation of the two tax factors stays static on purpose. The factory
  hands out a fresh calculator per call site, so an instance cache would memoise
  nothing. The `WeakMap` keying introduced by #3596 is untouched.

## Already done elsewhere

The issue also mentions the shared function-static cache that gave the second order
of a request the first order's tax factor, and the two back-office themes building
the calculator directly. The cache was fixed by #3596 (`WeakMap` keyed on the order
or the cart) and #3612 (an untaxable cart leaves its discount alone); the theme side
lives in `thelia-templates/default-twig` and `thelia-templates/back` and is not
touched here.

## How to verify

```
composer test:integration -- --filter TaxCalculatorReplacementTest
```

`tests/Integration/Domain/Taxation/TaxCalculatorReplacementTest.php` gains
`testCartDiscountSplitGoesThroughTheReplacedCalculator`,
`testOrderDiscountSplitGoesThroughTheReplacedCalculator` and
`testTheDeprecatedStaticsStillAnswer`.

Checked on `main` with only the test changes applied: the two replacement cases fail
(`Failed asserting that 10.0 is identical to 42.42` and `that 0.0 is identical to
32.42`) because the models call the statics; the deprecated-statics case passes there
and here, which is the point. All eight pass with this change.

Local run: unit 269, api 188 (1 legitimate skip), flexy 11, back office 11,
integration green apart from `FileProcessorServiceTest`, which needs the Twig back
office wired to keep `FileProcessorService` out of the inliner and is unrelated.
`cs-diff` 0/1799, PHPStan 0 errors.
