### PR TITLE
fix: convert the trusted proxy and host parameters to what Request accepts

### DIFF
--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -787,15 +787,59 @@ class TheliaKernel extends Kernel
 
         $container = $this->container;
 
+        self::configureTrustedRequestSources($container);
+
+        return $container;
+    }
+
+    /**
+     * Applies framework.trusted_hosts and framework.trusted_proxies to the Request class.
+     *
+     * FrameworkExtension stores a single trusted host or proxy as a scalar, and trusted
+     * headers as the list of header names taken from the configuration, while Request
+     * expects an array of host patterns and a bitmask of Request::HEADER_* constants.
+     */
+    protected static function configureTrustedRequestSources(ContainerInterface $container): void
+    {
         if ($container->hasParameter('kernel.trusted_hosts') && $trustedHosts = $container->getParameter('kernel.trusted_hosts')) {
-            Request::setTrustedHosts($trustedHosts);
+            Request::setTrustedHosts(\is_array($trustedHosts) ? $trustedHosts : preg_split('/\s*+,\s*+(?![^{]*})/', (string) $trustedHosts));
         }
 
         if ($container->hasParameter('kernel.trusted_proxies') && $container->hasParameter('kernel.trusted_headers') && $trustedProxies = $container->getParameter('kernel.trusted_proxies')) {
-            Request::setTrustedProxies(\is_array($trustedProxies) ? $trustedProxies : array_map('trim', explode(',', (string) $trustedProxies)), $container->getParameter('kernel.trusted_headers'));
+            Request::setTrustedProxies(
+                \is_array($trustedProxies) ? $trustedProxies : array_map('trim', explode(',', (string) $trustedProxies)),
+                self::trustedHeaderSet($container->getParameter('kernel.trusted_headers')),
+            );
+        }
+    }
+
+    private static function trustedHeaderSet(array|bool|float|int|string|\UnitEnum|null $trustedHeaders): int
+    {
+        if (\is_int($trustedHeaders)) {
+            return $trustedHeaders;
         }
 
-        return $container;
+        if (\is_string($trustedHeaders)) {
+            $trustedHeaders = array_map('trim', explode(',', $trustedHeaders));
+        }
+
+        if (!\is_array($trustedHeaders)) {
+            return Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO;
+        }
+
+        $trustedHeaderSet = 0;
+
+        foreach ($trustedHeaders as $trustedHeader) {
+            $constant = Request::class.'::HEADER_'.strtr(strtoupper((string) $trustedHeader), '-', '_');
+
+            if (!\defined($constant)) {
+                throw new \InvalidArgumentException(\sprintf('The trusted header "%s" is not supported.', $trustedHeader));
+            }
+
+            $trustedHeaderSet |= \constant($constant);
+        }
+
+        return $trustedHeaderSet;
     }
 
     private function loadModuleTranslationDirectories(

--- a/tests/Support/Kernel/TrustedRequestSourcesKernel.php
+++ b/tests/Support/Kernel/TrustedRequestSourcesKernel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Support\Kernel;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Thelia\Core\TheliaKernel;
+
+/**
+ * Exposes the trusted host and proxy wiring the kernel applies while booting,
+ * so it can be exercised without an installed Thelia behind it.
+ */
+final class TrustedRequestSourcesKernel extends TheliaKernel
+{
+    public static function applyTo(ContainerInterface $container): void
+    {
+        self::configureTrustedRequestSources($container);
+    }
+}

--- a/tests/Unit/Core/TrustedRequestSourcesTest.php
+++ b/tests/Unit/Core/TrustedRequestSourcesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Thelia\Tests\Support\Kernel\TrustedRequestSourcesKernel;
+
+/**
+ * framework.trusted_hosts and framework.trusted_proxies reach the container as the
+ * shapes FrameworkExtension produces: a scalar for a single value, and a list of
+ * header names for the trusted headers. The kernel has to translate them into what
+ * Request accepts, or booting fails on a TypeError.
+ */
+final class TrustedRequestSourcesTest extends TestCase
+{
+    /** @var array<int, string> */
+    private array $trustedProxies;
+
+    private int $trustedHeaderSet;
+
+    protected function setUp(): void
+    {
+        $this->trustedProxies = Request::getTrustedProxies();
+        $this->trustedHeaderSet = Request::getTrustedHeaderSet();
+    }
+
+    protected function tearDown(): void
+    {
+        Request::setTrustedProxies($this->trustedProxies, $this->trustedHeaderSet);
+        Request::setTrustedHosts([]);
+    }
+
+    public function testASingleTrustedProxyIsAccepted(): void
+    {
+        TrustedRequestSourcesKernel::applyTo($this->containerWith([
+            'kernel.trusted_proxies' => '10.0.0.1',
+            'kernel.trusted_headers' => ['x-forwarded-for', 'x-forwarded-proto'],
+        ]));
+
+        self::assertSame(['10.0.0.1'], Request::getTrustedProxies());
+        self::assertSame(
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PROTO,
+            Request::getTrustedHeaderSet(),
+        );
+    }
+
+    public function testTrustedProxiesFallBackToTheDefaultHeaderSet(): void
+    {
+        TrustedRequestSourcesKernel::applyTo($this->containerWith([
+            'kernel.trusted_proxies' => ['10.0.0.1', '10.0.0.2'],
+            'kernel.trusted_headers' => null,
+        ]));
+
+        self::assertSame(['10.0.0.1', '10.0.0.2'], Request::getTrustedProxies());
+        self::assertSame(
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO,
+            Request::getTrustedHeaderSet(),
+        );
+    }
+
+    public function testAProxyTerminatingTlsIsSeenAsAnHttpsRequest(): void
+    {
+        TrustedRequestSourcesKernel::applyTo($this->containerWith([
+            'kernel.trusted_proxies' => '10.0.0.1',
+            'kernel.trusted_headers' => ['x-forwarded-for', 'x-forwarded-proto'],
+        ]));
+
+        $request = Request::create('http://shop.example.com/admin/login', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '10.0.0.1',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+        ]);
+
+        self::assertSame('https', $request->getScheme());
+    }
+
+    public function testAnUnsupportedTrustedHeaderIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The trusted header "x-real-ip" is not supported.');
+
+        TrustedRequestSourcesKernel::applyTo($this->containerWith([
+            'kernel.trusted_proxies' => '10.0.0.1',
+            'kernel.trusted_headers' => ['x-real-ip'],
+        ]));
+    }
+
+    public function testASingleTrustedHostIsAccepted(): void
+    {
+        TrustedRequestSourcesKernel::applyTo($this->containerWith([
+            'kernel.trusted_hosts' => 'shop.example.com',
+        ]));
+
+        self::assertSame(['{shop.example.com}i'], Request::getTrustedHosts());
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function containerWith(array $parameters): ContainerInterface
+    {
+        $container = new Container();
+
+        foreach ($parameters as $name => $value) {
+            $container->setParameter($name, $value);
+        }
+
+        return $container;
+    }
+}


### PR DESCRIPTION
Fixes #3644.

## Symptom

Setting `framework.trusted_proxies` makes every request fail with a 500 at kernel boot:

```
Request::setTrustedProxies(): Argument #2 ($trustedHeaderSet) must be of type int, null given,
called in core/lib/Thelia/Core/TheliaKernel.php on line 793
```

Reproduced on 3.0.0-beta3 with `framework.trusted_proxies: '127.0.0.1'` (`null given`), and with
`trusted_headers` also declared (`array given`). Both `/` and `/admin/login` returned 500.

The same block breaks a second, unreported case: `framework.trusted_hosts: 'shop.example.com'` — a
single host, the common form — 500s too:

```
Request::setTrustedHosts(): Argument #1 ($hostPatterns) must be of type array, string given,
called in core/lib/Thelia/Core/TheliaKernel.php on line 789
```

## Cause

`TheliaKernel::preBoot()` carries a copy of Symfony's `Kernel::preBoot()` that has drifted from the
shapes `FrameworkExtension` produces:

- `core/lib/Thelia/Core/TheliaKernel.php:795` hands `kernel.trusted_headers` straight to
  `Request::setTrustedProxies()`. The parameter holds header *names*
  (`['x-forwarded-for', ...]`, or `null` when the option is left out), while `setTrustedProxies()`
  expects an `int` bitmask of `Request::HEADER_*` constants
  (`vendor/symfony/http-foundation/Request.php:607`).
- `core/lib/Thelia/Core/TheliaKernel.php:791` hands `kernel.trusted_hosts` straight to
  `Request::setTrustedHosts()`, which requires an array. `FrameworkExtension` unwraps a single-element
  list into the scalar itself (`FrameworkExtension.php:394`), so one trusted host arrives as a string.

Upstream does the two conversions in `vendor/symfony/http-kernel/Kernel.php:766-791`.

## Fix

The block moves to `configureTrustedRequestSources()`, which mirrors what Symfony's kernel does:
header names (or a comma-separated string) become a bitmask, an already-numeric value is passed
through, a missing value falls back to `X-Forwarded-For|Port|Proto`, an unsupported header name is
rejected with a clear message, and a scalar trusted host is wrapped back into a list.

Note for anyone tempted by the "just delete the block" option: `FrameworkExtension` only sets the
container parameters — the call to `Request::setTrustedProxies()` lives in `Kernel::preBoot()`, which
is private and which `TheliaKernel` overrides, so dropping the block would leave `trusted_proxies`
silently without effect.

## Verification

`tests/Unit/Core/TrustedRequestSourcesTest.php` covers the five cases. Checked red with the previous
one-liners restored (4 errors, 1 failure), green with the fix (5 tests, 8 assertions).

End to end on a DDEV install, with `trusted_proxies: 'private_ranges'` and the four forwarded headers
declared: `/` and `/admin/login` return 200 where they returned 500, the applied header set is 30
(`For|Proto|Port|Host`), and a request arriving through the TLS-terminating router is now read as
`https` instead of `http`.

Five suites green locally: unit 261, integration 391, api 187 (1 skip), flexy 11, backoffice 11.
`composer cs-diff` 0/1762, `composer phpstan` no errors.
