### PR TITLE
fix: export every order when no date range is given, and let the command supply one

### DIFF
--- a/core/lib/Thelia/Command/ExportCommand.php
+++ b/core/lib/Thelia/Command/ExportCommand.php
@@ -65,6 +65,18 @@ class ExportCommand extends ContainerAwareCommand
                 'en_US',
             )
             ->addOption(
+                'start',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only export records created on or after this date, for the exports that support a date range.',
+            )
+            ->addOption(
+                'end',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only export records created on or before this date, for the exports that support a date range.',
+            )
+            ->addOption(
                 'list-export',
                 null,
                 InputOption::VALUE_NONE,
@@ -136,6 +148,9 @@ class ExportCommand extends ContainerAwareCommand
             $serializer,
             $archiver,
             (new LangQuery())->findOneByLocale($input->getOption('locale')),
+            false,
+            false,
+            $this->readDateRange($input),
         );
 
         $formattedLine = $this->getHelper('formatter')->formatBlock(
@@ -148,6 +163,44 @@ class ExportCommand extends ContainerAwareCommand
         $output->writeln('<comment>'.$exportEvent->getFilePath().'</comment>');
 
         return 0;
+    }
+
+    /**
+     * A date range is optional: without one, an export covers every record.
+     * A single bound is honoured on its own.
+     *
+     * @return array{start: \DateTime|null, end: \DateTime|null}|null
+     */
+    protected function readDateRange(InputInterface $input): ?array
+    {
+        $start = $this->readDate($input, 'start');
+        $end = $this->readDate($input, 'end');
+
+        if (null === $start && null === $end) {
+            return null;
+        }
+
+        return ['start' => $start, 'end' => $end];
+    }
+
+    protected function readDate(InputInterface $input, string $option): ?\DateTime
+    {
+        $value = $input->getOption($option);
+
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        // A day given without a time covers that whole day, as the back-office range does.
+        if ('end' === $option && 1 === preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            $value .= ' 23:59:59';
+        }
+
+        try {
+            return new \DateTime($value);
+        } catch (\Exception $exception) {
+            throw new \InvalidArgumentException(\sprintf('--%s is not a readable date: %s', $option, $value), 0, $exception);
+        }
     }
 
     /**

--- a/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
@@ -155,7 +155,7 @@ class OrderExport extends JsonFileAbstractExport
                 LEFT JOIN country_i18n as delivery_country_i18n ON delivery_country_i18n.id = delivery_address.country_id AND delivery_country_i18n.locale = :locale
                 LEFT JOIN country_i18n as invoice_country_i18n ON invoice_country_i18n.id = invoice_address.country_id AND invoice_country_i18n.locale = :locale
                 LEFT JOIN currency ON currency.id = order.currency_id
-                WHERE `order`.created_at >= :start AND `order`.created_at <= :end
+                '.$this->buildDateRangeCondition().'
                 GROUP BY `order`.id
                 ORDER BY `order`.created_at DESC
             ) as tmp
@@ -163,10 +163,49 @@ class OrderExport extends JsonFileAbstractExport
 
         $stmt = $con->prepare($query);
         $stmt->bindValue('locale', $locale);
-        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d H:i:s'));
-        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d H:i:s'));
+
+        foreach ($this->getDateRangeBounds() as $bound => $date) {
+            $stmt->bindValue($bound, $date->format('Y-m-d H:i:s'));
+        }
+
         $stmt->execute();
 
         return $this->getDataJsonCache($stmt, 'order');
+    }
+
+    /**
+     * A date range is optional: without one, the export covers every order.
+     * A single bound is honoured on its own, so `--start` alone exports
+     * everything since that date.
+     *
+     * @return array<string, \DateTimeInterface>
+     */
+    private function getDateRangeBounds(): array
+    {
+        $bounds = [];
+
+        foreach (['start', 'end'] as $bound) {
+            if (($this->rangeDate[$bound] ?? null) instanceof \DateTimeInterface) {
+                $bounds[$bound] = $this->rangeDate[$bound];
+            }
+        }
+
+        return $bounds;
+    }
+
+    private function buildDateRangeCondition(): string
+    {
+        $comparisons = ['start' => '>=', 'end' => '<='];
+        $conditions = [];
+
+        foreach ($this->getDateRangeBounds() as $bound => $date) {
+            $conditions[] = '`order`.created_at '.$comparisons[$bound].' :'.$bound;
+        }
+
+        if ($conditions === []) {
+            return '';
+        }
+
+        return 'WHERE '.implode(' AND ', $conditions);
     }
 }

--- a/tests/Integration/Domain/DataTransfer/OrderExportTest.php
+++ b/tests/Integration/Domain/DataTransfer/OrderExportTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\DataTransfer;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Domain\DataTransfer\Export\Type\OrderExport;
+use Thelia\Model\Lang;
+use Thelia\Model\Order;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The order export is the only one bounded by dates. `php Thelia export` used
+ * to be unable to run it at all, having no way to supply a range.
+ */
+final class OrderExportTest extends IntegrationTestCase
+{
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = $this->createFixtureFactory();
+
+        // getDataJsonCache() writes its row cache there without creating it;
+        // only ExportHandler::processExport() does, and this test does not go
+        // through the handler.
+        (new Filesystem())->mkdir(THELIA_CACHE_DIR.'export');
+    }
+
+    public function testItExportsEveryOrderWhenNoRangeIsGiven(): void
+    {
+        $old = $this->orderCreatedAt('-3 years');
+        $recent = $this->orderCreatedAt('-1 day');
+
+        $refs = $this->exportedRefs(null);
+
+        self::assertContains($old->getRef(), $refs);
+        self::assertContains($recent->getRef(), $refs);
+    }
+
+    public function testItKeepsOnlyTheOrdersInsideTheRange(): void
+    {
+        $old = $this->orderCreatedAt('-3 years');
+        $recent = $this->orderCreatedAt('-1 day');
+
+        $refs = $this->exportedRefs([
+            'start' => new \DateTime('-1 month'),
+            'end' => new \DateTime(),
+        ]);
+
+        self::assertContains($recent->getRef(), $refs);
+        self::assertNotContains($old->getRef(), $refs);
+    }
+
+    public function testASingleBoundIsEnoughToFilter(): void
+    {
+        $old = $this->orderCreatedAt('-3 years');
+        $recent = $this->orderCreatedAt('-1 day');
+
+        $refs = $this->exportedRefs(['start' => new \DateTime('-1 month'), 'end' => null]);
+
+        self::assertContains($recent->getRef(), $refs);
+        self::assertNotContains($old->getRef(), $refs);
+    }
+
+    private function orderCreatedAt(string $modifier): Order
+    {
+        $order = $this->factory->order();
+        $order->setRef('EXP-'.uniqid());
+        $order->setCreatedAt(new \DateTime($modifier));
+        $order->save($this->getPropelConnection());
+
+        return $order;
+    }
+
+    /**
+     * @param array<string, \DateTime|null>|null $rangeDate
+     *
+     * @return array<int, string>
+     */
+    private function exportedRefs(?array $rangeDate): array
+    {
+        $export = new OrderExport();
+        $export->setLang(Lang::getDefaultLanguage());
+        $export->setRangeDate($rangeDate);
+
+        $refs = [];
+
+        foreach ($export as $row) {
+            if (isset($row['order_ref'])) {
+                $refs[] = $row['order_ref'];
+            }
+        }
+
+        return $refs;
+    }
+}


### PR DESCRIPTION
## Symptom

`php Thelia export thelia.export.orders thelia.csv` cannot run. `thelia.export.orders` is the only export declaring `USE_RANGE_DATE = true`, and it dereferenced its range unconditionally at `core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php:166`: `$this->rangeDate['start']->format(...)` on a `?array` that is `null` by default (`Export/AbstractExport.php:77`). The console has no option to supply a range, so from a terminal this export could only ever fail.

The back office never exercised that path. Its `DateType` uses `input => array`, so the submitted value is always a non-empty array and `ExportController` always passes a range.

## What it does now

- **No range means every order.** The `WHERE` clause is built from the bounds that are actually present, so the query is simply unbounded when there are none.
- **Each bound stands on its own.** `--start` alone exports everything since that date, `--end` alone everything up to it.
- **The command can supply a range** with `--start` and `--end`, forwarded to `ExportHandler` for any export that declares `USE_RANGE_DATE`. An `--end` given as a bare day covers that whole day (23:59:59), which matches what the back-office range does with its end month.

## Why every order, rather than a refusal

Measured, not guessed, on a disposable MariaDB 10.11 loaded with `setup/thelia.sql` and synthetic orders (three products carrying one tax line each, spread over four years), running this export's own SQL plus `getDataJsonCache()` and `CSVSerializer::serialize()` / `finalizeFile()`:

| orders | SQL | total | CSV | row cache on disk | peak PHP memory | peak RSS |
|---|---|---|---|---|---|---|
| 10 000 | 0.4 s | 0.5 s | 4.1 MB | 14 MB | 10 MB | 29 MB |
| 100 000 | 3.9 s | 5.6 s | 41 MB | 144 MB | 85 MB | 104 MB |
| 500 000 | 23 s | 32 s | 204 MB | 720 MB | 420 MB | 438 MB |

Half a million orders export in half a minute. An unbounded export is therefore not a new class of risk: it is the same code path the back office already reaches by picking the widest range its form offers, and a command that refuses to run without an option would be the more surprising of the two behaviours.

Three things the measurement surfaced that are pre-existing and left untouched here:

- the statement is buffered, so the whole result set sits in PHP memory. With a 128 MB limit this export dies inside `execute()` at roughly 150 000 orders, however the range is passed;
- `CSVSerializer::finalizeFile()` reads the finished CSV back with `file_get_contents()` and `stream_get_contents()` to prepend the header row, which is why peak memory lands at about twice the CSV size. Streaming rows to disk is careful about memory, and finalising throws that away;
- the intermediate row cache in `cache/export/order.json` is three and a half times the size of the CSV it produces, and it is never deleted after the export.

## How to verify

`tests/Integration/Domain/DataTransfer/OrderExportTest.php` creates one order three years old and one from yesterday, then asserts that both are exported with no range, only the recent one with a range, and only the recent one with `start` alone.

Reverting the `OrderExport` change on this branch while keeping the tests turned the CI red, on both PHP versions: `Error: Call to a member function format() on null` at `OrderExport.php:166` and `:167`, `Tests: 488, Errors: 2`. The middle test is the regression guard and passes either way, since it supplies both bounds.

The generated SQL was also run against the 500 000-order database in its four shapes: no bound 500 000 rows, `start` only 201 432, `end` only 173 311, both bounds 124 915.

Fixes #3642
