### PR TITLE
fix: make the tracked env, bundles and phpunit files match what the recipes install

### DIFF
--- a/.env
+++ b/.env
@@ -60,3 +60,11 @@ JWT_REFRESH_TOKEN_TTL=2592000
 # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
 DEFAULT_URI=http://localhost
 ###< symfony/routing ###
+
+###> thelia/backoffice-default-twig-template ###
+ACTIVE_ADMIN_TEMPLATE=default-twig
+###< thelia/backoffice-default-twig-template ###
+
+###> thelia/flexy ###
+ACTIVE_FRONT_TEMPLATE=flexy
+###< thelia/flexy ###

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /vendor/
 ###< symfony/framework-bundle ###
 
+# Seeded by the symfony/framework-bundle recipe with a locally generated
+# APP_SECRET, so it belongs to the install, not to the repository.
+/.env.dev
+
 composer.lock
 symfony.lock
 phpunit.xml
@@ -108,7 +112,6 @@ public/.htaccess
 local/modules/
 templates/frontOffice/
 templates/backOffice/*
-!templates/backOffice/default-twig
 templates/email/
 templates/pdf/
 ###> liip/imagine-bundle ###

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
@@ -18,4 +19,7 @@ return [
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    BackOfficeDefaultBundle\BackOfficeDefaultBundle::class => ['all' => true],
+    BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle::class => ['all' => true],
+    FlexyBundle\FlexyBundle::class => ['all' => true],
 ];

--- a/core/lib/Thelia/Domain/Module/Composer/ComposerHelper.php
+++ b/core/lib/Thelia/Domain/Module/Composer/ComposerHelper.php
@@ -198,7 +198,10 @@ class ComposerHelper
 
     private function dumpBundlesPhp(array $bundles): string
     {
-        $lines = ["<?php\n", "return [\n"];
+        // Same layout as Symfony Flex's BundlesConfigurator, so that enabling a
+        // theme bundle here and a "composer install" afterwards leave the file
+        // byte for byte identical instead of fighting over the blank line.
+        $lines = ["<?php\n", "\n", "return [\n"];
 
         foreach ($bundles as $fqcn => $envs) {
             $envParts = [];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -67,6 +67,9 @@
     </testsuites>
 
     <extensions>
-        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
+            <parameter name="clock-mock-namespaces" value="App" />
+            <parameter name="dns-mock-namespaces" value="App" />
+        </bootstrap>
     </extensions>
 </phpunit>


### PR DESCRIPTION
Fixes #3645

## Symptom

On a checkout of `main`, `composer install` alone leaves the working tree dirty:

```
 M .env
 M config/bundles.php
 M phpunit.xml.dist
?? .env.dev
?? templates/backOffice/default-twig/
```

Restoring the tracked `config/bundles.php` on that installed instance makes the application refuse to boot:

```
In Loader.php line 67:
  Cannot load resource ".". Make sure there is a loader supporting the "bo_default_attribute" type.
```

So the tracked state of the repository was not a state the application could run in, and any `git restore` on those paths silently changed what the next test run measured — which is how #3627 came to pass in CI and fail on a plain checkout.

## Cause

Three Flex configurators write into files that are tracked, because the tracked content is not what the recipes expect to find.

**`phpunit.xml.dist`** — the `symfony/phpunit-bridge` recipe (`symfony/recipes:main`, `>=7.3`) patches the file through the `add-lines` configurator with this block:

```xml
        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
            <parameter name="clock-mock-namespaces" value="App" />
            <parameter name="dns-mock-namespaces" value="App" />
        </bootstrap>
```

`AddLinesConfigurator::getPatchedContents()` (`vendor/symfony/flex/src/Configurator/AddLinesConfigurator.php:171-173`) returns early when the file already contains that exact string. The tracked file carried the self-closing one-line form `<bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />`, which does not match, so the block was appended next to it and the file ended up with **two** `<bootstrap>` entries for the same extension.

To be accurate about the consequence: with the locked versions (`phpunit/phpunit` 11.5.56, `symfony/phpunit-bridge` 7.4) the duplicate does not break the run. `DebugClassLoader::enable()` skips loaders it already wrapped, `ClockMock::register()` is guarded by `function_exists()`, and the duplicated subscribers are idempotent. What it does cost is a tracked file that is modified by every install, and a second registration of the whole subscriber set.

**`.env`** — the recipes of `thelia/backoffice-default-twig-template` (1.0) and `thelia/flexy` (1.0) declare `ACTIVE_ADMIN_TEMPLATE` and `ACTIVE_FRONT_TEMPLATE` in their `env` key. `EnvConfigurator::configureEnvDist()` (`vendor/symfony/flex/src/Configurator/EnvConfigurator.php:74-76`) skips a file that already carries the recipe's `###> package ###` marker; the tracked `.env` had neither marker.

**`config/bundles.php`** — the recipes of `thelia/backoffice-default-template`, `thelia/backoffice-default-twig-template` and `thelia/flexy` enable `BackOfficeDefaultBundle`, `BackOfficeDefaultTwigBundle` and `FlexyBundle`. None of the three was in the tracked file, although all three packages are in `require`. `BundlesConfigurator::configureBundles()` (`vendor/symfony/flex/src/Configurator/BundlesConfigurator.php:69`) leaves already-registered bundles alone, so listing them is enough to make the dump a no-op.

That last one is also the boot failure. `config/routes/bo_default.yaml`, installed by the `thelia/backoffice-default-template` recipe and invisible to git (the root `.gitignore` ignores `/config/` wholesale), declares `type: bo_default_attribute`. The loader for that type is provided by `BackOfficeDefaultBundle`. Restoring a `bundles.php` without the bundle left the route file behind with nothing able to read it.

Two writers also disagreed on the layout of `config/bundles.php`: Flex emits `<?php\n\nreturn [` (`BundlesConfigurator::buildContents()`), while `ComposerHelper::dumpBundlesPhp()` — reached from `TheliaTemplateHelper::enableThemeAsBundle()` during `template:set`, so on every `bin/install` — emits `<?php\nreturn [`. Whichever ran last reformatted the file, so no tracked content could be stable across an install.

## Fix

The tracked content becomes a fixed point of the recipes:

- `phpunit.xml.dist` carries the recipe's `<bootstrap>` block verbatim, so `add-lines` matches and does nothing. The two mock namespaces are inert here (Thelia's tests live under `Thelia\Tests\`), but this is the block every installed instance already runs with.
- `.env` carries the two recipe blocks, markers included.
- `config/bundles.php` lists the three template bundles.
- `ComposerHelper::dumpBundlesPhp()` uses the same layout as Flex, so `template:set` and `composer install` no longer fight over the blank line.
- `.gitignore` ignores `/.env.dev`, which the `symfony/framework-bundle` recipe seeds with a locally generated `APP_SECRET`, and stops un-ignoring `templates/backOffice/default-twig`, which is now a composer-installed package like every other theme.

### Why not untrack the three files

- `phpunit.xml.dist` holds project configuration no recipe provides: the five test suites, `tests/bootstrap.php`, the deprecation policy, the JWT key paths. Untracking it loses that.
- Untracking `.env` in favour of `.env.dist` only moves the problem: `EnvConfigurator::configureEnvDist()` writes to `$dotenvPath.'.dist'` **before** `$dotenvPath` (`EnvConfigurator.php:68-70`), so `.env.dist` would be the file rewritten by every install.
- `config/bundles.php` could be left to Flex, but it is the file that says which bundles the shop boots with; the defect was that it was stale, not that it was tracked. Keeping it accurate is what makes the tracked state a bootable state.

Making the recipes stop owning these files is not available either: the `phpunit.xml.dist` patch comes from `symfony/recipes`, and dropping the `bundles` / `env` keys from the Thelia recipes would stop `thelia-project` and every downstream project from enabling the theme bundles at all.

## Verified

Two disposable benches, each a checkout at this commit with its own DDEV instance and its own database.

**Fresh checkout, `composer install` only** — `git status --porcelain` prints nothing. On `main` the same sequence prints three modified and two untracked paths.

**Same bench, then `bin/install --with-demo --with-admin`** — `.env`, `phpunit.xml.dist` and `config/bundles.php` stay byte for byte identical; `git restore` on the three of them changes nothing, and `bin/console cache:clear` and `debug:router` (928 lines) still work. Before this change the same restore ended on `Cannot load resource "."`.

**Full install with both themes built** — `/` and `/admin/login` answer 200, and the baselines are green: `composer test` 973 tests over the five suites (unit 269, integration 485, api 197 with 1 skip, http-flexy 11, http-backoffice 11), `composer cs-diff` 0 of 1802, `composer phpstan` no errors.

## Left open

Two paths still show up after `bin/install`, both written by the installer rather than by `composer install`, and both worth their own ticket:

- `composer.json` gains PSR-4 entries for the selected themes, via `TheliaTemplateHelper::enableThemeAsBundle()` → `ComposerHelper::addPsr4NamespaceToComposer()`. They are redundant: the theme packages already declare those namespaces, and `vendor/composer/autoload_psr4.php` carries them straight after `composer install`. Which entries get written depends on the themes chosen, so no tracked content can absorb them — the write itself is what should go.
- `public/tiptap` is left untracked by a module's asset install, next to the `public/tinymce` line the `.gitignore` already carries.
