### PR TITLE
fix: drop the dead service declarations the Thelia prototype load overwrites

### DIFF
--- a/core/lib/Thelia/Config/Resources/services/handlers/file_manager.php
+++ b/core/lib/Thelia/Config/Resources/services/handlers/file_manager.php
@@ -14,54 +14,20 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Thelia\Core\File\FileManager;
 use Thelia\Core\File\Service\FileDeleteService;
 use Thelia\Core\File\Service\FilePositionService;
 use Thelia\Core\File\Service\FileProcessorService;
 use Thelia\Core\File\Service\FileUpdateService;
 use Thelia\Core\File\Service\FileVisibilityService;
 
+/*
+ * The services themselves come from the prototype load in services.php, which is
+ * processed after this file and overwrites whatever is declared here. Only the
+ * aliases survive, so this file must not carry definitions.
+ */
 return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
-    // Register file services
-    $services->set(FileProcessorService::class)
-        ->args([
-            service('thelia.file_manager'),
-            service('translator'),
-            service('thelia.admin.resources'),
-        ])
-        ->public();
 
-    $services->set(FileUpdateService::class)
-        ->public();
-
-    $services->set(FileDeleteService::class)
-        ->args([
-            service('thelia.file_manager'),
-            service('translator'),
-            service('thelia.admin.resources'),
-        ])
-        ->public();
-
-    $services->set(FilePositionService::class)
-        ->args([
-            service('thelia.file_manager'),
-            service('translator'),
-            service('thelia.admin.resources'),
-        ])
-        ->public();
-
-    $services->set(FileVisibilityService::class)
-        ->args([
-            service('thelia.file_manager'),
-            service('translator'),
-            service('thelia.admin.resources'),
-        ])
-        ->public();
-
-    $services->set(FileManager::class)->public();
-
-    // Create aliases for services
     $services->alias('thelia.file.processor', FileProcessorService::class);
     $services->alias('thelia.file.update', FileUpdateService::class);
     $services->alias('thelia.file.delete', FileDeleteService::class);


### PR DESCRIPTION
Fixes #3646

## Symptom

`core/lib/Thelia/Config/Resources/services/handlers/file_manager.php` declared six services with `->public()` and, for five of them, an explicit three-argument list. None of it reached the container, so the file described a wiring that never happened.

## Cause

`services.php:30-32` imports `services/*` — which includes this file — and only then, at `services.php:55`, runs the prototype registration:

```php
$serviceConfigurator->load('Thelia\\', THELIA_LIB)
```

`FileLoader::registerClasses()` calls `setDefinition($class, clone $prototype)` for every class it finds, unconditionally (`vendor/symfony/dependency-injection/Loader/FileLoader.php:194`, then `:299-316`). Every definition already registered for a `Thelia\` class is therefore replaced by the autowired, private prototype clone. The `alias()` calls in the same file are untouched, because aliases are a separate registry — they were the only part of the file that ever had an effect.

The declared argument lists could not have worked in any order, which is the clearest proof they were never applied:

- they pass `service('thelia.file_manager')`, and no service, alias or definition by that id exists anywhere in the container (`bin/console debug:container thelia.file_manager` → *No services found*). Had those arguments survived compilation, the container would have failed to build.
- they pass three arguments to constructors that take two (`FileProcessorService`, `FileDeleteService`, `FilePositionService`, `FileVisibilityService` all take `FileManager` and `TranslatorInterface`).

From the compiled container of an installed shop, `dev` environment:

| id | public | arguments |
|---|---|---|
| `Thelia\Core\File\Service\FileProcessorService` | no | `FileManager`, `Translator` |
| `Thelia\Core\File\Service\FileDeleteService` | no | `FileManager`, `Translator` |
| `Thelia\Core\File\Service\FilePositionService` | no | `FileManager`, `Translator` |
| `Thelia\Core\File\Service\FileVisibilityService` | no | `FileManager`, `Translator` |
| `Thelia\Core\File\Service\FileUpdateService` | no | `FileManager`, `request_stack`, `LangService` |
| `Thelia\Core\File\FileManager` | no | (default map) |

## Do these services need to be public?

No.

- Nothing fetches them by id at runtime. The only consumers are constructor injections: `Thelia\Api\Bridge\Propel\Service\ItemFileResourceService` in core, and the `FileController` of each back office template. The five `thelia.file.*` aliases are not referenced anywhere in core, in the templates or in the installed modules.
- The test container no longer depends on it. `TestPublicServicesPass`, added by #3639 and registered from `TheliaBundle::build()` at `TYPE_BEFORE_REMOVING`, makes every `Thelia\` definition public in the `test` environment. The same dump above, in `test`, shows all six as `public: yes` — from the compiler pass, not from this file.
- Marking them public for real would only enlarge the public surface of `dev` and `prod` and keep them out of the inlining pass, for no consumer.

So the fix is to delete the declarations rather than move them after the prototype load. The five aliases stay: they are the file's only working content, and dropping them would remove ids a module could legitimately reference.

## Verified

On a disposable bench (worktree at `main`, own DDEV instance, own database, `bin/install --with-demo`), the compiled container was dumped with `bin/console debug:container --format=json` from a cold cache, before and after the change, in both environments:

```
dev  container identical: True
test container identical: True
```

Definitions (3269 in `dev`, 3263 in `test`) and aliases (415 / 414) match entry by entry, including the six ids above and the five aliases. The declarations were dead, and removing them changes nothing in the container.

Baselines on the same bench: `composer test` green over the five suites — unit 269, integration 485, api 197 with 1 skip, http-flexy 11, http-backoffice 11 — `composer cs-diff` 0 of 1802, `composer phpstan` no errors.
