### PR TITLE
perf: aggregate the tfilters facet values in the database

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\BrandFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\CategoryFilter;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaChoiceFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Type\CheckboxType;
@@ -167,13 +168,32 @@ readonly class FilterService
         $locale ??= $this->langService->getLocale();
         $filters = $this->getAvailableFilters($resource);
 
+        // createFilterDto() drops every filter when no category is being browsed,
+        // so the facet values would be computed only to be thrown away.
+        if (!$this->hasFilter(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters)) {
+            return [];
+        }
+
+        $resourceIds = $this->resolveResourceIds($query);
+
+        if ($resourceIds === []) {
+            return [];
+        }
+
         foreach ($filters as $filter) {
-            $values = $this->getValues(
-                query: $query,
-                filter: $filter,
-                tfilters: $tfilters,
-                locale: $locale
-            );
+            $values = $filter instanceof TheliaAggregatedFilterInterface
+                ? $this->getAggregatedValues(
+                    filter: $filter,
+                    resourceIds: $resourceIds,
+                    tfilters: $tfilters,
+                    locale: $locale
+                )
+                : $this->getValues(
+                    query: $query,
+                    filter: $filter,
+                    tfilters: $tfilters,
+                    locale: $locale
+                );
             if ($values === []) {
                 continue;
             }
@@ -251,6 +271,41 @@ readonly class FilterService
         usort($filterObjects, static fn ($a, $b): int => $a->getPosition() <=> $b->getPosition());
 
         return $filterObjects;
+    }
+
+    /**
+     * The identifiers of the filtered set, read once and shared by every filter:
+     * a facet list needs to know which records are in the set, not what they hold.
+     *
+     * @return array<int>
+     */
+    private function resolveResourceIds(ModelCriteria $query): array
+    {
+        $ids = (clone $query)->select('Id')->find()->getData();
+
+        return array_map('intval', $ids);
+    }
+
+    /**
+     * @param array<int> $resourceIds
+     *
+     * @return array<FilterValue>
+     */
+    private function getAggregatedValues(TheliaAggregatedFilterInterface $filter, array $resourceIds, array $tfilters, string $locale): array
+    {
+        if ($filter instanceof CategoryFilter) {
+            return $filter->getAggregatedValues(
+                resourceIds: $resourceIds,
+                locale: $locale,
+                valueSearched: $this->retrieveFilterValue(
+                    theliaFilterNames: CategoryFilter::getFilterName(),
+                    tfilters: $tfilters,
+                ),
+                depth: (int) ($tfilters[CategoryFilter::CATEGORY_DEPTH_NAME] ?? 1),
+            );
+        }
+
+        return $filter->getAggregatedValues(resourceIds: $resourceIds, locale: $locale);
     }
 
     private function getValues($query, $filter, $tfilters, $locale): array

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
@@ -17,12 +17,16 @@ namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaChoiceFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
 use Thelia\Api\Resource\FilterValue;
 use Thelia\Model\Attribute;
+use Thelia\Model\AttributeAvQuery;
+use Thelia\Model\AttributeCombinationQuery;
+use Thelia\Model\AttributeQuery;
 
-class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface
+class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
 
@@ -98,6 +102,73 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
         }
 
         return $value;
+    }
+
+    /**
+     * The attribute values a product set offers are a DISTINCT over the combinations
+     * of its sale elements: one query instead of one per sale element.
+     */
+    public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
+    {
+        if ($resourceIds === []) {
+            return [];
+        }
+
+        $pairs = AttributeCombinationQuery::create()
+            ->useProductSaleElementsQuery()
+                ->filterByProductId($resourceIds, Criteria::IN)
+            ->endUse()
+            ->select(['AttributeId', 'AttributeAvId'])
+            ->distinct()
+            ->find()
+            ->getData();
+
+        if ($pairs === []) {
+            return [];
+        }
+
+        $attributes = AttributeQuery::create()
+            ->filterById(array_column($pairs, 'AttributeId'), Criteria::IN)
+            ->orderByPosition()
+            ->find()
+            ->toKeyIndex();
+
+        $attributeAvs = AttributeAvQuery::create()
+            ->filterById(array_column($pairs, 'AttributeAvId'), Criteria::IN)
+            ->orderByPosition()
+            ->find()
+            ->toKeyIndex();
+
+        // Both collections come back ordered by position: their order is the order
+        // the facets are presented in.
+        $attributeRank = array_flip(array_keys($attributes));
+        $attributeAvRank = array_flip(array_keys($attributeAvs));
+
+        usort(
+            $pairs,
+            static fn (array $left, array $right): int => [$attributeRank[$left['AttributeId']] ?? \PHP_INT_MAX, $attributeAvRank[$left['AttributeAvId']] ?? \PHP_INT_MAX]
+                <=> [$attributeRank[$right['AttributeId']] ?? \PHP_INT_MAX, $attributeAvRank[$right['AttributeAvId']] ?? \PHP_INT_MAX],
+        );
+
+        $values = [];
+
+        foreach ($pairs as $pair) {
+            $attribute = $attributes[$pair['AttributeId']] ?? null;
+            $attributeAv = $attributeAvs[$pair['AttributeAvId']] ?? null;
+
+            if (null === $attribute || null === $attributeAv) {
+                continue;
+            }
+
+            $values[] =
+                (new FilterValue())
+                    ->setMainTitle($this->localizedTitle($attribute, $locale))
+                    ->setMainId((int) $pair['AttributeId'])
+                    ->setId((int) $pair['AttributeAvId'])
+                    ->setTitle($this->localizedTitle($attributeAv, $locale));
+        }
+
+        return $values;
     }
 
     public function getChoiceFilterType(): ActiveRecordInterface

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
@@ -14,13 +14,17 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
 use Thelia\Api\Resource\FilterValue;
 use Thelia\Model\Brand;
+use Thelia\Model\BrandQuery;
+use Thelia\Model\ProductQuery;
 
-class BrandFilter implements TheliaFilterInterface
+class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
 
@@ -56,5 +60,39 @@ class BrandFilter implements TheliaFilterInterface
                 ->setId($brand->getId())
                 ->setTitle($this->localizedTitle($brand, $locale)),
         ];
+    }
+
+    /**
+     * The brands of a product set are one DISTINCT away; reading them product by
+     * product only to deduplicate them afterwards is what made this expensive.
+     */
+    public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
+    {
+        if ($resourceIds === []) {
+            return [];
+        }
+
+        $brandIds = ProductQuery::create()
+            ->filterById($resourceIds, Criteria::IN)
+            ->filterByBrandId(null, Criteria::ISNOTNULL)
+            ->select('BrandId')
+            ->distinct()
+            ->find()
+            ->getData();
+
+        if ($brandIds === []) {
+            return [];
+        }
+
+        $values = [];
+
+        foreach (BrandQuery::create()->filterById($brandIds, Criteria::IN)->orderByPosition()->find() as $brand) {
+            $values[] =
+                (new FilterValue())
+                    ->setId($brand->getId())
+                    ->setTitle($this->localizedTitle($brand, $locale));
+        }
+
+        return $values;
     }
 }

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
@@ -16,12 +16,13 @@ namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
 use Thelia\Api\Resource\FilterValue;
 use Thelia\Model\CategoryQuery;
 
-class CategoryFilter implements TheliaFilterInterface
+class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
 
@@ -66,6 +67,24 @@ class CategoryFilter implements TheliaFilterInterface
 
     public function getValue(ActiveRecordInterface $activeRecord, string $locale, $valueSearched = null, ?int $depth = 1): ?array
     {
+        return $this->browsedCategories($locale, $valueSearched, $depth);
+    }
+
+    /**
+     * The categories offered as facets are those below the browsed one, which the
+     * products of the set do not take part in: the set only has to be non-empty.
+     */
+    public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
+    {
+        if ($resourceIds === []) {
+            return [];
+        }
+
+        return $this->browsedCategories($locale, $valueSearched, $depth);
+    }
+
+    private function browsedCategories(string $locale, $valueSearched, ?int $depth): array
+    {
         if (\is_string($valueSearched) || \is_int($valueSearched)) {
             $valueSearched = explode(',', (string) $valueSearched);
         }
@@ -83,7 +102,7 @@ class CategoryFilter implements TheliaFilterInterface
                 continue;
             }
 
-            $categoriesWithDepth = $this->filterService->getCategoriesRecursively(categoryId: $categoryId, maxDepth: $depth);
+            $categoriesWithDepth = $this->filterService->getCategoriesRecursively(categoryId: $categoryId, maxDepth: $depth ?? 1);
 
             if ([] === $categoriesWithDepth) {
                 return [];

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
@@ -17,14 +17,17 @@ namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaChoiceFilterInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilterInterface;
 use Thelia\Api\Resource\FilterValue;
 use Thelia\Model\Feature;
 use Thelia\Model\FeatureAvQuery;
+use Thelia\Model\FeatureProductQuery;
+use Thelia\Model\FeatureQuery;
 use Thelia\Model\Map\FeatureProductTableMap;
 
-class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface
+class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
 
@@ -99,6 +102,73 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
         }
 
         return $value;
+    }
+
+    /**
+     * One query for the distinct (feature, value) pairs the set holds, then the
+     * features and values themselves — bounded by the shop's taxonomy, not by the
+     * number of products.
+     */
+    public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
+    {
+        if ($resourceIds === []) {
+            return [];
+        }
+
+        $pairs = FeatureProductQuery::create()
+            ->filterByProductId($resourceIds, Criteria::IN)
+            ->filterByFeatureAvId(null, Criteria::ISNOTNULL)
+            ->select(['FeatureId', 'FeatureAvId'])
+            ->distinct()
+            ->find()
+            ->getData();
+
+        if ($pairs === []) {
+            return [];
+        }
+
+        $features = FeatureQuery::create()
+            ->filterById(array_column($pairs, 'FeatureId'), Criteria::IN)
+            ->orderByPosition()
+            ->find()
+            ->toKeyIndex();
+
+        $featureAvs = FeatureAvQuery::create()
+            ->filterById(array_column($pairs, 'FeatureAvId'), Criteria::IN)
+            ->orderByPosition()
+            ->find()
+            ->toKeyIndex();
+
+        // Both collections come back ordered by position: their order is the order
+        // the facets are presented in.
+        $featureRank = array_flip(array_keys($features));
+        $featureAvRank = array_flip(array_keys($featureAvs));
+
+        usort(
+            $pairs,
+            static fn (array $left, array $right): int => [$featureRank[$left['FeatureId']] ?? \PHP_INT_MAX, $featureAvRank[$left['FeatureAvId']] ?? \PHP_INT_MAX]
+                <=> [$featureRank[$right['FeatureId']] ?? \PHP_INT_MAX, $featureAvRank[$right['FeatureAvId']] ?? \PHP_INT_MAX],
+        );
+
+        $values = [];
+
+        foreach ($pairs as $pair) {
+            $feature = $features[$pair['FeatureId']] ?? null;
+            $featureAv = $featureAvs[$pair['FeatureAvId']] ?? null;
+
+            if (null === $feature || null === $featureAv) {
+                continue;
+            }
+
+            $values[] =
+                (new FilterValue())
+                    ->setMainTitle($this->localizedTitle($feature, $locale))
+                    ->setMainId((int) $pair['FeatureId'])
+                    ->setId((int) $pair['FeatureAvId'])
+                    ->setTitle($this->localizedTitle($featureAv, $locale));
+        }
+
+        return $values;
     }
 
     public function getChoiceFilterType(): ActiveRecordInterface

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/Interface/TheliaAggregatedFilterInterface.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/Interface/TheliaAggregatedFilterInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface;
+
+/**
+ * A filter that can list its facet values for a whole result set at once.
+ *
+ * TheliaFilterInterface::getValue() answers for one record, so building a facet
+ * list with it costs at least one query per record. A filter implementing this
+ * interface is asked once for the identifiers of the whole set instead, and is
+ * expected to let the database do the aggregation.
+ */
+interface TheliaAggregatedFilterInterface
+{
+    /**
+     * @param array<int> $resourceIds identifiers of the records the facets must describe
+     *
+     * @return array<\Thelia\Api\Resource\FilterValue>
+     */
+    public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array;
+}

--- a/tests/Integration/Api/TFiltersQueryCountTest.php
+++ b/tests/Integration/Api/TFiltersQueryCountTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Propel\Runtime\Propel;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Api\Resource\Filter;
+use Thelia\Api\Resource\FilterValue;
+use Thelia\Model\Attribute;
+use Thelia\Model\AttributeCombination;
+use Thelia\Model\Category;
+use Thelia\Model\ChoiceFilter;
+use Thelia\Model\Feature;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Template;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A facet list describes which values a result set holds, which the database can
+ * answer in one aggregate per filter. Reading it record by record instead made the
+ * endpoint cost grow with the catalogue — the shop that reported it waited minutes
+ * on 15 000 products.
+ *
+ * The measurement that matters is therefore the number of queries, not the wall
+ * time: a catalogue four times bigger must not cost a single query more.
+ */
+final class TFiltersQueryCountTest extends IntegrationTestCase
+{
+    private const SMALL_CATALOGUE = 2;
+    private const LARGE_CATALOGUE = 8;
+
+    private FilterService $filterService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->filterService = static::getContainer()->get(FilterService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->getPropelConnection()->useDebug(false);
+        Propel::enableInstancePooling();
+
+        parent::tearDown();
+    }
+
+    public function testTheFacetCostDoesNotFollowTheCatalogueSize(): void
+    {
+        // Instance pooling would make the second measurement cheaper than the first
+        // for reasons that have nothing to do with what is being measured.
+        Propel::disableInstancePooling();
+
+        $small = $this->measure(self::SMALL_CATALOGUE);
+        $large = $this->measure(self::LARGE_CATALOGUE);
+
+        self::assertNotSame([], $small['facets'], 'The fixture must expose facets, otherwise nothing is measured.');
+        self::assertSame($small['facets'], $large['facets'], 'Four times more products holding the same values must expose the same facets.');
+        self::assertLessThanOrEqual(
+            $small['queries'],
+            $large['queries'],
+            \sprintf(
+                'The facet list cost %d queries for %d products and %d for %d: it still follows the catalogue size.',
+                $small['queries'],
+                self::SMALL_CATALOGUE,
+                $large['queries'],
+                self::LARGE_CATALOGUE,
+            ),
+        );
+
+        // The remaining queries are bounded by the shop's taxonomy, not by its catalogue.
+        self::assertLessThan(100, $large['queries']);
+    }
+
+    /**
+     * @return array{queries: int, facets: array<string, array<string>>}
+     */
+    private function measure(int $productCount): array
+    {
+        $categoryId = $this->createCatalogue($productCount);
+
+        $connection = $this->getPropelConnection();
+        $connection->useDebug(true);
+
+        $before = $connection->getQueryCount();
+        $filters = $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    // tfilters values are nested one level deeper than the filter name.
+                    'tfilters' => ['category' => [['eq' => $categoryId]]],
+                    'locale' => 'en_US',
+                ],
+            ],
+            'products',
+        );
+        $queries = $connection->getQueryCount() - $before;
+
+        return ['queries' => $queries, 'facets' => $this->describe($filters)];
+    }
+
+    /**
+     * @param array<Filter> $filters
+     *
+     * @return array<string, array<string>>
+     */
+    private function describe(array $filters): array
+    {
+        $facets = [];
+
+        foreach ($filters as $filter) {
+            $titles = array_map(
+                static fn (FilterValue $value): string => (string) $value->getTitle(),
+                $filter->getValues(),
+            );
+            sort($titles);
+            $facets[$filter->getType().'/'.$filter->getTitle()] = $titles;
+        }
+
+        ksort($facets);
+
+        return $facets;
+    }
+
+    /**
+     * Every product holds the same feature and attribute values, so the facets of a
+     * two-product catalogue and of an eight-product one are identical.
+     */
+    private function createCatalogue(int $productCount): int
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $template = new Template();
+        $template->setLocale('en_US');
+        $template->setName('Filtered template');
+        $template->save($connection);
+
+        $category = $factory->category();
+        $category->setDefaultTemplateId($template->getId());
+        $category->save($connection);
+
+        $feature = $factory->feature(['title' => 'Colour']);
+        $featureAv = $factory->featureAv($feature, ['title' => 'Blue']);
+
+        $attribute = $factory->attribute(['title' => 'Size']);
+        $attributeAv = $factory->attributeAv($attribute, ['title' => 'Large']);
+
+        $this->declareChoiceFilter($category, $template, $feature, null);
+        $this->declareChoiceFilter($category, $template, null, $attribute);
+
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        for ($i = 0; $i < $productCount; ++$i) {
+            $product = $factory->product($category, $taxRule, $currency);
+
+            $featureProduct = new FeatureProduct();
+            $featureProduct->setProductId($product->getId());
+            $featureProduct->setFeatureId($feature->getId());
+            $featureProduct->setFeatureAvId($featureAv->getId());
+            $featureProduct->save($connection);
+
+            $combination = new AttributeCombination();
+            $combination->setProductSaleElementsId($product->getDefaultSaleElements()->getId());
+            $combination->setAttributeId($attribute->getId());
+            $combination->setAttributeAvId($attributeAv->getId());
+            $combination->save($connection);
+        }
+
+        return $category->getId();
+    }
+
+    private function declareChoiceFilter(Category $category, Template $template, ?Feature $feature, ?Attribute $attribute): void
+    {
+        $choiceFilter = new ChoiceFilter();
+        $choiceFilter->setCategoryId($category->getId());
+        $choiceFilter->setTemplateId($template->getId());
+        $choiceFilter->setFeatureId($feature?->getId());
+        $choiceFilter->setAttributeId($attribute?->getId());
+        $choiceFilter->setPosition(1);
+        $choiceFilter->setVisible(true);
+        $choiceFilter->setType('checkbox');
+        $choiceFilter->save($this->getPropelConnection());
+    }
+}


### PR DESCRIPTION
Fixes #3648.

## Measurement

Reproduced on a DDEV install (PHP 8.3, MariaDB 10.11) with a generated catalogue, seeded inside a
transaction and rolled back: **15 000 products, 45 000 sale elements, 60 000 `feature_product` rows,
90 000 attribute combinations, 8 features / 80 feature values, 3 attributes / 24 attribute values,
16 visible `choice_filter` rows**. The endpoint was called in-process
(`GET /api/front/tfilters/products?tfilters[category][0][eq]=<id>`), queries counted with Propel's
connection counter and timed with `microtime()`.

| Catalogue | Queries before | Queries after | Time before | Time after |
|---|---|---|---|---|
| 200 products | 1 291 | 93 | 0.78 s | 0.33 s |
| 2 000 products | 12 091 | 100 | 3.78 s | 0.31 s |
| 15 000 products | 90 098 | 100 | 26.9 s | 0.65 s |
| 15 000, no `tfilters` at all | 90 320 | **2** | 25.8 s | 0.13 s |

Before: `queries ≈ 6 × products`. After: constant, bounded by the shop's taxonomy. The remote
database of the reporting shop pays a round trip per query, which is how 90 000 queries become minutes.

## Cause

`FilterService::getFilters()` asks every filter for its facet values one record at a time
(`FilterService.php:171` → `getValues()` at `FilterService.php:258`), and `getValues()` hydrates the
whole product set once per filter (`$query->find()`), then calls `getValue()` on every row. Each
`getValue()` walks relations of that single record:

- `FeatureAvFilter.php:82` and `:88` — `getFeatureProductsJoinFeatureAv()`, two queries per product;
- `AttributeAvFilter.php:82` — `getProductSaleElementss()`, one query per product, then
  `getAttributeCombinationsJoinAttributeAv()`, one per sale element;
- `BrandFilter.php:48`, `PriceFilter.php:48` — the same shape per product.

The values are then deduplicated in PHP (`FilterService.php:182-222`), so the per-record work
produces the same handful of facets a `DISTINCT` would have returned.

## Fix

`TheliaAggregatedFilterInterface` lets a filter answer for a whole set at once. `FilterService`
resolves the identifiers of the filtered set once (one query, no hydration) and hands them to the
filters implementing it; `getValue()` stays the fallback, so third-party filters keep working
unchanged.

- `FeatureAvFilter` and `AttributeAvFilter`: one `DISTINCT` over the pairs held by the set, then the
  features/attributes and their values by id.
- `BrandFilter`: one `DISTINCT brand_id`.
- `CategoryFilter`: its facets are the categories below the browsed one and never depended on the
  products, only on the set being non-empty.
- `getFilters()` returns early when no category is being browsed, because `createFilterDto()`
  (`FilterService.php:314`) already drops every filter in that case — this is the whole-catalogue row
  of the table above.

Facet values are now ordered by the position configured on the feature, attribute and their values,
where they used to follow the order products happened to come back in.

## Verification

`tests/Integration/Api/TFiltersQueryCountTest.php` builds two catalogues holding the same values, one
four times larger, and asserts the facet list costs no more queries for the larger one. Red without
the fix (`35 queries for 2 products and 95 for 8`), green with it. The same test asserts both
catalogues expose identical facets.

Output equivalence was also checked on the generated catalogue: the facet sets returned before and
after the change are identical (same filters, same titles, same values), only the order inside a
filter changes as described above.

Five suites green locally: unit 256, integration 392, api 187 (1 skip), flexy 11, backoffice 11.
`composer cs-diff` 0/1762, `composer phpstan` no errors.
