### PR TITLE
fix: export every order when no date range is given, and let the command supply one

### DIFF
--- a/core/lib/Thelia/Command/ExportCommand.php
+++ b/core/lib/Thelia/Command/ExportCommand.php
@@ -62,6 +62,18 @@ class ExportCommand extends ContainerAwareCommand
                 'en_US'
             )
             ->addOption(
+                'start',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only export records created on or after this date, for the exports that support a date range.'
+            )
+            ->addOption(
+                'end',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only export records created on or before this date, for the exports that support a date range.'
+            )
+            ->addOption(
                 'list-export',
                 null,
                 InputOption::VALUE_NONE,
@@ -134,7 +146,10 @@ class ExportCommand extends ContainerAwareCommand
             $export,
             $serializer,
             $archiver,
-            (new LangQuery())->findOneByLocale($input->getOption('locale'))
+            (new LangQuery())->findOneByLocale($input->getOption('locale')),
+            false,
+            false,
+            $this->readDateRange($input)
         );
 
         $formattedLine = $this->getHelper('formatter')->formatBlock(
@@ -147,6 +162,44 @@ class ExportCommand extends ContainerAwareCommand
         $output->writeln('<comment>'.$exportEvent->getFilePath().'</comment>');
 
         return 0;
+    }
+
+    /**
+     * A date range is optional: without one, an export covers every record.
+     * A single bound is honoured on its own.
+     *
+     * @return array{start: \DateTime|null, end: \DateTime|null}|null
+     */
+    protected function readDateRange(InputInterface $input): ?array
+    {
+        $start = $this->readDate($input, 'start');
+        $end = $this->readDate($input, 'end');
+
+        if (null === $start && null === $end) {
+            return null;
+        }
+
+        return ['start' => $start, 'end' => $end];
+    }
+
+    protected function readDate(InputInterface $input, string $option): ?\DateTime
+    {
+        $value = $input->getOption($option);
+
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        // A day given without a time covers that whole day, as the back-office range does.
+        if ('end' === $option && 1 === preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+            $value .= ' 23:59:59';
+        }
+
+        try {
+            return new \DateTime($value);
+        } catch (\Exception $exception) {
+            throw new \InvalidArgumentException(sprintf('--%s is not a readable date: %s', $option, $value), 0, $exception);
+        }
     }
 
     /**

--- a/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
@@ -152,7 +152,7 @@ class OrderExport extends JsonFileAbstractExport
                 LEFT JOIN country_i18n as delivery_country_i18n ON delivery_country_i18n.id = delivery_address.country_id AND delivery_country_i18n.locale = :locale
                 LEFT JOIN country_i18n as invoice_country_i18n ON invoice_country_i18n.id = invoice_address.country_id AND invoice_country_i18n.locale = :locale
                 LEFT JOIN currency ON currency.id = order.currency_id
-                WHERE `order`.created_at >= :start AND `order`.created_at <= :end
+                '.$this->buildDateRangeCondition().'
                 GROUP BY `order`.id
                 ORDER BY `order`.created_at DESC
             ) as tmp
@@ -160,10 +160,52 @@ class OrderExport extends JsonFileAbstractExport
 
         $stmt = $con->prepare($query);
         $stmt->bindValue('locale', $locale);
-        $stmt->bindValue('start', $this->rangeDate['start']->format('Y-m-d H:i:s'));
-        $stmt->bindValue('end', $this->rangeDate['end']->format('Y-m-d H:i:s'));
+
+        foreach ($this->getDateRangeBounds() as $bound => $date) {
+            $stmt->bindValue($bound, $date->format('Y-m-d H:i:s'));
+        }
+
         $stmt->execute();
 
         return $this->getDataJsonCache($stmt, 'order');
+    }
+
+    /**
+     * A date range is optional: without one, the export covers every order.
+     * A single bound is honoured on its own, so `--start` alone exports
+     * everything since that date.
+     *
+     * @return array<string, \DateTimeInterface>
+     */
+    private function getDateRangeBounds()
+    {
+        $bounds = [];
+
+        foreach (['start', 'end'] as $bound) {
+            if (($this->rangeDate[$bound] ?? null) instanceof \DateTimeInterface) {
+                $bounds[$bound] = $this->rangeDate[$bound];
+            }
+        }
+
+        return $bounds;
+    }
+
+    /**
+     * @return string
+     */
+    private function buildDateRangeCondition()
+    {
+        $comparisons = ['start' => '>=', 'end' => '<='];
+        $conditions = [];
+
+        foreach ($this->getDateRangeBounds() as $bound => $date) {
+            $conditions[] = '`order`.created_at '.$comparisons[$bound].' :'.$bound;
+        }
+
+        if ($conditions === []) {
+            return '';
+        }
+
+        return 'WHERE '.implode(' AND ', $conditions);
     }
 }


### PR DESCRIPTION
The `2.6` counterpart of #3650, whose pull request body carries the reasoning and the measurements. Same defect, same fix, transposed line for line.

## Symptom

`php Thelia export thelia.export.orders thelia.csv` cannot run. `thelia.export.orders` is the only export declaring `USE_RANGE_DATE = true`, and it dereferenced its range unconditionally at `core/lib/Thelia/ImportExport/Export/Type/OrderExport.php:166` — `$this->rangeDate['start']->format(...)` on a property that is `null` by default (`ImportExport/Export/AbstractExport.php:102`). The command has no option to supply a range, so from a terminal this export could only ever fail. Since #3635 an export without a range no longer dies in `ExportHandler`, which leaves this one the last one failing.

The back office never exercised that path: `ExportForm` builds its bounds with a `DateType` using `input => array`, so `$validatedForm->get('range_date_start')->getData()` is always a non-empty array and `ExportController` always passes a range.

## Fix

- The `WHERE` clause is built from the bounds actually present, so the query is unbounded when there are none: no range means every order.
- Each bound stands on its own — `--start` alone exports everything since that date.
- `--start` / `--end` on the `export` command, forwarded to `ExportHandler` for any export declaring `USE_RANGE_DATE`. An `--end` given as a bare day covers that whole day (23:59:59), matching what the back-office range does with its end month.

## How to verify

```
php Thelia export thelia.export.orders thelia.csv                      # every order
php Thelia export thelia.export.orders thelia.csv --start=2026-01-01   # since that day
php Thelia export thelia.export.orders thelia.csv --start=2026-01-01 --end=2026-06-30
```

The generated SQL was run in its four shapes against a MariaDB 10.11 database holding 500 000 orders: no bound 500 000 rows, `start` only 201 432, `end` only 173 311, both 124 915. A full export of those 500 000 orders takes 32 s and peaks at 420 MB of PHP memory for a 204 MB CSV.

The integration tests covering this behaviour live on `main` (#3650, `tests/Integration/Domain/DataTransfer/OrderExportTest.php`); the `2.6` suite has no runner in CI yet, which is #3565. `php-cs-fixer` 3.41.1, the version this branch pins, reports no violation on the two changed files.

Fixes #3642