### PR TITLE
fix: rate limit account activation code requests

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -60,6 +60,7 @@
         "symfony/property-access": "7.4.*",
         "symfony/property-info": "7.4.*",
         "symfony/psr-http-message-bridge": "^7.4",
+        "symfony/rate-limiter": "7.4.*",
         "symfony/routing": "7.4.*",
         "symfony/runtime": "7.4.*",
         "symfony/security-bundle": "7.4.*",

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -30,5 +30,22 @@ return static function (ContainerConfigurator $container): void {
                 ],
             ],
         ],
+        'rate_limiter' => [
+            // Asking for a new account activation code sends an email to an address
+            // the visitor typed, so an unauthenticated caller can make the shop mail
+            // someone else. Both limits are needed: the per-address one protects the
+            // owner of a single mailbox, the per-client one stops a single caller
+            // from walking a list of addresses.
+            'customer_code_request_per_email' => [
+                'policy' => 'sliding_window',
+                'limit' => 3,
+                'interval' => '1 hour',
+            ],
+            'customer_code_request_per_client' => [
+                'policy' => 'sliding_window',
+                'limit' => 10,
+                'interval' => '1 hour',
+            ],
+        ],
     ]);
 };

--- a/core/lib/Thelia/Domain/Customer/CustomerFacade.php
+++ b/core/lib/Thelia/Domain/Customer/CustomerFacade.php
@@ -109,10 +109,14 @@ readonly class CustomerFacade
     }
 
     /**
-     * Resend an account code email to the given address.
+     * Resend an account code email, within the rate limits of the activation flow.
+     *
+     * Returns nothing on purpose: a template must render the same page whether the
+     * mail went out or was held back, so that repeating the request tells a visitor
+     * nothing about the address it names.
      */
     public function sendCode(Customer $customer): void
     {
-        $this->customerCodeManager->createCodeAndSendIt($customer);
+        $this->customerCodeManager->requestCode($customer);
     }
 }

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerCodeManager.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerCodeManager.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
 namespace Thelia\Domain\Customer\Service;
 
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
@@ -23,7 +26,44 @@ readonly class CustomerCodeManager
 {
     public function __construct(
         private MailerFactory $mailerFactory,
+        #[Autowire(service: 'limiter.customer_code_request_per_email')]
+        private RateLimiterFactoryInterface $perEmailCodeRequestLimiter,
+        #[Autowire(service: 'limiter.customer_code_request_per_client')]
+        private RateLimiterFactoryInterface $perClientCodeRequestLimiter,
+        private RequestStack $requestStack,
     ) {
+    }
+
+    /**
+     * Send a fresh activation code, unless codes have already been asked for too often.
+     *
+     * This is the entry point for "send me the code again": it is reachable by anyone
+     * who knows an address, so the number of emails it can trigger has to be capped.
+     * Callers must answer the visitor the same way whether this returned true or false,
+     * otherwise the answer tells the caller whether the address has an account.
+     *
+     * @throws PropelException
+     */
+    public function requestCode(
+        Customer $customer,
+        int $expiryTimeInHours = 24,
+    ): bool {
+        // No request in a CLI context: the per-client limit simply does not apply.
+        // It is consumed first so that a caller who is already over it stops eating
+        // the budget of the mailbox owner, who would then be denied a resend.
+        $clientIp = $this->requestStack->getMainRequest()?->getClientIp();
+
+        if (null !== $clientIp && !$this->perClientCodeRequestLimiter->create($clientIp)->consume()->isAccepted()) {
+            return false;
+        }
+
+        if (!$this->perEmailCodeRequestLimiter->create(hash('sha256', strtolower((string) $customer->getEmail())))->consume()->isAccepted()) {
+            return false;
+        }
+
+        $this->createCodeAndSendIt($customer, $expiryTimeInHours);
+
+        return true;
     }
 
     /**

--- a/tests/Http/Flexy/CustomerActivationEnumerationTest.php
+++ b/tests/Http/Flexy/CustomerActivationEnumerationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Symfony\Component\Routing\RouterInterface;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * The account activation pages must not answer differently for an address that has
+ * an account and for one that does not: the difference alone is enough to tell
+ * whether someone is a customer of the shop, without logging in.
+ *
+ * These tests drive the routes of the installed Flexy theme. A theme older than the
+ * fix names the address in the url and is reported as skipped rather than failed,
+ * because the theme ships as its own package on its own release cycle.
+ */
+final class CustomerActivationEnumerationTest extends WebIntegrationTestCase
+{
+    public function testActivationAnswersTheSameWhetherTheAddressHasAnAccountOrNot(): void
+    {
+        $this->skipUnlessTheThemeKeepsTheAddressOutOfTheUrl('customer_activation');
+
+        self::assertSame(
+            $this->answerFor('customer_activation', $this->addressWithAnAccount()),
+            $this->answerFor('customer_activation', $this->addressWithoutAnAccount()),
+        );
+    }
+
+    public function testSendCodeAnswersTheSameWhetherTheAddressHasAnAccountOrNot(): void
+    {
+        $this->skipUnlessTheThemeKeepsTheAddressOutOfTheUrl('customer_send_code');
+
+        self::assertSame(
+            $this->answerFor('customer_send_code', $this->addressWithAnAccount()),
+            $this->answerFor('customer_send_code', $this->addressWithoutAnAccount()),
+        );
+    }
+
+    /**
+     * Everything a caller can read from the response: an activation flow that leaks
+     * through any of these is as good as one that says "this address is a customer".
+     *
+     * @return array<string, string|int|null>
+     */
+    private function answerFor(string $route, string $email): array
+    {
+        $url = $this->getService(RouterInterface::class)->generate($route, ['email' => $email]);
+
+        $this->client->request('GET', $url);
+        $response = $this->client->getResponse();
+
+        return [
+            'status' => $response->getStatusCode(),
+            'location' => $response->headers->get('Location'),
+            'length' => \strlen((string) $response->getContent()),
+        ];
+    }
+
+    private function addressWithAnAccount(): string
+    {
+        // Built without createFixtureFactory(): that helper pushes a synthetic request
+        // when the stack is empty, and it would then be the "main" request of the calls
+        // below, hiding a leak read from it.
+        $factory = new FixtureFactory($this->getPropelConnection());
+
+        return (string) $factory->customer($factory->customerTitle())->getEmail();
+    }
+
+    private function addressWithoutAnAccount(): string
+    {
+        return 'no-account-'.bin2hex(random_bytes(8)).'@example.com';
+    }
+
+    private function skipUnlessTheThemeKeepsTheAddressOutOfTheUrl(string $route): void
+    {
+        $definition = $this->getService(RouterInterface::class)->getRouteCollection()->get($route);
+
+        if (null === $definition) {
+            self::markTestSkipped(\sprintf('The installed front-office theme has no "%s" route.', $route));
+        }
+
+        if (str_contains($definition->getPath(), '{email}')) {
+            self::markTestSkipped(\sprintf('The installed Flexy theme still names the address in the "%s" url; the release that stopped doing so is not installed yet.', $route));
+        }
+    }
+}

--- a/tests/Unit/Domain/Customer/CustomerCodeManagerTest.php
+++ b/tests/Unit/Domain/Customer/CustomerCodeManagerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Domain\Customer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Thelia\Domain\Customer\Service\CustomerCodeManager;
+use Thelia\Mailer\MailerFactory;
+use Thelia\Model\Customer;
+
+/**
+ * "Send me the activation code again" is reachable by anyone who knows an address,
+ * so the number of emails it can trigger has to be capped per address and per caller.
+ */
+final class CustomerCodeManagerTest extends TestCase
+{
+    public function testCodeRequestsForOneAddressStopBeingSentOnceTheLimitIsReached(): void
+    {
+        $mailerFactory = $this->createMock(MailerFactory::class);
+        $mailerFactory->expects(self::exactly(3))->method('sendEmailToCustomer');
+
+        $manager = new CustomerCodeManager(
+            $mailerFactory,
+            $this->limiter(3),
+            $this->limiter(100),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        $customer = $this->customer('pending@example.com');
+
+        self::assertTrue($manager->requestCode($customer));
+        self::assertTrue($manager->requestCode($customer));
+        self::assertTrue($manager->requestCode($customer));
+        self::assertFalse($manager->requestCode($customer));
+        self::assertFalse($manager->requestCode($customer));
+    }
+
+    public function testTheAddressLimitIgnoresCaseSoItCannotBeSidesteppedByRetyping(): void
+    {
+        $mailerFactory = $this->createMock(MailerFactory::class);
+        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
+
+        $manager = new CustomerCodeManager(
+            $mailerFactory,
+            $this->limiter(2),
+            $this->limiter(100),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        self::assertTrue($manager->requestCode($this->customer('pending@example.com')));
+        self::assertTrue($manager->requestCode($this->customer('Pending@Example.COM')));
+        self::assertFalse($manager->requestCode($this->customer('PENDING@EXAMPLE.COM')));
+    }
+
+    public function testOneCallerWalkingManyAddressesIsStoppedByTheClientLimit(): void
+    {
+        $mailerFactory = $this->createMock(MailerFactory::class);
+        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
+
+        $manager = new CustomerCodeManager(
+            $mailerFactory,
+            $this->limiter(100),
+            $this->limiter(2),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        self::assertTrue($manager->requestCode($this->customer('first@example.com')));
+        self::assertTrue($manager->requestCode($this->customer('second@example.com')));
+        self::assertFalse($manager->requestCode($this->customer('third@example.com')));
+    }
+
+    public function testWithoutARequestOnlyTheAddressLimitApplies(): void
+    {
+        $mailerFactory = $this->createMock(MailerFactory::class);
+        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
+
+        // A command line caller (module, cron, install script) has no client IP:
+        // the per-client limit must be skipped instead of blocking the send. Here it
+        // would stop everything after the first mail if it were applied.
+        $manager = new CustomerCodeManager(
+            $mailerFactory,
+            $this->limiter(2),
+            $this->limiter(1),
+            new RequestStack(),
+        );
+
+        $customer = $this->customer('pending@example.com');
+
+        self::assertTrue($manager->requestCode($customer));
+        self::assertTrue($manager->requestCode($customer));
+        self::assertFalse($manager->requestCode($customer));
+    }
+
+    private function limiter(int $limit): RateLimiterFactoryInterface
+    {
+        return new RateLimiterFactory(
+            [
+                'id' => 'test',
+                'policy' => 'sliding_window',
+                'limit' => $limit,
+                'interval' => '1 hour',
+            ],
+            new InMemoryStorage(),
+        );
+    }
+
+    private function requestStackWithClientIp(string $clientIp): RequestStack
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/customer/send-code', server: ['REMOTE_ADDR' => $clientIp]));
+
+        return $requestStack;
+    }
+
+    private function customer(string $email): Customer
+    {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getEmail')->willReturn($email);
+        $customer->method('setConfirmationTokenWithExpiry')->willReturn('123456');
+
+        return $customer;
+    }
+}


### PR DESCRIPTION
Refs #3633. Half of the fix: this is the core mechanism, the front-office policy is thelia-templates/flexy#140, which needs this released in `thelia/core` first.

## Symptom

`GET /customer/send-code/{email}` mails an activation code to any address that has an account, without authentication and without any limit. Measured on a fresh 3.0 install with demo data: six unauthenticated requests, six mails delivered to two addresses that never asked for them. That is a confirmation oracle for "is this person a customer here", a nuisance for the mailbox owner, and a way to burn the shop's sending reputation.

## Cause

`Thelia\Domain\Customer\Service\CustomerCodeManager::createCodeAndSendIt()` (`core/lib/Thelia/Domain/Customer/Service/CustomerCodeManager.php:32`) is the only entry point for "send me the code again" and has no notion of how often it has already been called. `CustomerFacade::sendCode()` (`core/lib/Thelia/Domain/Customer/CustomerFacade.php:114`), the API a theme is meant to use, forwards straight to it.

## Fix

- `requestCode()` sits next to `createCodeAndSendIt()` and is the entry point for a resend. It consumes two sliding-window limiters before sending — one keyed on the recipient address, 3 per hour, one on the client IP, 10 per hour — and returns `false` without sending when either is exhausted. `createCodeAndSendIt()` keeps its behaviour for the first send of the registration flow, which is already behind a validated form.
- The client limiter is consumed first, so a caller who is already over it stops eating the budget of the mailbox owner, who would otherwise be denied a resend of their own code.
- The address key is a sha256 of the lowercased address: retyping the same mailbox with a different case does not buy a fresh budget, and no address is written into the limiter cache.
- There is no client IP on the command line. The per-client limit is skipped there instead of blocking the send, so a module, a cron or the install script is unaffected.
- `CustomerFacade::sendCode()` now goes through `requestCode()` and still returns nothing, so a template cannot render two different pages depending on whether the mail went out.
- New dependency: `symfony/rate-limiter` (7.4.*) in `thelia/core`. `symfony/lock` was already required, so the limiters pick up the project lock factory when `framework.lock` is configured and work without it otherwise. A project can retune both limits in its own `config/packages/framework.yaml`.

## Verify

`tests/Unit/Domain/Customer/CustomerCodeManagerTest.php` drives real limiters over in-memory storage and a mailer double: three mails for one address then nothing, case-insensitive on the address, one caller walking many addresses stopped by the client limit, and no client limit applied without a request. All four fail when the two limit checks are removed.

`tests/Http/Flexy/CustomerActivationEnumerationTest.php` asserts that `customer_activation` and `customer_send_code` return the same status, the same `Location` and the same body length for an address that has an account and for one that does not. Those routes belong to the Flexy theme, which ships on its own release cycle, so the test reports itself skipped — with the reason — while the installed theme still names the address in the url, and runs for real from the release that stops doing so. It was checked both ways against a patched theme: green with the fix, red with the leak put back (`302 /customer/activation` and 326 bytes against `302 /customer/register` and 318 bytes).

Measured end to end on a fresh install, with the theme change applied and the mailer pointed at a local SMTP catcher:

| | before | after |
|---|---|---|
| address with an account | `200`, 390 252 bytes, ~140 ms, mail sent | `302 /customer/register`, 318 bytes, ~70 ms, no mail |
| address without an account | `302 /customer/register`, 318 bytes, ~62 ms | `302 /customer/register`, 318 bytes, ~70 ms |

Timing was measured interleaved, twelve requests each: median 71.7 ms against 75.6 ms, ranges fully overlapping — the address in the query string is never read, so there is nothing left to time.

Baselines on a fresh 3.0 install with the change: `composer cs-diff` 0/1771, `composer phpstan` no errors, `composer test` green (unit 260, integration 430, api 188 with the one legitimate skip, http-flexy 13, http-backoffice 11).