### PR TITLE
feat: let each delivery module carry its own postage tax rule

### DIFF
--- a/core/lib/Thelia/Module/AbstractDeliveryModule.php
+++ b/core/lib/Thelia/Module/AbstractDeliveryModule.php
@@ -20,6 +20,8 @@ use Thelia\Model\Country;
 
 abstract class AbstractDeliveryModule extends BaseModule implements DeliveryModuleInterface
 {
+    use OrderPostageBuilderTrait;
+
     // This class is the base class for delivery modules
     // It may contains common methods in the future.
 

--- a/core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php
+++ b/core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php
@@ -14,19 +14,14 @@ declare(strict_types=1);
 
 namespace Thelia\Module;
 
-use Propel\Runtime\ActiveQuery\Criteria;
-use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
 use Thelia\Model\Area;
 use Thelia\Model\AreaDeliveryModuleQuery;
-use Thelia\Model\ConfigQuery;
 use Thelia\Model\Country;
-use Thelia\Model\OrderPostage;
 use Thelia\Model\State;
-use Thelia\Model\TaxRuleQuery;
 
 abstract class AbstractDeliveryModuleWithState extends BaseModule implements DeliveryModuleWithStateInterface
 {
-    use TaxCalculatorResolverTrait;
+    use OrderPostageBuilderTrait;
 
     // This class is the base class for delivery modules
     // It may contains common methods in the future.
@@ -57,38 +52,5 @@ abstract class AbstractDeliveryModuleWithState extends BaseModule implements Del
     public function getDeliveryMode()
     {
         return 'delivery';
-    }
-
-    public function buildOrderPostage(float $untaxedPostage, Country $country, $locale, $taxRuleId = null)
-    {
-        $taxRule = null;
-
-        $taxRuleId = ($taxRuleId) ?: ConfigQuery::read('taxrule_id_delivery_module');
-
-        if ($taxRuleId) {
-            $taxRule = TaxRuleQuery::create()
-                ->filterById($taxRuleId)
-                ->orderByIsDefault(Criteria::DESC)
-                ->findOne();
-        }
-
-        $orderPostage = new OrderPostage();
-
-        if ($taxRule) {
-            $taxCalculator = $this->createTaxCalculator();
-            $taxCalculator->loadTaxRuleWithoutProduct($taxRule, $country);
-
-            $orderPostage->setAmount($taxCalculator->getTaxedPrice($untaxedPostage));
-            $orderPostage->setAmountTax($taxCalculator->getTaxAmountFromUntaxedPrice($untaxedPostage));
-            $orderPostage->setTaxRuleTitle($taxRule->setLocale($locale)->getTitle());
-
-            return $orderPostage;
-        }
-
-        $orderPostage->setAmount($untaxedPostage);
-        $orderPostage->setAmountTax(0);
-        $orderPostage->setTaxRuleTitle(null);
-
-        return $orderPostage;
     }
 }

--- a/core/lib/Thelia/Module/OrderPostageBuilderTrait.php
+++ b/core/lib/Thelia/Module/OrderPostageBuilderTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Module;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Country;
+use Thelia\Model\ModuleConfigQuery;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\OrderPostage;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleQuery;
+
+/**
+ * Turns an untaxed shipping cost into an OrderPostage, applying the tax rule
+ * that governs this delivery module's postage.
+ *
+ * The rule is resolved in this order:
+ *
+ *  1. the tax rule id the module passes explicitly to buildOrderPostage();
+ *  2. this module's own POSTAGE_TAX_RULE_CONFIG_KEY setting;
+ *  3. the shop-wide `taxrule_id_delivery_module` setting.
+ *
+ * Without any of them, postage is left untaxed.
+ */
+trait OrderPostageBuilderTrait
+{
+    use TaxCalculatorResolverTrait;
+
+    /**
+     * Name of the module_config entry holding the tax rule applied to this
+     * delivery module's postage. An empty or missing value means "use the
+     * shop-wide delivery tax rule".
+     */
+    public const POSTAGE_TAX_RULE_CONFIG_KEY = 'postage_tax_rule_id';
+
+    public function buildOrderPostage(float $untaxedPostage, Country $country, $locale, $taxRuleId = null)
+    {
+        $taxRule = $this->resolvePostageTaxRule((int) $taxRuleId ?: $this->getPostageTaxRuleId());
+
+        $orderPostage = new OrderPostage();
+
+        if (!$taxRule instanceof TaxRule) {
+            $orderPostage->setAmount($untaxedPostage);
+            $orderPostage->setAmountTax(0);
+            $orderPostage->setTaxRuleTitle(null);
+
+            return $orderPostage;
+        }
+
+        $taxCalculator = $this->createTaxCalculator();
+        $taxCalculator->loadTaxRuleWithoutProduct($taxRule, $country);
+
+        $orderPostage->setAmount($taxCalculator->getTaxedPrice($untaxedPostage));
+        $orderPostage->setAmountTax($taxCalculator->getTaxAmountFromUntaxedPrice($untaxedPostage));
+        $orderPostage->setTaxRuleTitle($taxRule->setLocale($locale)->getTitle());
+
+        return $orderPostage;
+    }
+
+    /**
+     * Tax rule this delivery module applies to its postage: its own setting
+     * when one is configured, the shop-wide delivery tax rule otherwise.
+     */
+    public function getPostageTaxRuleId(): ?int
+    {
+        return $this->getModulePostageTaxRuleId() ?: ((int) ConfigQuery::read('taxrule_id_delivery_module') ?: null);
+    }
+
+    private function getModulePostageTaxRuleId(): ?int
+    {
+        $module = ModuleQuery::create()->findOneByCode($this->getCode());
+
+        if (null === $module) {
+            return null;
+        }
+
+        $taxRuleId = (int) ModuleConfigQuery::create()
+            ->getConfigValue($module->getId(), self::POSTAGE_TAX_RULE_CONFIG_KEY, '0');
+
+        return $taxRuleId ?: null;
+    }
+
+    private function resolvePostageTaxRule(?int $taxRuleId): ?TaxRule
+    {
+        if (!$taxRuleId) {
+            return null;
+        }
+
+        return TaxRuleQuery::create()
+            ->filterById($taxRuleId)
+            ->orderByIsDefault(Criteria::DESC)
+            ->findOne();
+    }
+}

--- a/tests/Integration/Module/DeliveryModulePostageTaxRuleTest.php
+++ b/tests/Integration/Module/DeliveryModulePostageTaxRuleTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Module;
+
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Country;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleConfig;
+use Thelia\Model\OrderPostage;
+use Thelia\Model\State;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleCountry;
+use Thelia\Module\AbstractDeliveryModuleWithState;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A shop that ships books at 5.5 % and gadgets at 20 % needs more than the one
+ * shop-wide postage tax rule: each delivery module must be able to carry its own.
+ */
+final class DeliveryModulePostageTaxRuleTest extends IntegrationTestCase
+{
+    private const MODULE_CODE = 'PostageTaxRuleTestDelivery';
+
+    protected function tearDown(): void
+    {
+        // ConfigQuery memoizes every variable it reads in a static cache that
+        // outlives the transaction rollback. Left alone, the value written here
+        // would answer the next test of the process while its row is gone.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testShopWideRuleAppliesWhenTheModuleHasNoSetting(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+        $shopWide = $this->createTaxRule($country, '20', 'VAT 20');
+        ConfigQuery::write('taxrule_id_delivery_module', (string) $shopWide->getId());
+
+        $postage = $this->buildPostage($country);
+
+        self::assertSame('VAT 20', $postage->getTaxRuleTitle());
+        self::assertEqualsWithDelta(12.0, $postage->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(2.0, $postage->getAmountTax(), 0.0001);
+    }
+
+    public function testModuleSettingOverridesTheShopWideRule(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+        $shopWide = $this->createTaxRule($country, '20', 'VAT 20');
+        $moduleRule = $this->createTaxRule($country, '5.5', 'VAT 5.5');
+        ConfigQuery::write('taxrule_id_delivery_module', (string) $shopWide->getId());
+
+        $module = $this->createDeliveryModuleRow();
+        $this->setModulePostageTaxRule($module, $moduleRule);
+
+        $postage = $this->buildPostage($country);
+
+        self::assertSame('VAT 5.5', $postage->getTaxRuleTitle());
+        self::assertEqualsWithDelta(10.55, $postage->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(0.55, $postage->getAmountTax(), 0.0001);
+    }
+
+    public function testExplicitTaxRuleArgumentStillWins(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+        $shopWide = $this->createTaxRule($country, '20', 'VAT 20');
+        $moduleRule = $this->createTaxRule($country, '5.5', 'VAT 5.5');
+        ConfigQuery::write('taxrule_id_delivery_module', (string) $shopWide->getId());
+
+        $module = $this->createDeliveryModuleRow();
+        $this->setModulePostageTaxRule($module, $moduleRule);
+
+        // Delivery modules that already carry their own tax rule setting pass it
+        // as the fourth argument. That call must keep the exact same result.
+        $postage = $this->buildPostage($country, $shopWide->getId());
+
+        self::assertSame('VAT 20', $postage->getTaxRuleTitle());
+        self::assertEqualsWithDelta(12.0, $postage->getAmount(), 0.0001);
+    }
+
+    public function testPostageStaysUntaxedWithoutAnyRule(): void
+    {
+        $country = $this->createFixtureFactory()->country();
+        ConfigQuery::write('taxrule_id_delivery_module', '0');
+
+        $postage = $this->buildPostage($country);
+
+        self::assertNull($postage->getTaxRuleTitle());
+        self::assertEqualsWithDelta(10.0, $postage->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(0.0, $postage->getAmountTax(), 0.0001);
+    }
+
+    private function buildPostage(Country $country, ?int $taxRuleId = null): OrderPostage
+    {
+        return $this->createDeliveryModule()->buildOrderPostage(10.0, $country, 'en_US', $taxRuleId);
+    }
+
+    private function createDeliveryModule(): AbstractDeliveryModuleWithState
+    {
+        return new class(self::MODULE_CODE) extends AbstractDeliveryModuleWithState {
+            public function __construct(private readonly string $code)
+            {
+            }
+
+            public function getCode(): string
+            {
+                return $this->code;
+            }
+
+            public function isValidDelivery(Country $country, ?State $state = null): bool
+            {
+                return true;
+            }
+
+            public function getPostage(Country $country, ?State $state = null): float
+            {
+                return 10.0;
+            }
+        };
+    }
+
+    private function createDeliveryModuleRow(): Module
+    {
+        $module = new Module();
+        $module
+            ->setCode(self::MODULE_CODE)
+            ->setType(BaseModule::DELIVERY_MODULE_TYPE)
+            ->setActivate(BaseModule::IS_ACTIVATED)
+            ->setFullNamespace(self::MODULE_CODE.'\\'.self::MODULE_CODE)
+            ->save($this->getPropelConnection());
+
+        return $module;
+    }
+
+    private function setModulePostageTaxRule(Module $module, TaxRule $taxRule): void
+    {
+        (new ModuleConfig())
+            ->setModuleId($module->getId())
+            ->setName(AbstractDeliveryModuleWithState::POSTAGE_TAX_RULE_CONFIG_KEY)
+            ->setValue((string) $taxRule->getId())
+            ->save($this->getPropelConnection());
+    }
+
+    private function createTaxRule(Country $country, string $percent, string $title): TaxRule
+    {
+        $factory = $this->createFixtureFactory();
+        // A non-empty override array forces a rule of its own instead of reusing the seeded one.
+        $taxRule = $factory->taxRule(['isDefault' => false]);
+        $taxRule->setLocale('en_US')->setTitle($title)->save($this->getPropelConnection());
+
+        $tax = $factory->tax(['requirements' => ['percent' => $percent], 'title' => $title]);
+
+        (new TaxRuleCountry())
+            ->setTaxRuleId($taxRule->getId())
+            ->setCountryId($country->getId())
+            ->setTaxId($tax->getId())
+            ->setPosition(1)
+            ->save($this->getPropelConnection());
+
+        return $taxRule;
+    }
+}


### PR DESCRIPTION
Refs #1664.

## Symptom

Postage can only be taxed with the one tax rule configured shop-wide. `AbstractDeliveryModuleWithState::buildOrderPostage()` (core/lib/Thelia/Module/AbstractDeliveryModuleWithState.php:66 before this change) read `taxrule_id_delivery_module` and nothing else, so every carrier in the shop was forced onto the same rate.

The method already accepted an explicit `$taxRuleId` fourth argument, and most bundled carriers use it — each one re-implementing its own setting, its own back-office controller and its own form:

- `ColissimoHomeDelivery.php:285`, `ColissimoPickupPoint.php:267`
- `ChronopostHomeDelivery.php:388`, `ChronopostPickupPoint.php:382`
- `MondialRelayHomeDelivery.php:392`, `MondialRelayPickupPoint.php:372`
- `DpdClassic.php:201`, `CustomDelivery.php:287`

A module that does not do this — `LocalPickup.php:65` calls `buildOrderPostage()` with three arguments — has no way to pick a rate at all.

## Change

The postage builder moves into `Thelia\Module\OrderPostageBuilderTrait`, which resolves the tax rule in three steps:

1. the id the module passes explicitly to `buildOrderPostage()`;
2. the module's own `postage_tax_rule_id` entry in `module_config`;
3. the shop-wide `taxrule_id_delivery_module`.

Step 2 is new; steps 1 and 3 behave exactly as before, so a carrier that already passes its own rule is unaffected. The setting lives in the existing `module_config` table, so there is no schema change.

`AbstractDeliveryModule` — the stateless base, which had no postage builder at all — now uses the same trait. `buildOrderPostage()` keeps its original signature, and no module in the ecosystem overrides it.

`getPostageTaxRuleId()` is exposed so a back-office screen can show which rule a given delivery module will actually apply.

## Scope

This makes the per-carrier choice first-class. It does not split postage VAT across a cart that mixes rates: the EU rule apportions the shipping charge over the goods pro rata their net values, which needs a per-rate breakdown next to `order.postage_tax` and therefore a new table. That design is written up on the issue.

## Verifying

`tests/Integration/Module/DeliveryModulePostageTaxRuleTest.php` covers the four branches: shop-wide rule with no module setting, module setting overriding it, explicit argument still winning over the module setting, and untaxed postage when nothing is configured.

Checked red before green: with the `module_config` lookup removed, `testModuleSettingOverridesTheShopWideRule` fails with `'VAT 20'` where `'VAT 5.5'` is expected.
