### PR TITLE
fix: rate limit lost-password requests per address and per client

### DIFF
--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -29,6 +29,7 @@ use Thelia\Core\Translation\Translator;
 use Thelia\Domain\Cart\Service\CartContext;
 use Thelia\Domain\Cart\Service\CartRetriever;
 use Thelia\Domain\Customer\Exception\CustomerException;
+use Thelia\Domain\Customer\Service\CustomerEmailRequestLimiter;
 use Thelia\Domain\Customer\Service\CustomerTitleService;
 use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Mailer\MailerFactory;
@@ -57,6 +58,7 @@ class Customer extends BaseAction implements EventSubscriberInterface
         protected LangService $langService,
         protected CartRetriever $cartRetriever,
         protected CartContext $cartContext,
+        protected CustomerEmailRequestLimiter $emailRequestLimiter,
     ) {
     }
 
@@ -280,10 +282,22 @@ class Customer extends BaseAction implements EventSubscriberInterface
     }
 
     /**
+     * Reset the password of the given address and mail the new one to it.
+     *
+     * The address comes from whoever asked, so this mails a third party on demand,
+     * and the mail carries a fresh password, which locks the owner out of the account
+     * every time. The cap is taken before the address is looked up, so a caller spends
+     * the same budget whether or not the address has an account, and a front office
+     * offering a "send it again" link cannot be turned into a mail cannon.
+     *
      * @throws PropelException
      */
     public function lostPassword(LostPasswordEvent $event): void
     {
+        if (!$this->emailRequestLimiter->allows((string) $event->getEmail())) {
+            return;
+        }
+
         if (null === $customer = CustomerQuery::create()->filterByEmail($event->getEmail())->findOne()) {
             return;
         }

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -31,17 +31,19 @@ return static function (ContainerConfigurator $container): void {
             ],
         ],
         'rate_limiter' => [
-            // Asking for a new account activation code sends an email to an address
-            // the visitor typed, so an unauthenticated caller can make the shop mail
-            // someone else. Both limits are needed: the per-address one protects the
-            // owner of a single mailbox, the per-client one stops a single caller
-            // from walking a list of addresses.
-            'customer_code_request_per_email' => [
+            // Asking for a new account activation code, or for a new password, sends an
+            // email to an address the visitor typed, so an unauthenticated caller can
+            // make the shop mail someone else. Both limits are needed: the per-address
+            // one protects the owner of a single mailbox, the per-client one stops a
+            // single caller from walking a list of addresses. Three an hour leaves room
+            // for the usual "it did not arrive, send it again" without a real customer
+            // ever noticing the cap.
+            'customer_email_request_per_address' => [
                 'policy' => 'sliding_window',
                 'limit' => 3,
                 'interval' => '1 hour',
             ],
-            'customer_code_request_per_client' => [
+            'customer_email_request_per_client' => [
                 'policy' => 'sliding_window',
                 'limit' => 10,
                 'interval' => '1 hour',

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerCodeManager.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerCodeManager.php
@@ -15,9 +15,6 @@ declare(strict_types=1);
 namespace Thelia\Domain\Customer\Service;
 
 use Propel\Runtime\Exception\PropelException;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
@@ -26,11 +23,7 @@ readonly class CustomerCodeManager
 {
     public function __construct(
         private MailerFactory $mailerFactory,
-        #[Autowire(service: 'limiter.customer_code_request_per_email')]
-        private RateLimiterFactoryInterface $perEmailCodeRequestLimiter,
-        #[Autowire(service: 'limiter.customer_code_request_per_client')]
-        private RateLimiterFactoryInterface $perClientCodeRequestLimiter,
-        private RequestStack $requestStack,
+        private CustomerEmailRequestLimiter $emailRequestLimiter,
     ) {
     }
 
@@ -48,16 +41,7 @@ readonly class CustomerCodeManager
         Customer $customer,
         int $expiryTimeInHours = 24,
     ): bool {
-        // No request in a CLI context: the per-client limit simply does not apply.
-        // It is consumed first so that a caller who is already over it stops eating
-        // the budget of the mailbox owner, who would then be denied a resend.
-        $clientIp = $this->requestStack->getMainRequest()?->getClientIp();
-
-        if (null !== $clientIp && !$this->perClientCodeRequestLimiter->create($clientIp)->consume()->isAccepted()) {
-            return false;
-        }
-
-        if (!$this->perEmailCodeRequestLimiter->create(hash('sha256', strtolower((string) $customer->getEmail())))->consume()->isAccepted()) {
+        if (!$this->emailRequestLimiter->allows((string) $customer->getEmail())) {
             return false;
         }
 

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerEmailRequestLimiter.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerEmailRequestLimiter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Customer\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * Caps the account emails an unauthenticated visitor can make the shop send.
+ *
+ * Every "mail me something about this address" entry point — a new activation code,
+ * a new password — takes the address from whoever is asking, so any of them can be
+ * used to mail a third party on demand, repeatedly, at the expense of the shop's
+ * sending reputation. Both windows are needed: the per-address one protects the
+ * owner of a single mailbox, the per-client one stops a single caller from walking
+ * a list of addresses.
+ *
+ * Callers must answer the visitor the same way whether this returned true or false,
+ * otherwise the answer tells the caller whether the address has an account.
+ */
+readonly class CustomerEmailRequestLimiter
+{
+    public function __construct(
+        #[Autowire(service: 'limiter.customer_email_request_per_address')]
+        private RateLimiterFactoryInterface $perAddressLimiter,
+        #[Autowire(service: 'limiter.customer_email_request_per_client')]
+        private RateLimiterFactoryInterface $perClientLimiter,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * Whether one more email may be sent to the given address on this visitor's behalf.
+     *
+     * Call this before looking the address up, so that a caller spends the same budget
+     * whether or not it names an account.
+     */
+    public function allows(string $email): bool
+    {
+        // No request in a CLI context: the per-client limit simply does not apply.
+        // It is consumed first so that a caller who is already over it stops eating
+        // the budget of the mailbox owner, who would then be denied a legitimate resend.
+        $clientIp = $this->requestStack->getMainRequest()?->getClientIp();
+
+        if (null !== $clientIp && !$this->perClientLimiter->create($clientIp)->consume()->isAccepted()) {
+            return false;
+        }
+
+        return $this->perAddressLimiter->create(hash('sha256', strtolower($email)))->consume()->isAccepted();
+    }
+}

--- a/tests/Integration/Action/CustomerLostPasswordRateLimitTest.php
+++ b/tests/Integration/Action/CustomerLostPasswordRateLimitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Core\Event\LostPasswordEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Customer\Service\CustomerEmailRequestLimiter;
+use Thelia\Model\CustomerQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * A lost-password request names an address the caller typed, and the answer to it
+ * carries a brand new password: left uncapped, it mails a third party on demand and
+ * locks the owner out of the account on every call.
+ */
+final class CustomerLostPasswordRateLimitTest extends ActionIntegrationTestCase
+{
+    private RequestStack $requestStack;
+
+    private ?string $previousClientIp = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Give this test its own caller address, so the per-client window it spends is
+        // its own and neither the rest of the suite nor an earlier run is in the way.
+        $this->requestStack = $this->getService(RequestStack::class);
+        $request = $this->requestStack->getMainRequest();
+        $this->previousClientIp = $request?->server->get('REMOTE_ADDR');
+        $request?->server->set('REMOTE_ADDR', '203.0.113.'.random_int(1, 254));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->requestStack->getMainRequest()?->server->set('REMOTE_ADDR', $this->previousClientIp);
+
+        parent::tearDown();
+    }
+
+    public function testAPasswordIsNoLongerResetOnceTheAddressHasAskedTooOften(): void
+    {
+        $email = 'lost-password-'.bin2hex(random_bytes(8)).'@example.com';
+        $customer = $this->factory->customer($this->factory->customerTitle(), ['email' => $email]);
+        $storedPassword = $customer->getPassword();
+
+        // Spend the address window through the limiter itself rather than by asking for
+        // three passwords: the request below is then the first one over the cap, and no
+        // email leaves this test.
+        $limiter = $this->getService(CustomerEmailRequestLimiter::class);
+        self::assertTrue($limiter->allows($email));
+        self::assertTrue($limiter->allows($email));
+        self::assertTrue($limiter->allows($email));
+        self::assertFalse($limiter->allows($email));
+
+        $this->dispatch(new LostPasswordEvent($email), TheliaEvents::LOST_PASSWORD);
+
+        self::assertSame(
+            $storedPassword,
+            CustomerQuery::create()->findPk($customer->getId())?->getPassword(),
+            'Over the cap, a lost-password request must leave the account alone instead of replacing its password and mailing the new one.',
+        );
+    }
+}

--- a/tests/Unit/Domain/Customer/CustomerCodeManagerTest.php
+++ b/tests/Unit/Domain/Customer/CustomerCodeManagerTest.php
@@ -21,12 +21,15 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Thelia\Domain\Customer\Service\CustomerCodeManager;
+use Thelia\Domain\Customer\Service\CustomerEmailRequestLimiter;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\Customer;
 
 /**
  * "Send me the activation code again" is reachable by anyone who knows an address,
- * so the number of emails it can trigger has to be capped per address and per caller.
+ * so the number of emails it can trigger has to be capped. The windows themselves
+ * are covered by {@see CustomerEmailRequestLimiterTest}; what matters here is that
+ * asking for a code goes through them.
  */
 final class CustomerCodeManagerTest extends TestCase
 {
@@ -35,12 +38,7 @@ final class CustomerCodeManagerTest extends TestCase
         $mailerFactory = $this->createMock(MailerFactory::class);
         $mailerFactory->expects(self::exactly(3))->method('sendEmailToCustomer');
 
-        $manager = new CustomerCodeManager(
-            $mailerFactory,
-            $this->limiter(3),
-            $this->limiter(100),
-            $this->requestStackWithClientIp('203.0.113.7'),
-        );
+        $manager = new CustomerCodeManager($mailerFactory, $this->limiterAllowing(3));
 
         $customer = $this->customer('pending@example.com');
 
@@ -51,63 +49,19 @@ final class CustomerCodeManagerTest extends TestCase
         self::assertFalse($manager->requestCode($customer));
     }
 
-    public function testTheAddressLimitIgnoresCaseSoItCannotBeSidesteppedByRetyping(): void
+    private function limiterAllowing(int $limit): CustomerEmailRequestLimiter
     {
-        $mailerFactory = $this->createMock(MailerFactory::class);
-        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/customer/send-code', server: ['REMOTE_ADDR' => '203.0.113.7']));
 
-        $manager = new CustomerCodeManager(
-            $mailerFactory,
-            $this->limiter(2),
-            $this->limiter(100),
-            $this->requestStackWithClientIp('203.0.113.7'),
+        return new CustomerEmailRequestLimiter(
+            $this->window($limit),
+            $this->window(100),
+            $requestStack,
         );
-
-        self::assertTrue($manager->requestCode($this->customer('pending@example.com')));
-        self::assertTrue($manager->requestCode($this->customer('Pending@Example.COM')));
-        self::assertFalse($manager->requestCode($this->customer('PENDING@EXAMPLE.COM')));
     }
 
-    public function testOneCallerWalkingManyAddressesIsStoppedByTheClientLimit(): void
-    {
-        $mailerFactory = $this->createMock(MailerFactory::class);
-        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
-
-        $manager = new CustomerCodeManager(
-            $mailerFactory,
-            $this->limiter(100),
-            $this->limiter(2),
-            $this->requestStackWithClientIp('203.0.113.7'),
-        );
-
-        self::assertTrue($manager->requestCode($this->customer('first@example.com')));
-        self::assertTrue($manager->requestCode($this->customer('second@example.com')));
-        self::assertFalse($manager->requestCode($this->customer('third@example.com')));
-    }
-
-    public function testWithoutARequestOnlyTheAddressLimitApplies(): void
-    {
-        $mailerFactory = $this->createMock(MailerFactory::class);
-        $mailerFactory->expects(self::exactly(2))->method('sendEmailToCustomer');
-
-        // A command line caller (module, cron, install script) has no client IP:
-        // the per-client limit must be skipped instead of blocking the send. Here it
-        // would stop everything after the first mail if it were applied.
-        $manager = new CustomerCodeManager(
-            $mailerFactory,
-            $this->limiter(2),
-            $this->limiter(1),
-            new RequestStack(),
-        );
-
-        $customer = $this->customer('pending@example.com');
-
-        self::assertTrue($manager->requestCode($customer));
-        self::assertTrue($manager->requestCode($customer));
-        self::assertFalse($manager->requestCode($customer));
-    }
-
-    private function limiter(int $limit): RateLimiterFactoryInterface
+    private function window(int $limit): RateLimiterFactoryInterface
     {
         return new RateLimiterFactory(
             [
@@ -118,14 +72,6 @@ final class CustomerCodeManagerTest extends TestCase
             ],
             new InMemoryStorage(),
         );
-    }
-
-    private function requestStackWithClientIp(string $clientIp): RequestStack
-    {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('/customer/send-code', server: ['REMOTE_ADDR' => $clientIp]));
-
-        return $requestStack;
     }
 
     private function customer(string $email): Customer

--- a/tests/Unit/Domain/Customer/CustomerEmailRequestLimiterTest.php
+++ b/tests/Unit/Domain/Customer/CustomerEmailRequestLimiterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Domain\Customer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Thelia\Domain\Customer\Service\CustomerEmailRequestLimiter;
+
+/**
+ * "Send me the activation code again" and "send me a new password" are reachable by
+ * anyone who knows an address, so the number of emails they can trigger has to be
+ * capped per address and per caller.
+ */
+final class CustomerEmailRequestLimiterTest extends TestCase
+{
+    public function testRequestsForOneAddressStopBeingAllowedOnceTheLimitIsReached(): void
+    {
+        $limiter = new CustomerEmailRequestLimiter(
+            $this->window(3),
+            $this->window(100),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertFalse($limiter->allows('someone@example.com'));
+        self::assertFalse($limiter->allows('someone@example.com'));
+    }
+
+    public function testTheAddressLimitIgnoresCaseSoItCannotBeSidesteppedByRetyping(): void
+    {
+        $limiter = new CustomerEmailRequestLimiter(
+            $this->window(2),
+            $this->window(100),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertTrue($limiter->allows('Someone@Example.COM'));
+        self::assertFalse($limiter->allows('SOMEONE@EXAMPLE.COM'));
+    }
+
+    public function testOneCallerWalkingManyAddressesIsStoppedByTheClientLimit(): void
+    {
+        $limiter = new CustomerEmailRequestLimiter(
+            $this->window(100),
+            $this->window(2),
+            $this->requestStackWithClientIp('203.0.113.7'),
+        );
+
+        self::assertTrue($limiter->allows('first@example.com'));
+        self::assertTrue($limiter->allows('second@example.com'));
+        self::assertFalse($limiter->allows('third@example.com'));
+    }
+
+    public function testWithoutARequestOnlyTheAddressLimitApplies(): void
+    {
+        // A command line caller (module, cron, install script) has no client IP:
+        // the per-client limit must be skipped instead of blocking the send. Here it
+        // would deny everything after the first call if it were applied.
+        $limiter = new CustomerEmailRequestLimiter(
+            $this->window(2),
+            $this->window(1),
+            new RequestStack(),
+        );
+
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertTrue($limiter->allows('someone@example.com'));
+        self::assertFalse($limiter->allows('someone@example.com'));
+    }
+
+    private function window(int $limit): RateLimiterFactoryInterface
+    {
+        return new RateLimiterFactory(
+            [
+                'id' => 'test',
+                'policy' => 'sliding_window',
+                'limit' => $limit,
+                'interval' => '1 hour',
+            ],
+            new InMemoryStorage(),
+        );
+    }
+
+    private function requestStackWithClientIp(string $clientIp): RequestStack
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/password/resend', server: ['REMOTE_ADDR' => $clientIp]));
+
+        return $requestStack;
+    }
+}


### PR DESCRIPTION
Fixes #3658. Front-office half in thelia-templates/flexy#141.

## Symptom

`POST /password/forgotten` accepts any address and puts it in the visitor's own session. `GET /password/resend` then asks the shop to mail that address again, with no form, no token and no limit. Fifty requests from one caller on a fresh 3.0 install with demo data, half of them naming a customer of the shop:

- **25 emails went out**, to someone who never asked for any of them.
- The account named was reset **25 times**: `Thelia\Action\Customer::lostPassword` replaces the password with a random one before mailing it, so repeating the request also locks the owner out of the account. The mail cannon is a lockout as well.

The response says nothing on its own, which is correct and stays that way: for a known and an unknown address it is byte for byte the same (`302`, same `Location`, 418 bytes on the form and 422 on the resend). What it did leak is how long it took.

| Before | known address | unknown address | ratio |
|---|---|---|---|
| `POST /password/forgotten` | median 187.0 ms, range 178-307 | median 78.9 ms, range 66-97 | 2.37x |
| `GET /password/resend` | median 184.5 ms, range 169-208 | median 63.6 ms, range 60-84 | 2.90x |

Twelve interleaved samples each. The two ranges do not overlap on either route, so one request was enough to tell whether an address is a customer of the shop, without logging in, and the resend could be repeated forever.

## Cause

`core/lib/Thelia/Action/Customer.php:288` did the whole thing unconditionally: look the address up, generate a password, hash it, save, mail. Nothing capped how often that could be asked for, and the work only happened for an address that has an account, which is where the 117 ms gap comes from (about 49 ms of bcrypt, the rest the mail).

`Thelia\Form\CustomerLostPasswordForm` has a firewall of 6 attempts an hour per IP, but only in `prod` and only on the form: `/password/resend` posts no form and was not covered by anything.

## Fix

#3656 already introduced the mechanism for the activation code: two sliding windows, per address and per client, the client one consumed first so a caller already over it stops eating the mailbox owner's budget. Rather than copying a second variant of it, the two windows move out of `CustomerCodeManager` into `Thelia\Domain\Customer\Service\CustomerEmailRequestLimiter`, and both flows call it:

- `CustomerCodeManager::requestCode()` keeps its behaviour, now expressed through the limiter.
- `Action\Customer::lostPassword()` takes the cap **before looking the address up**, so an address that has no account spends the same budget as one that has, and every caller of `TheliaEvents::LOST_PASSWORD` is covered: both routes of the Flexy theme, and any other theme or module, without a line of theme code.

The rate limiter ids are renamed to match what they now cover (`customer_email_request_per_address`, `customer_email_request_per_client`). They were introduced by #3656 and are not in a released `thelia/core` yet, so nothing outside this repository refers to them.

### Limits, and why

Three an hour per address, ten an hour per client. The flow a real customer walks is: submit the form (one mail), then click "resend" if it has not arrived. Measured on the bench, submit plus two resends all go out and the fourth request is held, so someone asking twice in ten minutes is never punished. Ten per client leaves room for a household or an office behind one address, while an attacker walking a list gets ten addresses an hour per IP.

## After

Same fifty requests, same bench:

| After | known address | unknown address | ratio |
|---|---|---|---|
| `POST /password/forgotten` | median 76.2 ms | median 69.3 ms | 1.10x |
| `GET /password/resend` | median 60.6 ms | median 61.7 ms | 0.98x |

**3 emails** instead of 25, and the account reset three times instead of twenty-five.

One honest caveat: the first three requests for an address are still slower when it has an account (233, 194, 199 ms against 65-83 ms). The gap is caused by the reset and the mail being done inside the request, and closing it entirely means moving the send off the request path, which is a redesign rather than a fix. What this change does is bound it: three timed probes per address and ten per client per hour, in place of an unlimited supply.

## Verify

`tests/Integration/Action/CustomerLostPasswordRateLimitTest.php` spends the address window through the limiter, dispatches `LOST_PASSWORD` once more and asserts the stored password is untouched. It sends no mail, so it needs no mail catcher. Checked red against `main` (the password was replaced: `$2y$10$P4Xd...` became `$2y$10$cg0P...`) and green with the change.

`tests/Unit/Domain/Customer/CustomerEmailRequestLimiterTest.php` carries the four window tests from #3656, and `CustomerCodeManagerTest` keeps the one that matters there: asking for a code goes through the limiter.

On a throwaway 3.0 install with demo data and the mailer pointed at a local catcher: unit 279/279, http-flexy 13/13 (including the activation enumeration tests of #3656), integration same failure set as the same bench on `main`, plus the new test. The bench carries pre-existing failures of its own, from a `local/config` seed older than the released `thelia/config`; they are identical with and without this change.
