### PR TITLE
fix: remove the exports and imports a deleted module leaves behind

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -31,6 +31,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\File\Exception\FileNotFoundException;
 use Thelia\Core\Translation\Translator;
+use Thelia\Domain\DataTransfer\Service\HandlerCleaner;
 use Thelia\Domain\Module\Exception\ModuleException;
 use Thelia\Log\Tlog;
 use Thelia\Model\Base\OrderQuery;
@@ -47,8 +48,10 @@ use Thelia\Module\Validator\ModuleValidator;
  */
 class Module extends BaseAction implements EventSubscriberInterface
 {
-    public function __construct(protected ContainerInterface $container)
-    {
+    public function __construct(
+        protected ContainerInterface $container,
+        protected HandlerCleaner $handlerCleaner,
+    ) {
     }
 
     public function toggleActivation(ModuleToggleActivationEvent $event, $eventName, EventDispatcherInterface $dispatcher): void
@@ -308,6 +311,10 @@ class Module extends BaseAction implements EventSubscriberInterface
                     ),
                 );
             }
+
+            // The export and import tables carry no module id, so the entries the module
+            // declared are matched on the namespace of their handler class.
+            $this->handlerCleaner->removeHandlersProvidedBy((string) $module->getFullNamespace(), $con);
 
             $module->delete($con);
 

--- a/core/lib/Thelia/Command/DataTransferCleanCommand.php
+++ b/core/lib/Thelia/Command/DataTransferCleanCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Thelia\Domain\DataTransfer\Service\HandlerCleaner;
+
+#[AsCommand(name: 'import-export:clean', description: 'Delete the exports and imports whose handler class is no longer available.')]
+class DataTransferCleanCommand extends ContainerAwareCommand
+{
+    public function __construct(protected HandlerCleaner $handlerCleaner)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp(
+                'Exports and imports are declared by modules, and the entries they leave behind when they are '
+                ."removed keep pointing at a class that no longer exists.\n"
+                .'This deletes those entries, and the export or import categories they leave empty. '
+                .'Use --dry-run to list them first.',
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'List the entries that would be deleted, and delete nothing');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        [$exports, $imports] = $this->handlerCleaner->findUnavailableHandlers();
+
+        if ([] === $exports && [] === $imports) {
+            $output->writeln('<info>No export or import points at a missing handler class.</info>');
+
+            return 0;
+        }
+
+        foreach ($exports as $export) {
+            $output->writeln(\sprintf('export <comment>%s</comment> => %s', $export->getRef(), $export->getHandleClass()));
+        }
+
+        foreach ($imports as $import) {
+            $output->writeln(\sprintf('import <comment>%s</comment> => %s', $import->getRef(), $import->getHandleClass()));
+        }
+
+        if ($input->getOption('dry-run')) {
+            $output->writeln(\sprintf('<info>%d entrie(s) would be deleted.</info>', \count($exports) + \count($imports)));
+
+            return 0;
+        }
+
+        $removed = $this->handlerCleaner->removeUnavailableHandlers();
+
+        $output->writeln(\sprintf('<info>%d entrie(s) deleted.</info>', $removed));
+
+        return 0;
+    }
+}

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -555,6 +555,8 @@ return [
     'The brand name or title' => 'The brand name or title',
     'The cart item count should match the condition' => 'The cart item count should match the condition',
     'The category title' => 'The category title',
+    'The export "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.' => 'The export "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.',
+    'The import "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.' => 'The import "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.',
     'The class "%class" doesn\'t exist' => 'The class "%class" doesn\'t exist',
     'The class "%class" must extend %baseClass' => 'The class "%class" must extend %baseClass',
     'The container should not be null in this form. Please use the FormFactory to get an instance.' => 'The container should not be null in this form. Please use the FormFactory to get an instance.',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -554,6 +554,8 @@ return [
     'The brand name or title' => 'Le nom ou le titre de la marque',
     'The cart item count should match the condition' => 'Le nombre d\'articles dans le panier doit vérifier la condition',
     'The category title' => 'Titre de cette catégorie',
+    'The export "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.' => 'L\'export "%ref" ne peut pas être exécuté : sa classe de traitement "%class" n\'est pas disponible. Le module qui la fournissait a probablement été supprimé.',
+    'The import "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.' => 'L\'import "%ref" ne peut pas être exécuté : sa classe de traitement "%class" n\'est pas disponible. Le module qui la fournissait a probablement été supprimé.',
     'The class "%class" doesn\'t exist' => 'La classe "%class" n\'existe pas',
     'The class "%class" must extend %baseClass' => 'La classe "%class" doit hériter de %baseClass',
     'The coupon applies if the cart contains at least one product of the selected categories' => 'Le code promo est valable si le panier contient/ne contient pas des produits appartenant aux catégories sélectionnées',

--- a/core/lib/Thelia/Domain/DataTransfer/ExportHandler.php
+++ b/core/lib/Thelia/Domain/DataTransfer/ExportHandler.php
@@ -84,10 +84,11 @@ class ExportHandler
         bool $includeDocuments = false,
         ?array $rangeDate = null,
     ): ExportEvent {
-        $exportHandleClass = $export->getHandleClass();
+        if (!$export->isHandlerAvailable()) {
+            throw new \ErrorException(Translator::getInstance()->trans('The export "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.', ['%ref' => $export->getRef(), '%class' => $export->getHandleClass()]));
+        }
 
-        /** @var AbstractExport $instance */
-        $instance = new $exportHandleClass();
+        $instance = $export->getHandleClassInstance();
 
         // Configure handle class
         $instance->setLang($language);

--- a/core/lib/Thelia/Domain/DataTransfer/ImportHandler.php
+++ b/core/lib/Thelia/Domain/DataTransfer/ImportHandler.php
@@ -104,6 +104,10 @@ class ImportHandler
             throw new FormValidationException(Translator::getInstance()->trans('The extension "%extension" is not allowed', ['%extension' => pathinfo($file->getFilename(), \PATHINFO_EXTENSION)]));
         }
 
+        if (!$import->isHandlerAvailable()) {
+            throw new \ErrorException(Translator::getInstance()->trans('The import "%ref" cannot be run: its handler class "%class" is not available. The module that provided it has probably been removed.', ['%ref' => $import->getRef(), '%class' => $import->getHandleClass()]));
+        }
+
         $importHandleClass = $import->getHandleClass();
 
         /** @var AbstractImport $instance */

--- a/core/lib/Thelia/Domain/DataTransfer/Service/HandlerCleaner.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Service/HandlerCleaner.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\DataTransfer\Service;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Thelia\Domain\DataTransfer\Export\AbstractExport;
+use Thelia\Domain\DataTransfer\Import\AbstractImport;
+use Thelia\Model\Export;
+use Thelia\Model\ExportCategory;
+use Thelia\Model\ExportCategoryQuery;
+use Thelia\Model\ExportQuery;
+use Thelia\Model\Import;
+use Thelia\Model\ImportCategory;
+use Thelia\Model\ImportCategoryQuery;
+use Thelia\Model\ImportQuery;
+
+/**
+ * Removes the export and import entries a module left behind.
+ *
+ * The export and import tables hold no reference to the module that declared a
+ * handler, so the owner is read back from the handler class: a module declares
+ * handlers that live under its own root namespace. Entries a module no longer
+ * accounts for are deleted, along with the categories they leave empty.
+ */
+class HandlerCleaner
+{
+    /**
+     * Deletes the entries whose handler class belongs to the given module namespace,
+     * for instance "Acme\Acme" for a module whose handlers live under "Acme\".
+     */
+    public function removeHandlersProvidedBy(string $moduleNamespace, ?ConnectionInterface $con = null): int
+    {
+        $rootNamespace = $this->rootNamespace($moduleNamespace);
+
+        if ('' === $rootNamespace) {
+            return 0;
+        }
+
+        $exports = array_filter(
+            iterator_to_array(ExportQuery::create()->find($con)),
+            fn (Export $export): bool => $rootNamespace === $this->rootNamespace((string) $export->getHandleClass()),
+        );
+
+        $imports = array_filter(
+            iterator_to_array(ImportQuery::create()->find($con)),
+            fn (Import $import): bool => $rootNamespace === $this->rootNamespace((string) $import->getHandleClass()),
+        );
+
+        return $this->remove($exports, $imports, $con);
+    }
+
+    /**
+     * Deletes the entries whose handler class can no longer be loaded, which is
+     * what a module removed before its entries were cleaned up leaves behind.
+     */
+    public function removeUnavailableHandlers(?ConnectionInterface $con = null): int
+    {
+        [$exports, $imports] = $this->findUnavailableHandlers($con);
+
+        return $this->remove($exports, $imports, $con);
+    }
+
+    /**
+     * @return array{0: list<Export>, 1: list<Import>}
+     */
+    public function findUnavailableHandlers(?ConnectionInterface $con = null): array
+    {
+        $exports = [];
+        foreach (ExportQuery::create()->find($con) as $export) {
+            if (!$this->isAvailable((string) $export->getHandleClass(), AbstractExport::class)) {
+                $exports[] = $export;
+            }
+        }
+
+        $imports = [];
+        foreach (ImportQuery::create()->find($con) as $import) {
+            if (!$this->isAvailable((string) $import->getHandleClass(), AbstractImport::class)) {
+                $imports[] = $import;
+            }
+        }
+
+        return [$exports, $imports];
+    }
+
+    /**
+     * @param iterable<Export> $exports
+     * @param iterable<Import> $imports
+     */
+    private function remove(iterable $exports, iterable $imports, ?ConnectionInterface $con): int
+    {
+        $removed = 0;
+        $exportCategories = [];
+        $importCategories = [];
+
+        foreach ($exports as $export) {
+            $exportCategories[$export->getExportCategoryId()] = true;
+            $export->delete($con);
+            ++$removed;
+        }
+
+        foreach ($imports as $import) {
+            $importCategories[$import->getImportCategoryId()] = true;
+            $import->delete($con);
+            ++$removed;
+        }
+
+        foreach (array_keys($exportCategories) as $categoryId) {
+            $category = ExportCategoryQuery::create()->findPk($categoryId, $con);
+            $remaining = ExportQuery::create()->filterByExportCategoryId($categoryId)->count($con);
+
+            if ($category instanceof ExportCategory && 0 === $remaining) {
+                $category->delete($con);
+            }
+        }
+
+        foreach (array_keys($importCategories) as $categoryId) {
+            $category = ImportCategoryQuery::create()->findPk($categoryId, $con);
+            $remaining = ImportQuery::create()->filterByImportCategoryId($categoryId)->count($con);
+
+            if ($category instanceof ImportCategory && 0 === $remaining) {
+                $category->delete($con);
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * @param class-string $expectedBaseClass
+     */
+    private function isAvailable(string $handleClass, string $expectedBaseClass): bool
+    {
+        $handleClass = ltrim($handleClass, '\\');
+
+        return '' !== $handleClass
+            && class_exists($handleClass)
+            && is_subclass_of($handleClass, $expectedBaseClass);
+    }
+
+    private function rootNamespace(string $class): string
+    {
+        $class = ltrim($class, '\\');
+        $separatorPosition = strpos($class, '\\');
+
+        return false === $separatorPosition ? $class : substr($class, 0, $separatorPosition);
+    }
+}

--- a/core/lib/Thelia/Model/Export.php
+++ b/core/lib/Thelia/Model/Export.php
@@ -24,30 +24,34 @@ class Export extends BaseExport
 {
     use PositionManagementTrait;
 
-    protected static ?AbstractExport $cache = null;
+    protected ?AbstractExport $cache = null;
 
     /**
-     * @throws \ErrorException
+     * Whether the class named by handle_class can still be loaded. It cannot when the
+     * module that declared the export has been removed, as nothing deletes the export
+     * entries a module leaves behind.
+     */
+    public function isHandlerAvailable(): bool
+    {
+        $class = ltrim((string) $this->getHandleClass(), '\\');
+
+        return '' !== $class && class_exists($class) && is_subclass_of($class, AbstractExport::class);
+    }
+
+    /**
+     * @throws \ErrorException when the handler class is missing or is not an export
      */
     public function getHandleClassInstance(): AbstractExport
     {
-        $class = $this->getHandleClass();
+        $class = '\\'.ltrim((string) $this->getHandleClass(), '\\');
 
-        if ('\\' !== $class[0]) {
-            $class = '\\'.$class;
-        }
-
-        if (!class_exists($class)) {
-            $this->delete();
-
+        if ('\\' === $class || !class_exists($class)) {
             throw new \ErrorException(Translator::getInstance()->trans('The class "%class" doesn\'t exist', ['%class' => $class]));
         }
 
         $instance = new $class();
 
         if (!$instance instanceof AbstractExport) {
-            $this->delete();
-
             throw new \ErrorException(Translator::getInstance()->trans('The class "%class" must extend %baseClass', ['%class' => $class, '%baseClass' => AbstractExport::class]));
         }
 
@@ -56,29 +60,26 @@ class Export extends BaseExport
 
     public function hasImages()
     {
-        if (null === static::$cache) {
-            static::$cache = $this->getHandleClassInstance();
-        }
-
-        return static::$cache->hasImages();
+        return $this->handler()?->hasImages() ?? false;
     }
 
     public function hasDocuments()
     {
-        if (null === static::$cache) {
-            static::$cache = $this->getHandleClassInstance();
-        }
-
-        return static::$cache->hasDocuments();
+        return $this->handler()?->hasDocuments() ?? false;
     }
 
     public function useRangeDate()
     {
-        if (null === static::$cache) {
-            static::$cache = $this->getHandleClassInstance();
+        return $this->handler()?->useRangeDate() ?? false;
+    }
+
+    private function handler(): ?AbstractExport
+    {
+        if (!$this->isHandlerAvailable()) {
+            return null;
         }
 
-        return static::$cache->useRangeDate();
+        return $this->cache ??= $this->getHandleClassInstance();
     }
 
     public function preInsert(?ConnectionInterface $con = null): bool

--- a/core/lib/Thelia/Model/Import.php
+++ b/core/lib/Thelia/Model/Import.php
@@ -15,12 +15,25 @@ declare(strict_types=1);
 namespace Thelia\Model;
 
 use Propel\Runtime\Connection\ConnectionInterface;
+use Thelia\Domain\DataTransfer\Import\AbstractImport;
 use Thelia\Model\Base\Import as BaseImport;
 use Thelia\Model\Tools\PositionManagementTrait;
 
 class Import extends BaseImport
 {
     use PositionManagementTrait;
+
+    /**
+     * Whether the class named by handle_class can still be loaded. It cannot when the
+     * module that declared the import has been removed, as nothing deletes the import
+     * entries a module leaves behind.
+     */
+    public function isHandlerAvailable(): bool
+    {
+        $class = ltrim((string) $this->getHandleClass(), '\\');
+
+        return '' !== $class && class_exists($class) && is_subclass_of($class, AbstractImport::class);
+    }
 
     public function preInsert(?ConnectionInterface $con = null): bool
     {

--- a/tests/Integration/Domain/DataTransfer/HandlerCleanerTest.php
+++ b/tests/Integration/Domain/DataTransfer/HandlerCleanerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\DataTransfer;
+
+use Thelia\Core\Serializer\SerializerManager;
+use Thelia\Domain\DataTransfer\Export\Type\MailingExport;
+use Thelia\Domain\DataTransfer\Export\Type\OrderExport;
+use Thelia\Domain\DataTransfer\ExportHandler;
+use Thelia\Domain\DataTransfer\ImportHandler;
+use Thelia\Domain\DataTransfer\Service\HandlerCleaner;
+use Thelia\Model\Export;
+use Thelia\Model\ExportCategory;
+use Thelia\Model\ExportCategoryQuery;
+use Thelia\Model\ExportQuery;
+use Thelia\Model\Import;
+use Thelia\Model\ImportCategory;
+use Thelia\Model\ImportCategoryQuery;
+use Thelia\Model\ImportQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Exports and imports are declared by modules, but their tables hold no module id,
+ * so removing a module used to leave entries behind pointing at a class that no
+ * longer exists. Ownership is read back from the handler class namespace.
+ */
+final class HandlerCleanerTest extends IntegrationTestCase
+{
+    private const MISSING_EXPORT_CLASS = 'AcmeGone\Export\GoneExport';
+    private const MISSING_IMPORT_CLASS = 'AcmeGone\Import\GoneImport';
+
+    public function testEntriesDeclaredByAModuleAreRemovedWithTheirEmptyCategories(): void
+    {
+        $exportCategory = $this->createExportCategory();
+        $export = $this->createExport($exportCategory, self::MISSING_EXPORT_CLASS);
+        $importCategory = $this->createImportCategory();
+        $import = $this->createImport($importCategory, self::MISSING_IMPORT_CLASS);
+
+        $removed = $this->cleaner()->removeHandlersProvidedBy('AcmeGone\AcmeGone');
+
+        self::assertSame(2, $removed);
+        self::assertNull(ExportQuery::create()->findPk($export->getId()));
+        self::assertNull(ImportQuery::create()->findPk($import->getId()));
+        self::assertNull(ExportCategoryQuery::create()->findPk($exportCategory->getId()));
+        self::assertNull(ImportCategoryQuery::create()->findPk($importCategory->getId()));
+    }
+
+    public function testEntriesDeclaredByAnotherModuleAreLeftAlone(): void
+    {
+        $export = $this->createExport($this->createExportCategory(), self::MISSING_EXPORT_CLASS);
+
+        self::assertSame(0, $this->cleaner()->removeHandlersProvidedBy('OtherModule\OtherModule'));
+        self::assertNotNull(ExportQuery::create()->findPk($export->getId()));
+    }
+
+    public function testEntriesWhoseHandlerIsStillInstalledSurviveTheOrphanSweep(): void
+    {
+        $category = $this->createExportCategory();
+        $orphan = $this->createExport($category, self::MISSING_EXPORT_CLASS);
+        $installed = $this->createExport($category, MailingExport::class);
+
+        $this->cleaner()->removeUnavailableHandlers();
+
+        self::assertNull(ExportQuery::create()->findPk($orphan->getId()));
+        self::assertNotNull(ExportQuery::create()->findPk($installed->getId()));
+        // The category still holds an export, so it is kept.
+        self::assertNotNull(ExportCategoryQuery::create()->findPk($category->getId()));
+    }
+
+    public function testAMissingHandlerIsReportedWithoutTouchingTheDatabase(): void
+    {
+        $export = $this->createExport($this->createExportCategory(), self::MISSING_EXPORT_CLASS);
+
+        self::assertFalse($export->isHandlerAvailable());
+        self::assertFalse($export->hasImages());
+        self::assertFalse($export->hasDocuments());
+        self::assertFalse($export->useRangeDate());
+
+        // Reading the flags of a broken export must not delete it: only an explicit
+        // module removal or `import-export:clean` may.
+        self::assertNotNull(ExportQuery::create()->findPk($export->getId()));
+    }
+
+    public function testAnExportFlagIsNotBorrowedFromAPreviouslyReadExport(): void
+    {
+        $category = $this->createExportCategory();
+        $ranged = $this->createExport($category, OrderExport::class);
+        $notRanged = $this->createExport($category, MailingExport::class);
+        $orphan = $this->createExport($category, self::MISSING_EXPORT_CLASS);
+
+        // The handler used to be cached statically, so every export read afterwards
+        // answered with the flags of the first one.
+        self::assertTrue($ranged->useRangeDate());
+        self::assertFalse($notRanged->useRangeDate());
+        self::assertFalse($orphan->useRangeDate());
+    }
+
+    public function testRunningAnExportWithAMissingHandlerReportsWhyRatherThanFataling(): void
+    {
+        $export = $this->createExport($this->createExportCategory(), self::MISSING_EXPORT_CLASS);
+
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessageMatches('/AcmeGone\\\\Export\\\\GoneExport/');
+
+        $this->getService(ExportHandler::class)->export(
+            $export,
+            $this->getService(SerializerManager::class)->get('thelia.csv'),
+        );
+    }
+
+    public function testRunningAnImportWithAMissingHandlerReportsWhyRatherThanFataling(): void
+    {
+        $import = $this->createImport($this->createImportCategory(), self::MISSING_IMPORT_CLASS);
+
+        $file = new \Symfony\Component\HttpFoundation\File\File(
+            $this->writeTemporaryCsv(),
+        );
+
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessageMatches('/AcmeGone\\\\Import\\\\GoneImport/');
+
+        $this->getService(ImportHandler::class)->import($import, $file);
+    }
+
+    private function cleaner(): HandlerCleaner
+    {
+        return new HandlerCleaner();
+    }
+
+    private function writeTemporaryCsv(): string
+    {
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('handler-cleaner-', true).'.csv';
+        file_put_contents($path, "ref;stock\n");
+
+        return $path;
+    }
+
+    private function createExportCategory(): ExportCategory
+    {
+        $category = new ExportCategory();
+        $category->setRef('acme-gone-export-'.uniqid());
+        $category->setPosition(1);
+        $category->setLocale('en_US');
+        $category->setTitle('Acme gone');
+        $category->save($this->getPropelConnection());
+
+        return $category;
+    }
+
+    private function createExport(ExportCategory $category, string $handleClass): Export
+    {
+        $export = new Export();
+        $export->setRef('acme-gone-export-'.uniqid());
+        $export->setExportCategoryId($category->getId());
+        $export->setHandleClass($handleClass);
+        $export->setLocale('en_US');
+        $export->setTitle('Acme gone export');
+        $export->save($this->getPropelConnection());
+
+        return $export;
+    }
+
+    private function createImportCategory(): ImportCategory
+    {
+        $category = new ImportCategory();
+        $category->setRef('acme-gone-import-'.uniqid());
+        $category->setPosition(1);
+        $category->setLocale('en_US');
+        $category->setTitle('Acme gone');
+        $category->save($this->getPropelConnection());
+
+        return $category;
+    }
+
+    private function createImport(ImportCategory $category, string $handleClass): Import
+    {
+        $import = new Import();
+        $import->setRef('acme-gone-import-'.uniqid());
+        $import->setImportCategoryId($category->getId());
+        $import->setHandleClass($handleClass);
+        $import->setLocale('en_US');
+        $import->setTitle('Acme gone import');
+        $import->save($this->getPropelConnection());
+
+        return $import;
+    }
+}


### PR DESCRIPTION
Refs #2513.

## Symptom

Exports and imports are declared by modules, in `Config/config.xml`. Nothing links a row of `export` / `import` to the module that declared it, so removing the module leaves the row behind with a `handle_class` that no longer exists on disk.

Measured on a fresh 3.0 install (demo data), with a module declaring one export and one import, activated then deleted from the back office:

| Step | Observed |
|---|---|
| module deleted | 6 rows survive: `export`, `export_i18n`, `export_category`, `import`, `import_i18n`, `import_category`. The module row and its directory are gone. |
| `GET /admin/export` | 200 — the dead export is listed as a normal, clickable entry |
| `GET /admin/export/{id}` | **500** `The class "\Acme\Export\AcmeExport" doesn't exist`, **and the export row is deleted by that GET** |
| `POST /admin/export/{id}` | flash `Class "Acme\Export\AcmeExport" not found` |
| `GET /admin/import/{id}` | 200 — a fully functional-looking import form for a handler that cannot run |
| `POST /admin/import/{id}` | flash `Class "Acme\Import\AcmeImport" not found` |
| `Thelia import <ref> file.csv` | uncaught `ClassNotFoundError` |

## Cause

- `core/lib/Thelia/Action/Module.php:246` (`delete()`) runs `$instance->destroy()`, removes the directory and deletes the module row. Nothing touches `export` / `import`.
- `core/lib/Thelia/Model/Export.php:40` guards `class_exists`, but calls `$this->delete()` before throwing: a read operation destroys a row and still answers a 500. `Thelia\Model\Import` has no guard at all.
- `core/lib/Thelia/Domain/DataTransfer/ExportHandler.php:87` and `ImportHandler.php:107` instantiate `new $handleClass()` with no check.
- `core/lib/Thelia/Model/Export.php:27` caches the handler in a **static** property, so `hasImages()`, `hasDocuments()` and `useRangeDate()` answer with the flags of the first export read in the request, whichever export they are called on.

## Fix

The tables hold no module id, so ownership is read back from the handler class namespace — a module declares handlers under its own root namespace.

- `Thelia\Domain\DataTransfer\Service\HandlerCleaner` removes the entries a namespace owns, or the entries whose class can no longer be loaded, together with the categories they leave empty.
- Deleting a module now removes the entries it declared, inside the same transaction.
- `import-export:clean` (with `--dry-run`) sweeps the entries already left in the database by modules removed before this change.
- `Export::isHandlerAvailable()` / `Import::isHandlerAvailable()`; the flag accessors answer `false` for a missing handler instead of throwing, and no read path deletes a row any more.
- Running an export or an import with a missing handler throws a translated message naming the export and the class, instead of a `Class not found` fatal.
- The handler cache is per instance.

`export` and `import` still have no `module_id` column: adding one needs a `thelia/config` release, and the deduction above makes it an optimisation rather than a prerequisite. The column definition is written up in #2513.

## Verify

```bash
php Thelia import-export:clean --dry-run   # lists nothing on a healthy install
```

With a module declaring an export, activated then deleted from the back office: its `export`, `import` and both categories are gone, the native entries are untouched, and `/admin/export/{id}` no longer 500s.

`tests/Integration/Domain/DataTransfer/HandlerCleanerTest.php` covers the seven behaviours above; each one fails on `main` without this change.

Baselines on a fresh install: `composer test` 998 tests / 5 suites green, `composer cs` 0 of 1814, `composer phpstan` no errors.
