### PR TITLE
fix: keep a module activated when its upgrade is refused

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -380,6 +380,12 @@ class Module extends BaseAction implements EventSubscriberInterface
             } catch (\Exception $ex) {
                 // if module has not been deleted
                 if ($fs->exists($modulePath)) {
+                    // The module was deactivated a few lines above so it could be replaced, and the
+                    // replacement is not going to happen. Put the shop back where it was: a payment
+                    // or delivery module left deactivated by a failed upgrade takes the checkout
+                    // down, silently, while the administrator only reads that the install failed.
+                    $this->restoreActivation((int) $oldModule->getId(), (bool) $activated, $dispatcher);
+
                     throw $ex;
                 }
             }
@@ -412,6 +418,18 @@ class Module extends BaseAction implements EventSubscriberInterface
         }
 
         $event->setModule($module);
+    }
+
+    private function restoreActivation(int $moduleId, bool $wasActivated, EventDispatcherInterface $dispatcher): void
+    {
+        if (!$wasActivated) {
+            return;
+        }
+
+        $toggleEvent = new ModuleToggleActivationEvent($moduleId);
+        $toggleEvent->setNoCheck(true);
+
+        $dispatcher->dispatch($toggleEvent, TheliaEvents::MODULE_TOGGLE_ACTIVATION);
     }
 
     /**

--- a/tests/Integration/Action/ModuleActionTest.php
+++ b/tests/Integration/Action/ModuleActionTest.php
@@ -15,9 +15,12 @@ declare(strict_types=1);
 namespace Thelia\Tests\Integration\Action;
 
 use Thelia\Core\Event\Module\ModuleEvent;
+use Thelia\Core\Event\Module\ModuleInstallEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Model\ModuleQuery;
+use Thelia\Module\BaseModule;
+use Thelia\Module\Validator\ModuleDefinition;
 use Thelia\Test\ActionIntegrationTestCase;
 
 final class ModuleActionTest extends ActionIntegrationTestCase
@@ -63,6 +66,44 @@ final class ModuleActionTest extends ActionIntegrationTestCase
         self::assertSame(
             $targetPosition,
             ModuleQuery::create()->findPk($module->getId())->getPosition(),
+        );
+    }
+
+    /**
+     * Installing a newer version of an already installed module deactivates the current one before
+     * replacing it. When the replacement cannot happen — an order was placed with this payment
+     * module, so its row cannot be deleted — the shop must not be left with the module switched off.
+     */
+    public function testFailedUpgradeLeavesTheModuleActivated(): void
+    {
+        $module = ModuleQuery::create()->findOneByCode('Cheque');
+        self::assertNotNull($module, 'Cheque module must be registered by bin/test-prepare');
+
+        $module->setActivate(BaseModule::IS_ACTIVATED)->save();
+
+        // References Cheque as its payment module, which is what blocks the deletion.
+        $this->factory->order();
+
+        $definition = new ModuleDefinition();
+        $definition->setCode((string) $module->getCode());
+        $definition->setNamespace((string) $module->getFullNamespace());
+        $definition->setVersion('99.0.0');
+
+        $event = new ModuleInstallEvent();
+        $event->setModuleDefinition($definition);
+        $event->setModulePath((string) $module->getAbsoluteBaseDir());
+
+        try {
+            $this->dispatch($event, TheliaEvents::MODULE_INSTALL);
+            self::fail('Installing over a module an order was placed with should have been refused.');
+        } catch (\Exception $exception) {
+            self::assertStringContainsString('in use by at least one order', $exception->getMessage());
+        }
+
+        self::assertSame(
+            BaseModule::IS_ACTIVATED,
+            ModuleQuery::create()->findPk($module->getId())->getActivate(),
+            'A refused upgrade must leave the module activated, not silently switched off.',
         );
     }
 }


### PR DESCRIPTION
## Symptom

Reproduced on a fresh `--with-demo` install, where the demo places 65 orders through `Cheque`.

Upload a newer `Cheque.zip` from **Modules → Install a module**. The install is refused:

> Module installation failed: The module "Cheque" is currently in use by at least one order, and can't be deleted. To stop offering it to your customers, deactivate the module instead of deleting it.

The message is about deletion, while the administrator was installing. Worse, the module is left **deactivated**: `SELECT code, activate FROM module WHERE code = 'Cheque'` returns `0`. The shop has just lost a payment method, and nothing in the interface says so.

Any shop that has taken a single order through a payment or delivery module is affected, which is every shop in production.

## Cause

`Action\Module::install()` deactivates the installed module before replacing it (`core/lib/Thelia/Action/Module.php:364-371`), then dispatches `MODULE_DELETE` for it. The delete is refused because `order.payment_module_id` and `order.delivery_module_id` are foreign keys to `module` declared `ON DELETE RESTRICT`, and the core guards against it first (`core/lib/Thelia/Action/Module.php:264`).

The `catch` re-throws when the module directory is still on disk (`:380-385`) — which it always is, since the guard fires before any file is touched. Nothing undoes the deactivation, and the re-activation at the end of `install()` is never reached.

## Change

When the replacement cannot happen, put the module back in the state it was found in before re-throwing. The install is still refused — that part needs the order to stop pointing at a live module row, which is the open half of thelia/thelia#1145 — but a refused upgrade no longer takes the checkout down.

## Verify

`ModuleActionTest::testFailedUpgradeLeavesTheModuleActivated` places an order through `Cheque`, dispatches `MODULE_INSTALL` for a higher version of it, and asserts the refusal *and* that the module is still activated. Without the change it fails on `Failed asserting that 0 is identical to 1`.

Checked on a demo install: before the change the module list showed `Cheque` switched off after the failed upload; after it, `Cheque` stays active and the error alert is unchanged. Full suite green (260 + 431 + 188/1 skip + 13 + 11), `cs-diff` and PHPStan clean.

Refs thelia/thelia#1145.
