### PR TITLE
fix: expose the virtual flags of an order product on the front order payload

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -266,7 +266,13 @@ class OrderProduct implements PropelResourceInterface
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, Order::GROUP_ADMIN_WRITE, self::GROUP_FRONT_READ_SINGLE])]
     public ?int $parent = null;
 
-    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, Order::GROUP_ADMIN_WRITE, self::GROUP_FRONT_READ_SINGLE])]
+    #[Groups([
+        self::GROUP_ADMIN_READ,
+        self::GROUP_ADMIN_WRITE,
+        Order::GROUP_ADMIN_WRITE,
+        Order::GROUP_FRONT_READ_SINGLE,
+        self::GROUP_FRONT_READ_SINGLE,
+    ])]
     #[Type(type: 'bool', groups: [Order::GROUP_ADMIN_WRITE])]
     #[NotNull(groups: [Order::GROUP_ADMIN_WRITE])]
     public bool $virtual;
@@ -275,6 +281,7 @@ class OrderProduct implements PropelResourceInterface
         self::GROUP_ADMIN_READ,
         self::GROUP_ADMIN_WRITE,
         Order::GROUP_ADMIN_WRITE,
+        Order::GROUP_FRONT_READ_SINGLE,
         self::GROUP_FRONT_READ_SINGLE,
     ])]
     public ?string $virtualDocument = null;

--- a/tests/Api/Front/AccountOrderApiTest.php
+++ b/tests/Api/Front/AccountOrderApiTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\OrderProduct;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Payload coverage for /api/front/account/orders/{id}.
+ *
+ * A theme rendering the order page reads the whole order from this single
+ * operation, so the virtual flags of each line have to travel with it.
+ */
+final class AccountOrderApiTest extends ApiTestCase
+{
+    public function testOrderPayloadExposesTheVirtualFlagsOfItsProducts(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+        $order = $factory->order($customer, ['statusCode' => 'paid']);
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('REF-VIRTUAL')
+            ->setProductSaleElementsRef('REF-VIRTUAL-PSE')
+            ->setTitle('Virtual product')
+            ->setQuantity(1.0)
+            ->setPrice('10.000000')
+            ->setPromoPrice('0.000000')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->setVirtual(1)
+            ->setVirtualDocument('user-guide.pdf')
+            ->save($this->getPropelConnection());
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/account/orders/'.$order->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+
+        self::assertCount(1, $data['orderProducts']);
+        self::assertTrue($data['orderProducts'][0]['virtual']);
+        self::assertSame('user-guide.pdf', $data['orderProducts'][0]['virtualDocument']);
+    }
+}


### PR DESCRIPTION
`GET /front/account/orders/{id}` normalizes with the `front:order:read` and
`front:order:read:single` groups, and those propagate to the nested `orderProducts`
collection. `OrderProduct::$virtual` and `OrderProduct::$virtualDocument` only carried
`front:order_product:read:single`, a group activated by the standalone
`GET /front/account/order_products/{id}` operation and never present in the order context.

A theme that reads the order page from that single operation therefore had no way to tell
a virtual line from a physical one: `{% if orderProduct.virtual %}` silently evaluated to
null. Both properties now also carry `Order::GROUP_FRONT_READ_SINGLE`.

No new class of information is exposed: the neighbouring order product operation, secured
by the same ownership rule, already returned both fields to the same customer.

Refs #3663