### PR TITLE
fix: the export console command fails on every reference

### DIFF
--- a/core/lib/Thelia/Command/ExportCommand.php
+++ b/core/lib/Thelia/Command/ExportCommand.php
@@ -22,8 +22,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\Archiver\ArchiverManager;
-use Thelia\Core\DependencyInjection\Compiler\RegisterArchiverPass;
-use Thelia\Core\DependencyInjection\Compiler\RegisterSerializerPass;
 use Thelia\Core\Serializer\SerializerInterface;
 use Thelia\Core\Serializer\SerializerManager;
 use Thelia\Domain\DataTransfer\ExportHandler;
@@ -38,6 +36,14 @@ use Thelia\Model\LangQuery;
 #[AsCommand(name: 'export', description: 'Export data')]
 class ExportCommand extends ContainerAwareCommand
 {
+    public function __construct(
+        private readonly ExportHandler $exportHandler,
+        private readonly SerializerManager $serializerManager,
+        private readonly ArchiverManager $archiverManager,
+    ) {
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this
@@ -123,27 +129,21 @@ class ExportCommand extends ContainerAwareCommand
             throw new \RuntimeException('Not enough arguments.'.\PHP_EOL.'If no options are provided, ref and serializer arguments are required.');
         }
 
-        /** @var ExportHandler $exportHandler */
-        $exportHandler = $this->getContainer()->get('thelia.export.handler');
-
-        $export = $exportHandler->getExportByRef($exportRef);
+        $export = $this->exportHandler->getExportByRef($exportRef);
 
         if (null === $export) {
             throw new \RuntimeException($exportRef." export doesn't exist.");
         }
 
-        $serializerManager = $this->getContainer()->get(RegisterSerializerPass::MANAGER_SERVICE_ID);
-        $serializer = $serializerManager->get($serializer);
+        $serializer = $this->serializerManager->get($serializer);
 
         $archiver = null;
 
         if ($input->getArgument('archiver')) {
-            /** @var ArchiverManager $archiverManager */
-            $archiverManager = $this->getContainer()->get(RegisterArchiverPass::MANAGER_SERVICE_ID);
-            $archiver = $archiverManager->get($input->getArgument('archiver'));
+            $archiver = $this->archiverManager->get($input->getArgument('archiver'));
         }
 
-        $exportEvent = $exportHandler->export(
+        $exportEvent = $this->exportHandler->export(
             $export,
             $serializer,
             $archiver,
@@ -238,11 +238,8 @@ class ExportCommand extends ContainerAwareCommand
     {
         $table = new Table($output);
 
-        /** @var SerializerManager $serializerManager */
-        $serializerManager = $this->getContainer()->get(RegisterSerializerPass::MANAGER_SERVICE_ID);
-
         /** @var SerializerInterface $serializer */
-        foreach ($serializerManager->getSerializers() as $serializer) {
+        foreach ($this->serializerManager->getSerializers() as $serializer) {
             $table->addRow([
                 $serializer->getId(),
                 $serializer->getName(),
@@ -270,11 +267,8 @@ class ExportCommand extends ContainerAwareCommand
     {
         $table = new Table($output);
 
-        /** @var ArchiverManager $archiverManager */
-        $archiverManager = $this->getContainer()->get(RegisterArchiverPass::MANAGER_SERVICE_ID);
-
         /** @var ArchiverInterface $archiver */
-        foreach ($archiverManager->getArchivers(true) as $archiver) {
+        foreach ($this->archiverManager->getArchivers(true) as $archiver) {
             $table->addRow([
                 $archiver->getId(),
                 $archiver->getName(),


### PR DESCRIPTION
`php Thelia export <ref> <serializer>` fails on every run, and so do `--list-serializer` and `--list-archiver`:

```
The "Thelia\Core\Serializer\SerializerManager" service or alias has been removed or
inlined when the container was compiled. You should either make it public, or stop
using the container directly and use dependency injection instead.
```

Only `--list-export` still works, because it is the one branch that goes through the public alias `thelia.export.handler`.

## Why the service is not public

`SerializerManager` and `ArchiverManager` *are* declared public:

- `core/lib/Thelia/Config/Resources/services/core/serializers.php:25-29`
- `core/lib/Thelia/Config/Resources/services/handlers/archiver.php:26-30`

But `core/lib/Thelia/Config/Resources/services.php` imports `services/*` (line 33) and *then* registers the whole `Thelia\` namespace by PSR-4 (lines 57-64). Neither manager is in the `exclude()` list, so the autowired, private definition of the second pass replaces the public one from the first. `debug:container Thelia\Core\Serializer\SerializerManager` confirms it: `Public no`, `Autowired yes`. The public *aliases* survive, which is why the error message talks about inlining.

Thelia 2.6 is not affected: `config.xml` declares `public="true"` and there is no PSR-4 pass to override it.

## Fix

`ExportCommand` is the only command in `core/lib/Thelia/Command/` that fetches services by FQCN from the container (4 call sites: lines 135, 142, 242, 274). It now takes `ExportHandler`, `SerializerManager` and `ArchiverManager` through its constructor, exactly like `ExportImportController` in the `default-twig` back-office already does, and like `DataTransferCleanCommand` does for `HandlerCleaner`. Private services inject fine; only `$container->get()` is blocked.

No DI configuration is touched, so the public surface of the container is unchanged. The command is registered by the PSR-4 pass with `autowire()->autoconfigure()`, so the three dependencies resolve on their own — each is a unique service id (`debug:container` on all three: `Autowired yes`). `getContainer()` is no longer called anywhere in the class.

`ImportCommand` has a single container lookup and it targets the public alias `thelia.import.handler`, so it is unaffected.

## About the test suite

No test is added, deliberately. `TheliaBundle` registers `TestPublicServicesPass` in the `test` environment (`core/lib/Thelia/Core/Bundle/TheliaBundle.php:77-79`), which makes every `Thelia\`-prefixed service public. A `CommandTester` test would therefore pass with or without this fix, and could not guard the regression. What is left is a class of bug that a CLI smoke test on a real install would catch, not a PHPUnit test.

Reproduced by hand on a dev install: `export --list-serializer` exits 1 with the trace above before the change. After it, no branch of the command touches the container.

Fixes #3675
