### PR TITLE
fix: export the shipping tax rule title as text, and the delivery country in its own column

### DIFF
--- a/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/ImportExport/Export/Type/OrderExport.php
@@ -51,7 +51,7 @@ class OrderExport extends JsonFileAbstractExport
         'delivery_address_address3' => 'delivery_address_3',
         'delivery_address_zipcode' => 'delivery_zip_code',
         'delivery_address_city' => 'delivery_city',
-        'delivery_country_i18n_title' => 'invoice_country',
+        'delivery_country_i18n_title' => 'delivery_country',
         'delivery_address_phone' => 'delivery_phone',
         'invoice_address_customer_title_long' => 'invoice_title',
         'invoice_address_company' => 'invoice_company',
@@ -90,7 +90,7 @@ class OrderExport extends JsonFileAbstractExport
                     order_coupon.code as order_coupon_code,
                     ROUND(`order`.postage, 2) as order_postage,
                     `order`.postage_tax as "order_postage_tax",
-                    ROUND(`order`.postage_tax_rule_title,2) as "order_postage_tax_rule_title",
+                    `order`.postage_tax_rule_title as "order_postage_tax_rule_title",
                     SUM(ROUND(order_product.quantity * IF(order_product.was_in_promo = 1, order_product.promo_price, order_product.price), 2) ) as order_total_price,
                     SUM(
                         ROUND(

--- a/tests/Legacy/ImportExport/Export/OrderExportTest.php
+++ b/tests/Legacy/ImportExport/Export/OrderExportTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\ImportExport\Export;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\ImportExport\Export\Type\OrderExport;
+use Thelia\Model\Cart;
+use Thelia\Model\Country;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerTitleQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderAddress;
+use Thelia\Model\OrderStatusQuery;
+
+/**
+ * The accounting export of an order. The demo data ships no order, so the
+ * test seeds its own and removes it again.
+ */
+class OrderExportTest extends TestCase
+{
+    /**
+     * @var Order|null
+     */
+    private $order;
+
+    /**
+     * @var Cart|null
+     */
+    private $cart;
+
+    /**
+     * @var Customer|null
+     */
+    private $customer;
+
+    /**
+     * @var array<int, OrderAddress>
+     */
+    private $addresses = [];
+
+    /**
+     * @var Country
+     */
+    private $invoiceCountry;
+
+    /**
+     * @var Country
+     */
+    private $deliveryCountry;
+
+    protected function setUp(): void
+    {
+        // getDataJsonCache() writes its row cache there without creating it;
+        // only ExportHandler::processExport() does, and this test does not go
+        // through the handler.
+        (new Filesystem())->mkdir(THELIA_CACHE_DIR.'export');
+
+        $countries = CountryQuery::create()->orderById()->limit(2)->find();
+
+        $this->assertCount(2, $countries, 'Two countries are part of every install.');
+
+        $this->invoiceCountry = $countries[0];
+        $this->deliveryCountry = $countries[1];
+
+        $this->customer = $this->seedCustomer();
+        $this->cart = $this->seedCart();
+
+        $anyModule = ModuleQuery::create()->findOne();
+
+        // Order::postInsert() overwrites the reference with a generated one.
+        $order = new Order();
+        $order->setCustomerId($this->customer->getId());
+        $order->setInvoiceOrderAddressId($this->seedOrderAddress($this->invoiceCountry)->getId());
+        $order->setDeliveryOrderAddressId($this->seedOrderAddress($this->deliveryCountry)->getId());
+        $order->setCurrencyId(Currency::getDefaultCurrency()->getId());
+        $order->setCurrencyRate(1.0);
+        $order->setPaymentModuleId($anyModule->getId());
+        $order->setDeliveryModuleId($anyModule->getId());
+        $order->setStatusId(OrderStatusQuery::create()->findOne()->getId());
+        $order->setLangId(Lang::getDefaultLanguage()->getId());
+        $order->setCartId($this->cart->getId());
+        $order->setPostage('4.9');
+        $order->setPostageTax('0.98');
+        $order->setPostageTaxRuleTitle('TVA 20%');
+        $order->save();
+
+        $this->order = $order;
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->order, $this->cart, $this->customer] as $model) {
+            if ($model !== null) {
+                $model->delete();
+            }
+        }
+
+        foreach ($this->addresses as $address) {
+            $address->delete();
+        }
+
+        $this->order = $this->cart = $this->customer = null;
+        $this->addresses = [];
+    }
+
+    /**
+     * `postage_tax_rule_title` is a VARCHAR. Wrapping it in ROUND() made
+     * MySQL coerce the label to a number, so every exported order carried
+     * 0.00 instead of the tax rule name.
+     */
+    public function testItExportsTheShippingTaxRuleTitleAsText(): void
+    {
+        $row = $this->exportedRow();
+
+        $this->assertSame('TVA 20%', $row['order_postage_tax_rule_title']);
+    }
+
+    /**
+     * Both country columns used to be aliased to `invoice_country`, and the
+     * second one silently overwrote the first: the delivery country never
+     * reached the file.
+     */
+    public function testTheDeliveryAndInvoiceCountriesGetTheirOwnColumn(): void
+    {
+        $locale = Lang::getDefaultLanguage()->getLocale();
+        $aliased = (new OrderExport())->applyOrderAndAliases($this->exportedRow());
+
+        $this->assertArrayHasKey('delivery_country', $aliased);
+        $this->assertSame($this->deliveryCountry->setLocale($locale)->getTitle(), $aliased['delivery_country']);
+        $this->assertSame($this->invoiceCountry->setLocale($locale)->getTitle(), $aliased['invoice_country']);
+    }
+
+    /**
+     * The export yields the raw column names, not the output aliases.
+     *
+     * @return array<string, mixed>
+     */
+    private function exportedRow(): array
+    {
+        $export = new OrderExport();
+        $export->setLang(Lang::getDefaultLanguage());
+        $export->setRangeDate(null);
+
+        foreach ($export as $row) {
+            if (isset($row['order_ref']) && $row['order_ref'] === $this->order->getRef()) {
+                return $row;
+            }
+        }
+
+        $this->fail('The seeded order is missing from the export.');
+    }
+
+    private function seedCustomer(): Customer
+    {
+        $customer = new Customer();
+        $customer->setTitleId(CustomerTitleQuery::create()->findOne()->getId());
+        $customer->setLangId(Lang::getDefaultLanguage()->getId());
+        $customer->setFirstname('John');
+        $customer->setLastname('Doe');
+        $customer->setEmail(uniqid('export-test-').'@example.com');
+        $customer->save();
+
+        return $customer;
+    }
+
+    private function seedCart(): Cart
+    {
+        $cart = new Cart();
+        $cart->setToken(uniqid('export-test-'));
+        $cart->setCustomerId($this->customer->getId());
+        $cart->setCurrencyId(Currency::getDefaultCurrency()->getId());
+        $cart->save();
+
+        return $cart;
+    }
+
+    private function seedOrderAddress(Country $country): OrderAddress
+    {
+        $address = new OrderAddress();
+        $address->setCustomerTitleId(CustomerTitleQuery::create()->findOne()->getId());
+        $address->setFirstname('John');
+        $address->setLastname('Doe');
+        $address->setAddress1('1 Main Street');
+        $address->setZipcode('75001');
+        $address->setCity('Paris');
+        $address->setCountryId($country->getId());
+        $address->save();
+
+        $this->addresses[] = $address;
+
+        return $address;
+    }
+}


### PR DESCRIPTION
The accounting order export carries two defects that both come from the same
copy-and-paste, and both are fixed here.

**`ROUND()` on a VARCHAR** — `core/lib/Thelia/ImportExport/Export/Type/OrderExport.php:93`
selected `ROUND(\`order\`.postage_tax_rule_title, 2)`. That column is a
`VARCHAR(255)` (`local/config/schema.xml:613`), so MySQL coerced the label to a
number and every exported order carried `0` instead of the tax rule name —
`SELECT ROUND('TVA 20%', 2)` returns `0.00`. The line dates back to 2020
(`03c0bd99c8`); the two lines around it round `discount` and `postage`, which
are real `DECIMAL(16,6)` columns.

**Alias collision on the delivery country** — `:54` and `:65` both mapped to the
output alias `invoice_country`. `applyOrderAndAliases()` writes the aliases in
order (`JsonFileAbstractExport.php:98-111`), so the invoice country overwrote
the delivery country and the latter never reached the file. Every other entry in
the surrounding block is already prefixed `delivery_`.

Note for integrators: the output gains a `delivery_country` column, in its
position in the column order. `invoice_country` keeps exactly the value it has
today, so no consumer loses data — only readers that index columns by position
need to be aware.

`tests/Legacy/ImportExport/Export/OrderExportTest.php` covers both. The demo data
ships no order, so the test seeds a minimal one — with two different countries
for the invoice and the delivery address — and removes it in `tearDown()`. Both
tests were checked red against the current code (`0` instead of `TVA 20%`, and no
`delivery_country` key) and green with the fix.

Refs #3667
