### PR TITLE
fix: read the postage estimate as the object it is

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Serializer/CartNormalizer.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Serializer/CartNormalizer.php
@@ -73,8 +73,8 @@ class CartNormalizer extends AbstractItemNormalizer
             country: $country,
             state: $state,
         );
-        $estimatedPostage = $postageInfo['postage'];
-        $postageTax = $postageInfo['tax'];
+        $estimatedPostage = $postageInfo->getBestPostageAmount();
+        $postageTax = $postageInfo->getBestPostageTax();
         /* @var Cart $object */
         $object
             ->setTotalWithoutTax($propelCart->getTotalAmount())

--- a/core/lib/Thelia/Domain/Shipping/Service/DeliverySetupService.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/DeliverySetupService.php
@@ -90,8 +90,8 @@ final readonly class DeliverySetupService
                 $estimate = $this->postageEstimator->estimatePostageForCountry($cart, $country, $state);
 
                 $cart
-                    ->setPostage((string) ($estimate['postage'] ?? 0))
-                    ->setPostageTax((string) ($estimate['tax'] ?? 0))
+                    ->setPostage((string) ($estimate->getBestPostageAmount() ?? 0))
+                    ->setPostageTax((string) ($estimate->getBestPostageTax() ?? 0))
                     ->save();
             }
         }

--- a/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
+++ b/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
@@ -71,8 +71,8 @@ final readonly class ShippingFacade
 
         $estimate = $this->postageEstimator->estimatePostageForCountry($cart, $country, $state);
 
-        $amountHt = isset($estimate['postage']) ? (float) $estimate['postage'] : null;
-        $tax = isset($estimate['tax']) ? (float) $estimate['tax'] : null;
+        $amountHt = $estimate->getBestPostageAmount();
+        $tax = $estimate->getBestPostageTax();
         $totalTtc = null;
 
         if (null !== $amountHt && null !== $tax) {

--- a/tests/Api/Front/CartApiTest.php
+++ b/tests/Api/Front/CartApiTest.php
@@ -34,6 +34,26 @@ final class CartApiTest extends ApiTestCase
         self::assertSame(404, $response->getStatusCode());
     }
 
+    /**
+     * Reading a cart estimates its postage, and the estimate used to be read
+     * as an array although the estimator answers with an object, which made
+     * every single cart read a 500.
+     */
+    public function testCustomerCanReadOwnCart(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+        $cart = $factory->cart($customer);
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/carts/'.$cart->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+        self::assertSame($cart->getId(), $data['id']);
+    }
+
     public function testCreateCartViaPost(): void
     {
         $response = $this->jsonRequest('POST', '/api/front/carts', []);

--- a/tests/Integration/Domain/Shipping/PostageEstimateTest.php
+++ b/tests/Integration/Domain/Shipping/PostageEstimateTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Shipping;
+
+use Thelia\Domain\Cart\Service\CartAddressService;
+use Thelia\Domain\Shipping\DTO\EstimatedPostageDTO;
+use Thelia\Domain\Shipping\DTO\PostageEstimateView;
+use Thelia\Domain\Shipping\Service\DeliverySetupService;
+use Thelia\Domain\Shipping\Service\PostageEstimator;
+use Thelia\Domain\Shipping\ShippingFacade;
+use Thelia\Model\Module;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The postage estimator answers with an EstimatedPostageDTO. Reading that
+ * answer as an array is a fatal error, whatever the cart contains and whatever
+ * delivery modules are installed.
+ */
+final class PostageEstimateTest extends IntegrationTestCase
+{
+    public function testEstimatingCartPostageAnswersAView(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $cart = $factory->cart();
+        $country = $factory->country();
+
+        $view = $this->getService(ShippingFacade::class)->estimateCartPostage($cart, $country);
+
+        self::assertInstanceOf(PostageEstimateView::class, $view);
+
+        if (null !== $view->amountHt && null !== $view->tax) {
+            self::assertEqualsWithDelta($view->amountHt + $view->tax, $view->totalTtc, 0.0001);
+        }
+    }
+
+    public function testVirtualDeliverySetupStoresTheEstimatedPostage(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+        $factory->address($customer);
+        $cart = $factory->cart($customer);
+
+        $this->installVirtualDeliveryModule();
+
+        $estimator = $this->createMock(PostageEstimator::class);
+        $estimator->method('estimatePostageForCountry')
+            ->willReturn(new EstimatedPostageDTO(7.5, 1.5));
+
+        $setup = new DeliverySetupService($estimator, $this->createMock(CartAddressService::class));
+        $setup->setupVirtualDelivery($cart);
+
+        self::assertSame(7.5, (float) $cart->getPostage());
+        self::assertSame(1.5, (float) $cart->getPostageTax());
+    }
+
+    private function installVirtualDeliveryModule(): void
+    {
+        (new Module())
+            ->setCode('VirtualProductDelivery')
+            ->setType(BaseModule::DELIVERY_MODULE_TYPE)
+            ->setActivate(1)
+            ->setVersion('1.0.0')
+            ->setFullNamespace('VirtualProductDelivery\VirtualProductDelivery')
+            ->save($this->getPropelConnection());
+    }
+}

--- a/tests/Integration/Domain/Shipping/PostageEstimateTest.php
+++ b/tests/Integration/Domain/Shipping/PostageEstimateTest.php
@@ -14,13 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Domain\Shipping;
 
-use Thelia\Domain\Cart\Service\CartAddressService;
-use Thelia\Domain\Shipping\DTO\EstimatedPostageDTO;
 use Thelia\Domain\Shipping\DTO\PostageEstimateView;
-use Thelia\Domain\Shipping\Service\DeliverySetupService;
-use Thelia\Domain\Shipping\Service\PostageEstimator;
 use Thelia\Domain\Shipping\ShippingFacade;
-use Thelia\Model\ModuleQuery;
 use Thelia\Test\IntegrationTestCase;
 
 /**
@@ -43,33 +38,5 @@ final class PostageEstimateTest extends IntegrationTestCase
         if (null !== $view->amountHt && null !== $view->tax) {
             self::assertEqualsWithDelta($view->amountHt + $view->tax, $view->totalTtc, 0.0001);
         }
-    }
-
-    public function testVirtualDeliverySetupStoresTheEstimatedPostage(): void
-    {
-        $factory = $this->createFixtureFactory();
-        $customer = $factory->customer($factory->customerTitle());
-        $factory->address($customer);
-        $cart = $factory->cart($customer);
-
-        $this->activateVirtualDeliveryModule();
-
-        $estimator = $this->createMock(PostageEstimator::class);
-        $estimator->method('estimatePostageForCountry')
-            ->willReturn(new EstimatedPostageDTO(7.5, 1.5));
-
-        $setup = new DeliverySetupService($estimator, $this->createMock(CartAddressService::class));
-        $setup->setupVirtualDelivery($cart);
-
-        self::assertSame(7.5, (float) $cart->getPostage());
-        self::assertSame(1.5, (float) $cart->getPostageTax());
-    }
-
-    private function activateVirtualDeliveryModule(): void
-    {
-        $module = ModuleQuery::create()->findOneByCode('VirtualProductDelivery')
-            ?? throw new \RuntimeException('The VirtualProductDelivery module is not installed — run bin/test-prepare.');
-
-        $module->setActivate(1)->save($this->getPropelConnection());
     }
 }

--- a/tests/Integration/Domain/Shipping/PostageEstimateTest.php
+++ b/tests/Integration/Domain/Shipping/PostageEstimateTest.php
@@ -20,8 +20,7 @@ use Thelia\Domain\Shipping\DTO\PostageEstimateView;
 use Thelia\Domain\Shipping\Service\DeliverySetupService;
 use Thelia\Domain\Shipping\Service\PostageEstimator;
 use Thelia\Domain\Shipping\ShippingFacade;
-use Thelia\Model\Module;
-use Thelia\Module\BaseModule;
+use Thelia\Model\ModuleQuery;
 use Thelia\Test\IntegrationTestCase;
 
 /**
@@ -53,7 +52,7 @@ final class PostageEstimateTest extends IntegrationTestCase
         $factory->address($customer);
         $cart = $factory->cart($customer);
 
-        $this->installVirtualDeliveryModule();
+        $this->activateVirtualDeliveryModule();
 
         $estimator = $this->createMock(PostageEstimator::class);
         $estimator->method('estimatePostageForCountry')
@@ -66,14 +65,11 @@ final class PostageEstimateTest extends IntegrationTestCase
         self::assertSame(1.5, (float) $cart->getPostageTax());
     }
 
-    private function installVirtualDeliveryModule(): void
+    private function activateVirtualDeliveryModule(): void
     {
-        (new Module())
-            ->setCode('VirtualProductDelivery')
-            ->setType(BaseModule::DELIVERY_MODULE_TYPE)
-            ->setActivate(1)
-            ->setVersion('1.0.0')
-            ->setFullNamespace('VirtualProductDelivery\VirtualProductDelivery')
-            ->save($this->getPropelConnection());
+        $module = ModuleQuery::create()->findOneByCode('VirtualProductDelivery')
+            ?? throw new \RuntimeException('The VirtualProductDelivery module is not installed — run bin/test-prepare.');
+
+        $module->setActivate(1)->save($this->getPropelConnection());
     }
 }


### PR DESCRIPTION
`PostageEstimator::estimatePostageForCountry()` answers with an `EstimatedPostageDTO`, and its three callers read that answer as an array. The object has no `ArrayAccess`, so every one of those reads is a fatal `Error`: reading a cart through the API returns a 500, and so does checking out a fully virtual cart on Flexy. `isset()` and `??` raise the same error, so none of the three sites is merely degraded.

The callers now call `getBestPostageAmount()` and `getBestPostageTax()`. Adding `ArrayAccess` to the DTO would reopen the hole the DTO closes. No amount, tax base or rounding changes here — the tax-excluded/tax-included asymmetry of `cart.postage` is a separate matter, tracked in #3668.

## Tests

They land in their own commits, before the code they cover, so the suite can be seen failing on them:

- `PostageEstimateTest::testEstimatingCartPostageAnswersAView` — red on `8cf72cf1` with `Cannot use object of type EstimatedPostageDTO as array`, green from `2f51c7ab` on.
- `CartApiTest::testCustomerCanReadOwnCart` — `GET /api/front/carts/{id}` with a real cart, where the suite only asserted the 404 returned without one. Red on `a42a8a39` with the same error raised from `CartNormalizer`, green from `faf66714` on.

A third test covered `setupVirtualDelivery()`, and could not stay: it fails on an unrelated bug, `cart.address_delivery_id` being written and read as an `address` id where the column is a foreign key on `cart_address`. Filed as #3694, left alone here.

Fixes #3681
