### PR TITLE
fix: purge the form firewall records that keep IP addresses forever

### DIFF
--- a/core/lib/Thelia/Command/MaintenancePurgeCommand.php
+++ b/core/lib/Thelia/Command/MaintenancePurgeCommand.php
@@ -20,6 +20,7 @@ use Thelia\Core\Event\Maintenance\MaintenancePurgeEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Domain\Admin\Service\AdminLogPurger;
 use Thelia\Domain\Cart\Service\CartPurger;
+use Thelia\Domain\Form\Service\FormFirewallPurger;
 use Thelia\Model\ConfigQuery;
 
 class MaintenancePurgeCommand extends ContainerAwareCommand
@@ -27,18 +28,22 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
     private const DEFAULT_CART_NO_ORDER_DAYS_KEY = 'purification_cart_no_order_days';
     private const DEFAULT_CART_ANONYMOUS_DAYS_KEY = 'purification_cart_anonymous_days';
     private const DEFAULT_ADMIN_LOGS_DAYS_KEY = 'purification_admin_logs_days';
+    private const DEFAULT_FORM_FIREWALL_DAYS_KEY = 'purification_form_firewall_days';
 
     public function configure(): void
     {
         $this
             ->setName('maintenance:purge')
             ->setDescription(
-                'Purge old data from the database: carts without orders, anonymous carts, and admin logs.'
+                'Purge old data from the database: carts without orders, anonymous carts, admin logs, and form firewall records.'
             );
     }
 
-    public function __construct(protected AdminLogPurger $adminLogPurger, protected CartPurger $cartPurger)
-    {
+    public function __construct(
+        protected AdminLogPurger $adminLogPurger,
+        protected CartPurger $cartPurger,
+        protected FormFirewallPurger $formFirewallPurger,
+    ) {
         parent::__construct();
     }
 
@@ -84,6 +89,19 @@ class MaintenancePurgeCommand extends ContainerAwareCommand
                 '<comment>Admin logs (>%d days):</comment> <info>%d deleted</info>',
                 $adminLogsDays,
                 $deletedAdminLogs
+            ));
+
+            $formFirewallDays = (int) ConfigQuery::read(
+                self::DEFAULT_FORM_FIREWALL_DAYS_KEY,
+                1
+            );
+
+            $deletedFormFirewall = $this->formFirewallPurger->purgeExpiredEntries($formFirewallDays);
+
+            $output->writeln(\sprintf(
+                '<comment>Form firewall records (>%d days):</comment> <info>%d deleted</info>',
+                $formFirewallDays,
+                $deletedFormFirewall
             ));
 
             $event = new MaintenancePurgeEvent();

--- a/core/lib/Thelia/Domain/Form/Service/FormFirewallPurger.php
+++ b/core/lib/Thelia/Domain/Form/Service/FormFirewallPurger.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Form\Service;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
+use Thelia\Form\BruteforceForm;
+use Thelia\Form\FirewallForm;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\FormFirewallQuery;
+
+/**
+ * The form firewall records the IP address of every form submission it watches.
+ * A record is only read back while it sits inside the waiting window, so anything
+ * older is an IP address kept for nothing.
+ */
+class FormFirewallPurger
+{
+    /**
+     * @throws PropelException
+     */
+    public function purgeExpiredEntries(int $days): int
+    {
+        return FormFirewallQuery::create()
+            ->filterByUpdatedAt($this->getThresholdDate($days), Criteria::LESS_THAN)
+            ->delete();
+    }
+
+    /**
+     * Never delete a record the firewall would still consult, whatever the
+     * configured retention is: purging one early would hand a blocked IP
+     * address a fresh set of attempts.
+     */
+    private function getThresholdDate(int $days): \DateTime
+    {
+        $threshold = (new \DateTime())->modify(\sprintf('-%d days', $days));
+        $waitingWindowStart = (new \DateTime())->modify(\sprintf('-%d minutes', $this->getLongestWaitingTime()));
+
+        return min($threshold, $waitingWindowStart);
+    }
+
+    private function getLongestWaitingTime(): int
+    {
+        return max(
+            (int) ConfigQuery::read('form_firewall_time_to_wait', FirewallForm::DEFAULT_TIME_TO_WAIT),
+            (int) ConfigQuery::read('form_firewall_bruteforce_time_to_wait', BruteforceForm::DEFAULT_TIME_TO_WAIT),
+        );
+    }
+}

--- a/tests/Integration/Domain/Form/FormFirewallPurgerTest.php
+++ b/tests/Integration/Domain/Form/FormFirewallPurgerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Form;
+
+use Thelia\Domain\Form\Service\FormFirewallPurger;
+use Thelia\Model\FormFirewall;
+use Thelia\Model\FormFirewallQuery;
+use Thelia\Test\IntegrationTestCase;
+
+final class FormFirewallPurgerTest extends IntegrationTestCase
+{
+    private FormFirewallPurger $purger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->purger = new FormFirewallPurger();
+        FormFirewallQuery::create()->deleteAll();
+    }
+
+    public function testPurgeDeletesRecordsOlderThanRetention(): void
+    {
+        $this->createRecord('203.0.113.1', '-10 days');
+
+        self::assertSame(1, $this->purger->purgeExpiredEntries(1));
+        self::assertSame(0, FormFirewallQuery::create()->count());
+    }
+
+    public function testPurgeKeepsRecordsInsideRetention(): void
+    {
+        $this->createRecord('203.0.113.2', '-2 hours');
+
+        self::assertSame(0, $this->purger->purgeExpiredEntries(1));
+        self::assertSame(1, FormFirewallQuery::create()->count());
+    }
+
+    public function testPurgeNeverDeletesRecordsStillInsideTheWaitingWindow(): void
+    {
+        $this->createRecord('203.0.113.3', '-30 minutes');
+
+        // A retention of 0 days would otherwise wipe every record, including the
+        // ones the firewall still uses to block an IP address.
+        self::assertSame(0, $this->purger->purgeExpiredEntries(0));
+        self::assertSame(1, FormFirewallQuery::create()->count());
+    }
+
+    private function createRecord(string $ipAddress, string $age): void
+    {
+        (new FormFirewall())
+            ->setFormName('thelia_customer_login')
+            ->setIpAddress($ipAddress)
+            ->setAttempts(1)
+            ->setUpdatedAt(new \DateTime($age))
+            ->save();
+    }
+}


### PR DESCRIPTION
Fixes #3682

`form_firewall` stores the client IP address of every submission the firewall watches (`local/config/schema.xml:1687`), and the only cleanup in the codebase is the opportunistic one inside `FirewallForm::isFirewallOk()` (`:46-52`). That one is filtered by form name and gated on `'prod' === $env && isFirewallActive()`, so rows belonging to a form that is never submitted again — or to any shop that turned the firewall off — stay in place indefinitely. `maintenance:purge` did not know about the table.

A record is only read back inside the waiting window: `isFirewallOk()` clears everything older before looking the caller up. Past that point it is an IP address kept for nothing, so it can be dropped.

### Changes

- `FormFirewallPurger`, following `AdminLogPurger` and `CartPurger`: delete rows whose `updated_at` is older than the retention.
- `maintenance:purge` runs it, reading `purification_form_firewall_days` (default 1), alongside the three retention keys it already handles.

The purge never deletes a record the firewall would still consult, whatever the configured retention: the threshold is clamped to the longest of `form_firewall_time_to_wait` and `form_firewall_bruteforce_time_to_wait`. Purging one early would hand a blocked IP address a fresh set of attempts.

No schema change — `updated_at` comes from the table's existing `timestampable` behavior.

### Tests

`FormFirewallPurgerTest` covers the three behaviors: expired rows go, recent rows stay, and rows inside the waiting window survive even a retention of 0 days. Each was checked red first — neutralizing the delete fails the first, dropping the clamp fails the third.
