### PR TITLE
fix: keep a module activated when its upgrade is refused

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -347,6 +347,12 @@ class Module extends BaseAction implements EventSubscriberInterface
             } catch (\Exception $ex) {
                 // if module has not been deleted
                 if ($fs->exists($modulePath)) {
+                    // The module was deactivated a few lines above so it could be replaced, and the
+                    // replacement is not going to happen. Put the shop back where it was: a payment
+                    // or delivery module left deactivated by a failed upgrade takes the checkout
+                    // down, silently, while the administrator only reads that the install failed.
+                    $this->restoreActivation((int) $oldModule->getId(), (bool) $activated, $dispatcher);
+
                     throw $ex;
                 }
             }
@@ -378,6 +384,18 @@ class Module extends BaseAction implements EventSubscriberInterface
         }
 
         $event->setModule($module);
+    }
+
+    private function restoreActivation(int $moduleId, bool $wasActivated, EventDispatcherInterface $dispatcher): void
+    {
+        if (!$wasActivated) {
+            return;
+        }
+
+        $toggleEvent = new ModuleToggleActivationEvent($moduleId);
+        $toggleEvent->setNoCheck(true);
+
+        $dispatcher->dispatch($toggleEvent, TheliaEvents::MODULE_TOGGLE_ACTIVATION);
     }
 
     /**

--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -340,7 +340,7 @@ class Module extends BaseAction implements EventSubscriberInterface
             // delete
             $modulePath = $oldModule->getAbsoluteBaseDir();
 
-            $deleteEvent = new ModuleDeleteEvent($oldModule);
+            $deleteEvent = new ModuleDeleteEvent($oldModule->getId());
 
             try {
                 $dispatcher->dispatch($deleteEvent, TheliaEvents::MODULE_DELETE);

--- a/core/lib/Thelia/Core/Event/Module/ModuleDeleteEvent.php
+++ b/core/lib/Thelia/Core/Event/Module/ModuleDeleteEvent.php
@@ -20,7 +20,9 @@ namespace Thelia\Core\Event\Module;
 class ModuleDeleteEvent extends ModuleEvent
 {
     protected $module_id;
-    protected $delete_data;
+    // getDeleteData() is typed bool: without a default, an event whose delete data was never set
+    // makes the delete listener fail on a TypeError instead of just keeping the module data.
+    protected $delete_data = false;
     protected $assume_delete;
 
     public function __construct(int $module_id, bool $assume_delete = false)

--- a/tests/Legacy/Action/ModuleInstallTest.php
+++ b/tests/Legacy/Action/ModuleInstallTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Action;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Thelia\Action\Module as ModuleAction;
+use Thelia\Core\Event\Module\ModuleDeleteEvent;
+use Thelia\Core\Event\Module\ModuleInstallEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Translation\Translator;
+use Thelia\Model\Module as ModuleModel;
+use Thelia\Model\ModuleQuery;
+use Thelia\Module\BaseModule;
+use Thelia\Module\Validator\ModuleDefinition;
+
+/**
+ * Uploading a newer zip of an installed module deactivates the current one, deletes it, then
+ * installs the new files. A payment or a delivery module referenced by an order cannot be deleted,
+ * so the replacement is refused — and the shop must not be left with its payment method switched
+ * off, which takes the checkout down while the administrator only reads that the install failed.
+ */
+class ModuleInstallTest extends BaseAction
+{
+    /** @var EventDispatcher */
+    private $dispatcher;
+
+    /** @var ModuleAction */
+    private $action;
+
+    /** @var ModuleModel */
+    private $module;
+
+    protected function setUp(): void
+    {
+        $module = ModuleQuery::create()->findOneByCode('Cheque');
+        self::assertNotNull($module, 'The Cheque module must be installed to run this test.');
+
+        $this->module = $module;
+        $this->module->setActivate(BaseModule::IS_ACTIVATED)->save();
+
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.cache_dir', THELIA_CACHE_DIR);
+        $container->set('thelia.translator', Translator::getInstance());
+
+        $this->action = new ModuleAction($container);
+
+        $this->dispatcher = new EventDispatcher();
+        $container->set('event_dispatcher', $this->dispatcher);
+
+        $this->dispatcher->addListener(TheliaEvents::MODULE_TOGGLE_ACTIVATION, [$this->action, 'checkToggleActivation'], 255);
+        $this->dispatcher->addListener(TheliaEvents::MODULE_TOGGLE_ACTIVATION, [$this->action, 'toggleActivation'], 128);
+        $this->dispatcher->addListener(TheliaEvents::CACHE_CLEAR, function (): void {});
+    }
+
+    public function testTheDeleteEventIsUsableByTheDeleteListener(): void
+    {
+        $seen = null;
+
+        $this->dispatcher->addListener(TheliaEvents::MODULE_DELETE, function (ModuleDeleteEvent $event) use (&$seen): void {
+            // The two values Module::delete() reads out of the event.
+            $seen = [$event->getModuleId(), $event->getDeleteData()];
+
+            throw new \LogicException('Deletion refused');
+        });
+
+        try {
+            $this->install();
+        } catch (\LogicException $exception) {
+            // The refusal itself is the subject of the next test.
+        }
+
+        self::assertSame(
+            [$this->module->getId(), false],
+            $seen,
+            'Upgrading a module must dispatch a delete event carrying its id and no delete-data flag.'
+        );
+    }
+
+    public function testARefusedUpgradeLeavesTheModuleActivated(): void
+    {
+        // Stands for the guard of Module::delete(): a module an order was placed with is not deletable.
+        $this->dispatcher->addListener(TheliaEvents::MODULE_DELETE, function (): void {
+            throw new \LogicException('The module "Cheque" is currently in use by at least one order.');
+        });
+
+        try {
+            $this->install();
+
+            self::fail('Installing over a module an order was placed with should have been refused.');
+        } catch (\LogicException $exception) {
+            self::assertStringContainsString('in use by at least one order', $exception->getMessage());
+        }
+
+        self::assertSame(
+            BaseModule::IS_ACTIVATED,
+            ModuleQuery::create()->findPk($this->module->getId())->getActivate(),
+            'A refused upgrade must leave the module activated, not silently switched off.'
+        );
+    }
+
+    private function install(): void
+    {
+        $definition = new ModuleDefinition();
+        $definition->setCode($this->module->getCode());
+        $definition->setNamespace($this->module->getFullNamespace());
+        $definition->setVersion('99.0.0');
+
+        $event = new ModuleInstallEvent();
+        $event->setModuleDefinition($definition);
+        $event->setModulePath($this->module->getAbsoluteBaseDir());
+
+        $this->action->install($event, TheliaEvents::MODULE_INSTALL, $this->dispatcher);
+    }
+}


### PR DESCRIPTION
Fixes #3676 — the `2.6` transposition of #3671.

Uploading a newer zip of an installed module deactivates the current one before replacing it, then dispatches `MODULE_DELETE`. When the deletion is refused — a payment or a delivery module referenced by an order cannot be deleted — the module was left switched off, taking the checkout down while the administrator only read that the install failed.

Transposing #3671 alone was not enough: on `2.6` this path fails on a `TypeError` well before reaching the code that fix touches. Three commits, each one needed for the next to be reachable.

### `ModuleDeleteEvent` keeps the module data by default

`getDeleteData()` is typed `bool` and `$delete_data` had no default. `Module::delete()` reads it, so any event whose delete data was never set made the listener fail on a `TypeError` instead of simply keeping the module data. The admin controller always sets it; `Module::install()` does not.

### The delete event gets the module id

`Module::install()` built the event with the model instead of its id:

```php
- $deleteEvent = new ModuleDeleteEvent($oldModule);
+ $deleteEvent = new ModuleDeleteEvent($oldModule->getId());
```

`__construct(int $module_id)` threw a `TypeError` on every upgrade of an already installed module, and it threw *after* the deactivation and *outside* the `try` — so the module was left deactivated whatever the reason. The default branch already passes the id.

### A refused upgrade leaves the module activated

`restoreActivation()`, transposed from #3671: the toggle is dispatched back before the exception is rethrown.

### Tests

`tests/Legacy/Action/ModuleInstallTest.php`, in the suite gated by #3606. Both tests were checked red before the fix and green after:

- `testTheDeleteEventIsUsableByTheDeleteListener` — the event carries the module id and a usable delete-data flag.
- `testARefusedUpgradeLeavesTheModuleActivated` — a refusal leaves `Cheque` activated. Without the second and third commits it fails on `Failed asserting that 0 is identical to 1`, which is exactly the reported symptom.

Legacy suite: 587 tests, no failure. Unit: 46, no failure.

### Out of scope

#3674 — the upgrade destroying the `module` row (hooks, positions, configuration) when the deletion *succeeds*. That one needs its own work, on both lines.
