### PR TITLE
feat: expose the virtual documents of a product sale element

### DIFF
--- a/core/lib/Thelia/Model/ProductSaleElements.php
+++ b/core/lib/Thelia/Model/ProductSaleElements.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Model;
 
+use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorResolverTrait;
@@ -25,6 +26,14 @@ class ProductSaleElements extends BaseProductSaleElements
 {
     use PositionManagementTrait;
     use TaxCalculatorResolverTrait;
+
+    /**
+     * The meta data key holding the virtual document association.
+     *
+     * Read it through getVirtualDocuments() rather than directly: the storage is
+     * meant to move to a dedicated table, the accessor is not.
+     */
+    public const VIRTUAL_DOCUMENT_META_KEY = 'virtual';
 
     /**
      * @throws PropelException
@@ -122,6 +131,47 @@ class ProductSaleElements extends BaseProductSaleElements
         }
 
         return new ProductPriceTools((float) $price, (float) $promoPrice);
+    }
+
+    /**
+     * The documents a customer buying this sale element is entitled to download.
+     *
+     * An association pointing at a document that has since been deleted is dropped:
+     * nothing cleans the meta data when a ProductDocument goes away, so a stale id
+     * would otherwise surface as a virtual product with no file behind it.
+     *
+     * @return ObjectCollection<ProductDocument>
+     */
+    public function getVirtualDocuments(): ObjectCollection
+    {
+        $documents = new ObjectCollection();
+        $documents->setModel(ProductDocument::class);
+
+        $document = $this->getVirtualDocument();
+
+        if (null !== $document) {
+            $documents->append($document);
+        }
+
+        return $documents;
+    }
+
+    /**
+     * The single document a sale element currently holds.
+     */
+    public function getVirtualDocument(): ?ProductDocument
+    {
+        $documentId = MetaDataQuery::getVal(
+            self::VIRTUAL_DOCUMENT_META_KEY,
+            MetaData::PSE_KEY,
+            $this->getId()
+        );
+
+        if (!is_numeric($documentId)) {
+            return null;
+        }
+
+        return ProductDocumentQuery::create()->findPk((int) $documentId);
     }
 
     protected function addCriteriaToPositionQuery($query): void

--- a/tests/Integration/Model/ProductSaleElementsVirtualDocumentTest.php
+++ b/tests/Integration/Model/ProductSaleElementsVirtualDocumentTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\ProductDocument;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * ProductSaleElements::getVirtualDocuments() is the supported way to reach the
+ * documents attached to a sale element. It hides the meta data the association
+ * currently lives in, so that a module reading it keeps working when the storage
+ * moves to its own table.
+ */
+final class ProductSaleElementsVirtualDocumentTest extends IntegrationTestCase
+{
+    public function testASaleElementWithoutAssociationHasNoDocument(): void
+    {
+        $saleElement = $this->createSaleElement();
+
+        self::assertTrue($saleElement->getVirtualDocuments()->isEmpty());
+        self::assertNull($saleElement->getVirtualDocument());
+    }
+
+    public function testTheAssociatedDocumentIsReturned(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        $this->associate($saleElement, $document->getId());
+
+        $documents = $saleElement->getVirtualDocuments();
+
+        self::assertCount(1, $documents);
+        self::assertSame($document->getId(), $documents->getFirst()->getId());
+        self::assertSame($document->getId(), $saleElement->getVirtualDocument()?->getId());
+    }
+
+    public function testAnAssociationLeftBehindByADeletedDocumentIsIgnored(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+        $documentId = $document->getId();
+
+        $this->associate($saleElement, $documentId);
+        $document->delete();
+
+        // Deleting a document leaves its meta data behind: the accessor is the place
+        // that keeps a dangling id from being mistaken for a downloadable file.
+        self::assertSame(
+            (string) $documentId,
+            (string) MetaDataQuery::getVal(
+                ProductSaleElements::VIRTUAL_DOCUMENT_META_KEY,
+                MetaData::PSE_KEY,
+                $saleElement->getId()
+            )
+        );
+        self::assertTrue($saleElement->getVirtualDocuments()->isEmpty());
+        self::assertNull($saleElement->getVirtualDocument());
+    }
+
+    private function createSaleElement(): ProductSaleElements
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $saleElement = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        self::assertInstanceOf(ProductSaleElements::class, $saleElement);
+
+        return $saleElement;
+    }
+
+    private function createDocument(ProductSaleElements $saleElement): ProductDocument
+    {
+        $document = new ProductDocument();
+        $document
+            ->setProductId($saleElement->getProductId())
+            ->setFile('handbook.pdf')
+            ->setVisible(0)
+            ->setPosition(1)
+            ->save();
+
+        return $document;
+    }
+
+    private function associate(ProductSaleElements $saleElement, int $documentId): void
+    {
+        MetaDataQuery::setVal(
+            ProductSaleElements::VIRTUAL_DOCUMENT_META_KEY,
+            MetaData::PSE_KEY,
+            $saleElement->getId(),
+            $documentId
+        );
+    }
+}


### PR DESCRIPTION
The document behind a virtual product is associated to a `ProductSaleElements` through a
`meta_data` row, and every reader has to know that storage to reach it. This adds the accessor
that hides it:

- `getVirtualDocument(): ?ProductDocument` — the single document a sale element holds today
- `getVirtualDocuments(): ObjectCollection` — plural, because #3520 leaves the door open to
  several documents per sale element

Both drop an id whose document has been deleted: nothing cleans `meta_data` when a
`ProductDocument` goes away, so a dangling id otherwise travels downstream as a virtual product
with no file behind it.

No schema change and no behaviour change for existing readers — `meta_data` keeps being written
and read as before. This is step 1 of the deprecation window described in #3520, which stays open
as the design entry for the storage migration.

Fixes #3686