### PR TITLE
fix: stop Customer::getLocale() from fatalling when the account has no language

### DIFF
--- a/core/lib/Thelia/Command/Import/Importer/CustomersImporter.php
+++ b/core/lib/Thelia/Command/Import/Importer/CustomersImporter.php
@@ -18,6 +18,7 @@ use Thelia\Command\Import\AbstractDemoImporter;
 use Thelia\Command\Import\DemoImportContext;
 use Thelia\Model\Address;
 use Thelia\Model\Customer;
+use Thelia\Model\LangQuery;
 
 /**
  * Creates demo customers and their addresses directly through Propel models.
@@ -42,6 +43,11 @@ final class CustomersImporter extends AbstractDemoImporter
 
     public function import(DemoImportContext $context): void
     {
+        $defaultLangId = LangQuery::create()
+            ->filterByByDefault(1)
+            ->findOne($context->connection)
+            ?->getId();
+
         $isFirst = true;
         foreach ($this->readCsv($context->dataDir.'customers.csv') as $data) {
             $titleId = (int) $data[0];
@@ -52,6 +58,7 @@ final class CustomersImporter extends AbstractDemoImporter
             $customer->setLastname($data[2]);
             $customer->setEmail($data[3]);
             $customer->setPassword(self::DEMO_PASSWORD);
+            $customer->setLangId($defaultLangId);
             $customer->save($context->connection);
 
             (new Address())

--- a/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataExporter.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerPersonalDataExporter.php
@@ -75,8 +75,8 @@ final readonly class CustomerPersonalDataExporter
      */
     private function exportAccount(Customer $customer): array
     {
-        // Customer::getLocale() fatals when the account carries no language,
-        // which the schema allows.
+        // Deliberately not Customer::getLocale(): the export reports the language the
+        // account actually carries, not the shop default it falls back to.
         $locale = $customer->getLangModel()?->getLocale();
 
         return [

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -175,15 +175,7 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
      */
     public function getCustomerLang(): Lang
     {
-        $lang = $this->getLangModel();
-
-        if (null === $lang) {
-            $lang = (new LangQuery())
-                ->filterByByDefault(1)
-                ->findOne();
-        }
-
-        return $lang;
+        return $this->getLangModel() ?? Lang::getDefaultLanguage();
     }
 
     /**
@@ -352,7 +344,7 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
      */
     public function getLocale(): string
     {
-        return $this->getLangModel()->getLocale();
+        return $this->getCustomerLang()->getLocale();
     }
 
     public function hasOrder()

--- a/tests/Integration/Command/DemoImportCommandTest.php
+++ b/tests/Integration/Command/DemoImportCommandTest.php
@@ -43,6 +43,11 @@ final class DemoImportCommandTest extends IntegrationTestCase
         );
 
         self::assertGreaterThan(1, CustomerQuery::create()->count(), 'multiple customers');
+        self::assertSame(
+            0,
+            CustomerQuery::create()->filterByLangId(null, Criteria::ISNULL)->count(),
+            'every demo customer carries a language',
+        );
         self::assertGreaterThan(0, NewsletterQuery::create()->count(), 'newsletter subscribers');
         self::assertGreaterThan(0, CouponQuery::create()->count(), 'coupons');
 

--- a/tests/Integration/Model/CustomerLocaleTest.php
+++ b/tests/Integration/Model/CustomerLocaleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Model\LangQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The customer.lang_id column is nullable, and the lang foreign key sets it back
+ * to NULL when a language is deleted, so a customer without a language is a
+ * reachable state that getLocale() has to answer for.
+ */
+final class CustomerLocaleTest extends IntegrationTestCase
+{
+    public function testLocaleFallsBackToTheDefaultLanguageWhenTheCustomerHasNone(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+
+        self::assertNull($customer->getLangId(), 'the fixture leaves the customer without a language');
+
+        $defaultLang = LangQuery::create()->findOneByByDefault(1);
+        self::assertNotNull($defaultLang, 'the test database defines a default language');
+
+        self::assertSame($defaultLang->getLocale(), $customer->getLocale());
+    }
+
+    public function testLocaleIsTheCustomerOwnLanguageWhenItHasOne(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $lang = $factory->lang(['title' => 'Deutsch', 'code' => 'de', 'locale' => 'de_DE']);
+        $customer = $factory->customer($factory->customerTitle());
+        $customer->setLangId((int) $lang->getId());
+        $customer->save();
+
+        self::assertSame('de_DE', $customer->getLocale());
+    }
+}


### PR DESCRIPTION
Closes #3669.

`customer.lang_id` is nullable by design, and the `lang` foreign key is declared `onDelete="SET NULL"`, so deleting a language in the back-office empties the column for every customer that used it. `Customer::getLocale()` dereferenced that relation without a guard and fatalled with `Call to a member function getLocale() on null`, while the interface it implements (`Thelia\Core\Security\User\UserInterface::getLocale(): string`) promises a string.

No core caller hits it today — they all work around it, one of them with a comment describing this very bug — but any module or theme coding against the interface does.

**Return the default locale when the customer has no language**

`getLocale()` now goes through `getCustomerLang()`, which already implements that fallback, so the rule lives in one place. `getCustomerLang()` itself switches to `Lang::getDefaultLanguage()`: its `Lang` return type was a lie, since `findOne()` returns `null` on a shop with no default language, and the helper raises an explicit message instead of a `TypeError`. The obsolete comment in `CustomerPersonalDataExporter` is reworded — the export deliberately reports the language the account carries, not the fallback.

**Give demo customers the default language**

`CustomersImporter` never set `lang_id`, so `--with-demo` produced ten accounts without a language. It now resolves the default language once and assigns it.

No schema change and no migration for existing databases: `NULL` keeps its meaning of "no preference, follow the shop default", and with the guard in place it is safe again.

Verified red before the fix and green after: the new `CustomerLocaleTest` reproduced the exact fatal, and the demo-import assertion reported the ten customers.

Baselines: 858 tests green across the five suites, `cs-diff` 0/1761, PHPStan 0 errors.
