### PR TITLE
fix: export the shipping tax rule title as text, and the delivery country in its own column

### DIFF
--- a/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
@@ -54,7 +54,7 @@ class OrderExport extends JsonFileAbstractExport
         'delivery_address_address3' => 'delivery_address_3',
         'delivery_address_zipcode' => 'delivery_zip_code',
         'delivery_address_city' => 'delivery_city',
-        'delivery_country_i18n_title' => 'invoice_country',
+        'delivery_country_i18n_title' => 'delivery_country',
         'delivery_address_phone' => 'delivery_phone',
         'invoice_address_customer_title_long' => 'invoice_title',
         'invoice_address_company' => 'invoice_company',
@@ -93,7 +93,7 @@ class OrderExport extends JsonFileAbstractExport
                     order_coupon.code as order_coupon_code,
                     ROUND(`order`.postage, 2) as order_postage,
                     `order`.postage_tax as "order_postage_tax",
-                    ROUND(`order`.postage_tax_rule_title,2) as "order_postage_tax_rule_title",
+                    `order`.postage_tax_rule_title as "order_postage_tax_rule_title",
                     SUM(ROUND(order_product.quantity * IF(order_product.was_in_promo = 1, order_product.promo_price, order_product.price), 2) ) as order_total_price,
                     SUM(
                         ROUND(

--- a/tests/Integration/Domain/DataTransfer/OrderExportTest.php
+++ b/tests/Integration/Domain/DataTransfer/OrderExportTest.php
@@ -76,6 +76,42 @@ final class OrderExportTest extends IntegrationTestCase
         self::assertNotContains($old->getRef(), $refs);
     }
 
+    /**
+     * `postage_tax_rule_title` is a VARCHAR. Wrapping it in ROUND() made
+     * MySQL coerce the label to a number, so every exported order carried
+     * 0.00 instead of the tax rule name.
+     */
+    public function testItExportsTheShippingTaxRuleTitleAsText(): void
+    {
+        $order = $this->factory->order();
+        $order->setRef('EXP-'.uniqid());
+        $order->setPostageTaxRuleTitle('TVA 20%');
+        $order->save($this->getPropelConnection());
+
+        $row = $this->exportedRow($order->getRef());
+
+        self::assertSame('TVA 20%', $row['order_postage_tax_rule_title']);
+    }
+
+    /**
+     * Both country columns used to be aliased to `invoice_country`, and the
+     * second one silently overwrote the first: the delivery country never
+     * reached the file.
+     */
+    public function testTheDeliveryAndInvoiceCountriesGetTheirOwnColumn(): void
+    {
+        $order = $this->factory->order();
+        $order->setRef('EXP-'.uniqid());
+        $order->save($this->getPropelConnection());
+
+        $row = $this->exportedRow($order->getRef());
+        $aliased = (new OrderExport())->applyOrderAndAliases($row);
+
+        self::assertArrayHasKey('delivery_country', $aliased);
+        self::assertSame($row['delivery_country_i18n_title'], $aliased['delivery_country']);
+        self::assertSame($row['invoice_country_i18n_title'], $aliased['invoice_country']);
+    }
+
     private function orderCreatedAt(string $modifier): Order
     {
         $order = $this->factory->order();
@@ -106,5 +142,25 @@ final class OrderExportTest extends IntegrationTestCase
         }
 
         return $refs;
+    }
+
+    /**
+     * The export yields the raw column names, not the output aliases.
+     *
+     * @return array<string, mixed>
+     */
+    private function exportedRow(string $ref): array
+    {
+        $export = new OrderExport();
+        $export->setLang(Lang::getDefaultLanguage());
+        $export->setRangeDate(null);
+
+        foreach ($export as $row) {
+            if (($row['order_ref'] ?? null) === $ref) {
+                return $row;
+            }
+        }
+
+        self::fail("Order $ref is missing from the export.");
     }
 }


### PR DESCRIPTION
The accounting order export carries two defects that both come from the same
copy-and-paste, and both are fixed here. Same change as #3680, ported to `main`
(the two files have diverged, so no cherry-pick).

**`ROUND()` on a VARCHAR** — `core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php:96`
selected `ROUND(\`order\`.postage_tax_rule_title, 2)`. That column is a
`VARCHAR(255)` (`local/config/schema.xml:624`), so MySQL coerced the label to a
number and every exported order carried `0` instead of the tax rule name —
`SELECT ROUND('TVA 20%', 2)` returns `0.00`. The line dates back to 2020
(`03c0bd99c8`); the two lines around it round `discount` and `postage`, which
are real `DECIMAL(16,6)` columns.

**Alias collision on the delivery country** — `:57` and `:68` both mapped to the
output alias `invoice_country`. `applyOrderAndAliases()` writes the aliases in
order (`JsonFileAbstractExport.php:96-106`), so the invoice country overwrote the
delivery country and the latter never reached the file. Every other entry in the
surrounding block is already prefixed `delivery_`.

Note for integrators: the output gains a `delivery_country` column, in its
position in the column order. `invoice_country` keeps exactly the value it has
today, so no consumer loses data — only readers that index columns by position
need to be aware.

Two cases were added to `tests/Integration/Domain/DataTransfer/OrderExportTest.php`,
along with an `exportedRow()` helper next to the existing `exportedRefs()`. Both
were checked red against the current code (`0` instead of `TVA 20%`, and no
`delivery_country` key) and green with the fix.

Fixes #3667
