### PR TITLE
fix: carry the virtual document of each sale element when cloning a product

### DIFF
--- a/core/lib/Thelia/Action/File.php
+++ b/core/lib/Thelia/Action/File.php
@@ -121,6 +121,10 @@ class File extends BaseAction implements EventSubscriberInterface
                         case 'documents':
                             $dispatcher->dispatch($clonedProductCreateFileEvent, TheliaEvents::DOCUMENT_SAVE);
 
+                            // Keep track of which copy replaces which source document, so the
+                            // virtual document of each sale element can be remapped later on.
+                            $event->addClonedDocumentId((int) $originalProductFile->getId(), (int) $clonedProductFile->getId());
+
                             // Get original product document I18n
                             $originalProductFileI18ns = ProductDocumentI18nQuery::create()
                                 ->findById($originalProductFile->getId());

--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -20,6 +20,7 @@ use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
 use Thelia\Core\Event\Product\ProductCloneEvent;
 use Thelia\Core\Event\Product\ProductCombinationGenerationEvent;
 use Thelia\Core\Event\ProductSaleElement\ProductSaleElementCreateEvent;
@@ -31,11 +32,14 @@ use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Template\Loop\ProductSaleElementsDocument;
 use Thelia\Core\Template\Loop\ProductSaleElementsImage;
 use Thelia\Core\Translation\Translator;
+use Thelia\Log\Tlog;
 use Thelia\Model\AttributeAvQuery;
 use Thelia\Model\AttributeCombination;
 use Thelia\Model\AttributeCombinationQuery;
 use Thelia\Model\Map\AttributeCombinationTableMap;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
 use Thelia\Model\ProductDocumentQuery;
 use Thelia\Model\ProductImageQuery;
 use Thelia\Model\ProductPrice;
@@ -386,7 +390,48 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
             if (null !== $originalProductPSEDocuments) {
                 $this->clonePSEAssociatedFiles($clonedProduct->getId(), $clonedProductPSEId, $originalProductPSEDocuments, $type = 'document');
             }
+
+            $this->cloneVirtualDocumentAssociation($event, $originalProductPSE->getId(), $clonedProductPSEId);
         }
+    }
+
+    /**
+     * Point the cloned sale element at the clone's own copy of the document a virtual
+     * product is downloaded from. The association lives in a meta_data row (virtual key,
+     * pse element), and is copied whenever the source has one, whether or not the product
+     * is currently flagged as virtual.
+     */
+    private function cloneVirtualDocumentAssociation(ProductCloneEvent $event, int $originalPseId, int $clonedPseId): void
+    {
+        $originalDocumentId = (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $originalPseId);
+
+        if ($originalDocumentId <= 0) {
+            return;
+        }
+
+        $clonedDocumentId = $event->getClonedDocumentId($originalDocumentId);
+
+        if (null === $clonedDocumentId) {
+            // The source document was not copied — its file is missing from the disk, or the
+            // meta_data row points outside of the product. Reusing the source id would make the
+            // clone depend on a file deleted along with the original product, so the clone is
+            // left without a virtual document and the merchant has to pick one.
+            Tlog::getInstance()->addWarning(
+                \sprintf(
+                    'Product clone %s: sale element %d has no virtual document, the document %d of the source product was not copied.',
+                    $event->getClonedProduct()->getRef(),
+                    $clonedPseId,
+                    $originalDocumentId
+                )
+            );
+
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(
+            new MetaDataCreateOrUpdateEvent('virtual', MetaData::PSE_KEY, $clonedPseId, $clonedDocumentId),
+            TheliaEvents::META_DATA_UPDATE
+        );
     }
 
     /**

--- a/core/lib/Thelia/Core/Event/Product/ProductCloneEvent.php
+++ b/core/lib/Thelia/Core/Event/Product/ProductCloneEvent.php
@@ -23,6 +23,15 @@ class ProductCloneEvent extends ActionEvent
     protected array $types = ['images', 'documents'];
 
     /**
+     * Documents copied for the clone, keyed by the id of the source document.
+     * Filled while the files are cloned, so later steps of the cloning process
+     * can point the clone at its own copy of a document instead of the source one.
+     *
+     * @var array<int, int>
+     */
+    protected array $clonedDocumentIds = [];
+
+    /**
      * ProductCloneEvent constructor.
      *
      * @param string $lang the locale (such as fr_FR)
@@ -80,5 +89,15 @@ class ProductCloneEvent extends ActionEvent
     public function getTypes(): array
     {
         return $this->types;
+    }
+
+    public function addClonedDocumentId(int $originalDocumentId, int $clonedDocumentId): void
+    {
+        $this->clonedDocumentIds[$originalDocumentId] = $clonedDocumentId;
+    }
+
+    public function getClonedDocumentId(int $originalDocumentId): ?int
+    {
+        return $this->clonedDocumentIds[$originalDocumentId] ?? null;
     }
 }

--- a/tests/Integration/Action/ProductSaleElementActionTest.php
+++ b/tests/Integration/Action/ProductSaleElementActionTest.php
@@ -24,13 +24,39 @@ use Thelia\Core\Event\ProductSaleElement\ProductSaleElementUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Model\AttributeCombinationQuery;
+use Thelia\Model\Currency;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductDocument;
+use Thelia\Model\ProductDocumentQuery;
 use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Test\ActionIntegrationTestCase;
 
 final class ProductSaleElementActionTest extends ActionIntegrationTestCase
 {
+    private ?string $documentUploadDir = null;
+
+    /** @var list<string> */
+    private array $preexistingDocumentFiles = [];
+
+    protected function tearDown(): void
+    {
+        // Cloning documents writes to the media directory, which the database rollback
+        // does not undo: both the source file and the copy made for the clone must go.
+        if (null !== $this->documentUploadDir && is_dir($this->documentUploadDir)) {
+            foreach ($this->documentFiles() as $file) {
+                if (is_file($file) && !\in_array($file, $this->preexistingDocumentFiles, true)) {
+                    unlink($file);
+                }
+            }
+        }
+
+        parent::tearDown();
+    }
+
     public function testCreateWithoutCombinationReusesOrphanPse(): void
     {
         $currency = $this->factory->currency();
@@ -449,5 +475,168 @@ final class ProductSaleElementActionTest extends ActionIntegrationTestCase
         self::assertNotNull($clonedPse);
         self::assertSame(0, $clonedPse->getPromo());
         self::assertSame(0, $clonedPse->getNewness());
+    }
+
+    public function testCloneCarriesTheVirtualDocumentOfEachSaleElement(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->createVirtualProduct($currency);
+        $document = $this->createDocument($product, 'handbook-'.$product->getRef().'.pdf', withFile: true);
+
+        foreach ($this->generateTwoSaleElements($product, $currency) as $salesElement) {
+            MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $salesElement->getId(), $document->getId());
+        }
+
+        $event = new ProductCloneEvent($product->getRef().'-CLONE', 'en_US', $product);
+        $this->dispatch($event, TheliaEvents::PRODUCT_CLONE);
+
+        $clonedProduct = $event->getClonedProduct();
+        $clonedSaleElements = ProductSaleElementsQuery::create()
+            ->filterByProductId($clonedProduct->getId())
+            ->find();
+        self::assertCount(2, $clonedSaleElements);
+
+        foreach ($clonedSaleElements as $clonedSaleElement) {
+            $clonedDocumentId = MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $clonedSaleElement->getId());
+            self::assertNotNull(
+                $clonedDocumentId,
+                'Every cloned sale element must keep the document its virtual product is downloaded from',
+            );
+            self::assertNotSame(
+                $document->getId(),
+                (int) $clonedDocumentId,
+                'The clone must point at its own copy, not at the document of the source product',
+            );
+
+            $clonedDocument = ProductDocumentQuery::create()->findPk((int) $clonedDocumentId);
+            self::assertNotNull($clonedDocument);
+            self::assertSame($clonedProduct->getId(), $clonedDocument->getProductId());
+        }
+    }
+
+    public function testCloneLeavesNoVirtualAssociationWhenTheSourceFileIsMissing(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->createVirtualProduct($currency);
+
+        // The association points at a document whose file is absent from the disk, so the
+        // cloning process has nothing to copy.
+        $document = $this->createDocument($product, 'never-uploaded-'.$product->getRef().'.pdf', withFile: false);
+
+        $defaultSaleElement = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->findOne();
+        self::assertNotNull($defaultSaleElement);
+        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultSaleElement->getId(), $document->getId());
+
+        $event = new ProductCloneEvent($product->getRef().'-CLONE', 'en_US', $product);
+        $this->dispatch($event, TheliaEvents::PRODUCT_CLONE);
+
+        $clonedProduct = $event->getClonedProduct();
+        self::assertSame(1, $clonedProduct->getVirtual(), 'The clone keeps the intent of the source product');
+
+        $clonedSaleElements = ProductSaleElementsQuery::create()
+            ->filterByProductId($clonedProduct->getId())
+            ->find();
+        self::assertCount(1, $clonedSaleElements);
+
+        foreach ($clonedSaleElements as $clonedSaleElement) {
+            self::assertNull(
+                MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $clonedSaleElement->getId()),
+                'A document deleted with the source product must not be handed over to the clone',
+            );
+        }
+    }
+
+    private function createVirtualProduct(Currency $currency): Product
+    {
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $currency,
+        );
+
+        // cloneProduct() reads the source i18n row, which the fixture does not create.
+        $product
+            ->setLocale('en_US')
+            ->setTitle('Digital handbook')
+            ->setVirtual(1)
+            ->save();
+
+        return $product;
+    }
+
+    private function createDocument(Product $product, string $fileName, bool $withFile): ProductDocument
+    {
+        $document = new ProductDocument();
+        $document
+            ->setProductId($product->getId())
+            ->setFile($fileName)
+            // Virtual documents are the hidden ones.
+            ->setVisible(0)
+            ->setPosition(1)
+            ->save();
+
+        $this->rememberDocumentUploadDir($document);
+
+        if ($withFile) {
+            if (!is_dir($this->documentUploadDir)) {
+                mkdir($this->documentUploadDir, 0o775, true);
+            }
+            file_put_contents($this->documentUploadDir.\DIRECTORY_SEPARATOR.$fileName, '%PDF-1.4 test document');
+        }
+
+        return $document;
+    }
+
+    /**
+     * Replaces the default sale element with two combinations, the way a merchant
+     * declining a virtual product would.
+     *
+     * @return list<\Thelia\Model\ProductSaleElements>
+     */
+    private function generateTwoSaleElements(Product $product, Currency $currency): array
+    {
+        $attribute = $this->factory->attribute();
+        $firstValue = $this->factory->attributeAv($attribute);
+        $secondValue = $this->factory->attributeAv($attribute);
+
+        $event = new ProductCombinationGenerationEvent(
+            $product,
+            $currency->getId(),
+            [[$firstValue->getId()], [$secondValue->getId()]],
+        );
+        $event
+            ->setPrice(10.0)
+            ->setSalePrice(8.0)
+            ->setWeight(0.0)
+            ->setQuantity(5)
+            ->setOnsale(false)
+            ->setIsnew(false)
+            ->setEanCode('');
+
+        $this->dispatch($event, TheliaEvents::PRODUCT_COMBINATION_GENERATION);
+
+        return iterator_to_array(
+            ProductSaleElementsQuery::create()->filterByProductId($product->getId())->find(),
+        );
+    }
+
+    private function rememberDocumentUploadDir(ProductDocument $document): void
+    {
+        if (null !== $this->documentUploadDir) {
+            return;
+        }
+
+        $this->documentUploadDir = $document->getUploadDir();
+        $this->preexistingDocumentFiles = $this->documentFiles();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function documentFiles(): array
+    {
+        return array_values(glob($this->documentUploadDir.\DIRECTORY_SEPARATOR.'*') ?: []);
     }
 }


### PR DESCRIPTION
Cloning a virtual product produced a clone still flagged `virtual = 1`, but with no `meta_data` row telling which document the customer downloads. The order then went through — `VirtualProductHandler::resolve()` (`core/lib/Thelia/Domain/Order/Service/VirtualProductHandler.php:35-42`) dispatches on the flag alone — while `VirtualProductDelivery` found no association, so `order_product.virtual_document` stayed empty and the customer paid for nothing.

Fixes #3662

## Why it could not be fixed where the flag is copied

`updateClone()` (`core/lib/Thelia/Action/Product.php:196-246`) runs before `FILE_CLONE` (`:161`), so the clone has no documents yet and no id to point at. The only place holding both the source and cloned sale element ids, with the cloned documents already created, is `PSE_CLONE`.

The missing link was the source document id to cloned document id correspondence: `File::cloneFile()` had it in memory but never exposed it.

## Changes

- `core/lib/Thelia/Core/Event/Product/ProductCloneEvent.php` — carries the map, `addClonedDocumentId()` / `getClonedDocumentId()`. Additive, no signature changed.
- `core/lib/Thelia/Action/File.php:124-127` — fills it right after `DOCUMENT_SAVE`, where the copy has its id.
- `core/lib/Thelia/Action/ProductSaleElement.php:394` — `clonePSE()` copies the `virtual`/`pse` `meta_data` row of every sale element, remapped onto the clone's own document.

Two deliberate rules:

- The association is copied whenever the source has one, whether or not the product is currently flagged virtual, so a temporarily unchecked flag does not silently destroy data on clone.
- When the source document was not copied (its file is missing from the disk), the clone gets no association and a `Tlog` warning is logged, rather than a pointer to a file that will be deleted with the original product. The `virtual` flag is kept: it carries a merchant intent, and the clone is created invisible anyway.

Position matching, as `clonePSEAssociatedFiles()` (`:480-484`) does for regular file associations, was rejected: `position` is not unique per product, and a source document skipped for a missing file shifts the match onto the wrong document.

No schema change.

## Tests

`tests/Integration/Action/ProductSaleElementActionTest.php`

- `testCloneCarriesTheVirtualDocumentOfEachSaleElement()` — a virtual product with two combinations, a real file on disk, one association per sale element; asserts each cloned sale element points at a document that exists, belongs to the clone, and is not the source one. Red without the fix.
- `testCloneLeavesNoVirtualAssociationWhenTheSourceFileIsMissing()` — locks the behaviour above; red if the fix falls back to the source document id.

Both clean up the media directory in `tearDown()`, which the database rollback does not cover.

The same defect exists on 2.6; this PR only covers the Thelia 3 line.
