### PR TITLE
fix: give cart.postage and order.postage the same meaning

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -143,7 +143,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         try {
             $postage = $this->getPostageByDeliveryModuleId($cart, $dispatcher, $moduleId, $deliveryAddressId);
             $cart
-                ->setPostage((string) ($postage->getAmount() - $postage->getAmountTax()))
+                ->setPostage((string) $postage->getAmount())
                 ->setPostageTax((string) ($postage->getAmountTax() ?? 0.0))
                 ->setPostageTaxRuleTitle($postage->getTaxRuleTitle())
                 ->save();

--- a/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
@@ -238,8 +238,14 @@ class AttributeAccessService
             case 'taxed_postage':
                 $result = $cart->getTaxedPostage();
                 break;
+            case 'untaxed_postage':
+                $result = $cart->getUntaxedPostage();
+                break;
             case 'postage':
                 $result = $cart->getPostage();
+                break;
+            case 'postage_tax':
+                $result = $cart->getPostageTax();
                 break;
             case 'total_price':
             case 'total_price_with_discount':

--- a/core/lib/Thelia/Domain/Checkout/Service/CheckoutPaymentService.php
+++ b/core/lib/Thelia/Domain/Checkout/Service/CheckoutPaymentService.php
@@ -48,7 +48,7 @@ readonly class CheckoutPaymentService
             ->setInvoiceOrderAddressId($invoiceAddressId)
             ->setPaymentModuleId($paymentModuleId)
             ->setDeliveryModuleId($deliveryModuleId)
-            ->setPostage((string) ((float) $cart->getPostage() + (float) $cart->getPostageTax()))
+            ->setPostage((string) $cart->getPostage())
             ->setPostageTax($cart->getPostageTax())
             ->setPostageTaxRuleTitle($cart->getPostageTaxRuleTitle())
             ->setCustomerId($cart->getCustomerId())

--- a/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
@@ -45,7 +45,7 @@ class PostageEstimator
     }
 
     /**
-     * Return the minimum expected postage for a cart in a given country.
+     * Return the minimum expected postage, tax included, for a cart in a given country.
      *
      * @throws PropelException
      */
@@ -75,11 +75,11 @@ class PostageEstimator
             $modulePostage = $this->computePostageForModule($deliveryModule, $cart, $country, $state);
 
             if ($modulePostage instanceof OrderPostage) {
-                $amountHt = $modulePostage->getAmount() - $modulePostage->getAmountTax();
+                $amountTtc = $modulePostage->getAmount();
                 $tax = $modulePostage->getAmountTax();
 
-                if (null === $bestPostageAmount || $bestPostageAmount > $amountHt) {
-                    $bestPostageAmount = $amountHt;
+                if (null === $bestPostageAmount || $bestPostageAmount > $amountTtc) {
+                    $bestPostageAmount = $amountTtc;
                     $bestPostageTax = $tax;
                     $bestModuleId = $deliveryModule->getId();
                 }

--- a/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
+++ b/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
@@ -71,12 +71,12 @@ final readonly class ShippingFacade
 
         $estimate = $this->postageEstimator->estimatePostageForCountry($cart, $country, $state);
 
-        $amountHt = $estimate->getBestPostageAmount();
+        $totalTtc = $estimate->getBestPostageAmount();
         $tax = $estimate->getBestPostageTax();
-        $totalTtc = null;
+        $amountHt = null;
 
-        if (null !== $amountHt && null !== $tax) {
-            $totalTtc = $amountHt + $tax;
+        if (null !== $totalTtc && null !== $tax) {
+            $amountHt = $totalTtc - $tax;
         }
 
         return new PostageEstimateView($amountHt, $tax, $totalTtc);

--- a/core/lib/Thelia/Model/Cart.php
+++ b/core/lib/Thelia/Model/Cart.php
@@ -180,7 +180,7 @@ class Cart extends BaseCart
         }
 
         if ($withPostage) {
-            $total += (float) $this->getPostage();
+            $total += $this->getUntaxedPostage();
         }
 
         return round($total, 2);
@@ -263,8 +263,24 @@ class Cart extends BaseCart
         return round($this->createTaxCalculator()->computeUntaxedCartDiscount($this, $country, $state), 2);
     }
 
+    /**
+     * Return the postage, tax included.
+     *
+     * The postage column is stored tax included, exactly like Order::getPostage(),
+     * so this method only spells the convention out for the caller.
+     */
     public function getTaxedPostage(): float
     {
-        return (float) $this->getPostage() + (float) $this->getPostageTax();
+        return (float) $this->getPostage();
+    }
+
+    /**
+     * Return the postage without tax.
+     */
+    public function getUntaxedPostage(): float
+    {
+        return 0 < (float) $this->getPostageTax()
+            ? (float) $this->getPostage() - (float) $this->getPostageTax()
+            : (float) $this->getPostage();
     }
 }

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -358,6 +358,8 @@ class Order extends BaseOrder
 
     /**
      * Return the postage without tax.
+     *
+     * The postage column is stored tax included, like Cart::getPostage().
      */
     public function getUntaxedPostage(): float|int
     {

--- a/core/lib/Thelia/Model/OrderQuery.php
+++ b/core/lib/Thelia/Model/OrderQuery.php
@@ -135,9 +135,15 @@ class OrderQuery extends BaseOrderQuery
                 ->findOne();
 
         if ($includeShipping) {
+            // The postage column is stored tax included, so a tax-excluded
+            // turnover has to drop the postage tax as well.
+            $postage = $withTaxes
+                ? 'SUM(`order`.postage)'
+                : 'SUM(`order`.postage) - SUM(`order`.postage_tax)';
+
             $amount += (float)
                 self::baseSaleStats($startDate, $endDate)
-                    ->withColumn('SUM(`order`.postage)', 'POSTAGE')
+                    ->withColumn($postage, 'POSTAGE')
                     ->select('POSTAGE')
                     ->findOne();
         }

--- a/tests/Integration/Domain/Checkout/CartOrderPostageSemanticsTest.php
+++ b/tests/Integration/Domain/Checkout/CartOrderPostageSemanticsTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Checkout;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Action\Cart as CartAction;
+use Thelia\Core\Event\Cart\CartCheckoutEvent;
+use Thelia\Core\Event\Order\OrderEvent;
+use Thelia\Core\Event\Order\OrderPaymentEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Domain\Checkout\Service\CheckoutPaymentService;
+use Thelia\Model\Cart;
+use Thelia\Model\CartAddress;
+use Thelia\Model\CartItem;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderPostage;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * cart.postage and order.postage carry the same name, so they must carry the
+ * same meaning: both hold the amount the customer pays, tax included.
+ *
+ * The amount a delivery module quotes therefore has to reach the placed order
+ * untouched. Anything that converts it on the way — even a conversion undone
+ * further down — leaves two columns of opposite meaning behind, and every
+ * reader gets one chance in two.
+ */
+final class CartOrderPostageSemanticsTest extends ActionIntegrationTestCase
+{
+    private const QUOTED_POSTAGE = 12.0;
+    private const QUOTED_POSTAGE_TAX = 2.0;
+
+    /** @var list<array{0: string, 1: callable}> */
+    private array $registeredListeners = [];
+
+    protected function tearDown(): void
+    {
+        // The kernel dispatcher outlives the test, so listeners left behind
+        // would answer the next test of the process.
+        foreach ($this->registeredListeners as [$eventName, $listener]) {
+            $this->kernelDispatcher()->removeListener($eventName, $listener);
+        }
+        $this->registeredListeners = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheCartStoresTheAmountTheDeliveryModuleQuoted(): void
+    {
+        $cart = $this->createCheckoutReadyCart()['cart'];
+
+        $this->quotePostageOnCart($cart);
+
+        self::assertEqualsWithDelta(self::QUOTED_POSTAGE, (float) $cart->getPostage(), 0.0001);
+        self::assertEqualsWithDelta(self::QUOTED_POSTAGE_TAX, (float) $cart->getPostageTax(), 0.0001);
+        self::assertEqualsWithDelta(self::QUOTED_POSTAGE, $cart->getTaxedPostage(), 0.0001);
+        self::assertEqualsWithDelta(10.0, $cart->getUntaxedPostage(), 0.0001);
+    }
+
+    public function testTheCheckoutHandsTheCartPostageToTheOrderUnchanged(): void
+    {
+        $fixtures = $this->createCheckoutReadyCart();
+        $cart = $fixtures['cart'];
+
+        $this->quotePostageOnCart($cart);
+        $order = $this->checkout($fixtures);
+
+        self::assertEqualsWithDelta(
+            (float) $cart->getPostage(),
+            (float) $order->getPostage(),
+            0.0001,
+            'cart.postage and order.postage must hold the same amount.',
+        );
+        self::assertEqualsWithDelta(
+            $cart->getTaxedPostage(),
+            (float) $order->getPostage(),
+            0.0001,
+        );
+        self::assertEqualsWithDelta(
+            $cart->getUntaxedPostage(),
+            (float) $order->getUntaxedPostage(),
+            0.0001,
+        );
+        self::assertEqualsWithDelta(self::QUOTED_POSTAGE, (float) $order->getPostage(), 0.0001);
+        self::assertEqualsWithDelta(self::QUOTED_POSTAGE_TAX, (float) $order->getPostageTax(), 0.0001);
+    }
+
+    /**
+     * Runs the real CART_SET_POSTAGE listener on a fixed quote.
+     *
+     * Only the delivery module lookup is replaced: it would need an installed
+     * module configured for the test country, which says nothing about the
+     * amount the listener then writes.
+     */
+    private function quotePostageOnCart(Cart $cart): void
+    {
+        $action = new class extends CartAction {
+            public OrderPostage $quote;
+
+            public function __construct()
+            {
+                // The overridden method below is the only one this test calls,
+                // and it uses none of the parent's dependencies.
+            }
+
+            protected function getPostageByDeliveryModuleId(
+                Cart $cart,
+                EventDispatcherInterface $dispatcher,
+                int $moduleId,
+                int $deliveryAddressId,
+            ): OrderPostage {
+                return $this->quote;
+            }
+        };
+        $action->quote = new OrderPostage(self::QUOTED_POSTAGE, self::QUOTED_POSTAGE_TAX, 'VAT 20');
+
+        $action->calculatePostage(new CartCheckoutEvent($cart), TheliaEvents::CART_SET_POSTAGE, $this->dispatcher);
+
+        $cart->reload();
+    }
+
+    /**
+     * @param array{cart: Cart, customer: Customer, currency: Currency, deliveryModule: Module, paymentModule: Module, deliveryAddressId: int, invoiceAddressId: int} $fixtures
+     */
+    private function checkout(array $fixtures): Order
+    {
+        $session = $this->session();
+        $session->setCustomerUser($fixtures['customer']);
+        $session->setSessionCart($fixtures['cart']);
+        $session->setCurrency($fixtures['currency']);
+
+        $placedOrder = null;
+        $this->listen(
+            TheliaEvents::ORDER_BEFORE_PAYMENT,
+            static function (OrderEvent $event) use (&$placedOrder): void {
+                $placedOrder = $event->getOrder();
+            },
+        );
+        // The payment module would answer with its own payment page. The
+        // postage contract is settled by then, so the chain stops here.
+        $this->listen(
+            TheliaEvents::MODULE_PAY,
+            static function (OrderPaymentEvent $event): void {
+                $event->stopPropagation();
+            },
+            256,
+        );
+
+        $this->getService(CheckoutPaymentService::class)->pay(
+            $fixtures['cart'],
+            $fixtures['deliveryAddressId'],
+            $fixtures['invoiceAddressId'],
+            $fixtures['deliveryModule']->getId(),
+            $fixtures['paymentModule']->getId(),
+        );
+
+        self::assertInstanceOf(Order::class, $placedOrder, 'The checkout did not place an order.');
+
+        return $placedOrder;
+    }
+
+    /**
+     * @return array{cart: Cart, customer: Customer, currency: Currency, deliveryModule: Module, paymentModule: Module, deliveryAddressId: int, invoiceAddressId: int}
+     */
+    private function createCheckoutReadyCart(): array
+    {
+        $currency = $this->factory->currency();
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $country = $this->factory->country();
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $currency,
+            ['baseQuantity' => 100],
+        );
+
+        $deliveryAddress = $this->createCartAddress($customerTitle->getId(), $country->getId());
+        $invoiceAddress = $this->createCartAddress($customerTitle->getId(), $country->getId());
+
+        $deliveryModule = ModuleQuery::create()->findOneByCode('CustomDelivery')
+            ?? throw new \RuntimeException('No delivery module installed — run bin/test-prepare.');
+        $paymentModule = ModuleQuery::create()->findOneByCode('Cheque')
+            ?? throw new \RuntimeException('No payment module installed — run bin/test-prepare.');
+
+        $cart = (new Cart())
+            ->setCustomerId($customer->getId())
+            ->setCurrencyId($currency->getId())
+            ->setToken(uniqid('postage-semantics-', true))
+            ->setAddressDeliveryId($deliveryAddress->getId())
+            ->setAddressInvoiceId($invoiceAddress->getId())
+            ->setDeliveryModuleId($deliveryModule->getId())
+            ->setPaymentModuleId($paymentModule->getId());
+        $cart->save($this->getPropelConnection());
+
+        $productSaleElements = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->findOne();
+        self::assertNotNull($productSaleElements);
+
+        (new CartItem())
+            ->setCartId($cart->getId())
+            ->setProductId($product->getId())
+            ->setProductSaleElementsId($productSaleElements->getId())
+            ->setQuantity(1)
+            ->setPrice('10.00')
+            ->setPromoPrice('10.00')
+            ->setPromo(0)
+            ->save($this->getPropelConnection());
+
+        return [
+            'cart' => $cart,
+            'customer' => $customer,
+            'currency' => $currency,
+            'deliveryModule' => $deliveryModule,
+            'paymentModule' => $paymentModule,
+            'deliveryAddressId' => $deliveryAddress->getId(),
+            'invoiceAddressId' => $invoiceAddress->getId(),
+        ];
+    }
+
+    private function createCartAddress(int $customerTitleId, int $countryId): CartAddress
+    {
+        $address = (new CartAddress())
+            ->setCustomerTitleId($customerTitleId)
+            ->setFirstname('Jane')
+            ->setLastname('Doe')
+            ->setAddress1('1 rue du Port')
+            ->setZipcode('44000')
+            ->setCity('Nantes')
+            ->setCountryId($countryId);
+        $address->save($this->getPropelConnection());
+
+        return $address;
+    }
+
+    private function listen(string $eventName, callable $listener, int $priority = 0): void
+    {
+        $this->kernelDispatcher()->addListener($eventName, $listener, $priority);
+        $this->registeredListeners[] = [$eventName, $listener];
+    }
+
+    private function kernelDispatcher(): EventDispatcherInterface
+    {
+        return static::getContainer()->get('event_dispatcher');
+    }
+
+    private function session(): Session
+    {
+        return static::getContainer()->get('request_stack')->getCurrentRequest()->getSession();
+    }
+}


### PR DESCRIPTION
`cart.postage` and `order.postage` carry the same name, the same Propel type and the opposite meaning: the cart column was stored tax **excluded**, the order column tax **included**. Nothing said so — no `description` in the schema, no docblock at either definition — and both models shipped a mirror helper to undo the other one's convention (`Cart::getTaxedPostage()` adds the tax, `Order::getUntaxedPostage()` removes it).

A single postage travelled through two conversions:

```
DeliveryModule::getPostage()  ->  OrderPostage(amount=12.00, amountTax=2.00)   tax included
Action\Cart::calculatePostage ->  cart.postage = 10.00, cart.postage_tax = 2.00  tax excluded
CheckoutPaymentService::pay   ->  order.postage = 12.00, order.postage_tax = 2.00  tax included
```

The core and the shipped themes were correct, because they all went through the helpers. Readers that did not — and there are several, in modules — got one chance in two.

This converges the cart on the convention every other part of the system already applies: the `OrderPostage` value object, the `order` and `delivery` loops, the `{postage}` Smarty function, the PDF invoice, the order emails, the back office, and ten years of `order` rows. Going the other way was never an option: it would break every delivery and payment module, every invoice and all historical data.

## What changed

`cart.postage` now holds the amount the delivery module quoted, tax included, exactly like `order.postage`. `cart.postage_tax` is unchanged.

- `Action\Cart::calculatePostage()` writes `OrderPostage::getAmount()` instead of `getAmount() - getAmountTax()`.
- `Cart::getTaxedPostage()` returns the column as-is; a new `Cart::getUntaxedPostage()` mirrors `Order::getUntaxedPostage()`.
- `Cart::getTotalAmount(withPostage: true)` adds the untaxed postage, so the tax-excluded total stays tax-excluded.
- `CheckoutPaymentService::pay()` copies the cart postage to the order instead of re-adding the tax.
- `PostageEstimator::estimatePostageForCountry()` returns the tax-included amount, so `DeliverySetupService` keeps writing a consistent cart and `ShippingFacade::estimateCartPostage()` keeps returning the same `PostageEstimateView(amountHt, tax, totalTtc)` triple.
- `OrderQuery::getSaleStats()` no longer adds a tax-included postage to a tax-excluded turnover.

## For integrators

**Read `cart.postage` directly and you now get a tax-included amount.** Code that used to add `cart.postage_tax` on top of it — because that is what the cart demanded — now counts the shipping VAT twice.

| Expression | Before | After |
|---|---|---|
| `$cart->getPostage()` | tax excluded | tax included |
| `$cart->getPostage() + $cart->getPostageTax()` | the amount to charge | shipping VAT counted twice: call `getPostage()` alone |
| `$cart->getTaxedPostage()` | the amount to charge | the amount to charge, unchanged |
| `$cart->getUntaxedPostage()` | did not exist | the tax-excluded amount |

`Cart::getTaxedPostage()` keeps working and stays the safest thing to call: it returned the customer-facing amount before this change and it still does.

Data access and API:

- `attributeCart('postage')` becomes tax included; `attributeCart('taxed_postage')` is unchanged; `attributeCart('untaxed_postage')` and `attributeCart('postage_tax')` are new. The cart attribute set is now the exact mirror of the order one.
- `GET /api/front/carts/{id}` returns `delivery` tax included. It is now consistent with `total`, which is tax included too — adding the two used to under-charge the shipping VAT.

No migration is needed: `cart.postage` is recomputed on every cart mutation (`PostageHandler::handlePostageOnCart()`), so a cart that is touched is a cart that is repriced. A shop that wants existing carts realigned right away can run `UPDATE cart SET postage = postage + postage_tax WHERE postage_tax > 0;` once.

## Tests

`tests/Integration/Domain/Checkout/CartOrderPostageSemanticsTest.php` walks a taxed postage from the delivery quote to the placed order through the real `CART_SET_POSTAGE` listener and a real `CheckoutPaymentService::pay()`, and asserts the amount never changes on the way. Without this fix it reports `cart.postage = 10.00` against `order.postage = 12.00`.

## Out of scope

- The `description` attributes proposed on the six schema columns are left for a batched `local/config/schema.xml` change, since each one costs a `thelia/config` release cycle.
- Seven modules read the columns on the wrong basis today (PayPal, Shopimind, AdminOrderCreation, Statistic, TheliaGiftCard, GoogleTagManager, ColissimoLabel). They are tracked in their own repositories.
- The Flexy `account-order.html.twig` VAT line is wrong for an unrelated reason (`totalAmount - totalAmountWithoutTaxes` mixes discount and postage into the tax figure) and is left alone while the theme rework lands.

Fixes #3668
