### PR TITLE
fix: upgrade a module in place instead of deleting and reinstalling it

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -360,13 +360,27 @@ class Module extends BaseAction implements EventSubscriberInterface
 
         $oldModule = ModuleQuery::create()->findOneByFullNamespace($moduleDefinition->getNamespace());
 
-        $fs = new Filesystem();
-
         $activated = false;
+
+        // Where the new files go. A new module lands in THELIA_MODULE_DIR; an upgrade goes
+        // back where the module already lives, which may be THELIA_LOCAL_MODULE_DIR. Writing
+        // it to THELIA_MODULE_DIR instead would leave two copies of the module on disk, and
+        // Module::getModuleDir() gives the local one priority: the old code would shadow the new.
+        $modulePathNewModule = \sprintf('%s%s', THELIA_MODULE_DIR, $moduleDefinition->getCode());
 
         // check existing module
         if (null !== $oldModule) {
-            $activated = $oldModule->getActivate();
+            // The namespace is already installed: this is an upgrade, and the row is kept.
+            // Deleting it would cascade to the hooks and their positions, the configuration,
+            // the hooks the administrator switched off, the module images, the access
+            // profiles, the delivery areas and the coupon conditions carrying its id.
+            if ($oldModule->getCode() !== $moduleDefinition->getCode()) {
+                throw new ModuleException(Translator::getInstance()->trans('The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".', ['%new%' => $moduleDefinition->getCode(), '%old%' => $oldModule->getCode(), '%namespace%' => $moduleDefinition->getNamespace()]));
+            }
+
+            $activated = BaseModule::IS_ACTIVATED === $oldModule->getActivate();
+
+            $modulePathNewModule = $oldModule->getAbsoluteBaseDir();
 
             if ($activated) {
                 // deactivate
@@ -376,45 +390,28 @@ class Module extends BaseAction implements EventSubscriberInterface
 
                 $dispatcher->dispatch($toggleEvent, TheliaEvents::MODULE_TOGGLE_ACTIVATION);
             }
-
-            // delete
-            $modulePath = $oldModule->getAbsoluteBaseDir();
-
-            $deleteEvent = new ModuleDeleteEvent($oldModule->getId());
-
-            try {
-                $dispatcher->dispatch($deleteEvent, TheliaEvents::MODULE_DELETE);
-            } catch (\Exception $ex) {
-                // if module has not been deleted
-                if ($fs->exists($modulePath)) {
-                    // The module was deactivated a few lines above so it could be replaced, and the
-                    // replacement is not going to happen. Put the shop back where it was: a payment
-                    // or delivery module left deactivated by a failed upgrade takes the checkout
-                    // down, silently, while the administrator only reads that the install failed.
-                    $this->restoreActivation((int) $oldModule->getId(), (bool) $activated, $dispatcher);
-
-                    throw $ex;
-                }
-            }
         }
-
-        // move new module
-        $modulePathNewModule = \sprintf('%s%s', THELIA_MODULE_DIR, $event->getModuleDefinition()->getCode());
 
         try {
-            $fs->mirror($event->getModulePath(), $modulePathNewModule);
-        } catch (IOException $ioException) {
-            if (!$fs->exists($modulePathNewModule)) {
-                throw $ioException;
-            }
-        }
+            $this->replaceModuleFiles($event->getModulePath(), $modulePathNewModule);
 
-        // Update the module
-        $moduleDescriptorFile = \sprintf('%s%s%s%s%s', $modulePathNewModule, DS, 'Config', DS, 'module.xml');
-        $eventDispatcher = $this->container->get('event_dispatcher');
-        $moduleManagement = new ModuleManagement($this->container, $eventDispatcher);
-        $file = new \SplFileInfo($moduleDescriptorFile);
-        $module = $moduleManagement->updateModule($file, $this->container);
+            // Update the module
+            $moduleDescriptorFile = \sprintf('%s%s%s%s%s', $modulePathNewModule, DS, 'Config', DS, 'module.xml');
+            $eventDispatcher = $this->container->get('event_dispatcher');
+            $moduleManagement = new ModuleManagement($this->container, $eventDispatcher);
+            $file = new \SplFileInfo($moduleDescriptorFile);
+            $module = $moduleManagement->updateModule($file, $this->container);
+        } catch (\Throwable $throwable) {
+            // The module was deactivated a few lines above so it could be replaced, and the
+            // replacement is not going to happen. Put the shop back where it was: a payment
+            // or delivery module left deactivated by a failed upgrade takes the checkout
+            // down, silently, while the administrator only reads that the install failed.
+            if (null !== $oldModule) {
+                $this->restoreActivation((int) $oldModule->getId(), $activated, $dispatcher);
+            }
+
+            throw $throwable;
+        }
 
         // activate if old was activated
         if ($activated) {
@@ -425,6 +422,33 @@ class Module extends BaseAction implements EventSubscriberInterface
         }
 
         $event->setModule($module);
+    }
+
+    /**
+     * Copies the files of the module being installed over the target directory.
+     */
+    private function replaceModuleFiles(string $sourcePath, string $targetPath): void
+    {
+        $fs = new Filesystem();
+
+        if (realpath($sourcePath) === realpath($targetPath)) {
+            // The module is installed from the directory it already lives in, which is what
+            // activating a dependency does. There is nothing to copy, and mirroring a
+            // directory onto itself would truncate every one of its files.
+            return;
+        }
+
+        try {
+            // 'delete' removes what the new version no longer ships and 'override' replaces
+            // files the archive dates earlier than the installed ones. The target directory
+            // is no longer wiped by the deletion of the module, so without these two the
+            // classes of the previous version would stay on disk, to be autoloaded and hooked.
+            $fs->mirror($sourcePath, $targetPath, null, ['override' => true, 'delete' => true]);
+        } catch (IOException $ioException) {
+            if (!$fs->exists($targetPath)) {
+                throw $ioException;
+            }
+        }
     }
 
     private function restoreActivation(int $moduleId, bool $wasActivated, EventDispatcherInterface $dispatcher): void

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -585,6 +585,7 @@ return [
     "The method %method% doesn't exist in classname %classname%" => "The method %method% doesn't exist in classname %classname%",
     'The method name that will handle the hook event.' => 'The method name that will handle the hook event.',
     'The module "%name%" is currently in use by at least one order, and can\'t be deleted.' => 'The module "%name%" is currently in use by at least one order, and can\'t be deleted.',
+    'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".' => 'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".',
     'The module %module has been installed successfully.' => 'The module %module has been installed successfully.',
     'The module %name is already installed in the same or greater version.' => 'The module %name is already installed in the same or greater version.',
     'The module %name requires Thelia %version or newer' => 'The module %name requires Thelia %version or newer',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -582,6 +582,7 @@ return [
     'The message has been successfully sent to %recipient.' => 'Le message a bien été envoyé à %recipient. ',
     'The method name that will handle the hook event.' => 'Le nom de la méthode qui va traiter l\'évènement du point d\'accroche.',
     'The module "%name%" is currently in use by at least one order, and can\'t be deleted.' => 'Le module "%name%" est utilisé par au moins une commande, et ne peut être supprimé.',
+    'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".' => 'Le module de l\'archive s\'appelle "%new%" mais l\'espace de noms "%namespace%" est déjà installé sous le nom "%old%". Désinstallez "%old%" avant d\'installer "%new%".',
     'The module %module has been installed successfully.' => 'Le module %module a été installé avec succès.',
     'The module %name is already installed in the same or greater version.' => 'Le module %name est déja installé dans la même version, ou dans une version plus récente.',
     'The module %name requires Thelia %version or newer' => 'Le module %name nécessite Thelia %version ou plus récent',

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -163,9 +163,11 @@ class ModuleManagement
                 $instance->update($currentVersion, $version, $con);
             }
 
-            if ('none' !== $action) {
-                $instance->registerHooks();
-            }
+            // Also when the version did not change: reinstalling a module whose files were
+            // fixed without a version bump must still register the hooks it now declares.
+            // createOrUpdateHook() is idempotent, and the positions the administrator set
+            // live in module_hook, which this does not touch.
+            $instance->registerHooks();
 
             $con->commit();
         } catch (\Throwable $exception) {

--- a/tests/Integration/Action/ModuleActionTest.php
+++ b/tests/Integration/Action/ModuleActionTest.php
@@ -14,17 +14,76 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Action;
 
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Component\Filesystem\Filesystem;
 use Thelia\Core\Event\Module\ModuleEvent;
 use Thelia\Core\Event\Module\ModuleInstallEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
+use Thelia\Model\Area;
+use Thelia\Model\AreaDeliveryModule;
+use Thelia\Model\AreaDeliveryModuleQuery;
+use Thelia\Model\HookQuery;
+use Thelia\Model\IgnoredModuleHook;
+use Thelia\Model\IgnoredModuleHookQuery;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleConfig;
+use Thelia\Model\ModuleConfigQuery;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
 use Thelia\Model\ModuleQuery;
+use Thelia\Model\OrderQuery;
+use Thelia\Model\ProfileModule;
+use Thelia\Model\ProfileModuleQuery;
 use Thelia\Module\BaseModule;
 use Thelia\Module\Validator\ModuleDefinition;
 use Thelia\Test\ActionIntegrationTestCase;
 
 final class ModuleActionTest extends ActionIntegrationTestCase
 {
+    private const SAMPLE_PREFIX = 'ZipUpgrade';
+
+    private const SAMPLE_CODE = 'ZipUpgradeSample';
+
+    private const SAMPLE_NAMESPACE = 'ZipUpgradeSample\ZipUpgradeSample';
+
+    private const LOCAL_SAMPLE_CODE = 'ZipUpgradeLocalSample';
+
+    private const LOCAL_SAMPLE_NAMESPACE = 'ZipUpgradeLocalSample\ZipUpgradeLocalSample';
+
+    private const DECLARED_HOOK_CODE = 'zipupgradesample.declared';
+
+    /**
+     * Where the sample module records the lifecycle methods Thelia calls on it.
+     */
+    private const CALL_LOG = '/tmp/thelia-zip-upgrade-sample-calls.log';
+
+    /**
+     * @var list<string> the temporary directories standing in for an uploaded archive
+     */
+    private array $archiveDirectories = [];
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem();
+
+        // The module upgrade path reinitializes Propel, which can drop the transaction
+        // this test case rolls back. Start from a known state rather than from whatever
+        // a previous run left behind.
+        $this->removeSampleModules();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeSampleModules();
+
+        parent::tearDown();
+    }
+
     public function testUpdateChangesI18nFields(): void
     {
         $module = ModuleQuery::create()->findOneByCode('Cheque');
@@ -69,41 +128,451 @@ final class ModuleActionTest extends ActionIntegrationTestCase
         );
     }
 
-    /**
-     * Installing a newer version of an already installed module deactivates the current one before
-     * replacing it. When the replacement cannot happen — an order was placed with this payment
-     * module, so its row cannot be deleted — the shop must not be left with the module switched off.
-     */
-    public function testFailedUpgradeLeavesTheModuleActivated(): void
+    public function testUpgradeKeepsTheModuleRow(): void
     {
-        $module = ModuleQuery::create()->findOneByCode('Cheque');
-        self::assertNotNull($module, 'Cheque module must be registered by bin/test-prepare');
+        $installed = $this->installSampleModule('1.0.0');
+        $moduleId = $installed->getId();
 
+        $upgraded = $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            $moduleId,
+            $upgraded->getId(),
+            'Upgrading a module must keep its row: a new id discards everything the foreign keys cascade on.',
+        );
+        self::assertSame('2.0.0', $upgraded->getVersion());
+    }
+
+    public function testUpgradeKeepsTheHookPositionsSetInTheBackOffice(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+        $hookId = HookQuery::create()->findOne()->getId();
+
+        $moduleHook = new ModuleHook();
+        $moduleHook
+            ->setModuleId($module->getId())
+            ->setHookId($hookId)
+            ->setClassname('ZipUpgradeSample\Hook\SampleHook')
+            ->setMethod('onSomething')
+            ->setActive(true)
+            ->setHookActive(true)
+            ->setModuleActive(true)
+            ->setPosition(42)
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        $reloaded = ModuleHookQuery::create()
+            ->filterByModuleId($module->getId())
+            ->filterByHookId($hookId)
+            ->findOne();
+
+        self::assertNotNull($reloaded, 'The module hooks must survive an upgrade.');
+        self::assertSame(42, $reloaded->getPosition(), 'The position set in the back office must survive an upgrade.');
+    }
+
+    public function testUpgradeKeepsTheModuleConfiguration(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $config = new ModuleConfig();
+        $config
+            ->setModuleId($module->getId())
+            ->setName('api_key')
+            ->setValue('the-key-the-merchant-typed')
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        $reloaded = ModuleConfigQuery::create()
+            ->filterByModuleId($module->getId())
+            ->filterByName('api_key')
+            ->findOne();
+
+        self::assertNotNull($reloaded, 'The module configuration must survive an upgrade.');
+        self::assertSame('the-key-the-merchant-typed', $reloaded->getValue());
+    }
+
+    public function testUpgradeKeepsTheHooksTheAdministratorSwitchedOff(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+        $hookId = HookQuery::create()->findOne()->getId();
+
+        $ignored = new IgnoredModuleHook();
+        $ignored
+            ->setModuleId($module->getId())
+            ->setHookId($hookId)
+            ->setClassname('ZipUpgradeSample\Hook\SampleHook')
+            ->setMethod('onSomething')
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            1,
+            IgnoredModuleHookQuery::create()->filterByModuleId($module->getId())->count(),
+            'A hook the administrator removed must not come back after an upgrade.',
+        );
+    }
+
+    public function testUpgradeKeepsTheAdministratorAccessAndDeliveryAreas(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $profileModule = new ProfileModule();
+        $profileModule
+            ->setProfileId($this->factory->profile()->getId())
+            ->setModuleId($module->getId())
+            ->setAccess(1)
+            ->save();
+
+        $area = new Area();
+        $area->setName('Zip upgrade sample area')->save();
+
+        $areaDeliveryModule = new AreaDeliveryModule();
+        $areaDeliveryModule
+            ->setAreaId($area->getId())
+            ->setDeliveryModuleId($module->getId())
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            1,
+            ProfileModuleQuery::create()->filterByModuleId($module->getId())->count(),
+            'The access an administrator profile has on a module must survive an upgrade.',
+        );
+        self::assertSame(
+            1,
+            AreaDeliveryModuleQuery::create()->filterByDeliveryModuleId($module->getId())->count(),
+            'The delivery areas a module is attached to must survive an upgrade.',
+        );
+    }
+
+    public function testUpgradeKeepsTheTitleTheAdministratorEdited(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $module->setLocale('en_US')->setTitle('Renamed by the merchant')->save();
+
+        $upgraded = $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            'Renamed by the merchant',
+            $upgraded->setLocale('en_US')->getTitle(),
+            'An upgrade must not overwrite the title with the one from the archive descriptor.',
+        );
+    }
+
+    /**
+     * Installing a newer version of an already installed module used to delete its row first,
+     * which the order table refuses for a payment module. Upgrading in place no longer reaches
+     * that constraint: the shop can upgrade the payment module it has taken orders with.
+     */
+    public function testUpgradeSucceedsForAPaymentModuleUsedByAnOrder(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
         $module->setActivate(BaseModule::IS_ACTIVATED)->save();
 
-        // References Cheque as its payment module, which is what blocks the deletion.
-        $this->factory->order();
+        $order = $this->factory->order(null, ['paymentModuleCode' => self::SAMPLE_CODE]);
+        self::assertSame($module->getId(), $order->getPaymentModuleId());
 
-        $definition = new ModuleDefinition();
-        $definition->setCode((string) $module->getCode());
-        $definition->setNamespace((string) $module->getFullNamespace());
-        $definition->setVersion('99.0.0');
+        $upgraded = $this->upgradeSampleModule('2.0.0');
 
-        $event = new ModuleInstallEvent();
-        $event->setModuleDefinition($definition);
-        $event->setModulePath((string) $module->getAbsoluteBaseDir());
-
-        try {
-            $this->dispatch($event, TheliaEvents::MODULE_INSTALL);
-            self::fail('Installing over a module an order was placed with should have been refused.');
-        } catch (\Exception $exception) {
-            self::assertStringContainsString('in use by at least one order', $exception->getMessage());
-        }
-
+        self::assertSame($module->getId(), $upgraded->getId());
+        self::assertSame('2.0.0', $upgraded->getVersion());
         self::assertSame(
             BaseModule::IS_ACTIVATED,
             ModuleQuery::create()->findPk($module->getId())->getActivate(),
-            'A refused upgrade must leave the module activated, not silently switched off.',
+            'An upgraded payment module must be left activated, not silently switched off.',
         );
+    }
+
+    public function testUpgradeCallsUpdateAndNotInstall(): void
+    {
+        $this->installSampleModule('1.0.0');
+
+        file_put_contents(self::CALL_LOG, '');
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            "update 1.0.0 2.0.0\n",
+            file_get_contents(self::CALL_LOG),
+            'An upgrade must call update() on the module, not install() again.',
+        );
+    }
+
+    public function testUpgradeRemovesTheFilesTheNewVersionDropped(): void
+    {
+        $this->installSampleModule('1.0.0', ['Config/dropped-in-2.0.0.txt' => 'obsolete']);
+
+        $droppedFile = THELIA_MODULE_DIR.self::SAMPLE_CODE.DS.'Config'.DS.'dropped-in-2.0.0.txt';
+        self::assertFileExists($droppedFile);
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertFileDoesNotExist(
+            $droppedFile,
+            'The files the new version no longer ships must be removed, or their classes stay autoloadable.',
+        );
+    }
+
+    public function testUpgradeOfAModuleInstalledLocallyStaysInLocalModules(): void
+    {
+        $localDirectory = THELIA_LOCAL_MODULE_DIR.self::LOCAL_SAMPLE_CODE;
+
+        $this->writeModuleFiles($localDirectory, self::LOCAL_SAMPLE_CODE, self::LOCAL_SAMPLE_NAMESPACE, '1.0.0');
+
+        $module = new Module();
+        $module
+            ->setCode(self::LOCAL_SAMPLE_CODE)
+            ->setFullNamespace(self::LOCAL_SAMPLE_NAMESPACE)
+            ->setVersion('1.0.0')
+            ->setType(BaseModule::PAYMENT_MODULE_TYPE)
+            ->setCategory('payment')
+            ->setActivate(BaseModule::IS_NOT_ACTIVATED)
+            ->save();
+
+        $this->dispatchInstall(
+            self::LOCAL_SAMPLE_CODE,
+            self::LOCAL_SAMPLE_NAMESPACE,
+            $this->buildArchive(self::LOCAL_SAMPLE_CODE, self::LOCAL_SAMPLE_NAMESPACE, '2.0.0'),
+            '2.0.0',
+        );
+
+        self::assertDirectoryDoesNotExist(
+            THELIA_MODULE_DIR.self::LOCAL_SAMPLE_CODE,
+            'Upgrading a module installed in local/modules must not leave a second copy in vendor/thelia/modules.',
+        );
+        self::assertStringContainsString(
+            '<version>2.0.0</version>',
+            file_get_contents($localDirectory.DS.'Config'.DS.'module.xml'),
+            'The new files must land where the module already lives.',
+        );
+    }
+
+    public function testReinstallingTheSameVersionRegistersTheHooksTheModuleDeclares(): void
+    {
+        $this->installSampleModule('1.0.0');
+
+        self::assertNotNull(HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE));
+
+        HookQuery::create()->filterByCode(self::DECLARED_HOOK_CODE)->delete();
+
+        $this->upgradeSampleModule('1.0.0');
+
+        self::assertNotNull(
+            HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE),
+            'Reinstalling an archive of the same version must still register the hooks the module declares.',
+        );
+    }
+
+    public function testInstallRefusesAnArchiveThatRenamesTheModuleCode(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $this->expectExceptionMessageMatches('/already installed as "'.self::SAMPLE_CODE.'"/');
+
+        $this->dispatchInstall(
+            'ZipUpgradeRenamed',
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, '2.0.0'),
+            '2.0.0',
+        );
+
+        self::assertSame('1.0.0', ModuleQuery::create()->findPk($module->getId())->getVersion());
+    }
+
+    private function installSampleModule(string $version, array $extraFiles = []): Module
+    {
+        return $this->dispatchInstall(
+            self::SAMPLE_CODE,
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, $version, $extraFiles),
+            $version,
+        );
+    }
+
+    private function upgradeSampleModule(string $version): Module
+    {
+        return $this->dispatchInstall(
+            self::SAMPLE_CODE,
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, $version),
+            $version,
+        );
+    }
+
+    private function dispatchInstall(string $code, string $namespace, string $archivePath, string $version): Module
+    {
+        $definition = new ModuleDefinition();
+        $definition->setCode($code);
+        $definition->setNamespace($namespace);
+        $definition->setVersion($version);
+
+        $event = new ModuleInstallEvent();
+        $event->setModuleDefinition($definition);
+        $event->setModulePath($archivePath);
+
+        $this->dispatch($event, TheliaEvents::MODULE_INSTALL);
+
+        return $event->getModule();
+    }
+
+    /**
+     * Writes the directory an administrator would get by unzipping an uploaded archive.
+     *
+     * @param array<string, string> $extraFiles paths relative to the module directory
+     */
+    private function buildArchive(string $code, string $namespace, string $version, array $extraFiles = []): string
+    {
+        $archiveDirectory = sys_get_temp_dir().DS.uniqid('thelia-module-archive-', true);
+        $this->archiveDirectories[] = $archiveDirectory;
+
+        $moduleDirectory = $archiveDirectory.DS.$code;
+        $this->writeModuleFiles($moduleDirectory, $code, $namespace, $version, $extraFiles);
+
+        return $moduleDirectory;
+    }
+
+    /**
+     * @param array<string, string> $extraFiles
+     */
+    private function writeModuleFiles(
+        string $moduleDirectory,
+        string $code,
+        string $namespace,
+        string $version,
+        array $extraFiles = [],
+    ): void {
+        [$moduleNamespace, $className] = explode('\\', $namespace);
+
+        $this->filesystem->dumpFile(
+            $moduleDirectory.DS.$className.'.php',
+            $this->moduleClassSource($moduleNamespace, $className),
+        );
+
+        $this->filesystem->dumpFile(
+            $moduleDirectory.DS.'Config'.DS.'module.xml',
+            $this->moduleDescriptorSource($namespace, $code, $version),
+        );
+
+        foreach ($extraFiles as $relativePath => $contents) {
+            $this->filesystem->dumpFile($moduleDirectory.DS.str_replace('/', DS, $relativePath), $contents);
+        }
+    }
+
+    private function moduleClassSource(string $moduleNamespace, string $className): string
+    {
+        $callLog = var_export(self::CALL_LOG, true);
+        $hookCode = var_export(self::DECLARED_HOOK_CODE, true);
+
+        return <<<PHP
+            <?php
+
+            namespace {$moduleNamespace};
+
+            use Propel\\Runtime\\Connection\\ConnectionInterface;
+            use Symfony\\Component\\HttpFoundation\\Response;
+            use Thelia\\Core\\Template\\TemplateDefinition;
+            use Thelia\\Model\\Order;
+            use Thelia\\Module\\BaseModule;
+            use Thelia\\Module\\PaymentModuleInterface;
+
+            class {$className} extends BaseModule implements PaymentModuleInterface
+            {
+                public function install(?ConnectionInterface \$con = null): void
+                {
+                    file_put_contents({$callLog}, "install\\n", \\FILE_APPEND);
+                }
+
+                public function update(\$currentVersion, \$newVersion, ?ConnectionInterface \$con = null): void
+                {
+                    file_put_contents({$callLog}, "update \$currentVersion \$newVersion\\n", \\FILE_APPEND);
+                }
+
+                public function getHooks(): array
+                {
+                    return [
+                        [
+                            'type' => TemplateDefinition::FRONT_OFFICE,
+                            'code' => {$hookCode},
+                            'title' => 'Zip upgrade sample hook',
+                            'active' => true,
+                        ],
+                    ];
+                }
+
+                public function pay(Order \$order): ?Response
+                {
+                    return null;
+                }
+
+                public function isValidPayment(): bool
+                {
+                    return true;
+                }
+
+                public function manageStockOnCreation(): bool
+                {
+                    return true;
+                }
+            }
+
+            PHP;
+    }
+
+    private function moduleDescriptorSource(string $namespace, string $code, string $version): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <module xmlns="http://thelia.net/schema/dic/module"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://thelia.net/schema/dic/module http://thelia.net/schema/dic/module/module-2_1.xsd">
+                <fullnamespace>{$namespace}</fullnamespace>
+                <descriptive locale="en_US">
+                    <title>{$code} from the archive</title>
+                </descriptive>
+                <languages>
+                    <language>en_US</language>
+                </languages>
+                <version>{$version}</version>
+                <author>
+                    <name>Thelia</name>
+                    <email>info@thelia.net</email>
+                </author>
+                <type>payment</type>
+                <thelia>2.5.5</thelia>
+                <stability>alpha</stability>
+            </module>
+
+            XML;
+    }
+
+    /**
+     * Installing a module reinitializes Propel, which drops the transaction this test case
+     * rolls back: the sample modules can survive a test. Clean them up on both ends so a
+     * leftover row never decides the outcome of the next run.
+     */
+    private function removeSampleModules(): void
+    {
+        $modules = ModuleQuery::create()->filterByCode(self::SAMPLE_PREFIX.'%', Criteria::LIKE)->find();
+
+        foreach ($modules as $module) {
+            OrderQuery::create()->filterByPaymentModuleId($module->getId())->delete();
+            $module->delete();
+        }
+
+        HookQuery::create()->filterByCode(self::DECLARED_HOOK_CODE)->delete();
+
+        $this->filesystem->remove(array_merge(
+            $this->archiveDirectories,
+            glob(THELIA_MODULE_DIR.self::SAMPLE_PREFIX.'*') ?: [],
+            glob(THELIA_LOCAL_MODULE_DIR.self::SAMPLE_PREFIX.'*') ?: [],
+            [self::CALL_LOG],
+        ));
+
+        $this->archiveDirectories = [];
     }
 }


### PR DESCRIPTION
Fixes #3674

Uploading a zip of a module that is already installed was not an upgrade. `Action\Module::install()` dispatched `MODULE_DELETE` on the existing row and let `ModuleManagement::updateModule()` insert a new one, so the module came back with a new id — and ten `ON DELETE CASCADE` foreign keys had emptied in between:

| Table | What the administrator lost |
|---|---|
| `module_hook` | the hooks, their **positions** and their active flag |
| `module_config` (+ `_i18n`) | the whole module configuration |
| `ignored_module_hook` | the hooks that had been switched off — they came back |
| `module_i18n` | the title, chapo and description edited in the back office |
| `module_image` (+ `_i18n`) | the module images |
| `profile_module` | the access rights of every administrator profile |
| `area_delivery_module` | the delivery areas the module was attached to |
| `coupon_module` | the coupon conditions carrying the module |
| `cart` | the payment and delivery module of the carts in progress |

`ModuleHookConfigurationStore` (#3561) does not catch this: its key starts with `module_id`, so a new id never finds its saved positions.

The module also never received the upgrade: with the row gone, `updateModule()` fell back to `action = 'install'` and called `install()` instead of `update($currentVersion, $newVersion)`, and rewrote the title from the archive descriptor.

## What changes

When `findOneByFullNamespace()` finds the namespace, the row is kept and the module is upgraded in place: no `MODULE_DELETE`, no cascade, `updateModule()` finds the row by code and calls `update()`. The `RESTRICT` on `order` is never reached either, so a payment or delivery module an order was placed with becomes upgradable again — the upgrade half of #1145.

Three points the in-place path had to handle:

- **The files of the previous version.** The directory used to be wiped by the deletion, so `mirror()` was clean by accident. It now mirrors with `delete` and `override`, otherwise the classes the new version dropped stay on disk, autoloadable and hookable.
- **Modules installed under `local/modules`.** `install()` always wrote to `THELIA_MODULE_DIR`, while `Module::getModuleDir()` gives `local/modules` priority. Keeping the row without keeping the location would leave two copies, the old one shadowing the new. The new files now go where the module already lives.
- **An archive that renames the module while keeping its namespace.** `install()` matches on the namespace, `updateModule()` matches on the code: the rename would have produced a second row and a second directory. It is refused with a message naming both codes.

Reinstalling an archive of the same version used to skip `registerHooks()` (`action = 'none'`), so a module whose files were fixed without a version bump never got its new hooks registered. It is now always called; `createOrUpdateHook()` is idempotent and the positions live in `module_hook`, which this does not touch.

`destroy()` no longer runs on an upgrade — `update()` does, which is the contract `BaseModule` already documents and what the composer path already did. A module that relied on destroy+install to migrate has to implement `update()`. Worth a line in the release notes.

## Tests

`tests/Integration/Action/ModuleActionTest.php` installs a sample module from a temporary directory standing in for an unzipped archive, then upgrades it. Every assertion was checked red before the fix.

- the row, its id and its version
- the hook positions set in the back office
- the module configuration
- the hooks the administrator switched off
- the profile access and the delivery areas
- the title edited in the back office
- **a payment module an order was placed with upgrades successfully** — this replaces `testFailedUpgradeLeavesTheModuleActivated`, which asserted the refusal that this PR removes
- `update()` is called, not `install()`
- the files the new version dropped are removed
- a module installed in `local/modules` stays there
- reinstalling the same version registers the declared hooks
- an archive renaming the module code is refused

`composer test` 5/5 green (1018 tests), `composer cs-diff` 0/1818, `composer phpstan` 0 errors.

Refs #1145, #3671, #3670, #3561, #3585
