### PR TITLE
test: cover the per-module postage tax rule screen

### DIFF
--- a/tests/Playwright/poms/backoffice/taxes-rules-page.ts
+++ b/tests/Playwright/poms/backoffice/taxes-rules-page.ts
@@ -49,4 +49,20 @@ export class TaxesRulesPage extends BaseAdminPage {
   get deleteTaxRuleForm(): Locator {
     return this.page.getByTestId('tax-rule-delete-form');
   }
+
+  get postageTaxRuleCard(): Locator {
+    return this.page.getByTestId('postage-tax-rule-card');
+  }
+
+  get postageTaxRuleForm(): Locator {
+    return this.page.getByTestId('postage-tax-rule-form');
+  }
+
+  get postageTaxRuleSave(): Locator {
+    return this.page.getByTestId('postage-tax-rule-save');
+  }
+
+  postageTaxRuleRow(moduleCode: string): Locator {
+    return this.page.getByTestId(`postage-tax-rule-row-${moduleCode}`);
+  }
 }

--- a/tests/Playwright/specs/backoffice/taxes-rules-list.spec.ts
+++ b/tests/Playwright/specs/backoffice/taxes-rules-list.spec.ts
@@ -53,4 +53,38 @@ test.describe('Back-office — Taxes rules list (BO Twig)', () => {
 
     await expect(listPage.deleteTaxRuleForm).toBeAttached();
   });
+
+  test('every activated delivery module gets a postage tax rule selector', async ({ page }) => {
+    const listPage = new TaxesRulesPage(page);
+    await listPage.goto();
+
+    await expect(listPage.postageTaxRuleCard).toBeVisible();
+    await expect(listPage.postageTaxRuleForm).toBeVisible();
+
+    const row = listPage.postageTaxRuleRow('CustomDelivery');
+    await expect(row).toBeVisible();
+    await expect(row.locator('select')).toBeVisible();
+  });
+
+  test('a postage tax rule survives its save', async ({ page }) => {
+    const listPage = new TaxesRulesPage(page);
+    await listPage.goto();
+
+    const select = listPage.postageTaxRuleRow('CustomDelivery').locator('select');
+    const taxRule = await select.locator('option:not([value=""])').first().getAttribute('value');
+    expect(taxRule).not.toBeNull();
+
+    await select.selectOption(taxRule as string);
+    await listPage.postageTaxRuleSave.click();
+    await listPage.expectLoaded();
+
+    await expect(listPage.postageTaxRuleRow('CustomDelivery').locator('select')).toHaveValue(
+      taxRule as string,
+    );
+
+    // Back to the shop-wide rule, so the run leaves no setting behind.
+    await listPage.postageTaxRuleRow('CustomDelivery').locator('select').selectOption('');
+    await listPage.postageTaxRuleSave.click();
+    await listPage.expectLoaded();
+  });
 });


### PR DESCRIPTION
Closes #3695.

#3664 gave every delivery module its own postage tax rule in `module_config.postage_tax_rule_id`, and no screen wrote it. The screen landed in thelia-templates/default-twig#32: the tax rules page now lists the activated delivery modules under the shop-wide rule, each with its own selector, "Shop default" meaning the shop-wide rule. Modules that resolve their own postage tax rule are flagged as such, since the shared key never reaches them.

This adds the back-office end-to-end coverage for it: the section renders a selector per activated delivery module, and a saved rule comes back selected after the round trip. Verified against a running install with `BO_TEMPLATE=default-twig`, 7 passed; the new selector test was checked red by renaming the card's test id.

`phpstan-botwig` was red on `main` before this branch, on a single pre-existing error in the theme (`array_values` on an already-list value) — run 31679027603 on `main` at d53ce82c. thelia-templates/default-twig#32 removes it, so the job goes green again here.
