### PR TITLE
fix: stop Customer::getLocale() from fatalling when the account has no language

### DIFF
--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -163,16 +163,7 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
      */
     public function getCustomerLang()
     {
-        $lang = $this->getLangModel();
-
-        if ($lang === null) {
-            $lang = (new LangQuery())
-                ->filterByByDefault(1)
-                ->findOne()
-            ;
-        }
-
-        return $lang;
+        return $this->getLangModel() ?? Lang::getDefaultLanguage();
     }
 
     /**
@@ -346,7 +337,7 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
      */
     public function getLocale()
     {
-        return $this->getLangModel()->getLocale();
+        return $this->getCustomerLang()->getLocale();
     }
 
     public function hasOrder()

--- a/tests/Legacy/Model/CustomerLocaleTest.php
+++ b/tests/Legacy/Model/CustomerLocaleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Model\Customer;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+
+/**
+ * The customer.lang_id column is nullable, and the lang foreign key sets it back
+ * to NULL when a language is deleted, so a customer without a language is a
+ * reachable state that getLocale() has to answer for.
+ */
+class CustomerLocaleTest extends TestCase
+{
+    public function testLocaleFallsBackToTheDefaultLanguageWhenTheCustomerHasNone(): void
+    {
+        $defaultLang = LangQuery::create()->findOneByByDefault(1);
+        $this->assertNotNull($defaultLang, 'the database defines a default language');
+
+        $customer = new Customer();
+        $this->assertNull($customer->getLangId(), 'a new customer carries no language');
+
+        $this->assertEquals($defaultLang->getLocale(), $customer->getLocale());
+    }
+
+    public function testLocaleIsTheCustomerOwnLanguageWhenItHasOne(): void
+    {
+        $lang = new Lang();
+        $lang->setLocale('de_DE');
+
+        $customer = new Customer();
+        $customer->setLangModel($lang);
+
+        $this->assertEquals('de_DE', $customer->getLocale());
+    }
+}


### PR DESCRIPTION
Fixes #3702. Backport of the 3.0 fix — #3669, merged as #3688.

`Customer::getLocale()` dereferenced the language relation without a guard, so a customer with no language made it fatal with `Call to a member function getLocale() on null`, while the interface it implements (`Thelia\Core\Security\User\UserInterface:99`) declares the method.

`customer.lang_id` is nullable by design and the foreign key is declared `onDelete="SET NULL"`, so deleting a language in the back-office empties the column for every customer that used it. The demo data ships without a language too — `setup/import.php` calls `createOrUpdate()` stopping at `$plainPassword`.

No core path reaches it today: `MailerFactory` already goes through `getCustomerLang()`, and the customer remember-me path never calls `applyUserLocale()`, only the admin one does. What is fixed here is the contract the model could not honour, which any module or template coding against `UserInterface` runs into.

`getLocale()` now goes through `getCustomerLang()`, which already implements that fallback, so the rule lives in one place. `getCustomerLang()` itself switches to `Lang::getDefaultLanguage()`: it is documented as returning a `Lang` but ended on `findOne()`, which returns `null` on a shop with no default language — the helper raises `No default language is defined. Please define one.` instead of a `TypeError` further down.

No schema change and no migration for existing databases: `NULL` keeps its meaning of "no preference, follow the shop default", and the guard makes it safe again.

The new test in the legacy suite was verified red before the fix, reproducing the exact fatal at `Customer.php:349`, and green after.
