### PR TITLE
fix: keep declared public visibility when the PSR-4 registration redefines a service

### DIFF
--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
 use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
 use Thelia\Core\Cache\ConfigCacheService;
@@ -25,7 +26,7 @@ use Thelia\Model\ConfigQuery;
 use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
-return static function (ContainerConfigurator $configurator): void {
+return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
     // Import service configurations
     $configurator->import('packages/*');
     $configurator->import('parameters/*');
@@ -52,6 +53,21 @@ return static function (ContainerConfigurator $configurator): void {
         ->bind('$apiResourceAddons', '%Thelia.api.resource.addons%')
         ->bind(Request::class, expr('service("request_stack").getMainRequest()'));
 
+    // TheliaKernel loads this file twice: once from configureContainer(), then again from
+    // buildContainer() through loadService(). The PSR-4 registration below redefines every
+    // Thelia\ class, so the second pass overwrites the definitions the services/*.php files
+    // declared in between and drops the public flag they set. The container then rejects
+    // $container->get() on those services (see https://github.com/thelia/thelia/issues/3675).
+    // Note which services are public before the registration and mark them public again after,
+    // so a declared visibility survives whatever the load redefines.
+    $publicServiceIds = [];
+
+    foreach ($container->getDefinitions() as $serviceId => $definition) {
+        if ($definition->isPublic()) {
+            $publicServiceIds[] = $serviceId;
+        }
+    }
+
     $serviceConfigurator->load('Thelia\\', THELIA_LIB)
         ->exclude(
             [
@@ -61,6 +77,12 @@ return static function (ContainerConfigurator $configurator): void {
         )
         ->autowire()
         ->autoconfigure();
+
+    foreach ($publicServiceIds as $serviceId) {
+        if ($container->hasDefinition($serviceId)) {
+            $container->getDefinition($serviceId)->setPublic(true);
+        }
+    }
 
     $serviceConfigurator->set(SessionStorageFactory::class)
         ->args(['%kernel.project_dir%/var/sessions/%kernel.environment%'])


### PR DESCRIPTION
`Config/Resources/services.php` is loaded twice during the container build: once from `TheliaKernel::configureContainer()`, which then imports every `Config/Resources/services/**/*.php` file (`core/lib/Thelia/Core/TheliaKernel.php:188-197`), and once more from `TheliaKernel::buildContainer()` through `loadService()` (`:366`, `:511-516`).

The second pass replays the PSR-4 registration of the whole `Thelia\` namespace (`services.php:55-63`), which redefines those classes as fresh autowired, private services — throwing away the public flag the `services/**` files had just set on them. The declaration reads as if it works; the failure only surfaces at runtime, on the first `$container->get()`, with a message that blames inlining (#3675).

This change notes which definitions are public just before the registration and marks them public again just after, so a declared visibility survives whatever the load redefines. Nothing else about the definitions is restored: the autowired definition the container has been using all along stays in place, so this is a visibility-only change.

## Services affected today

Replaying both loading passes over `main` gives three definitions that currently lose their flag:

| Service | Declared in |
| --- | --- |
| `Thelia\Core\Serializer\SerializerManager` | `services/core/serializers.php:25-29` |
| `Thelia\Core\Archiver\ArchiverManager` | `services/handlers/archiver.php:26-30` |
| `Thelia\Controller\Api\RefreshTokenController` | `services/core/security.php` |

The controller has no visible consequence: a later compiler pass makes controllers public again. The two managers are the ones that broke `php Thelia export` on every reference (#3675).

Every other `->public()` under `Config/Resources/services/**` targets an alias or a string service id, which the PSR-4 load never redefines, so those are unaffected — including the `thelia.serializer.manager` and `thelia.archiver.manager` aliases, which stayed public and pointed at a private id.

The existing `ConfigCacheService` workaround (`services.php:142-143`, the only service that already got its visibility back by being re-declared after the load) is left as is; it is now covered by the same mechanism.

## Verification

Replaying `TheliaKernel`'s two passes over the config directory, and counting public definitions after each:

```
before:  public after configureContainer: 12   after loadService: 9    lost: 3
after:   public after configureContainer: 12   after loadService: 12   lost: 0
```

The three ids listed above are exactly the ones in the `lost` set, and `debug:container` on the current build confirms the two managers as `Public no` / `Autowired yes` — the signature of the load, not of their own `set()`.

The test environment cannot cover this: `TheliaBundle` registers `TestPublicServicesPass` for `test` (`core/lib/Thelia/Core/Bundle/TheliaBundle.php:77-79`), which makes every `Thelia\`-prefixed service public, so a test would pass either way.

Fixes #3707
