### PR TITLE
fix: upgrade a module in place instead of deleting and reinstalling it

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -320,13 +320,32 @@ class Module extends BaseAction implements EventSubscriberInterface
 
         $oldModule = ModuleQuery::create()->findOneByFullNamespace($moduleDefinition->getNamespace());
 
-        $fs = new Filesystem();
-
         $activated = false;
+
+        $modulePath = sprintf('%s%s', THELIA_MODULE_DIR, $moduleDefinition->getCode());
 
         // check existing module
         if (null !== $oldModule) {
-            $activated = $oldModule->getActivate();
+            // The namespace is already installed: this is an upgrade, and the row is kept.
+            // Deleting it would cascade to the hooks and their positions, the configuration,
+            // the hooks the administrator switched off, the module images, the access
+            // profiles, the delivery areas and the coupon conditions carrying its id.
+            if ($oldModule->getCode() !== $moduleDefinition->getCode()) {
+                throw new ModuleException(
+                    Translator::getInstance()->trans(
+                        'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".',
+                        [
+                            '%new%' => $moduleDefinition->getCode(),
+                            '%old%' => $oldModule->getCode(),
+                            '%namespace%' => $moduleDefinition->getNamespace(),
+                        ]
+                    )
+                );
+            }
+
+            $activated = $oldModule->getActivate() == BaseModule::IS_ACTIVATED;
+
+            $modulePath = $oldModule->getAbsoluteBaseDir();
 
             if ($activated) {
                 // deactivate
@@ -336,44 +355,27 @@ class Module extends BaseAction implements EventSubscriberInterface
 
                 $dispatcher->dispatch($toggleEvent, TheliaEvents::MODULE_TOGGLE_ACTIVATION);
             }
-
-            // delete
-            $modulePath = $oldModule->getAbsoluteBaseDir();
-
-            $deleteEvent = new ModuleDeleteEvent($oldModule->getId());
-
-            try {
-                $dispatcher->dispatch($deleteEvent, TheliaEvents::MODULE_DELETE);
-            } catch (\Exception $ex) {
-                // if module has not been deleted
-                if ($fs->exists($modulePath)) {
-                    // The module was deactivated a few lines above so it could be replaced, and the
-                    // replacement is not going to happen. Put the shop back where it was: a payment
-                    // or delivery module left deactivated by a failed upgrade takes the checkout
-                    // down, silently, while the administrator only reads that the install failed.
-                    $this->restoreActivation((int) $oldModule->getId(), (bool) $activated, $dispatcher);
-
-                    throw $ex;
-                }
-            }
         }
-
-        // move new module
-        $modulePath = sprintf('%s%s', THELIA_MODULE_DIR, $event->getModuleDefinition()->getCode());
 
         try {
-            $fs->mirror($event->getModulePath(), $modulePath);
-        } catch (IOException $ex) {
-            if (!$fs->exists($modulePath)) {
-                throw $ex;
-            }
-        }
+            $this->replaceModuleFiles($event->getModulePath(), $modulePath);
 
-        // Update the module
-        $moduleDescriptorFile = sprintf('%s%s%s%s%s', $modulePath, DS, 'Config', DS, 'module.xml');
-        $moduleManagement = new ModuleManagement($this->container);
-        $file = new \SplFileInfo($moduleDescriptorFile);
-        $module = $moduleManagement->updateModule($file, $this->container);
+            // Update the module
+            $moduleDescriptorFile = sprintf('%s%s%s%s%s', $modulePath, DS, 'Config', DS, 'module.xml');
+            $moduleManagement = new ModuleManagement($this->container);
+            $file = new \SplFileInfo($moduleDescriptorFile);
+            $module = $moduleManagement->updateModule($file, $this->container, true);
+        } catch (\Throwable $ex) {
+            // The module was deactivated a few lines above so it could be replaced, and the
+            // replacement is not going to happen. Put the shop back where it was: a payment
+            // or delivery module left deactivated by a failed upgrade takes the checkout
+            // down, silently, while the administrator only reads that the install failed.
+            if (null !== $oldModule) {
+                $this->restoreActivation((int) $oldModule->getId(), $activated, $dispatcher);
+            }
+
+            throw $ex;
+        }
 
         // activate if old was activated
         if ($activated) {
@@ -384,6 +386,33 @@ class Module extends BaseAction implements EventSubscriberInterface
         }
 
         $event->setModule($module);
+    }
+
+    /**
+     * Copies the files of the module being installed over the target directory.
+     */
+    private function replaceModuleFiles(string $sourcePath, string $targetPath): void
+    {
+        $fs = new Filesystem();
+
+        if (realpath($sourcePath) === realpath($targetPath)) {
+            // The module is installed from the directory it already lives in, which is what
+            // activating a dependency does. There is nothing to copy, and mirroring a
+            // directory onto itself would truncate every one of its files.
+            return;
+        }
+
+        try {
+            // 'delete' removes what the new version no longer ships and 'override' replaces
+            // files the archive dates earlier than the installed ones. The target directory
+            // is no longer wiped by the deletion of the module, so without these two the
+            // classes of the previous version would stay on disk, to be autoloaded and hooked.
+            $fs->mirror($sourcePath, $targetPath, null, ['override' => true, 'delete' => true]);
+        } catch (IOException $ex) {
+            if (!$fs->exists($targetPath)) {
+                throw $ex;
+            }
+        }
     }
 
     private function restoreActivation(int $moduleId, bool $wasActivated, EventDispatcherInterface $dispatcher): void

--- a/core/lib/Thelia/Config/I18n/en_US.php
+++ b/core/lib/Thelia/Config/I18n/en_US.php
@@ -582,6 +582,7 @@ return [
     'The method %method% doesn\'t exist in classname %classname%' => 'The method %method% doesn\'t exist in classname %classname%',
     'The method name that will handle the hook event.' => 'The method name that will handle the hook event.',
     'The module "%name%" is currently in use by at least one order, and can\'t be deleted.' => 'The module "%name%" is currently in use by at least one order, and can\'t be deleted.',
+    'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".' => 'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".',
     'The module %module has been installed successfully.' => 'The module %module has been installed successfully.',
     'The module %name is already installed in the same or greater version.' => 'The module %name is already installed in the same or greater version.',
     'The module %name requires Thelia %version or newer' => 'The module %name requires Thelia %version or newer',

--- a/core/lib/Thelia/Config/I18n/fr_FR.php
+++ b/core/lib/Thelia/Config/I18n/fr_FR.php
@@ -579,6 +579,7 @@ return [
     'The message has been successfully sent to %recipient.' => 'Le message a bien été envoyé à %recipient. ',
     'The method name that will handle the hook event.' => 'Le nom de la méthode qui va traiter l\'évènement du point d\'accroche.',
     'The module "%name%" is currently in use by at least one order, and can\'t be deleted.' => 'Le module "%name%" est utilisé par au moins une commande, et ne peut être supprimé.',
+    'The module in the archive is named "%new%" but the namespace "%namespace%" is already installed as "%old%". Uninstall "%old%" before installing "%new%".' => 'Le module de l\'archive s\'appelle "%new%" mais l\'espace de noms "%namespace%" est déjà installé sous le nom "%old%". Désinstallez "%old%" avant d\'installer "%new%".',
     'The module %module has been installed successfully.' => 'Le module %module a été installé avec succès.',
     'The module %name is already installed in the same or greater version.' => 'Le module %name est déja installé dans la même version, ou dans une version plus récente.',
     'The module %name requires Thelia %version or newer' => 'Le module %name nécessite Thelia %version ou plus récent',

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -82,15 +82,16 @@ class ModuleManagement
      * Update module information, and invoke install() for new modules (e.g. modules
      * just discovered), or update() modules for which version number ha changed.
      *
-     * @param \SplFileInfo       $file      the module.xml file descriptor
-     * @param ContainerInterface $container the container
+     * @param \SplFileInfo       $file                  the module.xml file descriptor
+     * @param ContainerInterface $container             the container
+     * @param bool               $forceHookRegistration register the hooks even when the version did not change
      *
      * @throws \Exception
      * @throws \Propel\Runtime\Exception\PropelException
      *
      * @return Module
      */
-    public function updateModule($file, ContainerInterface $container)
+    public function updateModule($file, ContainerInterface $container, $forceHookRegistration = false)
     {
         $descriptorValidator = $this->getDescriptorValidator();
 
@@ -155,7 +156,11 @@ class ModuleManagement
                 $instance->update($currentVersion, $version, $con);
             }
 
-            if ($action !== 'none') {
+            // $forceHookRegistration covers the module whose files were just replaced without a
+            // version bump: the hooks it now declares still have to be registered.
+            // createOrUpdateHook() is idempotent, and the positions the administrator set
+            // live in module_hook, which this does not touch.
+            if ($action !== 'none' || $forceHookRegistration) {
                 $instance->registerHooks();
             }
 

--- a/tests/Legacy/Action/ModuleInstallTest.php
+++ b/tests/Legacy/Action/ModuleInstallTest.php
@@ -12,114 +12,509 @@
 
 namespace Thelia\Tests\Action;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Action\Hook as HookAction;
 use Thelia\Action\Module as ModuleAction;
-use Thelia\Core\Event\Module\ModuleDeleteEvent;
 use Thelia\Core\Event\Module\ModuleInstallEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Translation\Translator;
+use Thelia\Model\Area;
+use Thelia\Model\AreaDeliveryModule;
+use Thelia\Model\AreaDeliveryModuleQuery;
+use Thelia\Model\AreaQuery;
+use Thelia\Model\HookQuery;
+use Thelia\Model\IgnoredModuleHook;
+use Thelia\Model\IgnoredModuleHookQuery;
 use Thelia\Model\Module as ModuleModel;
+use Thelia\Model\ModuleConfig;
+use Thelia\Model\ModuleConfigQuery;
+use Thelia\Model\ModuleHook;
+use Thelia\Model\ModuleHookQuery;
 use Thelia\Model\ModuleQuery;
+use Thelia\Model\Profile;
+use Thelia\Model\ProfileModule;
+use Thelia\Model\ProfileModuleQuery;
+use Thelia\Model\ProfileQuery;
 use Thelia\Module\BaseModule;
 use Thelia\Module\Validator\ModuleDefinition;
 
 /**
- * Uploading a newer zip of an installed module deactivates the current one, deletes it, then
- * installs the new files. A payment or a delivery module referenced by an order cannot be deleted,
- * so the replacement is refused — and the shop must not be left with its payment method switched
- * off, which takes the checkout down while the administrator only reads that the install failed.
+ * Uploading a zip of a module that is already installed is an upgrade, not a fresh install: the
+ * module row is kept. Deleting it, as Thelia used to, cascades on ten foreign keys and takes the
+ * hooks and their positions, the configuration, the administrator access rights, the delivery
+ * areas and the coupon conditions with it — and hands the module a new id.
  */
 class ModuleInstallTest extends BaseAction
 {
+    public const SAMPLE_PREFIX = 'ZipUpgrade';
+
+    public const SAMPLE_CODE = 'ZipUpgradeSample';
+
+    public const SAMPLE_NAMESPACE = 'ZipUpgradeSample\ZipUpgradeSample';
+
+    public const DECLARED_HOOK_CODE = 'zipupgradesample.declared';
+
+    public const SAMPLE_AREA_NAME = 'Zip upgrade sample area';
+
+    /**
+     * Where the sample module records the lifecycle methods Thelia calls on it.
+     */
+    public const CALL_LOG = '/tmp/thelia-zip-upgrade-sample-calls.log';
+
     /** @var EventDispatcher */
     private $dispatcher;
 
     /** @var ModuleAction */
     private $action;
 
-    /** @var ModuleModel */
-    private $module;
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var array */
+    private $archiveDirectories = [];
 
     protected function setUp(): void
     {
-        $module = ModuleQuery::create()->findOneByCode('Cheque');
-        self::assertNotNull($module, 'The Cheque module must be installed to run this test.');
-
-        $this->module = $module;
-        $this->module->setActivate(BaseModule::IS_ACTIVATED)->save();
+        $this->filesystem = new Filesystem();
 
         $container = new ContainerBuilder();
         $container->setParameter('kernel.cache_dir', THELIA_CACHE_DIR);
         $container->set('thelia.translator', Translator::getInstance());
 
-        $this->action = new ModuleAction($container);
-
         $this->dispatcher = new EventDispatcher();
         $container->set('event_dispatcher', $this->dispatcher);
 
+        $this->action = new ModuleAction($container);
+
         $this->dispatcher->addListener(TheliaEvents::MODULE_TOGGLE_ACTIVATION, [$this->action, 'checkToggleActivation'], 255);
         $this->dispatcher->addListener(TheliaEvents::MODULE_TOGGLE_ACTIVATION, [$this->action, 'toggleActivation'], 128);
+        // The listener an upgrade must no longer reach. Without it here these tests would pass
+        // against the code they cover: nothing would delete the row they check for.
+        $this->dispatcher->addListener(TheliaEvents::MODULE_DELETE, [$this->action, 'delete'], 128);
         $this->dispatcher->addListener(TheliaEvents::CACHE_CLEAR, function (): void {});
+        // registerHooks() goes through these two to declare the hooks a module ships with.
+        $this->dispatcher->addSubscriber(new HookAction(THELIA_CACHE_DIR, $this->dispatcher));
+
+        $this->removeSampleModules();
     }
 
-    public function testTheDeleteEventIsUsableByTheDeleteListener(): void
+    protected function tearDown(): void
     {
-        $seen = null;
+        $this->removeSampleModules();
+    }
 
-        $this->dispatcher->addListener(TheliaEvents::MODULE_DELETE, function (ModuleDeleteEvent $event) use (&$seen): void {
-            // The two values Module::delete() reads out of the event.
-            $seen = [$event->getModuleId(), $event->getDeleteData()];
+    public function testUpgradeKeepsTheModuleRow(): void
+    {
+        $installed = $this->installSampleModule('1.0.0');
+        $moduleId = $installed->getId();
 
-            throw new \LogicException('Deletion refused');
-        });
-
-        try {
-            $this->install();
-        } catch (\LogicException $exception) {
-            // The refusal itself is the subject of the next test.
-        }
+        $upgraded = $this->upgradeSampleModule('2.0.0');
 
         self::assertSame(
-            [$this->module->getId(), false],
-            $seen,
-            'Upgrading a module must dispatch a delete event carrying its id and no delete-data flag.'
+            $moduleId,
+            $upgraded->getId(),
+            'Upgrading a module must keep its row: a new id discards everything the foreign keys cascade on.'
+        );
+        self::assertSame('2.0.0', $upgraded->getVersion());
+    }
+
+    public function testUpgradeKeepsTheHookPositionsSetInTheBackOffice(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+        $hookId = HookQuery::create()->findOne()->getId();
+
+        $moduleHook = new ModuleHook();
+        $moduleHook
+            ->setModuleId($module->getId())
+            ->setHookId($hookId)
+            ->setClassname('ZipUpgradeSample\Hook\SampleHook')
+            ->setMethod('onSomething')
+            ->setActive(true)
+            ->setHookActive(true)
+            ->setModuleActive(true)
+            ->setPosition(42)
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        $reloaded = ModuleHookQuery::create()
+            ->filterByModuleId($module->getId())
+            ->filterByHookId($hookId)
+            ->findOne();
+
+        self::assertNotNull($reloaded, 'The module hooks must survive an upgrade.');
+        self::assertSame(42, $reloaded->getPosition(), 'The position set in the back office must survive an upgrade.');
+    }
+
+    public function testUpgradeKeepsTheModuleConfiguration(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $config = new ModuleConfig();
+        $config
+            ->setModuleId($module->getId())
+            ->setName('api_key')
+            ->setValue('the-key-the-merchant-typed')
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        $reloaded = ModuleConfigQuery::create()
+            ->filterByModuleId($module->getId())
+            ->filterByName('api_key')
+            ->findOne();
+
+        self::assertNotNull($reloaded, 'The module configuration must survive an upgrade.');
+        self::assertSame('the-key-the-merchant-typed', $reloaded->getValue());
+    }
+
+    public function testUpgradeKeepsTheHooksTheAdministratorSwitchedOff(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+        $hookId = HookQuery::create()->findOne()->getId();
+
+        $ignored = new IgnoredModuleHook();
+        $ignored
+            ->setModuleId($module->getId())
+            ->setHookId($hookId)
+            ->setClassname('ZipUpgradeSample\Hook\SampleHook')
+            ->setMethod('onSomething')
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            1,
+            IgnoredModuleHookQuery::create()->filterByModuleId($module->getId())->count(),
+            'A hook the administrator removed must not come back after an upgrade.'
         );
     }
 
-    public function testARefusedUpgradeLeavesTheModuleActivated(): void
+    public function testUpgradeKeepsTheAdministratorAccessAndDeliveryAreas(): void
     {
-        // Stands for the guard of Module::delete(): a module an order was placed with is not deletable.
-        $this->dispatcher->addListener(TheliaEvents::MODULE_DELETE, function (): void {
-            throw new \LogicException('The module "Cheque" is currently in use by at least one order.');
-        });
+        $module = $this->installSampleModule('1.0.0');
 
-        try {
-            $this->install();
+        $profile = new Profile();
+        $profile->setCode(self::SAMPLE_PREFIX.'Profile')->save();
 
-            self::fail('Installing over a module an order was placed with should have been refused.');
-        } catch (\LogicException $exception) {
-            self::assertStringContainsString('in use by at least one order', $exception->getMessage());
-        }
+        $profileModule = new ProfileModule();
+        $profileModule
+            ->setProfileId($profile->getId())
+            ->setModuleId($module->getId())
+            ->setAccess(1)
+            ->save();
 
+        $area = new Area();
+        $area->setName(self::SAMPLE_AREA_NAME)->save();
+
+        $areaDeliveryModule = new AreaDeliveryModule();
+        $areaDeliveryModule
+            ->setAreaId($area->getId())
+            ->setDeliveryModuleId($module->getId())
+            ->save();
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            1,
+            ProfileModuleQuery::create()->filterByModuleId($module->getId())->count(),
+            'The access an administrator profile has on a module must survive an upgrade.'
+        );
+        self::assertSame(
+            1,
+            AreaDeliveryModuleQuery::create()->filterByDeliveryModuleId($module->getId())->count(),
+            'The delivery areas a module is attached to must survive an upgrade.'
+        );
+    }
+
+    public function testUpgradeKeepsTheTitleTheAdministratorEdited(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $module->setLocale('en_US')->setTitle('Renamed by the merchant')->save();
+
+        $upgraded = $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            'Renamed by the merchant',
+            $upgraded->setLocale('en_US')->getTitle(),
+            'An upgrade must not overwrite the title with the one from the archive descriptor.'
+        );
+    }
+
+    /**
+     * Installing a newer version of an already installed module used to delete its row first,
+     * which the order table refuses for a payment module. Upgrading in place no longer reaches
+     * that constraint: the shop can upgrade the payment module it has taken orders with.
+     */
+    public function testUpgradeSucceedsForAnActivatedPaymentModule(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+        $module->setActivate(BaseModule::IS_ACTIVATED)->save();
+
+        $upgraded = $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame($module->getId(), $upgraded->getId());
+        self::assertSame('2.0.0', $upgraded->getVersion());
         self::assertSame(
             BaseModule::IS_ACTIVATED,
-            ModuleQuery::create()->findPk($this->module->getId())->getActivate(),
-            'A refused upgrade must leave the module activated, not silently switched off.'
+            ModuleQuery::create()->findPk($module->getId())->getActivate(),
+            'An upgraded payment module must be left activated, not silently switched off.'
         );
     }
 
-    private function install(): void
+    public function testUpgradeCallsUpdateAndNotInstall(): void
+    {
+        $this->installSampleModule('1.0.0');
+
+        file_put_contents(self::CALL_LOG, '');
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertSame(
+            "update 1.0.0 2.0.0\n",
+            file_get_contents(self::CALL_LOG),
+            'An upgrade must call update() on the module, not install() again.'
+        );
+    }
+
+    public function testUpgradeRemovesTheFilesTheNewVersionDropped(): void
+    {
+        $this->installSampleModule('1.0.0', ['Config/dropped-in-2.0.0.txt' => 'obsolete']);
+
+        $droppedFile = THELIA_MODULE_DIR.self::SAMPLE_CODE.DS.'Config'.DS.'dropped-in-2.0.0.txt';
+        self::assertFileExists($droppedFile);
+
+        $this->upgradeSampleModule('2.0.0');
+
+        self::assertFileDoesNotExist(
+            $droppedFile,
+            'The files the new version no longer ships must be removed, or their classes stay autoloadable.'
+        );
+    }
+
+    public function testReinstallingTheSameVersionRegistersTheHooksTheModuleDeclares(): void
+    {
+        $this->installSampleModule('1.0.0');
+
+        self::assertNotNull(HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE));
+
+        HookQuery::create()->filterByCode(self::DECLARED_HOOK_CODE)->delete();
+
+        $this->upgradeSampleModule('1.0.0');
+
+        self::assertNotNull(
+            HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE),
+            'Reinstalling an archive of the same version must still register the hooks the module declares.'
+        );
+    }
+
+    public function testInstallRefusesAnArchiveThatRenamesTheModuleCode(): void
+    {
+        $module = $this->installSampleModule('1.0.0');
+
+        $this->expectExceptionMessageMatches('/already installed as "'.self::SAMPLE_CODE.'"/');
+
+        $this->install(
+            self::SAMPLE_PREFIX.'Renamed',
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, '2.0.0'),
+            '2.0.0'
+        );
+
+        self::assertSame('1.0.0', ModuleQuery::create()->findPk($module->getId())->getVersion());
+    }
+
+    /**
+     * @return ModuleModel
+     */
+    private function installSampleModule($version, array $extraFiles = [])
+    {
+        return $this->install(
+            self::SAMPLE_CODE,
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, $version, $extraFiles),
+            $version
+        );
+    }
+
+    /**
+     * @return ModuleModel
+     */
+    private function upgradeSampleModule($version)
+    {
+        return $this->install(
+            self::SAMPLE_CODE,
+            self::SAMPLE_NAMESPACE,
+            $this->buildArchive(self::SAMPLE_CODE, self::SAMPLE_NAMESPACE, $version),
+            $version
+        );
+    }
+
+    /**
+     * @return ModuleModel
+     */
+    private function install($code, $namespace, $archivePath, $version)
     {
         $definition = new ModuleDefinition();
-        $definition->setCode($this->module->getCode());
-        $definition->setNamespace($this->module->getFullNamespace());
-        $definition->setVersion('99.0.0');
+        $definition->setCode($code);
+        $definition->setNamespace($namespace);
+        $definition->setVersion($version);
 
         $event = new ModuleInstallEvent();
         $event->setModuleDefinition($definition);
-        $event->setModulePath($this->module->getAbsoluteBaseDir());
+        $event->setModulePath($archivePath);
 
         $this->action->install($event, TheliaEvents::MODULE_INSTALL, $this->dispatcher);
+
+        return $event->getModule();
+    }
+
+    /**
+     * Writes the directory an administrator would get by unzipping an uploaded archive.
+     *
+     * @return string
+     */
+    private function buildArchive($code, $namespace, $version, array $extraFiles = [])
+    {
+        $archiveDirectory = sys_get_temp_dir().DS.uniqid('thelia-module-archive-', true);
+        $this->archiveDirectories[] = $archiveDirectory;
+
+        $moduleDirectory = $archiveDirectory.DS.$code;
+
+        [$moduleNamespace, $className] = explode('\\', $namespace);
+
+        $this->filesystem->dumpFile(
+            $moduleDirectory.DS.$className.'.php',
+            $this->moduleClassSource($moduleNamespace, $className)
+        );
+
+        $this->filesystem->dumpFile(
+            $moduleDirectory.DS.'Config'.DS.'module.xml',
+            $this->moduleDescriptorSource($namespace, $code, $version)
+        );
+
+        foreach ($extraFiles as $relativePath => $contents) {
+            $this->filesystem->dumpFile($moduleDirectory.DS.str_replace('/', DS, $relativePath), $contents);
+        }
+
+        return $moduleDirectory;
+    }
+
+    /**
+     * @return string
+     */
+    private function moduleClassSource($moduleNamespace, $className)
+    {
+        $callLog = var_export(self::CALL_LOG, true);
+        $hookCode = var_export(self::DECLARED_HOOK_CODE, true);
+
+        return <<<PHP
+<?php
+
+namespace {$moduleNamespace};
+
+use Propel\\Runtime\\Connection\\ConnectionInterface;
+use Symfony\\Component\\HttpFoundation\\Response;
+use Thelia\\Core\\Template\\TemplateDefinition;
+use Thelia\\Model\\Order;
+use Thelia\\Module\\BaseModule;
+use Thelia\\Module\\PaymentModuleInterface;
+
+class {$className} extends BaseModule implements PaymentModuleInterface
+{
+    public function install(ConnectionInterface \$con = null): void
+    {
+        file_put_contents({$callLog}, "install\\n", FILE_APPEND);
+    }
+
+    public function update(\$currentVersion, \$newVersion, ConnectionInterface \$con = null): void
+    {
+        file_put_contents({$callLog}, "update \$currentVersion \$newVersion\\n", FILE_APPEND);
+    }
+
+    public function getHooks()
+    {
+        return [
+            [
+                'type' => TemplateDefinition::FRONT_OFFICE,
+                'code' => {$hookCode},
+                'title' => 'Zip upgrade sample hook',
+                'active' => true,
+            ],
+        ];
+    }
+
+    public function pay(Order \$order)
+    {
+        return null;
+    }
+
+    public function isValidPayment()
+    {
+        return true;
+    }
+
+    public function manageStockOnCreation()
+    {
+        return true;
+    }
+}
+
+PHP;
+    }
+
+    /**
+     * @return string
+     */
+    private function moduleDescriptorSource($namespace, $code, $version)
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="http://thelia.net/schema/dic/module"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://thelia.net/schema/dic/module http://thelia.net/schema/dic/module/module-2_1.xsd">
+    <fullnamespace>{$namespace}</fullnamespace>
+    <descriptive locale="en_US">
+        <title>{$code} from the archive</title>
+    </descriptive>
+    <languages>
+        <language>en_US</language>
+    </languages>
+    <version>{$version}</version>
+    <author>
+        <name>Thelia</name>
+        <email>info@thelia.net</email>
+    </author>
+    <type>payment</type>
+    <thelia>2.5.5</thelia>
+    <stability>alpha</stability>
+</module>
+
+XML;
+    }
+
+    private function removeSampleModules(): void
+    {
+        $modules = ModuleQuery::create()->filterByCode(self::SAMPLE_PREFIX.'%', Criteria::LIKE)->find();
+
+        foreach ($modules as $module) {
+            $module->delete();
+        }
+
+        HookQuery::create()->filterByCode(self::DECLARED_HOOK_CODE)->delete();
+        ProfileQuery::create()->filterByCode(self::SAMPLE_PREFIX.'%', Criteria::LIKE)->delete();
+        AreaQuery::create()->filterByName(self::SAMPLE_AREA_NAME)->delete();
+
+        $this->filesystem->remove(array_merge(
+            $this->archiveDirectories,
+            glob(THELIA_MODULE_DIR.self::SAMPLE_PREFIX.'*') ?: [],
+            [self::CALL_LOG]
+        ));
+
+        $this->archiveDirectories = [];
     }
 }


### PR DESCRIPTION
Backport of #3699 to 2.6 — the files diverged, so this is an adaptation, not a cherry-pick.

Refs #3674

Uploading a zip of a module that is already installed was not an upgrade. `Action\Module::install()` dispatched `MODULE_DELETE` on the existing row and let `ModuleManagement::updateModule()` insert a new one, so the module came back with a new id — and ten `ON DELETE CASCADE` foreign keys had emptied in between:

| Table | What the administrator lost |
|---|---|
| `module_hook` | the hooks, their **positions** and their active flag |
| `module_config` (+ `_i18n`) | the whole module configuration |
| `ignored_module_hook` | the hooks that had been switched off — they came back |
| `module_i18n` | the title, chapo and description edited in the back office |
| `module_image` (+ `_i18n`) | the module images |
| `profile_module` | the access rights of every administrator profile |
| `area_delivery_module` | the delivery areas the module was attached to |
| `coupon_module` | the coupon conditions carrying the module |

`ModuleHookConfigurationStore` (#3560) does not catch this: its key starts with `module_id`, so a new id never finds its saved positions.

The module also never received the upgrade: with the row gone, `updateModule()` fell back to `action = 'install'` and called `install()` instead of `update($currentVersion, $newVersion)`, and rewrote the title from the archive descriptor.

## What changes

When `findOneByFullNamespace()` finds the namespace, the row is kept and the module is upgraded in place: no `MODULE_DELETE`, no cascade, `updateModule()` finds the row by code and calls `update()`. The `RESTRICT` on `order` is never reached either, so a payment or delivery module an order was placed with becomes upgradable again — the upgrade half of #1145.

`restoreActivation()`, added by #3685 for the refused upgrade, now covers the new failure path: a replacement that fails part way leaves the module activated as it was.

Two points the in-place path had to handle:

- **The files of the previous version.** The directory used to be wiped by the deletion, so `mirror()` was clean by accident. It now mirrors with `delete` and `override`, otherwise the classes the new version dropped stay on disk, autoloadable and hookable.
- **An archive that renames the module while keeping its namespace.** `install()` matches on the namespace, `updateModule()` matches on the code: the rename would have produced a second row and a second directory. It is refused with a message naming both codes.

Reinstalling an archive of the same version used to skip `registerHooks()` (`action = 'none'`), so a module whose files were fixed without a version bump never got its new hooks registered. `updateModule()` takes a `$forceHookRegistration` flag that the install path sets. It stays off for `updateModules()`, which runs on every visit to the back-office module list — registering hooks there clears the kernel cache on each page load.

`destroy()` no longer runs on an upgrade — `update()` does, which is the contract `BaseModule` already documents and what the composer path already did. A module that relied on destroy+install to migrate has to implement `update()`. Worth a line in the release notes.

The `local/modules` versus `vendor/thelia/modules` relocation handled in #3699 has no equivalent here: 2.6 has a single module directory.

## Tests

`tests/Legacy/Action/ModuleInstallTest.php`, the harness #3685 introduced, is rewritten around the upgrade that now succeeds. It installs a sample module from a temporary directory standing in for an unzipped archive, then upgrades it, with the real `MODULE_DELETE` listener wired so the tests fail against the code they cover. Every assertion was checked red before the fix.

- the row, its id and its version
- the hook positions set in the back office
- the module configuration
- the hooks the administrator switched off
- the profile access and the delivery areas
- the title edited in the back office
- **an activated payment module upgrades successfully** — this replaces `testARefusedUpgradeLeavesTheModuleActivated`, which asserted the refusal that this PR removes
- `update()` is called, not `install()`
- the files the new version dropped are removed
- reinstalling the same version registers the declared hooks
- an archive renaming the module code is refused

`composer test` green: unit 46, functional 81, legacy 602 (24 skipped, 11 pre-existing risky). `composer cs-diff` 0/1962.

Refs #1145, #3685, #3560, #3599
