### PR TITLE
fix: register a module's hooks on install only, not on every module refresh

### DIFF
--- a/core/lib/Thelia/Action/Module.php
+++ b/core/lib/Thelia/Action/Module.php
@@ -400,7 +400,7 @@ class Module extends BaseAction implements EventSubscriberInterface
             $eventDispatcher = $this->container->get('event_dispatcher');
             $moduleManagement = new ModuleManagement($this->container, $eventDispatcher);
             $file = new \SplFileInfo($moduleDescriptorFile);
-            $module = $moduleManagement->updateModule($file, $this->container);
+            $module = $moduleManagement->updateModule($file, $this->container, true);
         } catch (\Throwable $throwable) {
             // The module was deactivated a few lines above so it could be replaced, and the
             // replacement is not going to happen. Put the shop back where it was: a payment

--- a/core/lib/Thelia/Module/ModuleManagement.php
+++ b/core/lib/Thelia/Module/ModuleManagement.php
@@ -100,7 +100,7 @@ class ModuleManagement
      * @throws \Exception
      * @throws PropelException
      */
-    public function updateModule(\SplFileInfo $file, ContainerInterface $container): Module
+    public function updateModule(\SplFileInfo $file, ContainerInterface $container, bool $forceHookRegistration = false): Module
     {
         $descriptorValidator = $this->getDescriptorValidator();
 
@@ -163,11 +163,13 @@ class ModuleManagement
                 $instance->update($currentVersion, $version, $con);
             }
 
-            // Also when the version did not change: reinstalling a module whose files were
-            // fixed without a version bump must still register the hooks it now declares.
+            // $forceHookRegistration covers the module whose files were just replaced without a
+            // version bump: the hooks it now declares still have to be registered.
             // createOrUpdateHook() is idempotent, and the positions the administrator set
             // live in module_hook, which this does not touch.
-            $instance->registerHooks();
+            if ('none' !== $action || $forceHookRegistration) {
+                $instance->registerHooks();
+            }
 
             $con->commit();
         } catch (\Throwable $exception) {

--- a/tests/Integration/Action/ModuleActionTest.php
+++ b/tests/Integration/Action/ModuleActionTest.php
@@ -36,6 +36,7 @@ use Thelia\Model\OrderQuery;
 use Thelia\Model\ProfileModule;
 use Thelia\Model\ProfileModuleQuery;
 use Thelia\Module\BaseModule;
+use Thelia\Module\ModuleManagement;
 use Thelia\Module\Validator\ModuleDefinition;
 use Thelia\Test\ActionIntegrationTestCase;
 
@@ -365,6 +366,28 @@ final class ModuleActionTest extends ActionIntegrationTestCase
         self::assertNotNull(
             HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE),
             'Reinstalling an archive of the same version must still register the hooks the module declares.',
+        );
+    }
+
+    /**
+     * The back-office module list refreshes every module on every visit. Registering the hooks
+     * there dispatches a hook create or update event, and those clear the kernel cache: a page
+     * of the back office would wipe the cache each time it is opened.
+     */
+    public function testRefreshingAModuleDoesNotRegisterItsHooksWhenNothingChanged(): void
+    {
+        $this->installSampleModule('1.0.0');
+
+        HookQuery::create()->filterByCode(self::DECLARED_HOOK_CODE)->delete();
+
+        $this->getService(ModuleManagement::class)->updateModule(
+            new \SplFileInfo(THELIA_MODULE_DIR.self::SAMPLE_CODE.DS.'Config'.DS.'module.xml'),
+            static::getContainer(),
+        );
+
+        self::assertNull(
+            HookQuery::create()->findOneByCode(self::DECLARED_HOOK_CODE),
+            'Refreshing an unchanged module must not touch its hooks.',
         );
     }
 


### PR DESCRIPTION
Follow-up to #3699.

#3699 made `ModuleManagement::updateModule()` call `registerHooks()` unconditionally, so that reinstalling an archive whose version did not change still registers the hooks the module now declares. That went one step too far: `updateModule()` is also the per-module step of `updateModules()`, which the back-office module list runs on every visit.

`registerHooks()` dispatches `HOOK_CREATE_ALL` or `HOOK_UPDATE` for each hook a module declares, and `Action\Hook` clears the kernel cache on both. Opening the module list therefore wiped the cache — including `var/cache/<env>/sessions` — once per page load, for every module shipping a `getHooks()` declaration.

Found while porting #3699 to 2.6, where the back office renders through the same path and eight functional tests started failing on `file_put_contents(var/cache/test/sessions/...): No such file or directory`.

`updateModule()` now takes `$forceHookRegistration`, which only `Action\Module::install()` sets — the one caller that has just replaced the files on disk. `updateModules()` leaves it off and goes back to registering hooks only when the version actually changed.

`testRefreshingAModuleDoesNotRegisterItsHooksWhenNothingChanged` covers the refresh path; `testReinstallingTheSameVersionRegistersTheHooksTheModuleDeclares`, from #3699, still covers the install path. Both were checked red against the opposite behaviour.

`composer test` 5/5 green (1045 tests), `composer cs-diff` 0/1827, `composer phpstan` 0 errors.

Refs #3674
