### PR TITLE
fix: read the cart delivery address from the table its foreign key points at

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -36,6 +36,7 @@ use Thelia\Model\AddressQuery;
 use Thelia\Model\Base\CustomerQuery;
 use Thelia\Model\Base\ProductSaleElementsQuery;
 use Thelia\Model\Cart as CartModel;
+use Thelia\Model\CartAddressQuery;
 use Thelia\Model\CartItem;
 use Thelia\Model\CartItemQuery;
 use Thelia\Model\CartQuery;
@@ -134,7 +135,10 @@ class Cart extends BaseAction implements EventSubscriberInterface
     {
         $cart = $event->getCart();
         $moduleId = $event->getDeliveryModuleId();
-        $deliveryAddressId = $event->getDeliveryAddressId();
+        // Postage is quoted on the address the cart ships to, which is the cart's
+        // own copy in `cart_address`. Reading it off the cart also covers an
+        // address typed in at checkout and never saved to the customer account.
+        $deliveryAddressId = $cart->getAddressDeliveryId();
 
         if (null === $moduleId || null === $deliveryAddressId) {
             return;
@@ -588,6 +592,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
     }
 
     /**
+     * @param int $deliveryAddressId id of the cart's delivery address, in `cart_address`
+     *
      * @throws PropelException
      */
     protected function getPostageByDeliveryModuleId(
@@ -596,7 +602,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         int $moduleId,
         int $deliveryAddressId,
     ): OrderPostage {
-        if (!$customer = $this->securityContext->getCustomerUser()) {
+        if (!$this->securityContext->getCustomerUser()) {
             throw new \Exception('Customer not found !');
         }
 
@@ -608,16 +614,9 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
         $moduleInstance = $deliveryModule->getDeliveryModuleInstance($this->container);
 
-        $deliveryAddress = AddressQuery::create()
-            ->useCustomerQuery()
-            ->filterById($customer->getId())
-            ->endUse()
-            ->useCartAddressQuery()
-                ->filterById($deliveryAddressId)
-            ->endUse()
-            ->findOne();
+        $cartAddress = CartAddressQuery::create()->findPk($deliveryAddressId);
 
-        if (!$deliveryAddress) {
+        if (!$cartAddress) {
             throw new \Exception('Delivery address not found !');
         }
 
@@ -625,8 +624,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
             throw new \Exception('Virtual product delivery failed ! ');
         }
 
-        $country = $deliveryAddress->getCountry();
-        $state = $deliveryAddress->getState();
+        $country = $cartAddress->getCountry();
+        $state = $cartAddress->getState();
+
+        // Delivery modules receive the customer address when the cart address was
+        // copied from one; country and state come from the cart address either way.
+        $deliveryAddress = $cartAddress->getAddress();
 
         $deliveryPostageEvent = new DeliveryPostageEvent($moduleInstance, $cart, $deliveryAddress, $country, $state);
 

--- a/core/lib/Thelia/Core/Event/Cart/CartCheckoutEvent.php
+++ b/core/lib/Thelia/Core/Event/Cart/CartCheckoutEvent.php
@@ -38,9 +38,12 @@ class CartCheckoutEvent extends ActionEvent
     {
         $this->cart = $cart;
 
-        $this->deliveryAddressId = $cart->getAddressDeliveryId();
+        // The cart columns hold `cart_address` ids — its own frozen copies of
+        // the addresses. The listeners of this event look these ids up in
+        // `address`, so the event carries the customer addresses instead.
+        $this->deliveryAddressId = $cart->getCartAddressRelatedByAddressDeliveryId()?->getAddressId();
         $this->deliveryModuleId = $cart->getDeliveryModuleId();
-        $this->invoiceAddressId = $cart->getAddressInvoiceId();
+        $this->invoiceAddressId = $cart->getCartAddressRelatedByAddressInvoiceId()?->getAddressId();
         $this->paymentModuleId = $cart->getPaymentModuleId();
     }
 

--- a/core/lib/Thelia/Core/Template/Loop/Delivery.php
+++ b/core/lib/Thelia/Core/Template/Loop/Delivery.php
@@ -97,8 +97,6 @@ class Delivery extends BaseSpecificModule
             try {
                 // Check if module is valid, by calling isValidDelivery(),
                 // or catching a DeliveryException.
-                /* @var CartModel $cart */
-                $cart->getAddressDeliveryId();
                 $deliveryPostageEvent = new DeliveryPostageEvent($moduleInstance, $cart, $address, $country, $state);
                 $this->dispatcher->dispatch(
                     $deliveryPostageEvent,

--- a/core/lib/Thelia/Domain/Addressing/Service/AddressService.php
+++ b/core/lib/Thelia/Domain/Addressing/Service/AddressService.php
@@ -165,8 +165,13 @@ readonly class AddressService
             ?? $request->query->get('addressId');
 
         if (null === $addressId) {
-            $session = $request->getSession();
-            $addressId = $session->getSessionCart($this->dispatcher)?->getAddressDeliveryId();
+            // The cart holds a `cart_address` id, which is its own frozen copy
+            // of the address, so the customer address it was copied from has to
+            // be read through it.
+            $addressId = $request->getSession()
+                ->getSessionCart($this->dispatcher)
+                ?->getCartAddressRelatedByAddressDeliveryId()
+                ?->getAddressId();
         }
 
         if (null !== $addressId) {

--- a/core/lib/Thelia/Domain/Checkout/CheckoutFacade.php
+++ b/core/lib/Thelia/Domain/Checkout/CheckoutFacade.php
@@ -100,8 +100,8 @@ final readonly class CheckoutFacade
 
         return $this->paymentService->pay(
             $dto->getCart(),
-            $dto->getDeliveryAddressId() ?? $dto->getCart()->getAddressDeliveryId(),
-            $dto->getInvoiceAddressId() ?? $dto->getCart()->getAddressInvoiceId(),
+            $dto->getDeliveryAddressId(),
+            $dto->getInvoiceAddressId(),
             $dto->getDeliveryModuleId() ?? $dto->getCart()->getDeliveryModuleId(),
             $dto->getPaymentModuleId() ?? $dto->getCart()->getPaymentModuleId(),
         );

--- a/core/lib/Thelia/Domain/Checkout/DTO/CheckoutDTO.php
+++ b/core/lib/Thelia/Domain/Checkout/DTO/CheckoutDTO.php
@@ -30,14 +30,17 @@ class CheckoutDTO implements DTOEventActionInterface, CartDTOInterface
         protected ?OrderPostage $postage = null,
         protected array $extendedData = [],
     ) {
+        // deliveryAddressId and invoiceAddressId are customer `address` ids.
+        // The cart stores `cart_address` ids — its own copies — so they are read
+        // through the copy.
         if (null === $this->deliveryAddressId) {
-            $this->deliveryAddressId = $cart->getAddressDeliveryId();
+            $this->deliveryAddressId = $cart->getCartAddressRelatedByAddressDeliveryId()?->getAddressId();
         }
         if (null === $this->deliveryModuleId) {
             $this->deliveryModuleId = $cart->getDeliveryModuleId();
         }
         if (null === $this->invoiceAddressId) {
-            $this->invoiceAddressId = $cart->getAddressInvoiceId();
+            $this->invoiceAddressId = $cart->getCartAddressRelatedByAddressInvoiceId()?->getAddressId();
         }
         if (null === $this->paymentModuleId) {
             $this->paymentModuleId = $cart->getPaymentModuleId();

--- a/core/lib/Thelia/Domain/Promotion/Coupon/BaseFacade.php
+++ b/core/lib/Thelia/Domain/Promotion/Coupon/BaseFacade.php
@@ -74,7 +74,11 @@ class BaseFacade implements FacadeInterface
     {
         try {
             return AddressQuery::create()->findPk(
-                $this->getRequest()->getSession()->getSessionCart($this->eventDispatcher)->getAddressDeliveryId()
+                $this->getRequest()
+                    ->getSession()
+                    ->getSessionCart($this->eventDispatcher)
+                    ->getCartAddressRelatedByAddressDeliveryId()
+                    ?->getAddressId()
             );
         } catch (\Exception $exception) {
             throw new \LogicException('Failed to get delivery address ('.$exception->getMessage().')', $exception->getCode(), $exception);

--- a/core/lib/Thelia/Domain/Promotion/Coupon/Service/CouponManager.php
+++ b/core/lib/Thelia/Domain/Promotion/Coupon/Service/CouponManager.php
@@ -23,7 +23,6 @@ use Thelia\Domain\Promotion\Coupon\Exception\InactiveCouponException;
 use Thelia\Domain\Promotion\Coupon\FacadeInterface;
 use Thelia\Domain\Promotion\Coupon\Type\CouponInterface;
 use Thelia\Log\Tlog;
-use Thelia\Model\AddressQuery;
 use Thelia\Model\Cart;
 use Thelia\Model\Coupon;
 use Thelia\Model\CouponCountry;
@@ -149,7 +148,7 @@ class CouponManager
                 $couponCountries = $coupon->getFreeShippingForCountries();
 
                 if (!$couponCountries->isEmpty()) {
-                    if (null === $deliveryAddress = AddressQuery::create()->findPk($cart->getAddressDeliveryId())) {
+                    if (null === $deliveryAddress = $cart->getCartAddressRelatedByAddressDeliveryId()) {
                         continue;
                     }
 

--- a/core/lib/Thelia/Domain/Shipping/Service/DeliverySetupService.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/DeliverySetupService.php
@@ -75,25 +75,27 @@ final readonly class DeliverySetupService
             }
 
             if (null !== $defaultAddress) {
-                $cart->setAddressDeliveryId($defaultAddress->getId())->save();
+                $cartAddress = $this->cartAddressService->getOrCreateCartAddressFromAddress(
+                    $defaultAddress,
+                    $cart->getCartAddressRelatedByAddressDeliveryId(),
+                );
+
+                $cart->setAddressDeliveryId($cartAddress->getId())->save();
             }
         }
 
         $cart->setDeliveryModuleId($virtualDeliveryModule->getId())->save();
 
-        $addressId = $cart->getAddressDeliveryId();
-        if (null !== $addressId) {
-            $address = AddressQuery::create()->findPk($addressId);
-            $country = $address?->getCountry();
-            if (null !== $country) {
-                $state = $address->getState();
-                $estimate = $this->postageEstimator->estimatePostageForCountry($cart, $country, $state);
+        $deliveryAddress = $cart->getCartAddressRelatedByAddressDeliveryId();
+        $country = $deliveryAddress?->getCountry();
 
-                $cart
-                    ->setPostage((string) ($estimate->getBestPostageAmount() ?? 0))
-                    ->setPostageTax((string) ($estimate->getBestPostageTax() ?? 0))
-                    ->save();
-            }
+        if (null !== $country) {
+            $estimate = $this->postageEstimator->estimatePostageForCountry($cart, $country, $deliveryAddress->getState());
+
+            $cart
+                ->setPostage((string) ($estimate->getBestPostageAmount() ?? 0))
+                ->setPostageTax((string) ($estimate->getBestPostageTax() ?? 0))
+                ->save();
         }
     }
 }

--- a/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
+++ b/core/lib/Thelia/Domain/Shipping/ShippingFacade.php
@@ -18,6 +18,7 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Thelia\Api\Resource\DeliveryModule as DeliveryModuleResource;
 use Thelia\Api\State\Collection\DeliveryModuleCollection;
+use Thelia\Domain\Cart\Service\CartAddressService;
 use Thelia\Domain\Shipping\DTO\DeliveryModuleWithOptionDTO;
 use Thelia\Domain\Shipping\DTO\PostageEstimateView;
 use Thelia\Domain\Shipping\Service\DeliveryModuleEligibilityChecker;
@@ -47,6 +48,7 @@ final readonly class ShippingFacade
         private DeliveryModuleEligibilityChecker $eligibilityChecker,
         private DeliveryOptionsProvider $deliveryOptionsProvider,
         private DeliveryModuleResourceBuilder $deliveryModuleResourceBuilder,
+        private CartAddressService $cartAddressService,
     ) {
     }
 
@@ -91,11 +93,25 @@ final readonly class ShippingFacade
     }
 
     /**
-     * Set the delivery address on the cart (setter + save).
+     * Set the delivery address on the cart, from the id of a customer `address`.
+     *
+     * The cart does not point at `address` but at its own copy of it, in
+     * `cart_address`, so the copy is made (or refreshed) on the way.
      */
     public function chooseDeliveryAddress(Cart $cart, int $addressId): void
     {
-        $cart->setAddressDeliveryId($addressId)->save();
+        $address = AddressQuery::create()->findPk($addressId);
+
+        if (null === $address) {
+            throw new \InvalidArgumentException(\sprintf('Address #%d not found', $addressId));
+        }
+
+        $cartAddress = $this->cartAddressService->getOrCreateCartAddressFromAddress(
+            $address,
+            $cart->getCartAddressRelatedByAddressDeliveryId(),
+        );
+
+        $cart->setAddressDeliveryId($cartAddress->getId())->save();
     }
 
     /**
@@ -232,8 +248,11 @@ final readonly class ShippingFacade
      *
      * Rules:
      * - If country is provided, use the provided (country, state) over address.
-     * - Else, if addressId is provided (or present on the cart), resolve through the address.
+     * - Else, if addressId is provided, resolve through that customer address.
+     * - Else, resolve through the cart's own copy of its delivery address.
      * - Else, return (null, null, null).
+     *
+     * @param int|null $addressId id of a customer `address`
      *
      * @return array{0: ?\Thelia\Model\Address, 1: ?Country, 2: ?State}
      */
@@ -250,16 +269,10 @@ final readonly class ShippingFacade
             return [$address, $country, $state];
         }
 
-        $resolvedAddressId = $addressId ?? $cart->getAddressDeliveryId();
-        if (null === $resolvedAddressId) {
-            return [null, null, null];
-        }
+        $address = null === $addressId
+            ? $cart->getCartAddressRelatedByAddressDeliveryId()?->getAddress()
+            : AddressQuery::create()->findPk($addressId);
 
-        $address = AddressQuery::create()
-            ->useCartAddressQuery()
-            ->filterById($resolvedAddressId)
-            ->endUse()
-            ->findOne();
         if (null === $address) {
             return [null, null, null];
         }
@@ -285,15 +298,10 @@ final readonly class ShippingFacade
     private function handleCountry(Cart $cart, ?Country $country): Country
     {
         if ($country === null) {
-            $addressDeliveryId = $cart->getAddressDeliveryId();
-            if ($addressDeliveryId !== null) {
-                $addressDelivery = AddressQuery::create()
-                    ->useCartAddressQuery()
-                    ->filterById($addressDeliveryId)
-                    ->endUse()
-                    ->findOne();
-                $country = $addressDelivery?->getCountry();
-            }
+            // Read from the cart's own copy of the address: it carries a country
+            // of its own, so an address typed in at checkout and never saved to
+            // the customer account still ships to the right place.
+            $country = $cart->getCartAddressRelatedByAddressDeliveryId()?->getCountry();
         }
 
         if ($country === null) {

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxEngine.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxEngine.php
@@ -17,7 +17,6 @@ namespace Thelia\Domain\Taxation\TaxEngine;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Thelia\Model\AddressQuery;
 use Thelia\Model\Cart;
 use Thelia\Model\Country;
 use Thelia\Model\CountryQuery;
@@ -53,7 +52,7 @@ class TaxEngine
         $currentDeliveryAddress = null;
 
         if ($cart) {
-            $currentDeliveryAddress = AddressQuery::create()->findPk($cart->getAddressDeliveryId());
+            $currentDeliveryAddress = $cart->getCartAddressRelatedByAddressDeliveryId();
         }
 
         if ($currentDeliveryAddress) {

--- a/core/lib/Thelia/Model/Order.php
+++ b/core/lib/Thelia/Model/Order.php
@@ -89,7 +89,11 @@ class Order extends BaseOrder
      */
     public function getChoosenDeliveryAddress(): ?int
     {
-        $this->choosenDeliveryAddress = $this->getCart()?->getAddressDeliveryId();
+        // The cart points at its own copy of the address, in `cart_address`.
+        // Every caller looks the answer up in `address`.
+        $this->choosenDeliveryAddress = $this->getCart()
+            ?->getCartAddressRelatedByAddressDeliveryId()
+            ?->getAddressId();
 
         return $this->choosenDeliveryAddress;
     }
@@ -115,7 +119,9 @@ class Order extends BaseOrder
      */
     public function getChoosenInvoiceAddress(): ?int
     {
-        $this->choosenDeliveryAddress = $this->getCart()?->getAddressInvoiceId();
+        $this->choosenInvoiceAddress = $this->getCart()
+            ?->getCartAddressRelatedByAddressInvoiceId()
+            ?->getAddressId();
 
         return $this->choosenInvoiceAddress;
     }

--- a/tests/Integration/Domain/Shipping/CartDeliveryAddressIdTest.php
+++ b/tests/Integration/Domain/Shipping/CartDeliveryAddressIdTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Shipping;
+
+use Thelia\Core\Event\Cart\CartCheckoutEvent;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Domain\Cart\Service\CartAddressService;
+use Thelia\Domain\Shipping\Service\DeliverySetupService;
+use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
+use Thelia\Model\Address;
+use Thelia\Model\CartAddress;
+use Thelia\Model\CartAddressQuery;
+use Thelia\Model\Customer;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * `cart.address_delivery_id` is a foreign key on `cart_address.id`. Writing an
+ * `address.id` there is rejected outright by the database once the two
+ * auto-increment sequences have drifted apart, and accepted silently — pointing
+ * at somebody else's address — as long as they have not.
+ *
+ * Reading it back as an `address.id` has the same two outcomes, and the silent
+ * one is the dangerous one: the country it yields drives the VAT rate.
+ */
+final class CartDeliveryAddressIdTest extends ActionIntegrationTestCase
+{
+    public function testSettingUpVirtualDeliveryStoresACartAddressId(): void
+    {
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $country = $this->factory->country();
+        $address = $this->factory->address($customer, $country, $customerTitle);
+        $address->setIsDefault(1)->save($this->getPropelConnection());
+
+        $cart = $this->factory->cart($customer);
+
+        $this->getService(DeliverySetupService::class)->setupVirtualDelivery($cart);
+
+        $storedId = $cart->getAddressDeliveryId();
+        self::assertNotNull($storedId);
+
+        $cartAddress = CartAddressQuery::create()->findPk($storedId);
+        self::assertNotNull(
+            $cartAddress,
+            'The stored id must exist in cart_address, the table its foreign key points at.',
+        );
+        self::assertSame($address->getId(), $cartAddress->getAddressId());
+        self::assertSame($country->getId(), $cartAddress->getCountryId());
+    }
+
+    public function testTheDeliveryCountryComesFromTheAddressTheCustomerPicked(): void
+    {
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $deliveryCountry = $this->factory->country();
+        $address = $this->factory->address($customer, $deliveryCountry, $customerTitle);
+
+        $cart = $this->factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($this->cartAddressFor($address)->getId())
+            ->save($this->getPropelConnection());
+
+        // A cart that belongs to a customer is only handed back by the session
+        // to that customer; anybody else gets a fresh one.
+        $this->session()->setCustomerUser($customer);
+        $this->session()->setSessionCart($cart);
+
+        self::assertSame(
+            $deliveryCountry->getId(),
+            $this->getService(TaxEngine::class)->getDeliveryCountry()->getId(),
+            'VAT must be computed on the country of the address the customer picked.',
+        );
+    }
+
+    public function testTheCheckoutEventCarriesACustomerAddressId(): void
+    {
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $address = $this->factory->address($customer, $this->factory->country(), $customerTitle);
+        $cartAddress = $this->cartAddressFor($address);
+
+        $cart = $this->factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($cartAddress->getId())
+            ->setAddressInvoiceId($cartAddress->getId())
+            ->save($this->getPropelConnection());
+
+        $event = new CartCheckoutEvent($cart);
+
+        // The listeners of that event look the id up in `address`, so the event
+        // has to carry the customer address, not the cart's frozen copy of it.
+        self::assertSame($address->getId(), $event->getDeliveryAddressId());
+        self::assertSame($address->getId(), $event->getInvoiceAddressId());
+    }
+
+    public function testTheOrderExposesTheCustomerAddressItWasDeliveredTo(): void
+    {
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $address = $this->factory->address($customer, $this->factory->country(), $customerTitle);
+        $cartAddress = $this->cartAddressFor($address);
+
+        $cart = $this->cartWithAddress($customer, $cartAddress);
+        $order = $this->factory->order($customer);
+        $order->setCartId($cart->getId())->save($this->getPropelConnection());
+
+        self::assertSame($address->getId(), $order->getChoosenDeliveryAddress());
+        self::assertSame($address->getId(), $order->getChoosenInvoiceAddress());
+    }
+
+    private function cartWithAddress(Customer $customer, CartAddress $cartAddress): \Thelia\Model\Cart
+    {
+        $cart = $this->factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($cartAddress->getId())
+            ->setAddressInvoiceId($cartAddress->getId())
+            ->save($this->getPropelConnection());
+
+        return $cart;
+    }
+
+    private function cartAddressFor(Address $address): CartAddress
+    {
+        return $this->getService(CartAddressService::class)
+            ->getOrCreateCartAddressFromAddress($address);
+    }
+
+    private function session(): Session
+    {
+        return static::getContainer()->get('request_stack')->getCurrentRequest()->getSession();
+    }
+}

--- a/tests/Unit/Domain/Checkout/CheckoutFacadeTest.php
+++ b/tests/Unit/Domain/Checkout/CheckoutFacadeTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Thelia\Domain\Checkout\DTO\CheckoutDTO;
 use Thelia\Model\Cart;
+use Thelia\Model\CartAddress;
 use Thelia\Model\OrderPostage;
 
 class CheckoutFacadeTest extends TestCase
@@ -76,8 +77,10 @@ class CheckoutFacadeTest extends TestCase
     {
         $cart = $this->createMock(Cart::class);
         $cart->method('getId')->willReturn(1);
-        $cart->method('getAddressDeliveryId')->willReturn(100);
-        $cart->method('getAddressInvoiceId')->willReturn(200);
+        // The cart points at its own copies of the addresses, which in turn
+        // carry the id of the customer address each was copied from.
+        $cart->method('getCartAddressRelatedByAddressDeliveryId')->willReturn($this->cartAddressMock(100));
+        $cart->method('getCartAddressRelatedByAddressInvoiceId')->willReturn($this->cartAddressMock(200));
         $cart->method('getDeliveryModuleId')->willReturn(300);
         $cart->method('getPaymentModuleId')->willReturn(400);
 
@@ -93,8 +96,8 @@ class CheckoutFacadeTest extends TestCase
     {
         $cart = $this->createMock(Cart::class);
         $cart->method('getId')->willReturn(1);
-        $cart->method('getAddressDeliveryId')->willReturn(100);
-        $cart->method('getAddressInvoiceId')->willReturn(200);
+        $cart->method('getCartAddressRelatedByAddressDeliveryId')->willReturn($this->cartAddressMock(100));
+        $cart->method('getCartAddressRelatedByAddressInvoiceId')->willReturn($this->cartAddressMock(200));
         $cart->method('getDeliveryModuleId')->willReturn(300);
         $cart->method('getPaymentModuleId')->willReturn(400);
 
@@ -126,11 +129,19 @@ class CheckoutFacadeTest extends TestCase
     {
         $cart = $this->createMock(Cart::class);
         $cart->method('getId')->willReturn($id);
-        $cart->method('getAddressDeliveryId')->willReturn(null);
-        $cart->method('getAddressInvoiceId')->willReturn(null);
+        $cart->method('getCartAddressRelatedByAddressDeliveryId')->willReturn(null);
+        $cart->method('getCartAddressRelatedByAddressInvoiceId')->willReturn(null);
         $cart->method('getDeliveryModuleId')->willReturn(null);
         $cart->method('getPaymentModuleId')->willReturn(null);
 
         return $cart;
+    }
+
+    private function cartAddressMock(int $addressId): MockObject&CartAddress
+    {
+        $cartAddress = $this->createMock(CartAddress::class);
+        $cartAddress->method('getAddressId')->willReturn($addressId);
+
+        return $cartAddress;
     }
 }


### PR DESCRIPTION
`cart.address_delivery_id` and `cart.address_invoice_id` are foreign keys on `cart_address.id`. Part of the code read them that way, part of it read them as `address.id`, and two places wrote an `address.id` into them.

The two tables have independent auto-increment sequences. Where they have drifted apart, the database rejects the write:

```
1452 Cannot add or update a child row: a foreign key constraint fails
(`cart`, CONSTRAINT `fk_cart_address_delivery_id`
 FOREIGN KEY (`address_delivery_id`) REFERENCES `cart_address` (`id`))
```

Where they have not, nothing fails: the id resolves to a different address, which can belong to a different customer. That is the half that needs no special setup — any shop with a delivery address on the cart was computing VAT from whatever country that other address happened to be in.

## The rule this settles on

The column holds a `cart_address` id, as the schema says. Everything named `addressId` outside the column is a customer `address` id — which is what `CartFacade::getDeliveryAddressId()` already did.

Writers now go through `CartAddressService`, so the cart always points at its own copy of the address:

- `DeliverySetupService::setupVirtualDelivery()` — wrote `$defaultAddress->getId()` straight into the column; this is the 1452 above. Eight lines up, the same class already did it right.
- `ShippingFacade::chooseDeliveryAddress()` — wrote its `$addressId` argument unchanged.

Readers now go through the `cart_address` relation:

- `TaxEngine::getDeliveryCountry()` — the country that drives the VAT rate.
- `CouponManager::isCouponRemovingPostage()` — free-shipping-by-country conditions.
- `BaseFacade::getDeliveryAddress()`, `AddressService::getDeliveryAddress()`.
- `Order::getChoosenDeliveryAddress()` / `getChoosenInvoiceAddress()`, which four call sites look up in `address` (`BaseFrontController`, the delivery loop, `AttributeAccessService`). The invoice getter also assigned to the delivery property, so it only ever answered null.
- `CartCheckoutEvent` and `CheckoutDTO` seeded their address ids from the column while their own listeners look those ids up in `address`.

## Postage

`Action\Cart::getPostageByDeliveryModuleId()` compared the two ids directly — `useCartAddressQuery()->filterById($deliveryAddressId)` against an id coming from `address`. It now quotes on the cart address, which carries a country of its own, and hands the delivery module the customer address only when there is one. Same for `ShippingFacade::handleCountry()`.

That also fixes an address typed in at checkout and never saved to the account: it has no row in `address`, so it used to fall through to the shop's default country.

## Tests

`CartDeliveryAddressIdTest` covers the four outcomes: the write that raised 1452, the VAT country, the id the checkout event carries, and the one the order exposes. All four fail on `main` — the first with the exact constraint violation above.

Left for later: `Api\Resource\Cart` declares `addressDelivery` and `addressInvoice` with `relationAlias: 'AddressRelatedByAddress…Id'`, a relation the `Cart` model does not have — the FK points at `cart_address`, which has no API resource yet.

Fixes #3694
