### PR TITLE
fix: answer the cart API address fields with the cart address they point at

### DIFF
--- a/core/lib/Thelia/Api/Resource/Address.php
+++ b/core/lib/Thelia/Api/Resource/Address.php
@@ -134,6 +134,7 @@ class Address implements PropelResourceInterface
         self::GROUP_FRONT_READ,
         Customer::GROUP_ADMIN_READ_SINGLE,
         Cart::GROUP_ADMIN_READ_SINGLE,
+        Cart::GROUP_FRONT_READ_SINGLE,
         Customer::GROUP_ADMIN_WRITE_UPDATE,
     ])]
     public ?int $id = null;

--- a/core/lib/Thelia/Api/Resource/Cart.php
+++ b/core/lib/Thelia/Api/Resource/Cart.php
@@ -100,13 +100,13 @@ class Cart implements PropelResourceInterface
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_READ, self::GROUP_FRONT_WRITE])]
     public ?Customer $customer = null;
 
-    #[Relation(targetResource: Address::class, relationAlias: 'AddressRelatedByAddressDeliveryId')]
+    #[Relation(targetResource: CartAddress::class, relationAlias: 'CartAddressRelatedByAddressDeliveryId')]
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
-    public ?Address $addressDelivery = null;
+    public ?CartAddress $addressDelivery = null;
 
-    #[Relation(targetResource: Address::class, relationAlias: 'AddressRelatedByAddressInvoiceId')]
+    #[Relation(targetResource: CartAddress::class, relationAlias: 'CartAddressRelatedByAddressInvoiceId')]
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
-    public ?Address $addressInvoice = null;
+    public ?CartAddress $addressInvoice = null;
 
     #[Relation(targetResource: Currency::class)]
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
@@ -179,24 +179,24 @@ class Cart implements PropelResourceInterface
         return $this;
     }
 
-    public function getAddressDelivery(): ?Address
+    public function getAddressDelivery(): ?CartAddress
     {
         return $this->addressDelivery;
     }
 
-    public function setAddressDelivery(?Address $addressDelivery): self
+    public function setAddressDelivery(?CartAddress $addressDelivery): self
     {
         $this->addressDelivery = $addressDelivery;
 
         return $this;
     }
 
-    public function getAddressInvoice(): ?Address
+    public function getAddressInvoice(): ?CartAddress
     {
         return $this->addressInvoice;
     }
 
-    public function setAddressInvoice(?Address $addressInvoice): self
+    public function setAddressInvoice(?CartAddress $addressInvoice): self
     {
         $this->addressInvoice = $addressInvoice;
 

--- a/core/lib/Thelia/Api/Resource/CartAddress.php
+++ b/core/lib/Thelia/Api/Resource/CartAddress.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Resource;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Propel\Runtime\Map\TableMap;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Attribute\Relation;
+use Thelia\Api\Bridge\Propel\Filter\SearchFilter;
+use Thelia\Model\Map\CartAddressTableMap;
+
+/**
+ * The cart's own copy of a delivery or invoice address.
+ *
+ * A cart address is a snapshot: the customer may have picked one of the
+ * addresses saved on the account, in which case `address` points back at it,
+ * or typed it in at checkout, in which case `address` is null and this row is
+ * the only place the address exists. The order is built from this copy.
+ *
+ * Read-only: cart addresses are written by the checkout, never by the API.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/admin/cart_addresses',
+        ),
+        new Get(
+            uriTemplate: '/admin/cart_addresses/{id}',
+            normalizationContext: ['groups' => [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_READ_SINGLE]],
+        ),
+    ],
+    normalizationContext: ['groups' => [self::GROUP_ADMIN_READ]],
+)]
+#[ApiFilter(
+    filterClass: SearchFilter::class,
+    properties: [
+        'id',
+    ],
+)]
+class CartAddress implements PropelResourceInterface
+{
+    use PropelResourceTrait;
+
+    public const GROUP_ADMIN_READ = 'admin:cart_address:read';
+    public const GROUP_ADMIN_READ_SINGLE = 'admin:cart_address:read:single';
+
+    public const GROUP_CART_COMBINED = [
+        Cart::GROUP_ADMIN_READ_SINGLE,
+        Cart::GROUP_FRONT_READ_SINGLE,
+    ];
+
+    #[Groups([self::GROUP_ADMIN_READ, Cart::GROUP_ADMIN_READ, Cart::GROUP_FRONT_READ])]
+    public ?int $id = null;
+
+    /**
+     * The customer address this copy was made from, null when the address was
+     * typed in at checkout and never saved to the account.
+     */
+    #[Relation(targetResource: Address::class)]
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?Address $address = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, ...self::GROUP_CART_COMBINED])]
+    public string $firstname;
+
+    #[Groups([self::GROUP_ADMIN_READ, ...self::GROUP_CART_COMBINED])]
+    public string $lastname;
+
+    #[Groups([self::GROUP_ADMIN_READ, ...self::GROUP_CART_COMBINED])]
+    public ?string $company = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public string $address1;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?string $address2 = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?string $address3 = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public string $zipcode;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public string $city;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?string $phone = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?string $cellphone = null;
+
+    #[Relation(targetResource: CustomerTitle::class)]
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?CustomerTitle $customerTitle = null;
+
+    #[Relation(targetResource: Country::class)]
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?Country $country = null;
+
+    #[Relation(targetResource: State::class)]
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE, ...self::GROUP_CART_COMBINED])]
+    public ?State $state = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    public ?\DateTime $createdAt = null;
+
+    #[Groups([self::GROUP_ADMIN_READ_SINGLE])]
+    public ?\DateTime $updatedAt = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getAddress(): ?Address
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?Address $address): self
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    public function getFirstname(): string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(string $firstname): self
+    {
+        $this->firstname = $firstname;
+
+        return $this;
+    }
+
+    public function getLastname(): string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(string $lastname): self
+    {
+        $this->lastname = $lastname;
+
+        return $this;
+    }
+
+    public function getCompany(): ?string
+    {
+        return $this->company;
+    }
+
+    public function setCompany(?string $company): self
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+
+    public function getAddress1(): string
+    {
+        return $this->address1;
+    }
+
+    public function setAddress1(string $address1): self
+    {
+        $this->address1 = $address1;
+
+        return $this;
+    }
+
+    public function getAddress2(): ?string
+    {
+        return $this->address2;
+    }
+
+    public function setAddress2(?string $address2): self
+    {
+        $this->address2 = $address2;
+
+        return $this;
+    }
+
+    public function getAddress3(): ?string
+    {
+        return $this->address3;
+    }
+
+    public function setAddress3(?string $address3): self
+    {
+        $this->address3 = $address3;
+
+        return $this;
+    }
+
+    public function getZipcode(): string
+    {
+        return $this->zipcode;
+    }
+
+    public function setZipcode(string $zipcode): self
+    {
+        $this->zipcode = $zipcode;
+
+        return $this;
+    }
+
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
+
+        return $this;
+    }
+
+    public function getCellphone(): ?string
+    {
+        return $this->cellphone;
+    }
+
+    public function setCellphone(?string $cellphone): self
+    {
+        $this->cellphone = $cellphone;
+
+        return $this;
+    }
+
+    public function getCustomerTitle(): ?CustomerTitle
+    {
+        return $this->customerTitle;
+    }
+
+    public function setCustomerTitle(?CustomerTitle $customerTitle): self
+    {
+        $this->customerTitle = $customerTitle;
+
+        return $this;
+    }
+
+    public function getCountry(): ?Country
+    {
+        return $this->country;
+    }
+
+    public function setCountry(?Country $country): self
+    {
+        $this->country = $country;
+
+        return $this;
+    }
+
+    public function getState(): ?State
+    {
+        return $this->state;
+    }
+
+    public function setState(?State $state): self
+    {
+        $this->state = $state;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTime $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public static function getPropelRelatedTableMap(): ?TableMap
+    {
+        return new CartAddressTableMap();
+    }
+}

--- a/core/lib/Thelia/Api/Resource/Country.php
+++ b/core/lib/Thelia/Api/Resource/Country.php
@@ -106,6 +106,8 @@ class Country extends AbstractTranslatableResource
         self::GROUP_ADMIN_READ,
         self::GROUP_FRONT_READ,
         Order::GROUP_ADMIN_READ_SINGLE,
+        Cart::GROUP_ADMIN_READ_SINGLE,
+        Cart::GROUP_FRONT_READ_SINGLE,
         Customer::GROUP_ADMIN_READ_SINGLE,
         Address::GROUP_ADMIN_READ,
         Address::GROUP_FRONT_READ,

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -22,6 +22,7 @@ use Thelia\Model\Attribute;
 use Thelia\Model\AttributeAv;
 use Thelia\Model\Brand;
 use Thelia\Model\Cart;
+use Thelia\Model\CartAddress;
 use Thelia\Model\Category;
 use Thelia\Model\Content;
 use Thelia\Model\Country;
@@ -415,6 +416,35 @@ final class FixtureFactory
         $address->save($this->connection);
 
         return $address;
+    }
+
+    /**
+     * Creates the cart's own copy of an address. Pass the customer address it
+     * was copied from, or nothing for an address typed in at checkout and
+     * never saved to the account — which is a row with no `address_id`.
+     */
+    public function cartAddress(
+        ?Address $address = null,
+        ?Country $country = null,
+        ?CustomerTitle $title = null,
+        array $overrides = [],
+    ): CartAddress {
+        $n = $this->next();
+
+        $cartAddress = new CartAddress();
+        $cartAddress->setAddressId($address?->getId());
+        $cartAddress->setCustomerTitleId(($title ?? $this->customerTitle())->getId());
+        $cartAddress->setFirstname($overrides['firstname'] ?? $address?->getFirstname() ?? 'John');
+        $cartAddress->setLastname($overrides['lastname'] ?? $address?->getLastname() ?? 'Doe');
+        $cartAddress->setAddress1($overrides['address1'] ?? $address?->getAddress1() ?? $n.' Main Street');
+        $cartAddress->setAddress2($overrides['address2'] ?? '');
+        $cartAddress->setAddress3($overrides['address3'] ?? '');
+        $cartAddress->setZipcode($overrides['zipcode'] ?? $address?->getZipcode() ?? '75001');
+        $cartAddress->setCity($overrides['city'] ?? $address?->getCity() ?? 'Paris');
+        $cartAddress->setCountryId(($country ?? $this->country())->getId());
+        $cartAddress->save($this->connection);
+
+        return $cartAddress;
     }
 
     public function coupon(array $overrides = []): Coupon

--- a/tests/Api/Admin/AdminCollectionContractTest.php
+++ b/tests/Api/Admin/AdminCollectionContractTest.php
@@ -50,6 +50,7 @@ final class AdminCollectionContractTest extends ApiTestCase
         // value or configuration" (StateProvider config issue, not test-related)
         yield 'customer_titles' => ['/api/admin/customer_titles'];
         yield 'addresses' => ['/api/admin/addresses'];
+        yield 'cart_addresses' => ['/api/admin/cart_addresses'];
         yield 'product_sale_elements' => ['/api/admin/product_sale_elements'];
     }
 

--- a/tests/Api/Admin/CartApiTest.php
+++ b/tests/Api/Admin/CartApiTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Thelia\Test\ApiTestCase;
+
+final class CartApiTest extends ApiTestCase
+{
+    /**
+     * `cart.address_delivery_id` is a foreign key on `cart_address`, so the
+     * admin cart must answer the cart's own copy of the address rather than
+     * the null it used to answer through a relation the model does not have.
+     */
+    public function testAdminCartExposesTheAddressesItPointsAt(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title);
+        $country = $factory->country();
+
+        $deliveryAddress = $factory->cartAddress(
+            $factory->address($customer, $country, $title),
+            $country,
+            $title,
+            ['city' => 'Nantes'],
+        );
+
+        $cart = $factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($deliveryAddress->getId())
+            ->setAddressInvoiceId($deliveryAddress->getId())
+            ->save($this->getPropelConnection());
+
+        $token = $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest('GET', '/api/admin/carts/'.$cart->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+
+        self::assertIsArray($data['addressDelivery']);
+        self::assertSame($deliveryAddress->getId(), $data['addressDelivery']['id']);
+        self::assertSame('Nantes', $data['addressDelivery']['city']);
+        self::assertSame($country->getId(), $data['addressDelivery']['country']['id']);
+
+        self::assertIsArray($data['addressInvoice']);
+        self::assertSame($deliveryAddress->getId(), $data['addressInvoice']['id']);
+    }
+}

--- a/tests/Api/Front/CartApiTest.php
+++ b/tests/Api/Front/CartApiTest.php
@@ -54,6 +54,85 @@ final class CartApiTest extends ApiTestCase
         self::assertSame($cart->getId(), $data['id']);
     }
 
+    /**
+     * `cart.address_delivery_id` and `cart.address_invoice_id` are foreign keys
+     * on `cart_address`, so the two fields the cart exposes must answer the
+     * cart's own copy of the address — the copy the order is built from.
+     */
+    public function testCartExposesTheAddressesItPointsAt(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+        $country = $factory->country();
+        $address = $factory->address($customer, $country, $title);
+
+        $deliveryAddress = $factory->cartAddress($address, $country, $title, ['city' => 'Bordeaux']);
+        $invoiceAddress = $factory->cartAddress($address, $country, $title, ['city' => 'Toulouse']);
+
+        $cart = $factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($deliveryAddress->getId())
+            ->setAddressInvoiceId($invoiceAddress->getId())
+            ->save($this->getPropelConnection());
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/carts/'.$cart->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+
+        self::assertIsArray($data['addressDelivery'], 'The delivery address must carry data, not null.');
+        self::assertSame($deliveryAddress->getId(), $data['addressDelivery']['id']);
+        self::assertSame('Bordeaux', $data['addressDelivery']['city']);
+
+        self::assertIsArray($data['addressInvoice'], 'The invoice address must carry data, not null.');
+        self::assertSame($invoiceAddress->getId(), $data['addressInvoice']['id']);
+        self::assertSame('Toulouse', $data['addressInvoice']['city']);
+
+        // The copy keeps a link to the account address it was made from.
+        self::assertSame($address->getId(), $data['addressDelivery']['address']['id']);
+    }
+
+    /**
+     * An address typed in at checkout has no row in `address`, so resolving the
+     * cart's address through the account would answer null in exactly the case
+     * that matters most.
+     */
+    public function testCartExposesAnAddressTypedAtCheckout(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $typedAddress = $factory->cartAddress(null, $factory->country(), $title, ['city' => 'Lille']);
+
+        $cart = $factory->cart($customer);
+        $cart
+            ->setAddressDeliveryId($typedAddress->getId())
+            ->save($this->getPropelConnection());
+
+        $token = $this->authenticateAsCustomer($customer);
+
+        $response = $this->jsonRequest('GET', '/api/front/carts/'.$cart->getId(), token: $token);
+
+        self::assertJsonResponseSuccessful($response);
+        $data = json_decode($response->getContent(), true);
+
+        self::assertIsArray($data['addressDelivery']);
+        self::assertSame('Lille', $data['addressDelivery']['city']);
+
+        // Null values are dropped from the payload, so the account address the
+        // copy was never made from is simply absent.
+        self::assertArrayNotHasKey(
+            'address',
+            $data['addressDelivery'],
+            'An address typed at checkout has no account address.',
+        );
+        self::assertArrayNotHasKey('addressInvoice', $data);
+    }
+
     public function testCreateCartViaPost(): void
     {
         $response = $this->jsonRequest('POST', '/api/front/carts', []);


### PR DESCRIPTION
`Api\Resource\Cart` declared `addressDelivery` and `addressInvoice` through `AddressRelatedByAddress…Id`, a relation the `Cart` model does not have: `cart.address_delivery_id` is a foreign key on `cart_address`, so Propel names the getter `getCartAddressRelatedByAddressDeliveryId()`. Both the transformer and the eager-loading extension guard the alias with `method_exists()`, so the two fields were dropped without a word and answered null in every response since the day they were written.

## Which of the two designs

The issue left the choice between resolving the column through `cart_address.address_id` back to a customer `Address`, and giving `cart_address` its own resource.

An address typed in at checkout has no row in `address` — that is half the point of the `cart_address` copy, and #3714 fixed the postage path for exactly that case. Resolving through `address_id` would answer null again for a guest, which is the case worth reading. So the column gets the resource its foreign key points at.

## What the cart answers now

`CartAddress` mirrors `OrderAddress` — the same fields, since the two tables carry the same snapshot — plus the one column `order_address` does not have:

- `address`, the account address the copy was made from, or absent when the customer typed it in at checkout and never saved it. That is the only thing telling the two situations apart, and the front needs it to highlight the selected address in a list.

Read-only: cart addresses are written by the checkout, never by the API, so the resource exposes `GET /api/admin/cart_addresses` and `GET /api/admin/cart_addresses/{id}` and nothing else.

Two ids follow the new relation into the cart context: `Address::$id` picks up `Cart::GROUP_FRONT_READ_SINGLE`, next to the `firstname` and `lastname` Address already declared for the cart; and `Country::$id` picks up both cart read groups, the way it already does for the order, so the country the VAT is computed on is readable rather than an opaque IRI.

No schema change.

## Breaking change

`Cart::$addressDelivery` and `Cart::$addressInvoice` change type from `?Address` to `?CartAddress`, and the getters and setters follow. Anything type-hinting `Address` there stops compiling — but nothing can be reading a value, because the fields have never held one. In the payload the two fields go from missing (null values are dropped) to an object whose `@id` is `/api/admin/cart_addresses/{id}`.

## Tests

`Api\Front\CartApiTest` reads a customer's cart over `GET /api/front/carts/{id}` in the two situations: an address picked from the account, and one typed at checkout. Both fail on `main` on `addressDelivery` being null. `Api\Admin\CartApiTest` does the same on `GET /api/admin/carts/{id}`, and the admin collection contract test covers the new endpoint.

`FixtureFactory::cartAddress()` builds either kind of copy — pass the account address it was made from, or nothing for one typed at checkout.

Fixes #3715