### PR TITLE
feat: seed the shipped i18n translations when a language is added

### DIFF
--- a/core/lib/Thelia/Action/LangSeedI18n.php
+++ b/core/lib/Thelia/Action/LangSeedI18n.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Action;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Core\Event\Lang\LangToggleActiveEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Install\I18n\SeedI18nInstaller;
+use Thelia\Log\Tlog;
+use Thelia\Model\Event\LangEvent;
+
+/**
+ * Replays the translations shipped in `setup/I18n` for a language that was not
+ * part of the installation.
+ *
+ * `setup/insert.sql` only carries the locales of the languages it creates, and
+ * nothing brought the other files to the database afterwards. Seeding on
+ * creation covers new languages; seeding on activation covers the ones a shop
+ * added before this listener existed.
+ */
+class LangSeedI18n implements EventSubscriberInterface
+{
+    public function __construct(private readonly SeedI18nInstaller $installer)
+    {
+    }
+
+    public function seedCreatedLang(LangEvent $event): void
+    {
+        $this->seed($event->getModel()->getLocale());
+    }
+
+    public function seedActivatedLang(LangToggleActiveEvent $event): void
+    {
+        $lang = $event->getLang();
+
+        if (null === $lang || !$lang->getActive()) {
+            return;
+        }
+
+        $this->seed($lang->getLocale());
+    }
+
+    private function seed(?string $locale): void
+    {
+        if (null === $locale || '' === $locale) {
+            return;
+        }
+
+        try {
+            $this->installer->installLocale($locale);
+        } catch (\Throwable $throwable) {
+            // A shop must not be left without its language because the seed
+            // could not be replayed.
+            Tlog::getInstance()->addError(
+                \sprintf('Failed to seed the %s translations: %s', $locale, $throwable->getMessage()),
+            );
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LangEvent::POST_INSERT => ['seedCreatedLang', 64],
+            TheliaEvents::LANG_TOGGLEACTIVE => ['seedActivatedLang', 64],
+        ];
+    }
+}

--- a/core/lib/Thelia/Install/I18n/SeedI18nInstaller.php
+++ b/core/lib/Thelia/Install/I18n/SeedI18nInstaller.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Install\I18n;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Thelia\Model\Map\LangTableMap;
+
+/**
+ * Writes the translations shipped in `setup/I18n` into the i18n tables the
+ * installer seeds, for a locale that was not part of the installation.
+ *
+ * `setup/insert.sql` only carries the locales of the languages created at
+ * install time. A language added afterwards therefore lands on a shop where
+ * every seeded row — countries, states, messages, hooks… — is missing its
+ * wording, although that wording ships in `setup/I18n/<locale>.php`.
+ *
+ * Rows are read back from a locale already present in the table, their values
+ * are mapped back to their translation key, and the key is then translated into
+ * the target locale. A row is only written when at least one of its columns has
+ * a translation, so a row nobody translated keeps falling back to the default
+ * language instead of turning into a row full of NULLs. The columns of a
+ * written row that have no translation keep the source wording.
+ */
+class SeedI18nInstaller
+{
+    /**
+     * The i18n tables `setup/insert.sql.tpl` fills per locale, with the columns
+     * it translates.
+     *
+     * @var array<string, list<string>>
+     */
+    private const SEEDED_TABLES = [
+        'config_i18n' => ['title', 'chapo', 'description', 'postscriptum'],
+        'module_i18n' => ['title', 'chapo', 'description', 'postscriptum'],
+        'hook_i18n' => ['title', 'chapo', 'description'],
+        'customer_title_i18n' => ['short', 'long'],
+        'currency_i18n' => ['name'],
+        'country_i18n' => ['title', 'chapo', 'description', 'postscriptum'],
+        'state_i18n' => ['title'],
+        'tax_i18n' => ['title', 'description'],
+        'tax_rule_i18n' => ['title', 'description'],
+        'order_status_i18n' => ['title', 'description', 'chapo', 'postscriptum'],
+        'resource_i18n' => ['title', 'chapo', 'description', 'postscriptum'],
+        'message_i18n' => ['title', 'subject'],
+    ];
+
+    public function __construct(private readonly SeedTranslationCatalog $catalog)
+    {
+    }
+
+    /**
+     * @return int the number of rows written
+     */
+    public function installLocale(string $locale, ?string $sourceLocale = null): int
+    {
+        if (!$this->catalog->hasLocale($locale)) {
+            return 0;
+        }
+
+        $connection = Propel::getConnection(LangTableMap::DATABASE_NAME);
+        $writtenRows = 0;
+
+        foreach (self::SEEDED_TABLES as $table => $columns) {
+            $writtenRows += $this->installTable($connection, $table, $columns, $locale, $sourceLocale);
+        }
+
+        return $writtenRows;
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function installTable(
+        ConnectionInterface $connection,
+        string $table,
+        array $columns,
+        string $locale,
+        ?string $sourceLocale,
+    ): int {
+        $sourceLocale ??= $this->resolveSourceLocale($connection, $table, $locale);
+
+        if (null === $sourceLocale || $sourceLocale === $locale) {
+            return 0;
+        }
+
+        $existingIds = $this->getExistingIds($connection, $table, $locale);
+        $quotedColumns = array_map(static fn (string $column): string => '`'.$column.'`', $columns);
+
+        $sourceRows = $connection->prepare(
+            'SELECT `id`, '.implode(', ', $quotedColumns).' FROM `'.$table.'` WHERE `locale` = :locale',
+        );
+        $sourceRows->execute(['locale' => $sourceLocale]);
+
+        $insert = $connection->prepare(
+            'INSERT INTO `'.$table.'` (`id`, `locale`, '.implode(', ', $quotedColumns).') '
+            .'VALUES (:id, :locale, :'.implode(', :', $columns).')',
+        );
+
+        $writtenRows = 0;
+
+        foreach ($sourceRows->fetchAll(\PDO::FETCH_ASSOC) as $sourceRow) {
+            if (isset($existingIds[(int) $sourceRow['id']])) {
+                continue;
+            }
+
+            $values = $this->translateRow($sourceRow, $columns, $sourceLocale, $locale);
+
+            if (null === $values) {
+                continue;
+            }
+
+            $insert->execute(['id' => $sourceRow['id'], 'locale' => $locale] + $values);
+            ++$writtenRows;
+        }
+
+        return $writtenRows;
+    }
+
+    /**
+     * @param array<string, string|null> $sourceRow
+     * @param list<string>               $columns
+     *
+     * @return array<string, string|null>|null null when nothing could be translated
+     */
+    private function translateRow(array $sourceRow, array $columns, string $sourceLocale, string $locale): ?array
+    {
+        $values = [];
+        $hasTranslation = false;
+
+        foreach ($columns as $column) {
+            $sourceValue = $sourceRow[$column] ?? null;
+            $values[$column] = $sourceValue;
+
+            if (null === $sourceValue || '' === $sourceValue) {
+                continue;
+            }
+
+            $key = $this->catalog->getKeyForTranslation($sourceValue, $sourceLocale) ?? $sourceValue;
+            $translation = $this->catalog->translate($key, $locale);
+
+            if (null === $translation) {
+                // The source wording is kept: a mail whose subject column ends
+                // up empty is worse than a mail whose subject is not translated
+                // yet.
+                continue;
+            }
+
+            $values[$column] = $translation;
+            $hasTranslation = true;
+        }
+
+        return $hasTranslation ? $values : null;
+    }
+
+    /**
+     * Picks the locale the rows are read from.
+     *
+     * `en_US` comes first because the seed keys are the English strings, so its
+     * rows map back to their key without going through a translation table.
+     */
+    private function resolveSourceLocale(ConnectionInterface $connection, string $table, string $locale): ?string
+    {
+        $statement = $connection->prepare(
+            'SELECT `locale`, COUNT(*) AS `rows_count` FROM `'.$table.'` GROUP BY `locale`',
+        );
+        $statement->execute();
+
+        $candidates = [];
+
+        foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            $candidate = (string) $row['locale'];
+
+            if ($candidate === $locale || !$this->catalog->hasLocale($candidate)) {
+                continue;
+            }
+
+            $candidates[$candidate] = (int) $row['rows_count'];
+        }
+
+        if (isset($candidates['en_US'])) {
+            return 'en_US';
+        }
+
+        arsort($candidates);
+
+        return array_key_first($candidates);
+    }
+
+    /**
+     * @return array<int, true>
+     */
+    private function getExistingIds(ConnectionInterface $connection, string $table, string $locale): array
+    {
+        $statement = $connection->prepare('SELECT `id` FROM `'.$table.'` WHERE `locale` = :locale');
+        $statement->execute(['locale' => $locale]);
+
+        $existingIds = [];
+
+        foreach ($statement->fetchAll(\PDO::FETCH_COLUMN) as $id) {
+            $existingIds[(int) $id] = true;
+        }
+
+        return $existingIds;
+    }
+}

--- a/core/lib/Thelia/Install/I18n/SeedTranslationCatalog.php
+++ b/core/lib/Thelia/Install/I18n/SeedTranslationCatalog.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Install\I18n;
+
+/**
+ * Gives access to the translation files shipped in `setup/I18n`.
+ *
+ * Those files hold the wording the installer writes into the i18n tables: the
+ * `generate:sql` command loads them in the `install` domain and resolves every
+ * `{intl l='...' locale='...'}` of `setup/insert.sql.tpl` against them. Their
+ * keys are the English strings.
+ */
+class SeedTranslationCatalog
+{
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $catalogs = [];
+
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $reverseCatalogs = [];
+
+    private readonly string $directory;
+
+    public function __construct(?string $seedTranslationDirectory = null)
+    {
+        $seedTranslationDirectory ??= \defined('THELIA_SETUP_DIRECTORY')
+            ? THELIA_SETUP_DIRECTORY.'I18n'
+            : '';
+
+        $this->directory = rtrim($seedTranslationDirectory, \DIRECTORY_SEPARATOR);
+    }
+
+    public function hasLocale(string $locale): bool
+    {
+        return [] !== $this->getCatalog($locale);
+    }
+
+    public function translate(string $key, string $locale): ?string
+    {
+        $translation = $this->getCatalog($locale)[$key] ?? null;
+
+        return '' === $translation ? null : $translation;
+    }
+
+    /**
+     * Recovers the key a seeded value was produced from.
+     *
+     * The installer stores translations, not keys, so a row read back from the
+     * database only gives the wording of its own locale. `en_US.php` is almost
+     * an identity map, but not entirely: `Taïwan` is seeded as `Taiwan`, and
+     * `Confirm your %store account` as `Confirm your {config key="store_name"}
+     * account`. Going through the reverse index recovers the original key.
+     */
+    public function getKeyForTranslation(string $translation, string $locale): ?string
+    {
+        return $this->getReverseCatalog($locale)[$translation] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getCatalog(string $locale): array
+    {
+        if (isset($this->catalogs[$locale])) {
+            return $this->catalogs[$locale];
+        }
+
+        return $this->catalogs[$locale] = $this->loadCatalog($locale);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function loadCatalog(string $locale): array
+    {
+        if ('' === $this->directory || 1 !== preg_match('/^[a-zA-Z0-9_-]+$/', $locale)) {
+            return [];
+        }
+
+        $file = $this->directory.\DIRECTORY_SEPARATOR.$locale.'.php';
+
+        if (!is_file($file)) {
+            return [];
+        }
+
+        $catalog = include $file;
+
+        return \is_array($catalog) ? $catalog : [];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getReverseCatalog(string $locale): array
+    {
+        if (isset($this->reverseCatalogs[$locale])) {
+            return $this->reverseCatalogs[$locale];
+        }
+
+        $reverseCatalog = [];
+
+        foreach ($this->getCatalog($locale) as $key => $translation) {
+            if ('' === $translation) {
+                continue;
+            }
+
+            // Several keys may share the same translation. An entry that
+            // translates to itself is the one the installer used as key, so it
+            // wins over any other candidate.
+            if (!isset($reverseCatalog[$translation]) || $translation === $key) {
+                $reverseCatalog[$translation] = $key;
+            }
+        }
+
+        return $this->reverseCatalogs[$locale] = $reverseCatalog;
+    }
+}

--- a/tests/Integration/Action/LangSeedI18nTest.php
+++ b/tests/Integration/Action/LangSeedI18nTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Thelia\Core\Event\Lang\LangCreateEvent;
+use Thelia\Core\Event\Lang\LangToggleActiveEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\CountryI18n;
+use Thelia\Model\CountryI18nQuery;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\CustomerTitleI18nQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\LangQuery;
+use Thelia\Model\MessageI18nQuery;
+use Thelia\Model\StateI18nQuery;
+use Thelia\Model\StateQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * `setup/insert.sql` only seeds the locales of the languages the installer
+ * creates, so a language added afterwards used to land on a shop where none of
+ * the seeded rows had a title in its locale.
+ *
+ * `pl_PL` ships in `setup/I18n` but is not one of the installed languages,
+ * which makes it the case the shop hits.
+ */
+final class LangSeedI18nTest extends ActionIntegrationTestCase
+{
+    private const SEEDED_LOCALE = 'en_US';
+
+    private const ADDED_LOCALE = 'pl_PL';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (null !== LangQuery::create()->findOneByLocale(self::ADDED_LOCALE)) {
+            self::markTestSkipped(self::ADDED_LOCALE.' is already installed on this shop.');
+        }
+    }
+
+    public function testCreatingALanguageSeedsTheShippedTranslations(): void
+    {
+        self::assertNull(
+            CountryI18nQuery::create()->filterByLocale(self::ADDED_LOCALE)->findOne(),
+            'The added locale must not have any country title before the language exists.',
+        );
+
+        $this->createLang();
+
+        $poland = $this->getCountryIdByEnglishTitle('Poland');
+
+        self::assertSame(
+            'Polska',
+            CountryI18nQuery::create()->findPk([$poland, self::ADDED_LOCALE])?->getTitle(),
+        );
+
+        self::assertSame(
+            'Pan',
+            CustomerTitleI18nQuery::create()->findPk([1, self::ADDED_LOCALE])?->getShort(),
+        );
+    }
+
+    public function testKeepsTheFallbackForRowsThatNobodyTranslated(): void
+    {
+        $this->createLang();
+
+        // `Alabama` has no Polish translation in setup/I18n, `Aceh` has one.
+        // Writing a row with a NULL title for Alabama would replace the
+        // fallback to the default language by an empty title.
+        self::assertNull(
+            StateI18nQuery::create()->findPk([$this->getStateIdByEnglishTitle('Alabama'), self::ADDED_LOCALE]),
+        );
+        self::assertSame(
+            'Aceh',
+            StateI18nQuery::create()->findPk([$this->getStateIdByEnglishTitle('Aceh'), self::ADDED_LOCALE])?->getTitle(),
+        );
+    }
+
+    public function testKeepsTheSourceWordingOnAnUntranslatedColumnOfATranslatedRow(): void
+    {
+        $this->createLang();
+
+        // The mail subjects are seeded with placeholders the translation files
+        // do not carry. The row is still written for its translated columns,
+        // and the subject keeps the wording of the source locale rather than
+        // sending a mail with an empty subject.
+        $addedMessage = MessageI18nQuery::create()->findPk([2, self::ADDED_LOCALE]);
+        $seededMessage = MessageI18nQuery::create()->findPk([2, self::SEEDED_LOCALE]);
+
+        self::assertSame('Twoje nowe hasło', $addedMessage?->getTitle());
+        self::assertSame($seededMessage?->getSubject(), $addedMessage?->getSubject());
+    }
+
+    public function testSeedingAgainWritesNothingMore(): void
+    {
+        $lang = $this->createLang();
+        $seededRows = $this->countSeededCountryTitles();
+
+        self::assertGreaterThan(0, $seededRows);
+
+        $this->dispatch(new LangToggleActiveEvent($lang->getId()), TheliaEvents::LANG_TOGGLEACTIVE);
+        $this->dispatch(new LangToggleActiveEvent($lang->getId()), TheliaEvents::LANG_TOGGLEACTIVE);
+
+        self::assertSame($seededRows, $this->countSeededCountryTitles());
+    }
+
+    public function testLeavesAlreadyTranslatedRowsUntouched(): void
+    {
+        $poland = $this->getCountryIdByEnglishTitle('Poland');
+
+        (new CountryI18n())
+            ->setId($poland)
+            ->setLocale(self::ADDED_LOCALE)
+            ->setTitle('Set by the shop owner')
+            ->save();
+
+        $this->createLang();
+
+        self::assertSame(
+            'Set by the shop owner',
+            CountryI18nQuery::create()->findPk([$poland, self::ADDED_LOCALE])?->getTitle(),
+        );
+    }
+
+    public function testIgnoresALocaleThatShipsNoTranslationFile(): void
+    {
+        // The code stays `pl` so the listener that copies a missing flag has
+        // nothing to write outside the database.
+        $lang = $this->createLang('xx_XX');
+
+        self::assertNotNull($lang->getId());
+        self::assertNull(CountryI18nQuery::create()->filterByLocale('xx_XX')->findOne());
+    }
+
+    private function createLang(string $locale = self::ADDED_LOCALE): Lang
+    {
+        $event = new LangCreateEvent();
+        $event
+            ->setTitle('Polski')
+            ->setCode('pl')
+            ->setLocale($locale)
+            ->setDateFormat('d/m/Y')
+            ->setTimeFormat('H:i:s')
+            ->setDateTimeFormat('d/m/Y H:i:s')
+            ->setDecimalSeparator(',')
+            ->setThousandsSeparator(' ')
+            ->setDecimals('2');
+
+        $this->dispatch($event, TheliaEvents::LANG_CREATE);
+
+        $lang = $event->getLang();
+
+        self::assertNotNull($lang);
+
+        return $lang;
+    }
+
+    private function countSeededCountryTitles(): int
+    {
+        return CountryI18nQuery::create()->filterByLocale(self::ADDED_LOCALE)->count();
+    }
+
+    private function getCountryIdByEnglishTitle(string $title): int
+    {
+        $country = CountryQuery::create()
+            ->useCountryI18nQuery()
+                ->filterByLocale(self::SEEDED_LOCALE)
+                ->filterByTitle($title)
+            ->endUse()
+            ->findOne();
+
+        self::assertNotNull($country, \sprintf('No country titled "%s" in %s.', $title, self::SEEDED_LOCALE));
+
+        return $country->getId();
+    }
+
+    private function getStateIdByEnglishTitle(string $title): int
+    {
+        $state = StateQuery::create()
+            ->useStateI18nQuery()
+                ->filterByLocale(self::SEEDED_LOCALE)
+                ->filterByTitle($title)
+            ->endUse()
+            ->findOne();
+
+        self::assertNotNull($state, \sprintf('No state titled "%s" in %s.', $title, self::SEEDED_LOCALE));
+
+        return $state->getId();
+    }
+}

--- a/tests/Unit/Install/I18n/SeedTranslationCatalogTest.php
+++ b/tests/Unit/Install/I18n/SeedTranslationCatalogTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Install\I18n;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Install\I18n\SeedTranslationCatalog;
+
+final class SeedTranslationCatalogTest extends TestCase
+{
+    private string $directory;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->directory = sys_get_temp_dir().'/thelia-seed-catalog-'.uniqid('', true);
+
+        $this->filesystem->mkdir($this->directory);
+
+        $this->writeCatalog('en_US', [
+            'Taïwan' => 'Taiwan',
+            'Taiwan' => 'Taiwan',
+            'Poland' => 'Poland',
+            'France' => 'France',
+            'Untranslated everywhere' => '',
+        ]);
+
+        $this->writeCatalog('pl_PL', [
+            'Taïwan' => 'Tajwan',
+            'Poland' => 'Polska',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->directory);
+    }
+
+    public function testOnlyReportsTheShippedLocales(): void
+    {
+        $catalog = new SeedTranslationCatalog($this->directory);
+
+        self::assertTrue($catalog->hasLocale('pl_PL'));
+        self::assertFalse($catalog->hasLocale('xx_XX'));
+    }
+
+    public function testTranslatesAKeyIntoTheTargetLocale(): void
+    {
+        $catalog = new SeedTranslationCatalog($this->directory);
+
+        self::assertSame('Polska', $catalog->translate('Poland', 'pl_PL'));
+    }
+
+    public function testReportsAMissingTranslationAsNull(): void
+    {
+        $catalog = new SeedTranslationCatalog($this->directory);
+
+        self::assertNull($catalog->translate('France', 'pl_PL'));
+        self::assertNull($catalog->translate('Untranslated everywhere', 'en_US'));
+    }
+
+    public function testRecoversTheKeyASeededValueComesFrom(): void
+    {
+        $catalog = new SeedTranslationCatalog($this->directory);
+
+        // `Taïwan` and `Taiwan` both seed the English value `Taiwan`. The entry
+        // that translates to itself is the one the value has to map back to,
+        // otherwise the Polish translation of an unrelated key would be picked.
+        self::assertSame('Taiwan', $catalog->getKeyForTranslation('Taiwan', 'en_US'));
+        self::assertSame('Poland', $catalog->getKeyForTranslation('Poland', 'en_US'));
+        self::assertNull($catalog->getKeyForTranslation('Never seeded', 'en_US'));
+    }
+
+    public function testRecoversTheKeysOfTheShippedEnglishCatalog(): void
+    {
+        $catalog = new SeedTranslationCatalog(\dirname(__DIR__, 4).'/setup/I18n');
+
+        // `en_US.php` is not a plain identity map. The seed writes `Taiwan`
+        // into `country_i18n` although the key is `Taïwan`, and the subject of
+        // the account confirmation mail keeps a `%store` placeholder in its
+        // key only. Taking those values for keys finds no translation at all.
+        self::assertNull($catalog->translate('Taiwan', 'fr_FR'));
+        self::assertSame('Taïwan', $catalog->getKeyForTranslation('Taiwan', 'en_US'));
+        self::assertSame('Taïwan', $catalog->translate('Taïwan', 'fr_FR'));
+
+        $seededSubject = 'Confirm your {config key="store_name"} account';
+
+        self::assertNull($catalog->translate($seededSubject, 'fr_FR'));
+        self::assertSame(
+            'Confirmez la création de votre compte {config key="store_name"}',
+            $catalog->translate(
+                (string) $catalog->getKeyForTranslation($seededSubject, 'en_US'),
+                'fr_FR',
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, string> $translations
+     */
+    private function writeCatalog(string $locale, array $translations): void
+    {
+        $this->filesystem->dumpFile(
+            $this->directory.'/'.$locale.'.php',
+            '<?php return '.var_export($translations, true).';',
+        );
+    }
+}


### PR DESCRIPTION
Fixes #3697

`setup/insert.sql` only carries the locales of the seven languages the installer creates. The eleven other files of `setup/I18n` — `tr_TR` alone holds 1012 translations — never reached a database, and nothing replayed them afterwards. Adding one of those languages in the back office gave a shop with no country title, no state title and no message title in that locale.

## What changes

Creating a language (`LangEvent::POST_INSERT`, so the back office, the API and a fixture all go through it) or activating one (`LANG_TOGGLEACTIVE`, which is how a shop that added a language before this listener existed gets its rows) now writes the shipped translations into the twelve i18n tables `setup/insert.sql.tpl` fills per locale: `config`, `module`, `hook`, `customer_title`, `currency`, `country`, `state`, `tax`, `tax_rule`, `order_status`, `resource` and `message`.

Rows are read back from a locale already in the table, mapped back to their translation key, and the key is translated into the target locale. `en_US` comes first as source because the seed keys are the English strings — though not always: the seed writes `Taiwan` although the key is `Taïwan`, and turns `Confirm your %store account` into `Confirm your {config key="store_name"} account`. A reverse index over `en_US.php` recovers the original key, which a plain lookup on the stored value would miss.

Two rules keep the write conservative:

- a row is only written when at least one of its columns has a translation, so a row nobody translated keeps falling back to the default language instead of becoming a row full of `NULL`s;
- a column of a written row that has no translation keeps the source wording — a mail whose `subject` ends up empty is worse than a mail whose subject is not translated yet. The mail subjects are seeded with placeholders the translation files do not carry, so this is the common case there.

Nothing is written twice: only ids missing for the target locale are inserted, and a title the shop owner already set is left alone. A locale with no file in `setup/I18n` is a no-op. A failure is logged instead of leaving the shop without its language. Seeding `pl_PL` on the demo data takes 33 ms.

## Why the install still creates seven languages

The seed stays at seven. A shop should start with the languages it asked for, not with eleven more nobody enabled, and carrying all eighteen locales in `insert.sql` would add some 4500 `state_i18n` rows alone for languages that have no `lang` row and partial coverage (`pl_PL` translates 475 of 1517 keys, `el_GR` three). The gap the issue describes is the absence of a replay, and that is what this fixes: the eleven other languages now arrive with their wording the moment they are added.

## Tests

`tests/Integration/Action/LangSeedI18nTest.php` was red before the listener on four counts — no `Polska`, no `Aceh`, no `Twoje nowe hasło`, nothing seeded at all — and covers the fallback that must be preserved, the untranslated column that keeps its source wording, a second seeding writing nothing more, and a shop title left untouched. `tests/Unit/Install/I18n/SeedTranslationCatalogTest.php` covers the key recovery, including against the shipped `en_US.php`.

`composer test` (5 suites), `composer cs-diff` and `composer phpstan` green.

## Note for the maintainers

`setup/insert.sql` carries Twig placeholders (`{{ order_ref }}`) for the mail subjects while `setup/insert.sql.tpl` and `setup/I18n/*.php` still hold the Smarty ones (`{$order_ref}`). Running `generate:sql` today would take `insert.sql` back to Smarty syntax. Left untouched here.
