### PR TITLE
fix: erase the customer identity the admin log keeps after an anonymization

### DIFF
--- a/core/lib/Thelia/Domain/Customer/Service/CustomerAnonymizer.php
+++ b/core/lib/Thelia/Domain/Customer/Service/CustomerAnonymizer.php
@@ -17,7 +17,9 @@ namespace Thelia\Domain\Customer\Service;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Propel;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Model\AddressQuery;
+use Thelia\Model\AdminLogQuery;
 use Thelia\Model\CartAddressQuery;
 use Thelia\Model\CartQuery;
 use Thelia\Model\Customer;
@@ -35,7 +37,8 @@ use Thelia\Model\OrderQuery;
  * reference, their invoice number and date, their amounts, their taxes, their
  * coupons and their status history. What disappears is who placed them: the
  * account identity, the address book, the identity frozen on the invoice and
- * delivery order addresses, the carts and the newsletter subscription.
+ * delivery order addresses, the carts, the newsletter subscription and the
+ * identity the administrator audit trail recorded about that customer.
  *
  * The country and state of an order address are kept, because they justify
  * the tax rate applied on the order.
@@ -47,6 +50,7 @@ final readonly class CustomerAnonymizer
 {
     public const ANONYMIZED_VALUE = 'anonymous';
     public const ANONYMIZED_EMAIL_DOMAIN = 'anonymous.invalid';
+    public const ANONYMIZED_ADMIN_LOG_MESSAGE = 'Personal data erased from this entry';
 
     /**
      * @param iterable<CustomerPersonalDataProviderInterface> $personalDataProviders
@@ -71,6 +75,7 @@ final readonly class CustomerAnonymizer
             $this->deleteAddresses($customer, $connection);
             $this->deleteNewsletterSubscription($customer, $connection);
             $this->anonymizeAccount($customer, $connection);
+            $this->anonymizeAdminLogs($customer, $connection);
 
             foreach ($this->personalDataProviders as $provider) {
                 $provider->anonymizePersonalData($customer);
@@ -215,5 +220,33 @@ final readonly class CustomerAnonymizer
         // the account, identity included. Anonymizing the row is pointless
         // while that history is still readable.
         CustomerVersionQuery::create()->filterById($customer->getId())->delete($connection);
+    }
+
+    /**
+     * An ordinary back-office edit of a customer writes their identity twice
+     * in the audit trail: in the message, which is composed from the name, and
+     * in the serialized request, which holds the whole posted form
+     * (AdminLog::append() with $withRequestContent). Neither survives an
+     * erasure.
+     *
+     * What the trail is for does survive: admin_login, action and created_at
+     * are kept, so it still says who did what, to which customer, and when.
+     * Only the rows carrying this customer as their resource are rewritten,
+     * so the trail of every other resource is left untouched. updated_at
+     * records the rewrite itself, rather than letting the row change silently.
+     */
+    private function anonymizeAdminLogs(Customer $customer, ConnectionInterface $connection): void
+    {
+        AdminLogQuery::create()
+            ->filterByResource(AdminResources::CUSTOMER)
+            ->filterByResourceId($customer->getId())
+            ->update(
+                [
+                    'Message' => self::ANONYMIZED_ADMIN_LOG_MESSAGE,
+                    'Request' => null,
+                    'UpdatedAt' => new \DateTime(),
+                ],
+                $connection,
+            );
     }
 }

--- a/tests/Integration/Domain/Customer/CustomerAnonymizerTest.php
+++ b/tests/Integration/Domain/Customer/CustomerAnonymizerTest.php
@@ -17,9 +17,12 @@ namespace Thelia\Tests\Integration\Domain\Customer;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Customer\CustomerAnonymizeEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Domain\Customer\Service\CustomerAnonymizer;
 use Thelia\Domain\Customer\Service\CustomerPersonalDataProviderInterface;
 use Thelia\Model\AddressQuery;
+use Thelia\Model\AdminLog;
+use Thelia\Model\AdminLogQuery;
 use Thelia\Model\CartQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
@@ -162,6 +165,68 @@ final class CustomerAnonymizerTest extends IntegrationTestCase
         }
     }
 
+    /**
+     * A back-office edit of a customer writes their identity twice in the
+     * audit trail: in the message, composed from the name, and in the
+     * serialized request, which holds the whole posted form.
+     */
+    public function testAnonymizeErasesTheIdentityLeftInTheAdminLog(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+
+        $editLog = $this->adminLog(
+            AdminResources::CUSTOMER,
+            $customer->getId(),
+            'UPDATE',
+            'Customer Anonymizer Subject (ID '.$customer->getId().') modified',
+            'POST /admin/customer/save lastname=Subject&email=anonymizer-subject@test.com',
+        );
+
+        $this->anonymize($customer);
+
+        $rewritten = AdminLogQuery::create()->findPk($editLog->getId());
+        self::assertNotNull($rewritten);
+        self::assertSame(CustomerAnonymizer::ANONYMIZED_ADMIN_LOG_MESSAGE, $rewritten->getMessage());
+        self::assertNull($rewritten->getRequest());
+
+        self::assertSame('admin-login', $rewritten->getAdminLogin(), 'An erasure must not erase who performed the logged action.');
+        self::assertSame('UPDATE', $rewritten->getAction());
+        self::assertSame($customer->getId(), $rewritten->getResourceId());
+        self::assertSame('2020-01-02 03:04:05', $rewritten->getCreatedAt('Y-m-d H:i:s'), 'The trail must still say when the action happened.');
+        self::assertNotSame(
+            '2020-01-02 03:04:05',
+            $rewritten->getUpdatedAt('Y-m-d H:i:s'),
+            'The rewrite is itself recorded, rather than letting an audited row change silently.',
+        );
+    }
+
+    /**
+     * The rewrite is bounded to the rows about that customer: an audit trail
+     * that erased entries about other resources, or about other customers,
+     * would destroy evidence unrelated to the erasure.
+     */
+    public function testAnonymizeLeavesTheAdminLogOfOtherResourcesUntouched(): void
+    {
+        $customer = $this->createCustomerWithHistory();
+        $otherCustomer = $this->factory->customer($this->factory->customerTitle());
+
+        $orderLog = $this->adminLog(AdminResources::ORDER, $customer->getId(), 'UPDATE', 'Order 12 modified', 'order payload');
+        $otherCustomerLog = $this->adminLog(AdminResources::CUSTOMER, $otherCustomer->getId(), 'UPDATE', 'Customer Other Person modified', 'other payload');
+
+        $this->anonymize($customer);
+
+        $reloadedOrderLog = AdminLogQuery::create()->findPk($orderLog->getId());
+        self::assertNotNull($reloadedOrderLog);
+        self::assertSame('Order 12 modified', $reloadedOrderLog->getMessage());
+        self::assertSame('order payload', $reloadedOrderLog->getRequest());
+        self::assertSame('2020-01-02 03:04:05', $reloadedOrderLog->getUpdatedAt('Y-m-d H:i:s'), 'The row must not be written at all.');
+
+        $reloadedOtherCustomerLog = AdminLogQuery::create()->findPk($otherCustomerLog->getId());
+        self::assertNotNull($reloadedOtherCustomerLog);
+        self::assertSame('Customer Other Person modified', $reloadedOtherCustomerLog->getMessage());
+        self::assertSame('other payload', $reloadedOtherCustomerLog->getRequest());
+    }
+
     public function testAnonymizeCallsThePersonalDataProviders(): void
     {
         $customer = $this->createCustomerWithHistory();
@@ -223,6 +288,23 @@ final class CustomerAnonymizerTest extends IntegrationTestCase
         $this->expectExceptionMessage('module failure');
 
         (new CustomerAnonymizer([$failingProvider]))->anonymize($customer);
+    }
+
+    private function adminLog(string $resource, int $resourceId, string $action, string $message, string $request): AdminLog
+    {
+        $adminLog = new AdminLog();
+        $adminLog
+            ->setAdminLogin('admin-login')
+            ->setResource($resource)
+            ->setResourceId($resourceId)
+            ->setAction($action)
+            ->setMessage($message)
+            ->setRequest($request)
+            ->setCreatedAt(new \DateTime('2020-01-02 03:04:05'))
+            ->setUpdatedAt(new \DateTime('2020-01-02 03:04:05'))
+            ->save($this->getPropelConnection());
+
+        return $adminLog;
     }
 
     private function anonymize(Customer $customer): void


### PR DESCRIPTION
Last open point of #3589. Points 1, 2 and 3 landed in #3692, #3684 and the two
template pull requests; this is point 4, the identity the administrator audit
trail keeps after an erasure.

An ordinary back-office edit of a customer writes their identity **twice**:
in `message`, composed from the name (`Customer Kenji Tanaka (ID 3) modified`),
and in `request`, which `AdminLog::append()` fills with the whole posted form.
Anonymizing the account left both untouched, so the erased name stayed
readable in `admin_log` until the log purge got to it — up to
`purification_admin_logs_days`, 180 days by default.

This implements **option B** of the arbitration in the thread: the rows about
that customer are rewritten inside the transaction `CustomerAnonymizer`
already opens.

What the audit trail is for survives. `admin_login`, `action`, `resource`,
`resource_id` and `created_at` are kept, so the record still says who did
what, to which customer, and when — it simply no longer says who the customer
was. `updated_at` moves, so the rewrite is itself recorded rather than letting
an audited row change silently.

The rewrite is bounded to `resource = 'admin.customer' AND resource_id = <id>`,
a two-column lookup rather than a text search. Rows about other resources and
about other customers are not read and not written, so no evidence unrelated
to this erasure is destroyed. The cost, stated in the thread and unchanged
here: a row about this customer logged under another resource (an order an
administrator edited, say) keeps whatever it holds.

Option C — not writing the identity in the first place — is a rule for new
code rather than a migration, and the two back-office actions of
thelia-templates/default-twig#29 already follow it: they log the customer id
alone and carry no request content.

Retention picks this up for free: `CustomerPurger` anonymizes through
`CUSTOMER_ANONYMIZE`, so a nightly run cleans the audit trail exactly as an
administrator triggering the operation by hand does.

Two integration tests, both verified red before the fix: one on the rewrite
itself (sabotaged by removing the call — the customer name comes back), one on
the bounding (sabotaged by dropping the two filters — the unrelated order row
is rewritten).

Fixes #3589
