### PR TITLE
feat: store the virtual document of a sale element in its own table

### DIFF
--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -25,8 +25,6 @@ use Thelia\Core\Event\Feature\FeatureAvDeleteEvent;
 use Thelia\Core\Event\FeatureProduct\FeatureProductDeleteEvent;
 use Thelia\Core\Event\FeatureProduct\FeatureProductUpdateEvent;
 use Thelia\Core\Event\File\FileDeleteEvent;
-use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
-use Thelia\Core\Event\MetaData\MetaDataDeleteEvent;
 use Thelia\Core\Event\Product\ProductAddAccessoryEvent;
 use Thelia\Core\Event\Product\ProductAddCategoryEvent;
 use Thelia\Core\Event\Product\ProductAddContentEvent;
@@ -60,7 +58,6 @@ use Thelia\Model\Map\AttributeTemplateTableMap;
 use Thelia\Model\Map\FeatureTemplateTableMap;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
 use Thelia\Model\Map\ProductTableMap;
-use Thelia\Model\MetaData as MetaDataModel;
 use Thelia\Model\Product as ProductModel;
 use Thelia\Model\ProductAssociatedContent;
 use Thelia\Model\ProductAssociatedContentQuery;
@@ -381,7 +378,6 @@ class Product extends BaseAction implements EventSubscriberInterface
 
     /**
      * Store the document a virtual product is downloaded from, for the default sale element.
-     * The association lives in a meta_data row (virtual key, pse element).
      *
      * A null or negative value means the caller does not handle the association (a product with
      * several combinations sets it per combination), 0 removes it, and a document id sets it.
@@ -403,19 +399,7 @@ class Product extends BaseAction implements EventSubscriberInterface
             return;
         }
 
-        if (0 === (int) $virtualDocumentId) {
-            $this->eventDispatcher->dispatch(
-                new MetaDataDeleteEvent('virtual', MetaDataModel::PSE_KEY, $defaultPse->getId()),
-                TheliaEvents::META_DATA_DELETE
-            );
-
-            return;
-        }
-
-        $this->eventDispatcher->dispatch(
-            new MetaDataCreateOrUpdateEvent('virtual', MetaDataModel::PSE_KEY, $defaultPse->getId(), (int) $virtualDocumentId),
-            TheliaEvents::META_DATA_UPDATE
-        );
+        $defaultPse->setVirtualDocument(0 === (int) $virtualDocumentId ? null : (int) $virtualDocumentId);
     }
 
     public function updateSeo(UpdateSeoEvent $event, $eventName, EventDispatcherInterface $dispatcher): mixed

--- a/core/lib/Thelia/Action/ProductSaleElement.php
+++ b/core/lib/Thelia/Action/ProductSaleElement.php
@@ -20,7 +20,6 @@ use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Thelia\Core\Event\MetaData\MetaDataCreateOrUpdateEvent;
 use Thelia\Core\Event\Product\ProductCloneEvent;
 use Thelia\Core\Event\Product\ProductCombinationGenerationEvent;
 use Thelia\Core\Event\ProductSaleElement\ProductSaleElementCreateEvent;
@@ -38,8 +37,6 @@ use Thelia\Model\AttributeCombination;
 use Thelia\Model\AttributeCombinationQuery;
 use Thelia\Model\Map\AttributeCombinationTableMap;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
-use Thelia\Model\MetaData;
-use Thelia\Model\MetaDataQuery;
 use Thelia\Model\ProductDocumentQuery;
 use Thelia\Model\ProductImageQuery;
 use Thelia\Model\ProductPrice;
@@ -391,47 +388,45 @@ class ProductSaleElement extends BaseAction implements EventSubscriberInterface
                 $this->clonePSEAssociatedFiles($clonedProduct->getId(), $clonedProductPSEId, $originalProductPSEDocuments, $type = 'document');
             }
 
-            $this->cloneVirtualDocumentAssociation($event, $originalProductPSE->getId(), $clonedProductPSEId);
+            $this->cloneVirtualDocumentAssociation($event, $originalProductPSE, $clonedProductPSEId);
         }
     }
 
     /**
      * Point the cloned sale element at the clone's own copy of the document a virtual
-     * product is downloaded from. The association lives in a meta_data row (virtual key,
-     * pse element), and is copied whenever the source has one, whether or not the product
-     * is currently flagged as virtual.
+     * product is downloaded from. The association is copied whenever the source has one,
+     * whether or not the product is currently flagged as virtual.
      */
-    private function cloneVirtualDocumentAssociation(ProductCloneEvent $event, int $originalPseId, int $clonedPseId): void
+    private function cloneVirtualDocumentAssociation(ProductCloneEvent $event, ProductSaleElements $originalPse, int $clonedPseId): void
     {
-        $originalDocumentId = (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $originalPseId);
+        $originalDocument = $originalPse->getVirtualDocument();
 
-        if ($originalDocumentId <= 0) {
+        if (null === $originalDocument) {
             return;
         }
 
-        $clonedDocumentId = $event->getClonedDocumentId($originalDocumentId);
+        $clonedDocumentId = $event->getClonedDocumentId($originalDocument->getId());
 
         if (null === $clonedDocumentId) {
-            // The source document was not copied — its file is missing from the disk, or the
-            // meta_data row points outside of the product. Reusing the source id would make the
-            // clone depend on a file deleted along with the original product, so the clone is
-            // left without a virtual document and the merchant has to pick one.
+            // The source document was not copied — its file is missing from the disk, or it
+            // belongs to another product. Reusing the source id would make the clone depend
+            // on a file deleted along with the original product, so the clone is left without
+            // a virtual document and the merchant has to pick one.
             Tlog::getInstance()->addWarning(
                 \sprintf(
                     'Product clone %s: sale element %d has no virtual document, the document %d of the source product was not copied.',
                     $event->getClonedProduct()->getRef(),
                     $clonedPseId,
-                    $originalDocumentId
+                    $originalDocument->getId()
                 )
             );
 
             return;
         }
 
-        $this->eventDispatcher->dispatch(
-            new MetaDataCreateOrUpdateEvent('virtual', MetaData::PSE_KEY, $clonedPseId, $clonedDocumentId),
-            TheliaEvents::META_DATA_UPDATE
-        );
+        $clonedPse = ProductSaleElementsQuery::create()->findPk($clonedPseId);
+
+        $clonedPse?->setVirtualDocument($clonedDocumentId);
     }
 
     /**

--- a/core/lib/Thelia/Model/ProductSaleElements.php
+++ b/core/lib/Thelia/Model/ProductSaleElements.php
@@ -28,14 +28,6 @@ class ProductSaleElements extends BaseProductSaleElements
     use TaxCalculatorResolverTrait;
 
     /**
-     * The meta data key holding the virtual document association.
-     *
-     * Read it through getVirtualDocuments() rather than directly: the storage is
-     * meant to move to a dedicated table, the accessor is not.
-     */
-    public const VIRTUAL_DOCUMENT_META_KEY = 'virtual';
-
-    /**
      * @throws PropelException
      */
     public function getPrice(string $virtualColumnName = 'price_PRICE', float $discount = 0.0): float
@@ -136,24 +128,16 @@ class ProductSaleElements extends BaseProductSaleElements
     /**
      * The documents a customer buying this sale element is entitled to download.
      *
-     * An association pointing at a document that has since been deleted is dropped:
-     * nothing cleans the meta data when a ProductDocument goes away, so a stale id
-     * would otherwise surface as a virtual product with no file behind it.
-     *
      * @return ObjectCollection<ProductDocument>
      */
     public function getVirtualDocuments(): ObjectCollection
     {
-        $documents = new ObjectCollection();
-        $documents->setModel(ProductDocument::class);
-
-        $document = $this->getVirtualDocument();
-
-        if (null !== $document) {
-            $documents->append($document);
-        }
-
-        return $documents;
+        return ProductDocumentQuery::create()
+            ->useProductSaleElementsVirtualDocumentQuery()
+                ->filterByProductSaleElementsId($this->getId())
+                ->orderByPosition()
+            ->endUse()
+            ->find();
     }
 
     /**
@@ -161,17 +145,38 @@ class ProductSaleElements extends BaseProductSaleElements
      */
     public function getVirtualDocument(): ?ProductDocument
     {
-        $documentId = MetaDataQuery::getVal(
-            self::VIRTUAL_DOCUMENT_META_KEY,
-            MetaData::PSE_KEY,
-            $this->getId()
-        );
+        return ProductDocumentQuery::create()
+            ->useProductSaleElementsVirtualDocumentQuery()
+                ->filterByProductSaleElementsId($this->getId())
+                ->orderByPosition()
+            ->endUse()
+            ->findOne();
+    }
 
-        if (!is_numeric($documentId)) {
-            return null;
+    /**
+     * Set the document this sale element is downloaded from, or remove the association
+     * when given null.
+     *
+     * The table holds several rows per sale element so that offering more than one file
+     * stays a matter of allowing a second row. Until that product decision is taken, a
+     * sale element is downloaded from a single document, and this is where the rule is
+     * enforced.
+     */
+    public function setVirtualDocument(?int $documentId): void
+    {
+        ProductSaleElementsVirtualDocumentQuery::create()
+            ->filterByProductSaleElementsId($this->getId())
+            ->delete();
+
+        if (null === $documentId) {
+            return;
         }
 
-        return ProductDocumentQuery::create()->findPk((int) $documentId);
+        (new ProductSaleElementsVirtualDocument())
+            ->setProductSaleElementsId($this->getId())
+            ->setProductDocumentId($documentId)
+            ->setPosition(1)
+            ->save();
     }
 
     protected function addCriteriaToPositionQuery($query): void

--- a/core/lib/Thelia/Model/ProductSaleElementsVirtualDocument.php
+++ b/core/lib/Thelia/Model/ProductSaleElementsVirtualDocument.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\ProductSaleElementsVirtualDocument as BaseProductSaleElementsVirtualDocument;
+
+class ProductSaleElementsVirtualDocument extends BaseProductSaleElementsVirtualDocument
+{
+}

--- a/core/lib/Thelia/Model/ProductSaleElementsVirtualDocumentQuery.php
+++ b/core/lib/Thelia/Model/ProductSaleElementsVirtualDocumentQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\ProductSaleElementsVirtualDocumentQuery as BaseProductSaleElementsVirtualDocumentQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'product_sale_elements_virtual_document' table.
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements. This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class ProductSaleElementsVirtualDocumentQuery extends BaseProductSaleElementsVirtualDocumentQuery
+{
+}
+
+// ProductSaleElementsVirtualDocumentQuery

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1883,6 +1883,26 @@
       <index-column name="product_sale_elements_id" />
     </index>
   </table>
+  <table name="product_sale_elements_virtual_document" namespace="Thelia\Model">
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="product_sale_elements_id" required="true" type="INTEGER" />
+    <column name="product_document_id" required="true" type="INTEGER" />
+    <column defaultValue="1" name="position" required="true" type="INTEGER" />
+    <foreign-key foreignTable="product_sale_elements" name="fk_pse_virtual_document_product_sale_elements_id" onDelete="CASCADE" onUpdate="RESTRICT">
+      <reference foreign="id" local="product_sale_elements_id" />
+    </foreign-key>
+    <foreign-key foreignTable="product_document" name="fk_pse_virtual_document_product_document_id" onDelete="CASCADE" onUpdate="RESTRICT">
+      <reference foreign="id" local="product_document_id" />
+    </foreign-key>
+    <unique name="pse_virtual_document_unique_idx">
+      <unique-column name="product_sale_elements_id" />
+      <unique-column name="product_document_id" />
+    </unique>
+    <index name="fk_pse_virtual_document_product_document_idx">
+      <index-column name="product_document_id" />
+    </index>
+    <behavior name="timestampable" />
+  </table>
   <table name="hook" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="code" required="true" size="255" type="VARCHAR" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -2297,6 +2297,35 @@ CREATE TABLE `product_sale_elements_product_document`
 ) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
 
 -- ---------------------------------------------------------------------
+-- product_sale_elements_virtual_document
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `product_sale_elements_virtual_document`;
+
+CREATE TABLE `product_sale_elements_virtual_document`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `product_sale_elements_id` INTEGER NOT NULL,
+    `product_document_id` INTEGER NOT NULL,
+    `position` INTEGER DEFAULT 1 NOT NULL,
+    `created_at` TIMESTAMP NULL,
+    `updated_at` TIMESTAMP NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `pse_virtual_document_unique_idx` (`product_sale_elements_id`, `product_document_id`),
+    INDEX `fk_pse_virtual_document_product_document_idx` (`product_document_id`),
+    CONSTRAINT `fk_pse_virtual_document_product_sale_elements_id`
+        FOREIGN KEY (`product_sale_elements_id`)
+        REFERENCES `product_sale_elements` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE,
+    CONSTRAINT `fk_pse_virtual_document_product_document_id`
+        FOREIGN KEY (`product_document_id`)
+        REFERENCES `product_document` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------
 -- hook
 -- ---------------------------------------------------------------------
 

--- a/setup/update/sql/3.0.0-beta3.sql
+++ b/setup/update/sql/3.0.0-beta3.sql
@@ -263,4 +263,73 @@ CREATE TABLE IF NOT EXISTS `order_postage_tax`
         ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
 
+-- ---------------------------------------------------------------------
+-- product_sale_elements_virtual_document (#3520)
+--
+-- The file a virtual product is downloaded from was a meta_data row keyed
+-- ('virtual', 'pse', sale element id), holding the document id as text. Nothing
+-- tied it to the two tables it points at: deleting the document or the
+-- combination left the row behind, and since InnoDB does not persist
+-- AUTO_INCREMENT across a restart, a sale element created later could be given
+-- a freed id and inherit an association nobody set. The pair was not unique
+-- either, so two writes could leave two rows and the reader picked one.
+--
+-- The association now has its own table, with a foreign key on each side and a
+-- unique pair. `position` is there so that offering several files per
+-- combination becomes a second row rather than a second migration; the service
+-- layer keeps writing a single row until that product decision is taken.
+--
+-- Existing rows are moved over, then dropped: nothing reads the key any more.
+-- `value` is a CLOB any module can write through MetaDataQuery::setVal(), so a
+-- serialized payload would be cast to 0 - hence the two guards. Rows pointing
+-- at a document or a combination that no longer exists cannot be carried over
+-- and are reported by the SELECT below before they go.
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `product_sale_elements_virtual_document`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `product_sale_elements_id` INTEGER NOT NULL,
+    `product_document_id` INTEGER NOT NULL,
+    `position` INTEGER DEFAULT 1 NOT NULL,
+    `created_at` TIMESTAMP NULL,
+    `updated_at` TIMESTAMP NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `pse_virtual_document_unique_idx` (`product_sale_elements_id`, `product_document_id`),
+    INDEX `fk_pse_virtual_document_product_document_idx` (`product_document_id`),
+    CONSTRAINT `fk_pse_virtual_document_product_sale_elements_id`
+        FOREIGN KEY (`product_sale_elements_id`)
+        REFERENCES `product_sale_elements` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE,
+    CONSTRAINT `fk_pse_virtual_document_product_document_id`
+        FOREIGN KEY (`product_document_id`)
+        REFERENCES `product_document` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
+-- The associations that will not be carried over, listed rather than discarded
+-- in silence. An empty result means everything moved.
+SELECT `meta_data`.`element_id` AS `product_sale_elements_id`, `meta_data`.`value` AS `product_document_id`
+FROM `meta_data`
+LEFT JOIN `product_sale_elements` ON `product_sale_elements`.`id` = `meta_data`.`element_id`
+LEFT JOIN `product_document` ON `product_document`.`id` = CAST(`meta_data`.`value` AS UNSIGNED)
+WHERE `meta_data`.`meta_key` = 'virtual' AND `meta_data`.`element_key` = 'pse'
+  AND (`product_sale_elements`.`id` IS NULL OR `product_document`.`id` IS NULL
+       OR `meta_data`.`is_serialized` <> 0 OR `meta_data`.`value` NOT REGEXP '^[0-9]+$');
+
+INSERT IGNORE INTO `product_sale_elements_virtual_document`
+    (`product_sale_elements_id`, `product_document_id`, `position`, `created_at`, `updated_at`)
+SELECT `meta_data`.`element_id`, `product_document`.`id`, 1, NOW(), NOW()
+FROM `meta_data`
+INNER JOIN `product_sale_elements` ON `product_sale_elements`.`id` = `meta_data`.`element_id`
+INNER JOIN `product_document` ON `product_document`.`id` = CAST(`meta_data`.`value` AS UNSIGNED)
+WHERE `meta_data`.`meta_key` = 'virtual'
+  AND `meta_data`.`element_key` = 'pse'
+  AND `meta_data`.`is_serialized` = 0
+  AND `meta_data`.`value` REGEXP '^[0-9]+$';
+
+DELETE FROM `meta_data` WHERE `meta_key` = 'virtual' AND `element_key` = 'pse';
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/Integration/Action/ProductActionTest.php
+++ b/tests/Integration/Action/ProductActionTest.php
@@ -19,8 +19,6 @@ use Thelia\Core\Event\Product\ProductCreateEvent;
 use Thelia\Core\Event\Product\ProductDeleteEvent;
 use Thelia\Core\Event\Product\ProductUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Model\MetaData;
-use Thelia\Model\MetaDataQuery;
 use Thelia\Model\Product;
 use Thelia\Model\ProductDocument;
 use Thelia\Model\ProductPriceQuery;
@@ -179,7 +177,7 @@ final class ProductActionTest extends IntegrationTestCase
 
         self::assertSame(
             $document->getId(),
-            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $this->defaultSaleElement($product)->getId()),
+            $this->defaultSaleElement($product)->getVirtualDocument()?->getId(),
         );
     }
 
@@ -189,14 +187,14 @@ final class ProductActionTest extends IntegrationTestCase
         $document = $this->createDocument($product);
         $defaultPse = $this->defaultSaleElement($product);
 
-        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultPse->getId(), $document->getId());
+        $defaultPse->setVirtualDocument($document->getId());
 
         $this->dispatcher->dispatch(
             $this->virtualDocumentUpdateEvent($product, 0),
             TheliaEvents::PRODUCT_UPDATE,
         );
 
-        self::assertNull(MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $defaultPse->getId()));
+        self::assertNull($defaultPse->getVirtualDocument());
     }
 
     public function testUpdateKeepsTheAssociationsOfAProductWithSeveralCombinations(): void
@@ -206,8 +204,8 @@ final class ProductActionTest extends IntegrationTestCase
         $defaultPse = $this->defaultSaleElement($product);
         $secondPse = $this->factory->productSaleElement($product);
 
-        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultPse->getId(), $document->getId());
-        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $secondPse->getId(), $document->getId());
+        $defaultPse->setVirtualDocument($document->getId());
+        $secondPse->setVirtualDocument($document->getId());
 
         // -1 is what the back office sends when the association is managed per combination.
         $this->dispatcher->dispatch(
@@ -215,14 +213,8 @@ final class ProductActionTest extends IntegrationTestCase
             TheliaEvents::PRODUCT_UPDATE,
         );
 
-        self::assertSame(
-            $document->getId(),
-            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $defaultPse->getId()),
-        );
-        self::assertSame(
-            $document->getId(),
-            (int) MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $secondPse->getId()),
-        );
+        self::assertSame($document->getId(), $defaultPse->getVirtualDocument()?->getId());
+        self::assertSame($document->getId(), $secondPse->getVirtualDocument()?->getId());
     }
 
     private function createVirtualProduct(): Product

--- a/tests/Integration/Action/ProductSaleElementActionTest.php
+++ b/tests/Integration/Action/ProductSaleElementActionTest.php
@@ -26,11 +26,8 @@ use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Model\AttributeCombinationQuery;
 use Thelia\Model\Currency;
 use Thelia\Model\Map\ProductSaleElementsTableMap;
-use Thelia\Model\MetaData;
-use Thelia\Model\MetaDataQuery;
 use Thelia\Model\Product;
 use Thelia\Model\ProductDocument;
-use Thelia\Model\ProductDocumentQuery;
 use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Test\ActionIntegrationTestCase;
@@ -484,7 +481,7 @@ final class ProductSaleElementActionTest extends ActionIntegrationTestCase
         $document = $this->createDocument($product, 'handbook-'.$product->getRef().'.pdf', withFile: true);
 
         foreach ($this->generateTwoSaleElements($product, $currency) as $salesElement) {
-            MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $salesElement->getId(), $document->getId());
+            $salesElement->setVirtualDocument($document->getId());
         }
 
         $event = new ProductCloneEvent($product->getRef().'-CLONE', 'en_US', $product);
@@ -497,19 +494,16 @@ final class ProductSaleElementActionTest extends ActionIntegrationTestCase
         self::assertCount(2, $clonedSaleElements);
 
         foreach ($clonedSaleElements as $clonedSaleElement) {
-            $clonedDocumentId = MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $clonedSaleElement->getId());
+            $clonedDocument = $clonedSaleElement->getVirtualDocument();
             self::assertNotNull(
-                $clonedDocumentId,
+                $clonedDocument,
                 'Every cloned sale element must keep the document its virtual product is downloaded from',
             );
             self::assertNotSame(
                 $document->getId(),
-                (int) $clonedDocumentId,
+                $clonedDocument->getId(),
                 'The clone must point at its own copy, not at the document of the source product',
             );
-
-            $clonedDocument = ProductDocumentQuery::create()->findPk((int) $clonedDocumentId);
-            self::assertNotNull($clonedDocument);
             self::assertSame($clonedProduct->getId(), $clonedDocument->getProductId());
         }
     }
@@ -527,7 +521,7 @@ final class ProductSaleElementActionTest extends ActionIntegrationTestCase
             ->filterByProductId($product->getId())
             ->findOne();
         self::assertNotNull($defaultSaleElement);
-        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $defaultSaleElement->getId(), $document->getId());
+        $defaultSaleElement->setVirtualDocument($document->getId());
 
         $event = new ProductCloneEvent($product->getRef().'-CLONE', 'en_US', $product);
         $this->dispatch($event, TheliaEvents::PRODUCT_CLONE);
@@ -542,7 +536,7 @@ final class ProductSaleElementActionTest extends ActionIntegrationTestCase
 
         foreach ($clonedSaleElements as $clonedSaleElement) {
             self::assertNull(
-                MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $clonedSaleElement->getId()),
+                $clonedSaleElement->getVirtualDocument(),
                 'A document deleted with the source product must not be handed over to the clone',
             );
         }

--- a/tests/Integration/Install/VirtualDocumentMigrationTest.php
+++ b/tests/Integration/Install/VirtualDocumentMigrationTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Install;
+
+use Propel\Runtime\Propel;
+use Thelia\Model\Map\ProductSaleElementsTableMap;
+use Thelia\Model\MetaData;
+use Thelia\Model\MetaDataQuery;
+use Thelia\Model\ProductDocument;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\ProductSaleElementsVirtualDocumentQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The statements 3.0.0-beta3.sql runs to move the virtual document association out of
+ * meta_data, applied to the rows a shop upgrading from an earlier version can hold.
+ *
+ * The statements are read from the shipped script rather than repeated here, so the
+ * test fails if the script stops doing what it claims.
+ */
+final class VirtualDocumentMigrationTest extends IntegrationTestCase
+{
+    private const MARKER = 'product_sale_elements_virtual_document (#3520)';
+
+    public function testAnAssociationIsMovedToItsOwnTable(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        $this->writeMetaData($saleElement->getId(), (string) $document->getId());
+
+        $this->runMigration();
+
+        $association = ProductSaleElementsVirtualDocumentQuery::create()
+            ->filterByProductSaleElementsId($saleElement->getId())
+            ->findOne();
+
+        self::assertNotNull($association);
+        self::assertSame($document->getId(), $association->getProductDocumentId());
+        self::assertSame(1, $association->getPosition());
+        self::assertNotNull($association->getCreatedAt());
+    }
+
+    public function testTheMigratedRowsAreRemovedFromMetaData(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        $this->writeMetaData($saleElement->getId(), (string) $document->getId());
+        MetaDataQuery::setVal('color', MetaData::PSE_KEY, $saleElement->getId(), 'blue');
+
+        $this->runMigration();
+
+        self::assertNull(MetaDataQuery::getVal('virtual', MetaData::PSE_KEY, $saleElement->getId()));
+        self::assertSame('blue', MetaDataQuery::getVal('color', MetaData::PSE_KEY, $saleElement->getId()));
+    }
+
+    public function testAnAssociationPointingAtADeletedDocumentIsNotCarriedOver(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+        $documentId = $document->getId();
+
+        $this->writeMetaData($saleElement->getId(), (string) $documentId);
+        $document->delete();
+
+        $this->runMigration();
+
+        self::assertSame(0, $this->countAssociations($saleElement->getId()));
+    }
+
+    public function testAnAssociationOfADeletedSaleElementIsNotCarriedOver(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        $unknownSaleElementId = ((int) ProductSaleElementsQuery::create()->orderById('desc')->findOne()?->getId()) + 1000;
+        $this->writeMetaData($unknownSaleElementId, (string) $document->getId());
+
+        $this->runMigration();
+
+        self::assertSame(0, $this->countAssociations($unknownSaleElementId));
+    }
+
+    public function testASerializedValueIsNotCarriedOver(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        // `value` is a CLOB any module can write through MetaDataQuery::setVal(), and the
+        // row says so. Its content is not the document id it happens to look like.
+        $metaData = new MetaData();
+        $metaData
+            ->setMetaKey('virtual')
+            ->setElementKey(MetaData::PSE_KEY)
+            ->setElementId($saleElement->getId())
+            ->setIsSerialized(true)
+            ->setValue((string) $document->getId())
+            ->save();
+
+        $this->runMigration();
+
+        self::assertSame(0, $this->countAssociations($saleElement->getId()));
+    }
+
+    public function testANonNumericValueIsNotCarriedOver(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        // MySQL casts '12-handbook.pdf' to 12, so without the digit check this row would
+        // silently become an association with the document it merely starts with.
+        $this->writeMetaData($saleElement->getId(), $document->getId().'-handbook.pdf');
+
+        $this->runMigration();
+
+        self::assertSame(0, $this->countAssociations($saleElement->getId()));
+    }
+
+    private function runMigration(): void
+    {
+        $connection = Propel::getWriteConnection(ProductSaleElementsTableMap::DATABASE_NAME);
+
+        foreach ($this->migrationStatements() as $statement) {
+            $connection->exec($statement);
+        }
+    }
+
+    /**
+     * The INSERT and DELETE of the migration block, taken from the update script. The
+     * CREATE TABLE is left out: the test database already carries the table, and DDL
+     * would commit the transaction the test case rolls back.
+     *
+     * @return list<string>
+     */
+    private function migrationStatements(): array
+    {
+        $script = file_get_contents(THELIA_SETUP_DIRECTORY.'update'.\DIRECTORY_SEPARATOR.'sql'.\DIRECTORY_SEPARATOR.'3.0.0-beta3.sql');
+
+        $block = strstr((string) $script, self::MARKER);
+        self::assertIsString($block, 'The 3.0.0-beta3 script no longer holds the virtual document migration.');
+
+        $statements = [];
+
+        foreach (explode(";\n", $block) as $chunk) {
+            $sql = trim(preg_replace('/^\s*--.*$/m', '', $chunk) ?? '');
+
+            if (preg_match('/^(INSERT|DELETE)\b/i', $sql)) {
+                $statements[] = $sql;
+            }
+        }
+
+        self::assertCount(2, $statements, 'Expected the INSERT and the DELETE of the migration block.');
+
+        return $statements;
+    }
+
+    private function countAssociations(int $saleElementId): int
+    {
+        return ProductSaleElementsVirtualDocumentQuery::create()
+            ->filterByProductSaleElementsId($saleElementId)
+            ->count();
+    }
+
+    private function writeMetaData(int $saleElementId, string $value): void
+    {
+        MetaDataQuery::setVal('virtual', MetaData::PSE_KEY, $saleElementId, $value);
+    }
+
+    private function createSaleElement(): ProductSaleElements
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $saleElement = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+
+        self::assertInstanceOf(ProductSaleElements::class, $saleElement);
+
+        return $saleElement;
+    }
+
+    private function createDocument(ProductSaleElements $saleElement): ProductDocument
+    {
+        $document = new ProductDocument();
+        $document
+            ->setProductId($saleElement->getProductId())
+            ->setFile('handbook.pdf')
+            ->setVisible(0)
+            ->save();
+
+        return $document;
+    }
+}

--- a/tests/Integration/Model/ProductSaleElementsVirtualDocumentTest.php
+++ b/tests/Integration/Model/ProductSaleElementsVirtualDocumentTest.php
@@ -14,18 +14,15 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Model;
 
-use Thelia\Model\MetaData;
-use Thelia\Model\MetaDataQuery;
 use Thelia\Model\ProductDocument;
 use Thelia\Model\ProductSaleElements;
 use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\ProductSaleElementsVirtualDocumentQuery;
 use Thelia\Test\IntegrationTestCase;
 
 /**
- * ProductSaleElements::getVirtualDocuments() is the supported way to reach the
- * documents attached to a sale element. It hides the meta data the association
- * currently lives in, so that a module reading it keeps working when the storage
- * moves to its own table.
+ * The documents a sale element is downloaded from live in their own table, reached
+ * through getVirtualDocuments() and written through setVirtualDocument().
  */
 final class ProductSaleElementsVirtualDocumentTest extends IntegrationTestCase
 {
@@ -42,7 +39,7 @@ final class ProductSaleElementsVirtualDocumentTest extends IntegrationTestCase
         $saleElement = $this->createSaleElement();
         $document = $this->createDocument($saleElement);
 
-        $this->associate($saleElement, $document->getId());
+        $saleElement->setVirtualDocument($document->getId());
 
         $documents = $saleElement->getVirtualDocuments();
 
@@ -51,27 +48,67 @@ final class ProductSaleElementsVirtualDocumentTest extends IntegrationTestCase
         self::assertSame($document->getId(), $saleElement->getVirtualDocument()?->getId());
     }
 
-    public function testAnAssociationLeftBehindByADeletedDocumentIsIgnored(): void
+    public function testTheAssociationIsRemovedWithNull(): void
     {
         $saleElement = $this->createSaleElement();
         $document = $this->createDocument($saleElement);
-        $documentId = $document->getId();
 
-        $this->associate($saleElement, $documentId);
+        $saleElement->setVirtualDocument($document->getId());
+        $saleElement->setVirtualDocument(null);
+
+        self::assertNull($saleElement->getVirtualDocument());
+        self::assertSame(0, $this->countAssociations($saleElement));
+    }
+
+    public function testASaleElementKeepsASingleDocument(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $first = $this->createDocument($saleElement);
+        $second = $this->createDocument($saleElement);
+
+        $saleElement->setVirtualDocument($first->getId());
+        $saleElement->setVirtualDocument($second->getId());
+
+        self::assertSame(1, $this->countAssociations($saleElement));
+        self::assertSame($second->getId(), $saleElement->getVirtualDocument()?->getId());
+    }
+
+    public function testDeletingTheDocumentDropsTheAssociation(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+
+        $saleElement->setVirtualDocument($document->getId());
         $document->delete();
 
-        // Deleting a document leaves its meta data behind: the accessor is the place
-        // that keeps a dangling id from being mistaken for a downloadable file.
-        self::assertSame(
-            (string) $documentId,
-            (string) MetaDataQuery::getVal(
-                ProductSaleElements::VIRTUAL_DOCUMENT_META_KEY,
-                MetaData::PSE_KEY,
-                $saleElement->getId()
-            )
-        );
-        self::assertTrue($saleElement->getVirtualDocuments()->isEmpty());
+        // The foreign key is what keeps a deleted document from leaving behind an
+        // association that a sale element created later could inherit.
+        self::assertSame(0, $this->countAssociations($saleElement));
         self::assertNull($saleElement->getVirtualDocument());
+    }
+
+    public function testDeletingTheSaleElementDropsTheAssociation(): void
+    {
+        $saleElement = $this->createSaleElement();
+        $document = $this->createDocument($saleElement);
+        $saleElementId = $saleElement->getId();
+
+        $saleElement->setVirtualDocument($document->getId());
+        $saleElement->delete();
+
+        self::assertSame(
+            0,
+            ProductSaleElementsVirtualDocumentQuery::create()
+                ->filterByProductSaleElementsId($saleElementId)
+                ->count()
+        );
+    }
+
+    private function countAssociations(ProductSaleElements $saleElement): int
+    {
+        return ProductSaleElementsVirtualDocumentQuery::create()
+            ->filterByProductSaleElementsId($saleElement->getId())
+            ->count();
     }
 
     private function createSaleElement(): ProductSaleElements
@@ -96,19 +133,8 @@ final class ProductSaleElementsVirtualDocumentTest extends IntegrationTestCase
             ->setProductId($saleElement->getProductId())
             ->setFile('handbook.pdf')
             ->setVisible(0)
-            ->setPosition(1)
             ->save();
 
         return $document;
-    }
-
-    private function associate(ProductSaleElements $saleElement, int $documentId): void
-    {
-        MetaDataQuery::setVal(
-            ProductSaleElements::VIRTUAL_DOCUMENT_META_KEY,
-            MetaData::PSE_KEY,
-            $saleElement->getId(),
-            $documentId
-        );
     }
 }


### PR DESCRIPTION
Closes #3520 (its first question).

The file a virtual product is downloaded from was a `meta_data` row keyed `('virtual', 'pse', sale element id)`, holding the document id as text. Nothing tied it to the two tables it points at:

- deleting the document, or the combination, left the row behind;
- InnoDB does not persist `AUTO_INCREMENT` across a restart, so a sale element created later could be given a freed id and inherit an association nobody set;
- the block declared only a non-unique index, so the "one row per sale element" rule was held by the `findOne()` in `MetaDataQuery::setVal()` alone. Two concurrent writes, or a module inserting a `MetaData` by hand, left two rows and the reader picked one.

`product_sale_elements_virtual_document` gives the association a foreign key on each side and a unique pair, so both deletions cascade and the duplicate cannot exist.

### Why it diverges from the table it mirrors

It is shaped after `product_sale_elements_product_document`, and differs on four points, all deliberate:

| | `product_sale_elements_product_document` | this table |
|---|---|---|
| `position` | absent | `INTEGER NOT NULL DEFAULT 1` |
| `<unique>` | absent | on `(product_sale_elements_id, product_document_id)` |
| `timestampable` | absent | present |
| `isCrossRef` | `true` | not declared |

`timestampable` is what the backfill fills `created_at` with. The unique constraint is exactly what `meta_data` was missing. `position` is what makes several files per combination a second row rather than a second migration — the table allows it, `ProductSaleElements::setVirtualDocument()` keeps writing a single row until that product decision is taken (question 2 of the issue, still open, and it needs an answer on the order side first: `order_product.virtual_document` holds a single file name).

`isCrossRef` is left out because the pair `(product_sale_elements, product_document)` is already bridged by one cross-reference table: a second one makes Propel generate a second, colliding set of `getProductDocuments()` / `addProductDocument()` accessors on `ProductSaleElements`. The table also carries a payload column, so it is not a pure cross-reference.

### Migration

`setup/update/sql/3.0.0-beta3.sql` creates the table, moves the rows, then drops the key — there is no double-writing window to keep, since every reader and writer moves in this PR.

`value` is a `CLOB` any module can write through `MetaDataQuery::setVal()`, so the `INSERT ... SELECT` guards on `is_serialized = 0` and on `value REGEXP '^[0-9]+$'`: MySQL casts `'12-handbook.pdf'` to `12`, which would otherwise become an association with the document the name merely starts with. The rows that cannot be carried over — pointing at a document or a combination that no longer exists, or failing a guard — are listed by a `SELECT` before they go, rather than discarded in silence.

### Callers

- `ProductSaleElements::getVirtualDocuments()` / `getVirtualDocument()`, added in #3687 over `meta_data`, now read the table. Modules that adopted the accessor have nothing to do.
- `ProductSaleElements::setVirtualDocument()` is the matching writer, and the place the single-row rule is enforced.
- `Action\Product::updateVirtualDocumentAssociation()` (#3550) and `Action\ProductSaleElement::cloneVirtualDocumentAssociation()` (#3691) write through it.
- `Order::hasVirtualProductWithDocument()` (#3545) reads `order_product.virtual_document` and is untouched: an order keeps its own copy of the file name, so no order is rewritten.
- No API surface: there is no `MetaData` resource, and the sale element resource never exposed the association.

Out of tree, on the same storage, sent separately: [VirtualProductDelivery](https://github.com/thelia-modules/VirtualProductDelivery/pull/2), [default-twig](https://github.com/thelia-templates/default-twig/pull/35), [back](https://github.com/thelia-templates/back/pull/11).

### Tests

`VirtualDocumentMigrationTest` runs the `INSERT` and `DELETE` read straight out of the shipped update script, so it fails if the script stops doing what it claims: an association is moved with `position` 1 and timestamps, unrelated meta data survives, and the four kinds of row that cannot be carried over are not. Both guards were checked load-bearing — removing either turns two of those tests red.

`ProductSaleElementsVirtualDocumentTest` covers the accessors and both cascades.

### CI

`local/config/schema.xml` gains a table, so `composer install` on `main` extracts the published `thelia/config` over it and PHPStan reports the new classes as unknown until that package is re-tagged. Everything else is green, and the five suites pass locally against the schema carrying the table.
