### PR TITLE
feat: split the postage tax between the rates a mixed cart carries

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -32,6 +32,7 @@ use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Domain\Cart\Exception\NotEnoughStockException;
 use Thelia\Domain\Cart\Service\CartAddressService;
+use Thelia\Domain\Shipping\Service\PostageTaxBreakdownCalculator;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\Base\CustomerQuery;
 use Thelia\Model\Base\ProductSaleElementsQuery;
@@ -65,6 +66,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
         protected SecurityContext $securityContext,
         protected ContainerInterface $container,
         protected CartAddressService $cartAddressService,
+        protected PostageTaxBreakdownCalculator $postageTaxBreakdownCalculator,
     ) {
     }
 
@@ -638,11 +640,19 @@ class Cart extends BaseAction implements EventSubscriberInterface
             TheliaEvents::MODULE_DELIVERY_GET_POSTAGE
         );
 
-        if ($deliveryPostageEvent->getPostage()) {
-            return $deliveryPostageEvent->getPostage();
+        $postage = $deliveryPostageEvent->getPostage();
+
+        if (!$postage instanceof OrderPostage) {
+            return new OrderPostage();
         }
 
-        return new OrderPostage();
+        // The delivery module quotes a postage under a single tax rule; whether
+        // that tax follows the goods instead is a shop decision, and the cart is
+        // only known here. Doing it on the way out keeps buildOrderPostage()'s
+        // signature intact, so no delivery module has to change.
+        $this->postageTaxBreakdownCalculator->applyToPostage($postage, $cart, $country, $state);
+
+        return $postage;
     }
 
     protected function dispatchNewCart(EventDispatcherInterface $dispatcher): CartModel

--- a/core/lib/Thelia/Domain/Order/OrderFacade.php
+++ b/core/lib/Thelia/Domain/Order/OrderFacade.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Domain\Order;
 
+use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Security\User\UserInterface;
@@ -27,12 +28,16 @@ use Thelia\Domain\Order\Service\StockPolicy;
 use Thelia\Domain\Order\Service\TaxProvider;
 use Thelia\Domain\Order\Service\TranslationProvider;
 use Thelia\Domain\Order\Service\VirtualProductHandler;
+use Thelia\Domain\Shipping\Service\PostageTaxBreakdownCalculator;
 use Thelia\Exception\TheliaProcessException;
 use Thelia\Model\Cart as CartModel;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\Country;
 use Thelia\Model\Currency as CurrencyModel;
 use Thelia\Model\Lang as LangModel;
 use Thelia\Model\Order as ModelOrder;
+use Thelia\Model\OrderAddressQuery;
+use Thelia\Model\OrderPostageTax;
 use Thelia\Model\OrderProductTax;
 use Thelia\Model\OrderStatusQuery;
 
@@ -49,6 +54,7 @@ readonly class OrderFacade
         private OrderProductFactory $orderProductFactory,
         private OrderRefGeneratorInterface $orderRefGenerator,
         private StockDecrementer $stockDecrementer,
+        private PostageTaxBreakdownCalculator $postageTaxBreakdownCalculator,
     ) {
     }
 
@@ -99,6 +105,8 @@ readonly class OrderFacade
 
             $placedOrder->setStatusId(OrderStatusQuery::getNotPaidStatus()?->getId());
             $placedOrder->save($connection);
+
+            $this->persistPostageTaxBreakdown($placedOrder, $cart, $taxCountry, $lang, $connection);
 
             $manageStockOnCreation = $placedOrder->isStockManagedOnOrderCreation($dispatcher);
 
@@ -191,6 +199,46 @@ readonly class OrderFacade
         } catch (\Throwable $throwable) {
             $this->orderTransactionManager->rollback($connection);
             throw $throwable;
+        }
+    }
+
+    /**
+     * Freezes how the postage tax of the order splits between the tax rules its
+     * goods follow.
+     *
+     * Nothing is written when the shop applies a single rule to the postage,
+     * which is the default: an order with no line reads as the one rate named
+     * in `postage_tax_rule_title`, exactly like every order placed so far.
+     *
+     * @throws PropelException
+     */
+    private function persistPostageTaxBreakdown(
+        ModelOrder $placedOrder,
+        CartModel $cart,
+        Country $taxCountry,
+        LangModel $lang,
+        ConnectionInterface $connection,
+    ): void {
+        $postageTax = (float) $placedOrder->getPostageTax();
+        $untaxedPostage = (float) $placedOrder->getPostage() - $postageTax;
+
+        $lines = $this->postageTaxBreakdownCalculator->splitForOrder(
+            $cart,
+            $taxCountry,
+            OrderAddressQuery::create()->findPk($placedOrder->getDeliveryOrderAddressId())?->getState(),
+            $untaxedPostage,
+            $postageTax,
+            $lang->getLocale(),
+        );
+
+        foreach ($lines as $line) {
+            (new OrderPostageTax())
+                ->setOrderId($placedOrder->getId())
+                ->setTitle($line->title)
+                ->setDescription($line->description)
+                ->setUntaxedAmount((string) $line->untaxedAmount)
+                ->setAmount((string) $line->amount)
+                ->save($connection);
         }
     }
 

--- a/core/lib/Thelia/Domain/Shipping/DTO/PostageTaxLine.php
+++ b/core/lib/Thelia/Domain/Shipping/DTO/PostageTaxLine.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Shipping\DTO;
+
+/**
+ * One line of a postage tax breakdown: the share of the untaxed postage that
+ * follows a given tax rule, and the tax due on that share.
+ *
+ * It is the unsaved form of an `order_postage_tax` row.
+ */
+final readonly class PostageTaxLine
+{
+    public function __construct(
+        public string $title,
+        public ?string $description,
+        public float $untaxedAmount,
+        public float $amount,
+    ) {
+    }
+
+    public function withAmounts(float $untaxedAmount, float $amount): self
+    {
+        return new self($this->title, $this->description, $untaxedAmount, $amount);
+    }
+}

--- a/core/lib/Thelia/Domain/Shipping/Enum/PostageTaxStrategy.php
+++ b/core/lib/Thelia/Domain/Shipping/Enum/PostageTaxStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Shipping\Enum;
+
+use Thelia\Model\ConfigQuery;
+
+/**
+ * How a shop splits the tax on a postage between the tax rules its goods follow.
+ *
+ * SINGLE_RULE is the default and is what Thelia has always done: the delivery
+ * module applies one rule to the whole postage. The other two move the VAT a
+ * shop declares, so they are opt-in - an upgrade must never change that figure
+ * on its own.
+ */
+enum PostageTaxStrategy: string
+{
+    /** One rule for the whole postage, the one the delivery module resolved. */
+    case SINGLE_RULE = 'single_rule';
+
+    /** The postage follows the goods, split over the untaxed value of each rate. */
+    case PRO_RATA = 'pro_rata';
+
+    /** The whole postage follows the highest rate the cart carries. */
+    case HIGHEST_RATE = 'highest_rate';
+
+    public const CONFIG_KEY = 'postage_tax_strategy';
+
+    /**
+     * The strategy the shop configured, SINGLE_RULE when the variable is unset
+     * or holds a value this version does not know.
+     */
+    public static function fromShopConfiguration(): self
+    {
+        return self::tryFrom((string) ConfigQuery::read(self::CONFIG_KEY, self::SINGLE_RULE->value))
+            ?? self::SINGLE_RULE;
+    }
+}

--- a/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
@@ -41,6 +41,7 @@ class PostageEstimator
         protected ContainerInterface $container,
         protected Session $session,
         protected CouponFreeShippingEvaluator $couponFreeShippingEvaluator,
+        protected PostageTaxBreakdownCalculator $postageTaxBreakdownCalculator,
     ) {
     }
 
@@ -160,6 +161,10 @@ class PostageEstimator
                 $postage = $deliveryPostageEvent->getPostage();
 
                 if ($postage instanceof OrderPostage) {
+                    // Same post-processing as the checkout, so an estimate and
+                    // the cart it turns into never announce two different taxes.
+                    $this->postageTaxBreakdownCalculator->applyToPostage($postage, $cart, $country, $state);
+
                     return $postage;
                 }
             }

--- a/core/lib/Thelia/Domain/Shipping/Service/PostageTaxBreakdownCalculator.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/PostageTaxBreakdownCalculator.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Shipping\Service;
+
+use Propel\Runtime\Exception\PropelException;
+use Thelia\Domain\Shipping\DTO\PostageTaxLine;
+use Thelia\Domain\Shipping\Enum\PostageTaxStrategy;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\Cart;
+use Thelia\Model\CartItem;
+use Thelia\Model\Country;
+use Thelia\Model\Lang;
+use Thelia\Model\OrderPostage;
+use Thelia\Model\State;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleQuery;
+
+/**
+ * Splits the tax on a postage between the tax rules the goods of a cart follow.
+ *
+ * A cart holding a case at 20 % and a book at 5.5 % pays one postage, and the
+ * European rule is that the postage follows the goods. Thelia has always taxed
+ * it under a single rule, so the split only happens when the shop asks for it
+ * through the `postage_tax_strategy` variable: on the default `single_rule`
+ * this class returns nothing and leaves the postage exactly as the delivery
+ * module quoted it.
+ *
+ * The untaxed postage is the part that stays fixed. It is the price the module
+ * quoted, and the merchant charges it whatever the destination; the tax is the
+ * derived figure, so splitting recomputes the tax and the taxed total from it.
+ */
+readonly class PostageTaxBreakdownCalculator
+{
+    public function __construct(
+        private TaxCalculatorFactoryInterface $taxCalculatorFactory,
+    ) {
+    }
+
+    /**
+     * Rewrites the tax carried by an OrderPostage so that it follows the goods,
+     * and hands the breakdown back on the value object.
+     *
+     * A no-op on `single_rule`, on an untaxed or free postage, and on a cart
+     * whose lines carry no usable tax rule: the postage keeps the amount, the
+     * tax and the rule title the delivery module produced.
+     *
+     * @throws PropelException
+     */
+    public function applyToPostage(
+        OrderPostage $postage,
+        Cart $cart,
+        Country $country,
+        ?State $state = null,
+        ?string $locale = null,
+    ): void {
+        $untaxedPostage = round((float) $postage->getUntaxedAmount(), 2);
+
+        $lines = $this->split($cart, $country, $state, $untaxedPostage, $locale);
+
+        if ([] === $lines) {
+            return;
+        }
+
+        $tax = round(array_sum(array_map(static fn (PostageTaxLine $line): float => $line->amount, $lines)), 2);
+
+        $postage->setUntaxedAmount($untaxedPostage);
+        $postage->setAmountTax($tax);
+        $postage->setAmount(round($untaxedPostage + $tax, 2));
+        $postage->setTaxBreakdown($lines);
+    }
+
+    /**
+     * The breakdown of a postage already placed on an order.
+     *
+     * The order columns are what the customer was charged, so they are the
+     * reference: the lines are recomputed from the cart, then the rounding
+     * remainder of each column is given to the largest line so that
+     * sum(untaxed_amount) and sum(amount) match the order exactly.
+     *
+     * @return list<PostageTaxLine>
+     *
+     * @throws PropelException
+     */
+    public function splitForOrder(
+        Cart $cart,
+        Country $country,
+        ?State $state,
+        float $untaxedPostage,
+        float $postageTax,
+        ?string $locale = null,
+    ): array {
+        $lines = $this->split($cart, $country, $state, round($untaxedPostage, 2), $locale);
+
+        if ([] === $lines) {
+            return [];
+        }
+
+        $taxTotal = array_sum(array_map(static fn (PostageTaxLine $line): float => $line->amount, $lines));
+
+        return $this->giveRemainderToTheLargestLine($lines, round($postageTax - $taxTotal, 2));
+    }
+
+    /**
+     * @return list<PostageTaxLine>
+     *
+     * @throws PropelException
+     */
+    private function split(
+        Cart $cart,
+        Country $country,
+        ?State $state,
+        float $untaxedPostage,
+        ?string $locale,
+    ): array {
+        $strategy = PostageTaxStrategy::fromShopConfiguration();
+
+        if (PostageTaxStrategy::SINGLE_RULE === $strategy) {
+            return [];
+        }
+
+        if ($untaxedPostage <= 0.0 || null === $country->getId()) {
+            return [];
+        }
+
+        $groups = $this->groupCartByTaxRule($cart, $country, $state);
+
+        if ([] === $groups) {
+            return [];
+        }
+
+        if (PostageTaxStrategy::HIGHEST_RATE === $strategy) {
+            $groups = [$this->highestRatedGroup($groups)];
+        }
+
+        $locale ??= Lang::getDefaultLanguage()->getLocale();
+        $shares = $this->shareOut($untaxedPostage, array_map(static fn (array $group): float => $group['base'], $groups));
+
+        $lines = [];
+
+        foreach ($groups as $index => $group) {
+            /** @var TaxRule $taxRule */
+            $taxRule = $group['taxRule'];
+            /** @var TaxCalculatorInterface $calculator */
+            $calculator = $group['calculator'];
+
+            $taxRule->setLocale($locale);
+            $title = (string) $taxRule->getTitle();
+
+            $lines[] = new PostageTaxLine(
+                '' === $title ? \sprintf('Tax rule #%d', $taxRule->getId()) : $title,
+                $taxRule->getDescription(),
+                $shares[$index],
+                round((float) $calculator->getTaxAmountFromUntaxedPrice($shares[$index]), 2),
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The untaxed value each tax rule of the cart accounts for, with the tax
+     * calculator already loaded for the destination.
+     *
+     * @return list<array{base: float, rate: float, taxRule: TaxRule, calculator: TaxCalculatorInterface}>
+     *
+     * @throws PropelException
+     */
+    private function groupCartByTaxRule(Cart $cart, Country $country, ?State $state): array
+    {
+        $bases = [];
+
+        /** @var CartItem $cartItem */
+        foreach ($cart->getCartItems() as $cartItem) {
+            $taxRuleId = (int) $cartItem->getProduct()->getTaxRuleId();
+
+            if (0 === $taxRuleId) {
+                continue;
+            }
+
+            $bases[$taxRuleId] = ($bases[$taxRuleId] ?? 0.0) + $cartItem->getTotalRealPrice();
+        }
+
+        $groups = [];
+
+        foreach ($bases as $taxRuleId => $base) {
+            if ($base <= 0.0) {
+                continue;
+            }
+
+            $taxRule = TaxRuleQuery::create()->findPk($taxRuleId);
+
+            if (!$taxRule instanceof TaxRule) {
+                continue;
+            }
+
+            $calculator = $this->taxCalculatorFactory->createTaxCalculator();
+            $calculator->loadTaxRuleWithoutProduct($taxRule, $country, $state);
+
+            $groups[] = [
+                'base' => $base,
+                // Per hundred, so that two rules can be compared whatever they hold.
+                'rate' => (float) $calculator->getTaxAmountFromUntaxedPrice(100.0),
+                'taxRule' => $taxRule,
+                'calculator' => $calculator,
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param list<array{base: float, rate: float, taxRule: TaxRule, calculator: TaxCalculatorInterface}> $groups
+     *
+     * @return array{base: float, rate: float, taxRule: TaxRule, calculator: TaxCalculatorInterface}
+     */
+    private function highestRatedGroup(array $groups): array
+    {
+        $highest = $groups[0];
+
+        foreach ($groups as $group) {
+            // A tie is settled on the value at stake, so the answer does not
+            // depend on the order the cart items happen to come back in.
+            if ($group['rate'] > $highest['rate']
+                || ($group['rate'] === $highest['rate'] && $group['base'] > $highest['base'])) {
+                $highest = $group;
+            }
+        }
+
+        return $highest;
+    }
+
+    /**
+     * Spreads an amount over shares proportional to the given bases.
+     *
+     * Every share is rounded to the cent and the largest one takes what the
+     * rounding left over, so the shares always add up to the amount exactly.
+     *
+     * @param list<float> $bases
+     *
+     * @return list<float>
+     */
+    private function shareOut(float $amount, array $bases): array
+    {
+        $total = array_sum($bases);
+        $largest = (int) array_search(max($bases), $bases, true);
+
+        $shares = [];
+        $distributed = 0.0;
+
+        foreach ($bases as $index => $base) {
+            if ($index === $largest) {
+                $shares[$index] = 0.0;
+
+                continue;
+            }
+
+            $shares[$index] = round($amount * $base / $total, 2);
+            $distributed += $shares[$index];
+        }
+
+        $shares[$largest] = round($amount - $distributed, 2);
+
+        ksort($shares);
+
+        return array_values($shares);
+    }
+
+    /**
+     * @param list<PostageTaxLine> $lines
+     *
+     * @return list<PostageTaxLine>
+     */
+    private function giveRemainderToTheLargestLine(array $lines, float $remainder): array
+    {
+        if (0.0 === $remainder) {
+            return $lines;
+        }
+
+        $largest = 0;
+
+        foreach ($lines as $index => $line) {
+            if ($line->untaxedAmount > $lines[$largest]->untaxedAmount) {
+                $largest = $index;
+            }
+        }
+
+        $lines[$largest] = $lines[$largest]->withAmounts(
+            $lines[$largest]->untaxedAmount,
+            round($lines[$largest]->amount + $remainder, 2),
+        );
+
+        return $lines;
+    }
+}

--- a/core/lib/Thelia/Model/OrderPostage.php
+++ b/core/lib/Thelia/Model/OrderPostage.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Model;
 
+use Thelia\Domain\Shipping\DTO\PostageTaxLine;
+
 /**
  * Class OrderPostage.
  *
@@ -25,6 +27,15 @@ class OrderPostage
     protected ?float $amountTax = null;
     protected ?float $untaxedAmount = null;
     protected ?string $taxRuleTitle = null;
+
+    /**
+     * How the tax splits between the rules the goods follow, empty when a
+     * single rule covers the whole postage - which is what a delivery module
+     * produces and what a shop on the default strategy keeps.
+     *
+     * @var list<PostageTaxLine>
+     */
+    protected array $taxBreakdown = [];
 
     public function __construct(?float $amount = null, ?float $amountTax = null, ?string $taxRuleTitle = null)
     {
@@ -80,5 +91,21 @@ class OrderPostage
     public function setUntaxedAmount(float $untaxedAmount): void
     {
         $this->untaxedAmount = $untaxedAmount;
+    }
+
+    /**
+     * @return list<PostageTaxLine>
+     */
+    public function getTaxBreakdown(): array
+    {
+        return $this->taxBreakdown;
+    }
+
+    /**
+     * @param list<PostageTaxLine> $taxBreakdown
+     */
+    public function setTaxBreakdown(array $taxBreakdown): void
+    {
+        $this->taxBreakdown = $taxBreakdown;
     }
 }

--- a/core/lib/Thelia/Model/OrderPostageTax.php
+++ b/core/lib/Thelia/Model/OrderPostageTax.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\OrderPostageTax as BaseOrderPostageTax;
+
+class OrderPostageTax extends BaseOrderPostageTax
+{
+}

--- a/core/lib/Thelia/Model/OrderPostageTaxQuery.php
+++ b/core/lib/Thelia/Model/OrderPostageTaxQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\OrderPostageTaxQuery as BaseOrderPostageTaxQuery;
+
+class OrderPostageTaxQuery extends BaseOrderPostageTaxQuery
+{
+}

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1513,6 +1513,21 @@
     </index>
     <behavior name="timestampable" />
   </table>
+  <table name="order_postage_tax" namespace="Thelia\Model">
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="order_id" required="true" type="INTEGER" />
+    <column description="the tax rule this share of the postage follows, frozen the way postage_tax_rule_title is" name="title" required="true" size="255" type="VARCHAR" />
+    <column name="description" type="CLOB" />
+    <column defaultValue="0.000000" description="the share of the untaxed postage this rule applies to" name="untaxed_amount" required="true" scale="6" size="16" type="DECIMAL" />
+    <column defaultValue="0.000000" description="the tax due on that share" name="amount" required="true" scale="6" size="16" type="DECIMAL" />
+    <foreign-key foreignTable="order" name="fk_order_postage_tax_order_id" onDelete="CASCADE" onUpdate="RESTRICT">
+      <reference foreign="id" local="order_id" />
+    </foreign-key>
+    <index name="idx_order_postage_tax_order_id">
+      <index-column name="order_id" />
+    </index>
+    <behavior name="timestampable" />
+  </table>
   <table name="newsletter" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="email" required="true" size="255" type="VARCHAR" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -1799,6 +1799,31 @@ CREATE TABLE `order_product_tax`
 ) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
 
 -- ---------------------------------------------------------------------
+-- order_postage_tax
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `order_postage_tax`;
+
+CREATE TABLE `order_postage_tax`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `order_id` INTEGER NOT NULL,
+    `title` VARCHAR(255) NOT NULL COMMENT 'the tax rule this share of the postage follows, frozen the way postage_tax_rule_title is',
+    `description` LONGTEXT,
+    `untaxed_amount` DECIMAL(16,6) DEFAULT 0.000000 NOT NULL COMMENT 'the share of the untaxed postage this rule applies to',
+    `amount` DECIMAL(16,6) DEFAULT 0.000000 NOT NULL COMMENT 'the tax due on that share',
+    `created_at` DATETIME,
+    `updated_at` DATETIME,
+    PRIMARY KEY (`id`),
+    INDEX `idx_order_postage_tax_order_id` (`order_id`),
+    CONSTRAINT `fk_order_postage_tax_order_id`
+        FOREIGN KEY (`order_id`)
+        REFERENCES `order` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------
 -- newsletter
 -- ---------------------------------------------------------------------
 

--- a/setup/update/sql/3.0.0-beta3.sql
+++ b/setup/update/sql/3.0.0-beta3.sql
@@ -227,4 +227,40 @@ WHERE `message`.`name` = 'customer_send_code'
   AND `message_i18n`.`locale` = 'fr_FR'
   AND (`message_i18n`.`subject` IS NULL OR `message_i18n`.`subject` = '');
 
+-- ---------------------------------------------------------------------
+-- order_postage_tax (#3701)
+--
+-- `order.postage_tax` is a single blended figure, and `postage_tax_rule_title`
+-- names one rule. A cart holding goods at two rates pays one postage, and
+-- nothing recorded how its tax split. This table holds one row per tax rule
+-- the postage follows, with the share of the untaxed postage it applies to
+-- and the tax due on that share.
+--
+-- No foreign key to `tax_rule`: the title is frozen on the order, the same
+-- snapshot discipline `order_product_tax` and `postage_tax_rule_title` follow.
+--
+-- Existing orders need no backfill. An order with no row reads as what it is,
+-- one rate named in `postage_tax_rule_title`, which is also what every order
+-- placed under the default `single_rule` strategy keeps looking like.
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `order_postage_tax`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `order_id` INTEGER NOT NULL,
+    `title` VARCHAR(255) NOT NULL COMMENT 'the tax rule this share of the postage follows, frozen the way postage_tax_rule_title is',
+    `description` LONGTEXT,
+    `untaxed_amount` DECIMAL(16,6) DEFAULT 0.000000 NOT NULL COMMENT 'the share of the untaxed postage this rule applies to',
+    `amount` DECIMAL(16,6) DEFAULT 0.000000 NOT NULL COMMENT 'the tax due on that share',
+    `created_at` DATETIME,
+    `updated_at` DATETIME,
+    PRIMARY KEY (`id`),
+    INDEX `idx_order_postage_tax_order_id` (`order_id`),
+    CONSTRAINT `fk_order_postage_tax_order_id`
+        FOREIGN KEY (`order_id`)
+        REFERENCES `order` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/Integration/Domain/Shipping/PostageTaxBreakdownTest.php
+++ b/tests/Integration/Domain/Shipping/PostageTaxBreakdownTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Shipping;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Action\Cart as CartAction;
+use Thelia\Core\Event\Delivery\DeliveryPostageEvent;
+use Thelia\Core\Event\Order\OrderEvent;
+use Thelia\Core\Event\Order\OrderPaymentEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Domain\Checkout\Service\CheckoutPaymentService;
+use Thelia\Domain\Shipping\DTO\PostageTaxLine;
+use Thelia\Domain\Shipping\Enum\PostageTaxStrategy;
+use Thelia\Model\Cart;
+use Thelia\Model\CartAddress;
+use Thelia\Model\CartItem;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Country;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderPostage;
+use Thelia\Model\OrderPostageTax;
+use Thelia\Model\OrderPostageTaxQuery;
+use Thelia\Model\Product;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\TaxRule;
+use Thelia\Model\TaxRuleCountry;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * A cart holding a case at 20 % and a book at 5.5 % pays one postage, and the
+ * European rule is that the postage follows the goods. Thelia taxes it under a
+ * single rule, which cannot say how that tax splits.
+ *
+ * The split has to stay opt-in: an upgrade that silently moved the VAT a shop
+ * declares would be worse than the missing feature.
+ */
+final class PostageTaxBreakdownTest extends ActionIntegrationTestCase
+{
+    /** The postage the delivery module quotes, tax excluded. */
+    private const UNTAXED_POSTAGE = 10.0;
+
+    /** @var list<array{0: string, 1: callable}> */
+    private array $registeredListeners = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->registeredListeners as [$eventName, $listener]) {
+            $this->kernelDispatcher()->removeListener($eventName, $listener);
+        }
+        $this->registeredListeners = [];
+
+        // ConfigQuery memoizes what it reads in a static cache that outlives
+        // the transaction rollback: left alone, the strategy written here would
+        // answer the next test of the process while its row is gone.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testTheDefaultStrategyLeavesTheDeliveryQuoteUntouched(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+
+        $postage = $this->quotePostage($fixtures);
+
+        self::assertSame([], $postage->getTaxBreakdown());
+        self::assertEqualsWithDelta(12.0, $postage->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(2.0, $postage->getAmountTax(), 0.0001);
+        self::assertSame('VAT 20', $postage->getTaxRuleTitle());
+    }
+
+    public function testProRataSpreadsThePostageOverTheRatesOfTheCart(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+        ConfigQuery::write(PostageTaxStrategy::CONFIG_KEY, PostageTaxStrategy::PRO_RATA->value);
+
+        $postage = $this->quotePostage($fixtures);
+
+        // 200.00 at 20 % and 100.00 at 5.5 %, so two thirds of the postage
+        // follow the dearer rate. The share of the largest base takes the
+        // rounding remainder: 10.00 - 3.33 = 6.67, not 6.66.
+        $breakdown = $this->indexByTitle($postage->getTaxBreakdown());
+
+        self::assertSame(['VAT 20', 'VAT 5.5'], array_keys($breakdown));
+        self::assertEqualsWithDelta(6.67, $breakdown['VAT 20']->untaxedAmount, 0.0001);
+        self::assertEqualsWithDelta(1.33, $breakdown['VAT 20']->amount, 0.0001);
+        self::assertEqualsWithDelta(3.33, $breakdown['VAT 5.5']->untaxedAmount, 0.0001);
+        self::assertEqualsWithDelta(0.18, $breakdown['VAT 5.5']->amount, 0.0001);
+
+        // The untaxed postage is what the merchant charges, so it does not move;
+        // the tax is the derived figure and it does.
+        self::assertEqualsWithDelta(self::UNTAXED_POSTAGE, $postage->getUntaxedAmount(), 0.0001);
+        self::assertEqualsWithDelta(1.51, $postage->getAmountTax(), 0.0001);
+        self::assertEqualsWithDelta(11.51, $postage->getAmount(), 0.0001);
+    }
+
+    public function testHighestRateTaxesTheWholePostageAtTheDearestRateOfTheCart(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+        ConfigQuery::write(PostageTaxStrategy::CONFIG_KEY, PostageTaxStrategy::HIGHEST_RATE->value);
+
+        $postage = $this->quotePostage($fixtures);
+
+        $breakdown = $postage->getTaxBreakdown();
+
+        self::assertCount(1, $breakdown);
+        self::assertSame('VAT 20', $breakdown[0]->title);
+        self::assertEqualsWithDelta(self::UNTAXED_POSTAGE, $breakdown[0]->untaxedAmount, 0.0001);
+        self::assertEqualsWithDelta(2.0, $breakdown[0]->amount, 0.0001);
+        self::assertEqualsWithDelta(12.0, $postage->getAmount(), 0.0001);
+    }
+
+    public function testAFreePostageIsNotSplit(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+        ConfigQuery::write(PostageTaxStrategy::CONFIG_KEY, PostageTaxStrategy::PRO_RATA->value);
+
+        $postage = $this->quotePostage($fixtures, new OrderPostage(0.0, 0.0, null));
+
+        self::assertSame([], $postage->getTaxBreakdown());
+        self::assertEqualsWithDelta(0.0, $postage->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(0.0, $postage->getAmountTax(), 0.0001);
+    }
+
+    public function testAnOrderPlacedUnderTheDefaultStrategyCarriesNoBreakdown(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+        $this->writeQuoteOnCart($fixtures['cart'], 12.0, 2.0);
+
+        $order = $this->checkout($fixtures);
+
+        self::assertSame(0, OrderPostageTaxQuery::create()->filterByOrderId($order->getId())->count());
+    }
+
+    public function testTheOrderFreezesTheBreakdownAndItsSumsMatchItsColumns(): void
+    {
+        $fixtures = $this->createMixedRateCart();
+        ConfigQuery::write(PostageTaxStrategy::CONFIG_KEY, PostageTaxStrategy::PRO_RATA->value);
+        // What Action\Cart wrote after the split: 10.00 untaxed, 1.51 of tax.
+        $this->writeQuoteOnCart($fixtures['cart'], 11.51, 1.51);
+
+        $order = $this->checkout($fixtures);
+
+        $lines = OrderPostageTaxQuery::create()
+            ->filterByOrderId($order->getId())
+            ->find()
+            ->getData();
+
+        self::assertCount(2, $lines);
+
+        $untaxedTotal = 0.0;
+        $taxTotal = 0.0;
+
+        /** @var OrderPostageTax $line */
+        foreach ($lines as $line) {
+            $untaxedTotal += (float) $line->getUntaxedAmount();
+            $taxTotal += (float) $line->getAmount();
+        }
+
+        // The order columns are what the customer was charged, so the breakdown
+        // has to add up to them exactly - to the cent, not to a rounding delta.
+        self::assertEqualsWithDelta((float) $order->getPostageTax(), $taxTotal, 0.0001);
+        self::assertEqualsWithDelta(
+            (float) $order->getPostage(),
+            $untaxedTotal + $taxTotal,
+            0.0001,
+            'sum(untaxed_amount) + sum(amount) must equal order.postage.',
+        );
+
+        $breakdown = [];
+        foreach ($lines as $line) {
+            $breakdown[$line->getTitle()] = $line;
+        }
+
+        self::assertEqualsWithDelta(6.67, (float) $breakdown['VAT 20']->getUntaxedAmount(), 0.0001);
+        self::assertEqualsWithDelta(1.33, (float) $breakdown['VAT 20']->getAmount(), 0.0001);
+        self::assertEqualsWithDelta(3.33, (float) $breakdown['VAT 5.5']->getUntaxedAmount(), 0.0001);
+        self::assertEqualsWithDelta(0.18, (float) $breakdown['VAT 5.5']->getAmount(), 0.0001);
+    }
+
+    /**
+     * Runs the real Action\Cart post-processing on a fixed delivery quote.
+     *
+     * Only the module's own answer is replaced, by a listener on the event the
+     * action dispatches: what is under test is what the action does with it.
+     *
+     * @param array{cart: Cart, deliveryModule: Module, deliveryAddressId: int, customer: Customer} $fixtures
+     */
+    private function quotePostage(array $fixtures, ?OrderPostage $quote = null): OrderPostage
+    {
+        $quote ??= new OrderPostage(12.0, 2.0, 'VAT 20');
+
+        $this->listen(
+            TheliaEvents::MODULE_DELIVERY_GET_POSTAGE,
+            static function (DeliveryPostageEvent $event) use ($quote): void {
+                $event->setPostage($quote);
+                $event->setValidModule(true);
+                $event->stopPropagation();
+            },
+            1024,
+        );
+
+        $this->getService(SecurityContext::class)->setCustomerUser($fixtures['customer']);
+
+        $quote = \Closure::bind(
+            fn (Cart $cart, EventDispatcherInterface $dispatcher, int $moduleId, int $addressId): OrderPostage => $this->getPostageByDeliveryModuleId($cart, $dispatcher, $moduleId, $addressId),
+            $this->getService(CartAction::class),
+            CartAction::class,
+        );
+
+        return $quote(
+            $fixtures['cart'],
+            $this->dispatcher,
+            $fixtures['deliveryModule']->getId(),
+            $fixtures['deliveryAddressId'],
+        );
+    }
+
+    private function writeQuoteOnCart(Cart $cart, float $taxedPostage, float $postageTax): void
+    {
+        $cart
+            ->setPostage((string) $taxedPostage)
+            ->setPostageTax((string) $postageTax)
+            ->setPostageTaxRuleTitle('VAT 20')
+            ->save($this->getPropelConnection());
+    }
+
+    /**
+     * @param array{cart: Cart, customer: Customer, currency: Currency, deliveryModule: Module, paymentModule: Module, deliveryAddressId: int, invoiceAddressId: int} $fixtures
+     */
+    private function checkout(array $fixtures): Order
+    {
+        $session = $this->session();
+        $session->setCustomerUser($fixtures['customer']);
+        $session->setSessionCart($fixtures['cart']);
+        $session->setCurrency($fixtures['currency']);
+
+        $placedOrder = null;
+        $this->listen(
+            TheliaEvents::ORDER_BEFORE_PAYMENT,
+            static function (OrderEvent $event) use (&$placedOrder): void {
+                $placedOrder = $event->getOrder();
+            },
+        );
+        // The payment module would answer with its own payment page, and the
+        // postage is settled by then.
+        $this->listen(
+            TheliaEvents::MODULE_PAY,
+            static function (OrderPaymentEvent $event): void {
+                $event->stopPropagation();
+            },
+            256,
+        );
+
+        $this->getService(CheckoutPaymentService::class)->pay(
+            $fixtures['cart'],
+            $fixtures['deliveryAddressId'],
+            $fixtures['invoiceAddressId'],
+            $fixtures['deliveryModule']->getId(),
+            $fixtures['paymentModule']->getId(),
+        );
+
+        self::assertInstanceOf(Order::class, $placedOrder, 'The checkout did not place an order.');
+
+        return $placedOrder;
+    }
+
+    /**
+     * A cart worth 200.00 at 20 % and 100.00 at 5.5 %, tax excluded.
+     *
+     * @return array{cart: Cart, customer: Customer, currency: Currency, deliveryModule: Module, paymentModule: Module, deliveryAddressId: int, invoiceAddressId: int}
+     */
+    private function createMixedRateCart(): array
+    {
+        $currency = $this->factory->currency();
+        $customerTitle = $this->factory->customerTitle();
+        $customer = $this->factory->customer($customerTitle);
+        $country = $this->factory->country();
+        $category = $this->factory->category();
+
+        $standardRate = $this->createTaxRule($country, '20', 'VAT 20');
+        $reducedRate = $this->createTaxRule($country, '5.5', 'VAT 5.5');
+
+        $deliveryAddress = $this->createCartAddress($customerTitle->getId(), $country->getId());
+        $invoiceAddress = $this->createCartAddress($customerTitle->getId(), $country->getId());
+
+        $deliveryModule = ModuleQuery::create()->findOneByCode('CustomDelivery')
+            ?? throw new \RuntimeException('No delivery module installed - run bin/test-prepare.');
+        $paymentModule = ModuleQuery::create()->findOneByCode('Cheque')
+            ?? throw new \RuntimeException('No payment module installed - run bin/test-prepare.');
+
+        $cart = (new Cart())
+            ->setCustomerId($customer->getId())
+            ->setCurrencyId($currency->getId())
+            ->setToken(uniqid('postage-breakdown-', true))
+            ->setAddressDeliveryId($deliveryAddress->getId())
+            ->setAddressInvoiceId($invoiceAddress->getId())
+            ->setDeliveryModuleId($deliveryModule->getId())
+            ->setPaymentModuleId($paymentModule->getId());
+        $cart->save($this->getPropelConnection());
+
+        $this->addCartItem($cart, $this->factory->product($category, $standardRate, $currency, ['baseQuantity' => 100]), '200.00');
+        $this->addCartItem($cart, $this->factory->product($category, $reducedRate, $currency, ['baseQuantity' => 100]), '100.00');
+
+        return [
+            'cart' => $cart,
+            'customer' => $customer,
+            'currency' => $currency,
+            'deliveryModule' => $deliveryModule,
+            'paymentModule' => $paymentModule,
+            'deliveryAddressId' => $deliveryAddress->getId(),
+            'invoiceAddressId' => $invoiceAddress->getId(),
+        ];
+    }
+
+    private function addCartItem(Cart $cart, Product $product, string $price): void
+    {
+        $productSaleElements = ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->findOne();
+        self::assertNotNull($productSaleElements);
+
+        (new CartItem())
+            ->setCartId($cart->getId())
+            ->setProductId($product->getId())
+            ->setProductSaleElementsId($productSaleElements->getId())
+            ->setQuantity(1)
+            ->setPrice($price)
+            ->setPromoPrice($price)
+            ->setPromo(0)
+            ->save($this->getPropelConnection());
+    }
+
+    private function createTaxRule(Country $country, string $percent, string $title): TaxRule
+    {
+        // A non-empty override array forces a rule of its own instead of reusing the seeded one.
+        $taxRule = $this->factory->taxRule(['isDefault' => false]);
+        $taxRule->setLocale('en_US')->setTitle($title)->save($this->getPropelConnection());
+
+        $tax = $this->factory->tax(['requirements' => ['percent' => $percent], 'title' => $title]);
+
+        (new TaxRuleCountry())
+            ->setTaxRuleId($taxRule->getId())
+            ->setCountryId($country->getId())
+            ->setTaxId($tax->getId())
+            ->setPosition(1)
+            ->save($this->getPropelConnection());
+
+        return $taxRule;
+    }
+
+    private function createCartAddress(int $customerTitleId, int $countryId): CartAddress
+    {
+        $address = (new CartAddress())
+            ->setCustomerTitleId($customerTitleId)
+            ->setFirstname('Jane')
+            ->setLastname('Doe')
+            ->setAddress1('1 rue du Port')
+            ->setZipcode('44000')
+            ->setCity('Nantes')
+            ->setCountryId($countryId);
+        $address->save($this->getPropelConnection());
+
+        return $address;
+    }
+
+    /**
+     * @param list<PostageTaxLine> $lines
+     *
+     * @return array<string, PostageTaxLine>
+     */
+    private function indexByTitle(array $lines): array
+    {
+        $indexed = [];
+
+        foreach ($lines as $line) {
+            $indexed[$line->title] = $line;
+        }
+
+        ksort($indexed);
+
+        return $indexed;
+    }
+
+    private function listen(string $eventName, callable $listener, int $priority = 0): void
+    {
+        $this->kernelDispatcher()->addListener($eventName, $listener, $priority);
+        $this->registeredListeners[] = [$eventName, $listener];
+    }
+
+    private function kernelDispatcher(): EventDispatcherInterface
+    {
+        return static::getContainer()->get('event_dispatcher');
+    }
+
+    private function session(): Session
+    {
+        return static::getContainer()->get('request_stack')->getCurrentRequest()->getSession();
+    }
+}


### PR DESCRIPTION
`order.postage_tax` is a single blended figure and `postage_tax_rule_title` names one rule. A cart holding a book-case at 20 % and a book at 5.5 % pays one postage, and today the whole of its tax is attributed to one rule — nothing records how it splits, so the European rule that the postage follows the goods cannot be expressed.

Default behaviour does not change. A minor version cannot silently move the VAT a shop declares, so the split is a setting the merchant ticks.

## Where the calculation goes

A post-processing step on the `OrderPostage` value object, at the two points where the cart and the postage already meet:

- `Action\Cart::getPostageByDeliveryModuleId()` — the `DeliveryPostageEvent` already carries the `Cart` and gives the `OrderPostage` back
- `PostageEstimator::computePostageForModule()` — the estimation path, so an estimate and the cart it turns into never announce two different taxes

`buildOrderPostage()` keeps its signature, so **no delivery module in the ecosystem is affected**, and the estimate and the order stay consistent with one place to fix.

## The setting

`postage_tax_strategy`, a `Config` variable, no column:

| Value | What it does |
|---|---|
| `single_rule` *(default)* | Today's behaviour to the byte: one rule for the whole postage, no breakdown written |
| `pro_rata` | The untaxed postage is spread over the untaxed value each rate accounts for |
| `highest_rate` | The whole postage follows the dearest rate the cart carries |

`Calculator::computeCartTaxFactor()` is deliberately **not** reused: it averages the per-line factors unweighted, which is not a valid basis for a value pro rata. Each rate group goes through `TaxCalculatorInterface::getTaxAmountFromUntaxedPrice()` on a calculator loaded with its own rule.

The untaxed postage is the fixed part — it is the price the delivery module quoted and what the merchant charges. The tax is the derived figure, so opting in recomputes the tax and the taxed total from it. On a 10.00 postage with 200.00 at 20 % and 100.00 at 5.5 %, `pro_rata` gives 6.67 at 20 % and 3.33 at 5.5 %, so 1.51 of tax instead of 2.00.

## Persistence

`order_postage_tax`, one row per rule, written at order creation inside the order transaction (`OrderFacade::createOrder()`, so the admin-created order goes through it too).

`untaxed_amount` is deliberate and is **not** a mirror of `order_product_tax`, which carries `amount` + `promo_amount` and no untaxed column: without it the rate cannot be reconstructed from the row. No foreign key to `tax_rule` — the same snapshot discipline `postage_tax_rule_title` already follows.

One row per **rate group**, not per tax: `untaxed_amount` is a base, and a base repeated across the taxes of one rule would break the sums. The rounding remainder of each column goes to the largest line, so the two invariants hold exactly:

```
sum(untaxed_amount) + sum(amount) == order.postage
sum(amount)                       == order.postage_tax
```

The order columns are what the customer was charged, so they are the reference: the lines are reconciled against them, never the other way round.

Existing orders need no backfill. An order with no line reads correctly as one rate named in `postage_tax_rule_title` — which is also what every order placed under the default strategy keeps looking like. No recomputing of a paid invoice.

A free-shipping coupon needs nothing either: it nulls the cart postage columns, the order is then placed with a postage of zero and no line is written.

## Tests

`tests/Integration/Domain/Shipping/PostageTaxBreakdownTest.php` drives the real `Action\Cart` post-processing on a mixed-rate cart, replacing only the delivery module's own answer, then takes the cart through a real `CheckoutPaymentService::pay()`:

- the default strategy leaves the quote untouched and writes no row
- `pro_rata` splits 6.67 / 3.33 with the remainder on the largest share, and the exact taxes 1.33 / 0.18
- `highest_rate` taxes the whole postage at 20 %
- a free postage is not split
- the placed order carries two rows whose sums match its own columns

Verified red first: with the split neutralised, the three cases that need it fail (`0` lines against `2`), and the three that assert the unchanged default stay green.

Five suites green locally against a database carrying the new table (284 unit, 562 integration, 203 api, 12 flexy, 10 back-office), `phpstan` and `phpstan-botwig` clean, `cs-diff` clean.

## Schema release

The table is new, so `thelia/config` and `thelia/setup` need a release carrying it: CI installs those packages over `local/config/schema.xml` and `setup/`, builds the Propel models from the package copy, and until then `Thelia\Model\Base\OrderPostageTax` does not exist and the table is missing from the test database. The migration is appended to `setup/update/sql/3.0.0-beta3.sql`, guarded with `CREATE TABLE IF NOT EXISTS`, so a second run is a no-op.

## Not in this PR

- **Rendering the breakdown** — PDF invoice, back-office order detail, accounting export and the API resource. All of them read correctly today while an order has no line, and showing the detail is worth its own batch.
- **A back-office screen for `postage_tax_strategy`.** The Twig back office lives in its own repository; without a screen the setting is reachable only through `config`, exactly the gap #3664 left behind. It should land next.

Fixes #3701
