### PR TITLE
fix: let a country carry states without requiring one

### DIFF
--- a/core/lib/Thelia/Api/Resource/Address.php
+++ b/core/lib/Thelia/Api/Resource/Address.php
@@ -458,33 +458,45 @@ class Address implements PropelResourceInterface
         }
     }
 
-    #[Callback(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[Callback(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public function verifyState(ExecutionContextInterface $context): void
     {
         $resource = $context->getRoot();
 
-        if (isset($resource->country) && null !== ($country = $resource->getCountry()->getPropelModel()) && $country->getHasStates()) {
-            if (null !== $state = $resource->getState()->getPropelModel()) {
-                if ($state->getCountryId() !== $country->getId()) {
-                    $context->addViolation(
-                        Translator::getInstance()->trans(
-                            "This state doesn't belong to this country.",
-                            [],
-                            null,
-                            'en_US',
-                        ),
-                    );
-                }
-            } else {
+        if (!isset($resource->country) || null === $country = $resource->getCountry()?->getPropelModel()) {
+            return;
+        }
+
+        $state = $resource->getState()?->getPropelModel();
+
+        // A state stays tied to its country whether or not the country requires one:
+        // an optional department must not be kept when the address moves elsewhere.
+        if (null !== $state) {
+            if ($state->getCountryId() !== $country->getId()) {
                 $context->addViolation(
                     Translator::getInstance()->trans(
-                        'You should select a state for this country.',
+                        "This state doesn't belong to this country.",
                         [],
                         null,
                         'en_US',
                     ),
                 );
             }
+
+            return;
+        }
+
+        // Requiring a state from a country that carries none would reject every address
+        // with an error the caller cannot act on.
+        if ($country->getHasStates() && $country->hasSelectableStates()) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'You should select a state for this country.',
+                    [],
+                    null,
+                    'en_US',
+                ),
+            );
         }
     }
 }

--- a/core/lib/Thelia/Core/Template/Loop/Country.php
+++ b/core/lib/Thelia/Core/Template/Loop/Country.php
@@ -24,6 +24,7 @@ use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
 use Thelia\Model\CountryAreaQuery;
 use Thelia\Model\CountryQuery;
+use Thelia\Model\StateQuery;
 use Thelia\Type\BooleanOrBothType;
 use Thelia\Type\EnumListType;
 use Thelia\Type\TypeCollection;
@@ -175,6 +176,18 @@ class Country extends BaseI18nLoop implements PropelSearchLoopInterface
 
     public function parseResults(LoopResult $loopResult): LoopResult
     {
+        // HAS_STATES tells whether a state is mandatory, HAS_SELECTABLE_STATES whether
+        // the country carries any: a template asks the second one to decide if it shows
+        // the state field at all. Resolved in one query, the loop lists every country.
+        $countryIdsWithStates = array_flip(
+            StateQuery::create()
+                ->filterByVisible(1)
+                ->distinct()
+                ->select('CountryId')
+                ->find()
+                ->toArray(),
+        );
+
         /** @var \Thelia\Model\Country $country */
         foreach ($loopResult->getResultDataCollection() as $country) {
             $loopResultRow = new LoopResultRow($country);
@@ -193,6 +206,7 @@ class Country extends BaseI18nLoop implements PropelSearchLoopInterface
                 ->set('IS_DEFAULT', $country->getByDefault() ? '1' : '0')
                 ->set('IS_SHOP_COUNTRY', $country->getShopCountry() ? '1' : '0')
                 ->set('HAS_STATES', $country->getHasStates() ? '1' : '0')
+                ->set('HAS_SELECTABLE_STATES', isset($countryIdsWithStates[$country->getId()]) ? '1' : '0')
                 ->set('NEED_ZIP_CODE', $country->getNeedZipCode() ? '1' : '0')
                 ->set('ZIP_CODE_FORMAT', $country->getZipCodeFormat());
 

--- a/core/lib/Thelia/Form/AddressCountryValidationTrait.php
+++ b/core/lib/Thelia/Form/AddressCountryValidationTrait.php
@@ -48,22 +48,35 @@ trait AddressCountryValidationTrait
     {
         $data = $context->getRoot()->getData();
 
-        if (null !== ($country = CountryQuery::create()->findPk($data['country'])) && $country->getHasStates()) {
-            if (null !== $state = StateQuery::create()->findPk($data['state'])) {
-                if ($state->getCountryId() !== $country->getId()) {
-                    $context->addViolation(
-                        Translator::getInstance()->trans(
-                            "This state doesn't belong to this country.",
-                        ),
-                    );
-                }
-            } else {
+        if (null === $country = CountryQuery::create()->findPk($data['country'])) {
+            return;
+        }
+
+        $stateId = $data['state'] ?? null;
+        $state = empty($stateId) ? null : StateQuery::create()->findPk($stateId);
+
+        // A state stays tied to its country whether or not the country requires one:
+        // an optional department must not survive a change of country in the same submit.
+        if (null !== $state) {
+            if ($state->getCountryId() !== $country->getId()) {
                 $context->addViolation(
                     Translator::getInstance()->trans(
-                        'You should select a state for this country.',
+                        "This state doesn't belong to this country.",
                     ),
                 );
             }
+
+            return;
+        }
+
+        // Requiring a state from a country that carries none would leave the customer
+        // with an empty list and no way to submit the form.
+        if ($country->getHasStates() && $country->hasSelectableStates()) {
+            $context->addViolation(
+                Translator::getInstance()->trans(
+                    'You should select a state for this country.',
+                ),
+            );
         }
     }
 

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -58,6 +58,27 @@ class Country extends BaseCountry
     }
 
     /**
+     * Whether a customer has a state to pick for this country.
+     *
+     * `has_states` says a state is mandatory, not that the country carries any: a
+     * country may hold states without requiring one (France and its departments), and
+     * a country flagged as requiring one may hold none yet. What an address form can
+     * offer is therefore the visible state rows attached to the country, this method,
+     * while `has_states` only decides whether leaving the field empty is an error.
+     */
+    public function hasSelectableStates(): bool
+    {
+        if (null === $this->getId()) {
+            return false;
+        }
+
+        return StateQuery::create()
+            ->filterByCountryId($this->getId())
+            ->filterByVisible(1)
+            ->count() > 0;
+    }
+
+    /**
      * This method ensure backward compatibility to Thelia 2.1, where a country belongs to one and
      * only one shipping zone.
      *

--- a/core/lib/Thelia/Tools/AddressFormat.php
+++ b/core/lib/Thelia/Tools/AddressFormat.php
@@ -149,7 +149,9 @@ class AddressFormat
             ->withGivenName($address->getFirstname())
             ->withFamilyName($address->getLastname());
 
-        if ($country->getHasStates() && 0 !== (int) $address->getStateId()) {
+        // The state comes from the address, not from a country setting: a shop that
+        // makes the state optional still has to see the one the customer picked.
+        if (0 !== (int) $address->getStateId()) {
             $addressModel = $addressModel->withAdministrativeArea(
                 \sprintf(
                     '%s-%s',

--- a/tests/Api/Admin/AddressApiTest.php
+++ b/tests/Api/Admin/AddressApiTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Thelia\Model\CountryQuery;
+use Thelia\Model\StateQuery;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * State coverage for /api/admin/addresses.
+ *
+ * A country requiring a state must answer a validation error rather than crash,
+ * and a state must always belong to the country it is posted with, even when the
+ * country leaves the choice optional.
+ */
+final class AddressApiTest extends ApiTestCase
+{
+    public function testMissingStateOnACountryRequiringOneIsAValidationError(): void
+    {
+        $country = CountryQuery::create()->findOneByIsoalpha3('USA');
+        self::assertNotNull($country);
+
+        $response = $this->jsonRequest('POST', '/api/admin/addresses', $this->payload($country->getId()), $this->authenticateAsAdmin());
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('You should select a state', (string) $response->getContent());
+    }
+
+    public function testAStateFromAnotherCountryIsRejectedWhenTheStateIsOptional(): void
+    {
+        $optional = CountryQuery::create()->findOneByIsoalpha3('FRA');
+        $elsewhere = CountryQuery::create()->findOneByIsoalpha3('USA');
+        self::assertNotNull($optional);
+        self::assertNotNull($elsewhere);
+        self::assertFalse((bool) $optional->getHasStates(), 'France leaves the department optional');
+
+        $state = StateQuery::create()->filterByCountryId($elsewhere->getId())->findOne();
+        self::assertNotNull($state);
+
+        $payload = $this->payload($optional->getId());
+        $payload['state'] = '/api/admin/states/'.$state->getId();
+
+        $response = $this->jsonRequest('POST', '/api/admin/addresses', $payload, $this->authenticateAsAdmin());
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('belong to this country', (string) $response->getContent());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(int $countryId): array
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title);
+
+        return [
+            'label' => 'Home',
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'address1' => '1 Main Street',
+            'address2' => '',
+            'address3' => '',
+            'city' => 'Springfield',
+            'zipcode' => '12345',
+            'country' => '/api/admin/countries/'.$countryId,
+            'customer' => '/api/admin/customers/'.$customer->getId(),
+            'customerTitle' => '/api/admin/customer_titles/'.$title->getId(),
+        ];
+    }
+}

--- a/tests/Api/Front/AddressApiTest.php
+++ b/tests/Api/Front/AddressApiTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\Front;
 
+use Thelia\Model\CountryQuery;
+use Thelia\Model\StateQuery;
 use Thelia\Test\ApiTestCase;
 
 /**
@@ -68,6 +70,38 @@ final class AddressApiTest extends ApiTestCase
 
         self::assertJsonResponseSuccessful($response);
         self::assertHydraTotalItems(1, $response);
+    }
+
+    public function testAStateFromAnotherCountryIsRejected(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $country = CountryQuery::create()->findOneByIsoalpha3('FRA');
+        $elsewhere = CountryQuery::create()->findOneByIsoalpha3('USA');
+        self::assertNotNull($country);
+        self::assertNotNull($elsewhere);
+
+        $state = StateQuery::create()->filterByCountryId($elsewhere->getId())->findOne();
+        self::assertNotNull($state);
+
+        $response = $this->jsonRequest('POST', '/api/front/account/addresses', [
+            'label' => 'Home',
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'address1' => '1 Main Street',
+            'address2' => '',
+            'address3' => '',
+            'city' => 'Paris',
+            'zipcode' => '75001',
+            'country' => '/api/front/countries/'.$country->getId(),
+            'state' => '/api/admin/states/'.$state->getId(),
+            'customerTitle' => '/api/admin/customer_titles/'.$title->getId(),
+        ], $this->authenticateAsCustomer($customer));
+
+        self::assertSame(422, $response->getStatusCode(), substr((string) $response->getContent(), 0, 500));
+        self::assertStringContainsString('belong to this country', (string) $response->getContent());
     }
 
     public function testUnauthenticatedReadIsRejected(): void

--- a/tests/Integration/Core/Template/CountryLoopStatesTest.php
+++ b/tests/Integration/Core/Template/CountryLoopStatesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Template;
+
+use Thelia\Core\Template\Loop\LoopExecutor;
+use Thelia\Model\CountryQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * France carries its 101 departments while leaving the choice optional, so a
+ * template asking HAS_STATES to decide whether to show the state field would
+ * hide a list the shop does have. HAS_SELECTABLE_STATES answers that question.
+ */
+final class CountryLoopStatesTest extends IntegrationTestCase
+{
+    public function testACountryCarriesStatesWithoutRequiringOne(): void
+    {
+        $france = CountryQuery::create()->findOneByIsoalpha3('FRA');
+        self::assertNotNull($france, 'the seeded countries are missing from the test database');
+        self::assertFalse((bool) $france->getHasStates(), 'France leaves the department optional');
+
+        $row = $this->countryRow($france->getId());
+
+        self::assertSame('0', $row['HAS_STATES']);
+        self::assertSame('1', $row['HAS_SELECTABLE_STATES']);
+    }
+
+    public function testACountryWithoutStatesOffersNone(): void
+    {
+        $country = $this->createFixtureFactory()->country([
+            'isocode' => '902',
+            'isoalpha2' => 'ZY',
+            'isoalpha3' => 'ZYY',
+            'shopCountry' => false,
+        ]);
+
+        // The loop joins the i18n title of the language it runs for.
+        foreach (LangQuery::create()->find() as $lang) {
+            $country->setLocale($lang->getLocale())->setTitle('Stateless country')->save();
+        }
+
+        $row = $this->countryRow($country->getId());
+
+        self::assertSame('0', $row['HAS_SELECTABLE_STATES']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function countryRow(int $countryId): array
+    {
+        $lang = LangQuery::create()->filterByByDefault(1)->findOne() ?? LangQuery::create()->findOne();
+
+        $result = $this->getService(LoopExecutor::class)->execute('country', [
+            'id' => $countryId,
+            'lang' => $lang->getId(),
+        ]);
+
+        $rows = [];
+        foreach ($result as $row) {
+            $rows[] = $row->getVarVal();
+        }
+
+        self::assertCount(1, $rows);
+
+        return $rows[0];
+    }
+}

--- a/tests/Integration/Form/AddressStateValidationTest.php
+++ b/tests/Integration/Form/AddressStateValidationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormInterface;
+use Thelia\Core\Form\TheliaFormFactory;
+use Thelia\Form\AddressCreateForm;
+use Thelia\Model\Country;
+use Thelia\Model\CustomerTitle;
+use Thelia\Model\LangQuery;
+use Thelia\Model\State;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * `country.has_states` says a state is mandatory, not that the country carries any.
+ *
+ * The states a customer may pick come from the state rows attached to the country,
+ * so a country can offer states without forcing one (France and its departments),
+ * and a country flagged as requiring one may hold none yet.
+ */
+final class AddressStateValidationTest extends IntegrationTestCase
+{
+    private CustomerTitle $title;
+    private int $sequence = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->title = $this->createFixtureFactory()->customerTitle();
+    }
+
+    public function testAStateFromAnotherCountryIsRejectedEvenWhenTheStateIsOptional(): void
+    {
+        $optional = $this->country(required: false);
+        $state = $this->state($optional);
+        $elsewhere = $this->country(required: false);
+
+        // The customer picked the state, then switched the country in the same submit.
+        $form = $this->submit($optional, [
+            'country' => (string) $elsewhere->getId(),
+            'state' => (string) $state->getId(),
+        ]);
+
+        self::assertCount(1, $form->get('state')->getErrors());
+        self::assertStringContainsString(
+            "doesn't belong to this country",
+            (string) $form->get('state')->getErrors()[0]->getMessage(),
+        );
+    }
+
+    public function testACountryRequiringAStateStillRejectsAnEmptySelection(): void
+    {
+        $required = $this->country(required: true);
+        $this->state($required);
+
+        $form = $this->submit($required, ['state' => '']);
+
+        self::assertCount(1, $form->get('state')->getErrors());
+    }
+
+    public function testACountryRequiringAStateThatHoldsNoneDoesNotBlockTheCustomer(): void
+    {
+        $required = $this->country(required: true);
+
+        $form = $this->submit($required, ['state' => '']);
+
+        self::assertCount(0, $form->get('state')->getErrors(), 'an empty list leaves nothing to select');
+    }
+
+    public function testAnOptionalStateMayBeLeftEmpty(): void
+    {
+        $optional = $this->country(required: false);
+        $this->state($optional);
+
+        $form = $this->submit($optional, ['state' => '']);
+
+        self::assertCount(0, $form->get('state')->getErrors());
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function submit(Country $builtWith, array $overrides): FormInterface
+    {
+        $form = $this->getService(TheliaFormFactory::class)
+            ->createForm(
+                AddressCreateForm::class,
+                FormType::class,
+                ['country' => $builtWith->getId()],
+                ['csrf_protection' => false],
+            )
+            ->getForm();
+
+        $form->submit(array_merge([
+            'label' => 'Home',
+            'title' => (string) $this->title->getId(),
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'address1' => '1 Main Street',
+            'city' => 'Springfield',
+            'zipcode' => '12345',
+            'country' => (string) $builtWith->getId(),
+            'state' => '',
+        ], $overrides));
+
+        return $form;
+    }
+
+    private function country(bool $required): Country
+    {
+        $suffix = ++$this->sequence;
+
+        $country = $this->createFixtureFactory()->country([
+            'isocode' => (string) (900 + $suffix),
+            'isoalpha2' => 'Z'.$suffix,
+            'isoalpha3' => 'ZZ'.$suffix,
+            'shopCountry' => false,
+        ]);
+        $country->setHasStates($required ? 1 : 0)->save();
+
+        return $country;
+    }
+
+    private function state(Country $country): State
+    {
+        $state = new State();
+        $state->setCountry($country);
+        $state->setIsocode('S'.$this->sequence);
+        $state->setVisible(1);
+
+        // The form reads the title in the locale of the session, whichever it is.
+        foreach (LangQuery::create()->find() as $lang) {
+            $state->setLocale($lang->getLocale())->setTitle('Province '.$this->sequence);
+        }
+
+        $state->save();
+
+        return $state;
+    }
+}

--- a/tests/Integration/Tools/AddressFormatStateTest.php
+++ b/tests/Integration/Tools/AddressFormatStateTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Tools;
+
+use Thelia\Model\CountryQuery;
+use Thelia\Model\StateQuery;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Tools\AddressFormat;
+
+/**
+ * A state stored on an address belongs to the address, not to a country setting:
+ * a shop that makes the state optional (`has_states = 0`) still has to see the
+ * state it let the customer pick on the formatted address.
+ */
+final class AddressFormatStateTest extends IntegrationTestCase
+{
+    public function testAStoredStateIsRenderedWhenTheCountryDoesNotRequireOne(): void
+    {
+        $country = CountryQuery::create()->findOneByIsoalpha3('USA');
+        self::assertNotNull($country, 'the seeded countries are missing from the test database');
+
+        // The shop made the state optional, the customer picked one anyway.
+        $country->setHasStates(0)->save();
+
+        $state = StateQuery::create()
+            ->filterByCountryId($country->getId())
+            ->filterByIsocode('CA')
+            ->findOne();
+        self::assertNotNull($state, 'California is missing from the seeded states');
+
+        $address = $this->createFixtureFactory()
+            ->orderAddress($country, null, ['city' => 'Mountain View', 'zipcode' => '94043']);
+        $address->setStateId($state->getId())->save();
+
+        $formatted = AddressFormat::getInstance()->formatTheliaAddress($address, 'en_US', html: false);
+
+        self::assertStringContainsString('Mountain View, US-CA 94043', $formatted);
+    }
+}


### PR DESCRIPTION
Fixes #3696

`country.has_states` carried two meanings at once: whether the country has states at all, and whether picking one is mandatory. Nothing could express "states exist, choosing one is optional", so the 101 French departments added by #3536 sat in the database unreachable — France is seeded `has_states = 0`, and setting the flag would have made the department mandatory on every French address.

The two questions are now answered by two different things:

- **what a form offers** comes from the visible `state` rows of the country. This is already how `AddressCreateForm::getStatesChoices()` works, so the departments become selectable with no data change;
- **whether the field may be left empty** stays `has_states`, unchanged for the United States, Canada, Italy, Japan, Mexico, Argentina and Indonesia.

No schema change, no seed change, no migration: France keeps `has_states = 0` and gains an optional department.

### What changes

- `Country::hasSelectableStates()` — the country carries at least one visible state.
- `AddressCountryValidationTrait::verifyState()` — a submitted state is checked against its country whether or not the country requires one, so an optional department no longer survives a change of country in the same submit. A state is required only when the flag is set **and** the country carries some: a country flagged as requiring a state but holding none used to reject every address with an error the customer could not act on.
- `Api\Resource\Address::verifyState()` — same rule, and it no longer fatals: posting an address without a state to a country that requires one answered `500` (`Call to a member function getPropelModel() on null`) instead of a validation error. The callback now also runs on front writes, which had no state validation at all.
- `Tools\AddressFormat` — a state stored on an address is rendered even when the country leaves the choice optional; it used to be dropped.
- `Loop\Country` — new `HAS_SELECTABLE_STATES` output, resolved in one query for the whole loop. `HAS_STATES` keeps its meaning, now documented as "a state is required", so a template can tell the two apart.

### Tests

Each was checked failing first:

- `AddressStateValidationTest` — an out-of-country state is rejected on an optional country; an empty selection is still rejected when required; a country requiring a state but holding none does not block the form.
- `AddressFormatStateTest` — the state survives on the formatted address of a country that does not require one.
- `AddressApiTest` (admin and front) — `422` instead of `500` on a missing required state, and the out-of-country state is rejected on both sides.
- `CountryLoopStatesTest` — France reports `HAS_STATES = 0` and `HAS_SELECTABLE_STATES = 1`.

### Behaviour change to note

Front API address writes (`/api/front/account/addresses`) now validate the state. A client sending a state that belongs to another country, or omitting one for a country that requires it, gets a `422` where the address used to be saved as is.
