### PR TITLE
test: cover the postage tax strategy screen

### DIFF
--- a/tests/Playwright/poms/backoffice/taxes-rules-page.ts
+++ b/tests/Playwright/poms/backoffice/taxes-rules-page.ts
@@ -65,4 +65,20 @@ export class TaxesRulesPage extends BaseAdminPage {
   postageTaxRuleRow(moduleCode: string): Locator {
     return this.page.getByTestId(`postage-tax-rule-row-${moduleCode}`);
   }
+
+  get postageTaxStrategySection(): Locator {
+    return this.page.getByTestId('postage-tax-strategy-section');
+  }
+
+  get postageTaxStrategyForm(): Locator {
+    return this.page.getByTestId('postage-tax-strategy-form');
+  }
+
+  get postageTaxStrategySave(): Locator {
+    return this.page.getByTestId('postage-tax-strategy-save');
+  }
+
+  postageTaxStrategyOption(strategy: string): Locator {
+    return this.page.locator(`#postage-tax-strategy-${strategy}`);
+  }
 }

--- a/tests/Playwright/specs/backoffice/taxes-rules-list.spec.ts
+++ b/tests/Playwright/specs/backoffice/taxes-rules-list.spec.ts
@@ -87,4 +87,34 @@ test.describe('Back-office — Taxes rules list (BO Twig)', () => {
     await listPage.postageTaxRuleSave.click();
     await listPage.expectLoaded();
   });
+
+  test('the postage tax breakdown offers the three strategies, single rule by default', async ({ page }) => {
+    const listPage = new TaxesRulesPage(page);
+    await listPage.goto();
+
+    await expect(listPage.postageTaxStrategySection).toBeVisible();
+    await expect(listPage.postageTaxStrategyForm).toBeVisible();
+
+    await expect(listPage.postageTaxStrategyOption('single_rule')).toBeChecked();
+    await expect(listPage.postageTaxStrategyOption('pro_rata')).not.toBeChecked();
+    await expect(listPage.postageTaxStrategyOption('highest_rate')).not.toBeChecked();
+  });
+
+  test('a postage tax strategy survives its save', async ({ page }) => {
+    const listPage = new TaxesRulesPage(page);
+    await listPage.goto();
+
+    await listPage.postageTaxStrategyOption('pro_rata').check();
+    await listPage.postageTaxStrategySave.click();
+    await listPage.expectLoaded();
+
+    await expect(listPage.postageTaxStrategyOption('pro_rata')).toBeChecked();
+
+    // Back to the default, so the run leaves the shop on its original VAT behaviour.
+    await listPage.postageTaxStrategyOption('single_rule').check();
+    await listPage.postageTaxStrategySave.click();
+    await listPage.expectLoaded();
+
+    await expect(listPage.postageTaxStrategyOption('single_rule')).toBeChecked();
+  });
 });


### PR DESCRIPTION
Closes #3722.

#3721 gave shops a choice of how the postage tax splits across a mixed-rate cart, and nothing wrote `postage_tax_strategy`. The screen landed in thelia-templates/default-twig#37: a "Postage tax breakdown" section on the tax rules page, the three strategies as named and explained radio options, a value the enum does not know refused rather than silently degraded, and the change recorded in the admin log.

This adds the back-office end-to-end coverage: the three options render with `single_rule` checked by default, and a saved strategy comes back checked after the round trip, the run putting the shop back on its original behaviour. Verified against a running install with `BO_TEMPLATE=default-twig`, 9 passed on this page; the save test was checked red by removing the `ConfigQuery::write`.
