### PR TITLE
fix: make the front address endpoints usable and safe

### DIFF
--- a/core/lib/Thelia/Api/Resource/Address.php
+++ b/core/lib/Thelia/Api/Resource/Address.php
@@ -32,6 +32,7 @@ use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\NotInFilter;
 use Thelia\Api\Bridge\Propel\Filter\SearchFilter;
+use Thelia\Api\State\Processor\CustomerAddressProcessor;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\Map\AddressTableMap;
 
@@ -66,6 +67,7 @@ use Thelia\Model\Map\AddressTableMap;
         new Post(
             uriTemplate: '/front/account/addresses',
             normalizationContext: ['groups' => [self::GROUP_FRONT_READ, self::GROUP_FRONT_READ_SINGLE]],
+            processor: CustomerAddressProcessor::class,
         ),
         new GetCollection(
             uriTemplate: '/front/account/addresses',
@@ -78,6 +80,7 @@ use Thelia\Model\Map\AddressTableMap;
         new Put(
             uriTemplate: '/front/account/addresses/{id}',
             security: 'object.customer.getId() == user.getId()',
+            processor: CustomerAddressProcessor::class,
         ),
         new Delete(
             uriTemplate: '/front/account/addresses/{id}',
@@ -139,29 +142,31 @@ class Address implements PropelResourceInterface
     public ?int $id = null;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public string $label;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED, Cart::GROUP_ADMIN_READ_SINGLE, Cart::GROUP_FRONT_READ_SINGLE])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public string $firstname;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED, Cart::GROUP_ADMIN_READ_SINGLE, Cart::GROUP_FRONT_READ_SINGLE])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public string $lastname;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public string $address1;
 
+    // The column is not nullable and has no default: left uninitialized, it is
+    // skipped by the transformer and the insert fails on the database side.
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    public string $address2;
+    public string $address2 = '';
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    public string $address3;
+    public string $address3 = '';
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public string $zipcode;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
@@ -174,7 +179,7 @@ class Address implements PropelResourceInterface
     public ?string $phone = null;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public ?string $city = null;
 
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
@@ -188,19 +193,22 @@ class Address implements PropelResourceInterface
 
     #[Relation(targetResource: Country::class)]
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
-    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public Country $country;
 
     #[Relation(targetResource: State::class)]
     #[Groups([...self::GROUP_ADMIN_COMBINED, ...self::GROUP_FRONT_COMBINED])]
     public ?State $state = null;
 
+    // The front never sets the owner: CustomerAddressProcessor takes it from
+    // the token, so an account endpoint cannot write into another address book.
     #[Relation(targetResource: Customer::class)]
-    #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_READ_SINGLE, self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE])]
+    #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_READ_SINGLE, self::GROUP_ADMIN_WRITE])]
     public Customer $customer;
 
     #[Relation(targetResource: CustomerTitle::class)]
     #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE, self::GROUP_FRONT_READ, self::GROUP_FRONT_WRITE])]
+    #[NotBlank(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     #[Column(propelSetter: 'setTitleId')]
     public CustomerTitle $customerTitle;
 
@@ -437,7 +445,7 @@ class Address implements PropelResourceInterface
         return new AddressTableMap();
     }
 
-    #[Callback(groups: [self::GROUP_ADMIN_WRITE, Customer::GROUP_ADMIN_WRITE])]
+    #[Callback(groups: [self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_WRITE, Customer::GROUP_ADMIN_WRITE])]
     public function verifyZipcode(ExecutionContextInterface $context): void
     {
         $resource = $context->getRoot();

--- a/core/lib/Thelia/Api/State/Processor/CustomerAddressProcessor.php
+++ b/core/lib/Thelia/Api/State/Processor/CustomerAddressProcessor.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\State\Processor;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Thelia\Api\Bridge\Propel\State\PropelPersistProcessor;
+use Thelia\Api\Resource\Address;
+use Thelia\Api\Resource\Customer as CustomerResource;
+use Thelia\Model\Customer;
+
+/**
+ * An address written under /front/account belongs to the customer holding the
+ * token. The owner never comes from the body: a caller sending someone else's
+ * customer would otherwise write into that customer's address book, and a
+ * caller sending none would reach the database with no owner at all.
+ */
+final readonly class CustomerAddressProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private PropelPersistProcessor $persistProcessor,
+        private TokenStorageInterface $tokenStorage,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        $customer = $this->tokenStorage->getToken()?->getUser();
+
+        if ($data instanceof Address && $customer instanceof Customer) {
+            $data->setCustomer((new CustomerResource())->setId($customer->getId()));
+        }
+
+        return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+    }
+}

--- a/tests/Api/Admin/AddressApiTest.php
+++ b/tests/Api/Admin/AddressApiTest.php
@@ -58,6 +58,19 @@ final class AddressApiTest extends ApiTestCase
         self::assertStringContainsString('belong to this country', (string) $response->getContent());
     }
 
+    public function testTheOptionalAddressLinesMayBeOmitted(): void
+    {
+        $country = CountryQuery::create()->findOneByIsoalpha3('FRA');
+        self::assertNotNull($country);
+
+        $payload = $this->payload($country->getId());
+        unset($payload['address2'], $payload['address3']);
+
+        $response = $this->jsonRequest('POST', '/api/admin/addresses', $payload, $this->authenticateAsAdmin());
+
+        self::assertJsonResponseSuccessful($response);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Api/Front/AddressApiTest.php
+++ b/tests/Api/Front/AddressApiTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\Front;
 
+use Thelia\Model\AddressQuery;
 use Thelia\Model\CountryQuery;
+use Thelia\Model\CustomerTitle;
 use Thelia\Model\StateQuery;
 use Thelia\Test\ApiTestCase;
 
@@ -104,6 +106,106 @@ final class AddressApiTest extends ApiTestCase
         self::assertStringContainsString('belong to this country', (string) $response->getContent());
     }
 
+    public function testACreatedAddressBelongsToTheAuthenticatedCustomer(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/front/account/addresses',
+            $this->payload($title),
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertJsonResponseSuccessful($response);
+
+        $created = AddressQuery::create()->findPk(json_decode((string) $response->getContent(), true)['id']);
+        self::assertNotNull($created);
+        self::assertSame($customer->getId(), $created->getCustomerId());
+    }
+
+    public function testAnAddressCannotBeCreatedInAnotherCustomersAddressBook(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $victim = $factory->customer($title);
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $payload = $this->payload($title);
+        $payload['customer'] = '/api/admin/customers/'.$victim->getId();
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/front/account/addresses',
+            $payload,
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertNotSame(500, $response->getStatusCode());
+        self::assertSame(0, AddressQuery::create()->filterByCustomerId($victim->getId())->count());
+    }
+
+    public function testTheZipCodeIsCheckedAgainstTheCountryFormat(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        // France is seeded with the NNNNN format.
+        $payload = $this->payload($title);
+        $payload['zipcode'] = '75';
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/front/account/addresses',
+            $payload,
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('zip code', (string) $response->getContent());
+    }
+
+    public function testTheOptionalAddressLinesMayBeOmitted(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $payload = $this->payload($title);
+        unset($payload['address2'], $payload['address3']);
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/front/account/addresses',
+            $payload,
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertJsonResponseSuccessful($response);
+    }
+
+    public function testAMissingRequiredFieldIsAValidationError(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $title = $factory->customerTitle();
+        $customer = $factory->customer($title, ['password' => 'password']);
+
+        $payload = $this->payload($title);
+        unset($payload['label'], $payload['customerTitle']);
+
+        $response = $this->jsonRequest(
+            'POST',
+            '/api/front/account/addresses',
+            $payload,
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
     public function testUnauthenticatedReadIsRejected(): void
     {
         $factory = $this->createFixtureFactory();
@@ -113,5 +215,27 @@ final class AddressApiTest extends ApiTestCase
         $response = $this->jsonRequest('GET', '/api/front/account/addresses/'.$address->getId());
 
         self::assertContains($response->getStatusCode(), [401, 403]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(CustomerTitle $title): array
+    {
+        $country = CountryQuery::create()->findOneByIsoalpha3('FRA');
+        self::assertNotNull($country);
+
+        return [
+            'label' => 'Home',
+            'firstname' => 'John',
+            'lastname' => 'Doe',
+            'address1' => '1 Main Street',
+            'address2' => '',
+            'address3' => '',
+            'city' => 'Paris',
+            'zipcode' => '75001',
+            'country' => '/api/front/countries/'.$country->getId(),
+            'customerTitle' => '/api/admin/customer_titles/'.$title->getId(),
+        ];
     }
 }


### PR DESCRIPTION
Three defects on the same write path, each proved failing first.

### The owner came from the body — #3729

`POST /api/front/account/addresses` with another customer's IRI answered `201` and filed the address in that customer's address book; without a `customer` it reached the database with no owner and crashed on a `NOT NULL` column. `CustomerAddressProcessor` now reads the owner from the token on the front `Post` and `Put`, and `customer` leaves the front write group so the body cannot name it. The item operations already carried `security: 'object.customer.getId() == user.getId()'`; only the creation path was open.

### Front writes were validated against nothing — #3731

Every constraint carried the admin groups only, while the front operations denormalize with `front:address:write` and the transformer validates with the denormalization groups. A zip code of `75` on France was stored as sent, and a missing `label` answered `500` where the back office answers `422`. The `NotBlank` constraints and the zip-code callback now carry the front write group too, and `customerTitle` gains the `NotBlank` it never had.

### The optional address lines could not be omitted — #3728

`address2` and `address3` are non-nullable strings with no default, so omitting them left the properties uninitialized, the transformer skipped them, and MySQL rejected the insert. They now default to an empty string — no schema change.

### Tests

`tests/Api/Front/AddressApiTest.php` and `tests/Api/Admin/AddressApiTest.php`: the created address belongs to the caller, another customer's address book stays empty, the zip code is checked against the country format, a missing required field is a `422`, and the optional lines may be omitted on both sides. All seven were checked failing against `main` before the fix.

### Behaviour change

A front client that relied on sending `customer` will find the field ignored, and payloads the endpoint used to accept without checking now answer `422`.

Fixes #3728
Fixes #3729
Fixes #3731