### PR TITLE
fix: read a single customer title from the front API

### DIFF
--- a/core/lib/Thelia/Api/Resource/CustomerTitle.php
+++ b/core/lib/Thelia/Api/Resource/CustomerTitle.php
@@ -59,6 +59,12 @@ use Thelia\Model\Map\CustomerTitleTableMap;
         new GetCollection(
             uriTemplate: '/front/customer_titles',
         ),
+        // Without a front item operation, the collection hands out admin IRIs
+        // and a front client has no title to name on an address or a
+        // registration.
+        new Get(
+            uriTemplate: '/front/customer_titles/{id}',
+        ),
     ],
     normalizationContext: ['groups' => [self::GROUP_FRONT_READ]],
 )]

--- a/tests/Api/Front/CustomerTitleApiTest.php
+++ b/tests/Api/Front/CustomerTitleApiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Test\ApiTestCase;
+
+/**
+ * A front client has to name the customer title of an address or of a
+ * registration, and it can only do that with an IRI the front API answers to.
+ * The collection alone left the title reachable through the admin surface only.
+ */
+final class CustomerTitleApiTest extends ApiTestCase
+{
+    public function testACustomerTitleIsReadableOnItsOwn(): void
+    {
+        $title = $this->createFixtureFactory()->customerTitle();
+
+        $response = $this->jsonRequest('GET', '/api/front/customer_titles/'.$title->getId());
+
+        self::assertJsonResponseSuccessful($response);
+        self::assertSame($title->getId(), json_decode((string) $response->getContent(), true)['id']);
+    }
+}


### PR DESCRIPTION
`GET /api/front/customer_titles/1` answered `404`: the front side of the resource declared a collection and nothing else, so the only readable item was `/api/admin/customer_titles/1`. A front client naming the title of an address or of a registration had to quote a URL under a surface it cannot call.

The item operation reuses the existing `front:customer_title:read` group, so the payload is the one the collection already returns.

`tests/Api/Front/CustomerTitleApiTest.php` was checked failing against `main` first.

Not fixed here: the collection still advertises admin IRIs in its members, which is not specific to customer titles — #3732.

Fixes #3730