### PR TITLE
fix: name an item on the surface the request was served from

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Routing/SurfaceAwareIriConverter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Routing/SurfaceAwareIriConverter.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Routing;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\IriConverterInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Keeps an IRI on the surface the request is being served from.
+ *
+ * A resource declares its admin and its front side in two #[ApiResource] blocks
+ * on the same class. When the serializer asks for the IRI of an item it has no
+ * operation to hand — a member of a collection, a relation, the body of a POST —
+ * and API Platform then resolves the first item operation of the class, which is
+ * the admin one. A front collection therefore answered with admin IRIs: links a
+ * front client cannot follow, pointing at a surface it should not know about.
+ *
+ * The operation being served says which surface the answer belongs to, so the
+ * item operation is looked up under the same first path segment.
+ */
+final class SurfaceAwareIriConverter implements IriConverterInterface
+{
+    /** @var array<string, HttpOperation|false> */
+    private array $operationCache = [];
+
+    public function __construct(
+        private readonly IriConverterInterface $decorated,
+        private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null): object
+    {
+        return $this->decorated->getResourceFromIri($iri, $context, $operation);
+    }
+
+    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string
+    {
+        if ($this->needsSurfaceOperation($resource, $operation, $context)) {
+            /** @var object $resource */
+            $resourceClass = $context['force_resource_class'] ?? $resource::class;
+            $operation = $this->itemOperationOnCurrentSurface($resourceClass) ?? $operation;
+        }
+
+        return $this->decorated->getIriFromResource($resource, $referenceType, $operation, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function needsSurfaceOperation(object|string $resource, ?Operation $operation, array $context): bool
+    {
+        // A class is asked for the IRI of a collection, which already carries its
+        // own operation, and an explicit item template is a deliberate choice.
+        if (\is_string($resource) || isset($context['item_uri_template'])) {
+            return false;
+        }
+
+        // Anything else than an item operation leaves API Platform resolving one
+        // on its own: no operation at all, or the POST that just created the item.
+        return null === $operation
+            || $operation instanceof CollectionOperationInterface
+            || ($operation instanceof HttpOperation && 'POST' === $operation->getMethod());
+    }
+
+    private function itemOperationOnCurrentSurface(string $resourceClass): ?HttpOperation
+    {
+        $surface = $this->currentSurface();
+
+        if (null === $surface) {
+            return null;
+        }
+
+        $cacheKey = $surface.'|'.$resourceClass;
+
+        if (!isset($this->operationCache[$cacheKey])) {
+            $this->operationCache[$cacheKey] = $this->findItemOperation($resourceClass, $surface);
+        }
+
+        return $this->operationCache[$cacheKey] ?: null;
+    }
+
+    private function findItemOperation(string $resourceClass, string $surface): HttpOperation|false
+    {
+        try {
+            $metadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        foreach ($metadataCollection as $resourceMetadata) {
+            foreach ($resourceMetadata->getOperations() ?? [] as $operation) {
+                if (
+                    $operation instanceof HttpOperation
+                    && !$operation instanceof CollectionOperationInterface
+                    && 'GET' === $operation->getMethod()
+                    && $surface === $this->surfaceOf($operation)
+                ) {
+                    return $operation;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function currentSurface(): ?string
+    {
+        $operation = $this->requestStack->getCurrentRequest()?->attributes->get('_api_operation');
+
+        return $operation instanceof HttpOperation ? $this->surfaceOf($operation) : null;
+    }
+
+    private function surfaceOf(HttpOperation $operation): ?string
+    {
+        $uriTemplate = $operation->getUriTemplate();
+
+        if (null === $uriTemplate) {
+            return null;
+        }
+
+        $segments = explode('/', ltrim($uriTemplate, '/'));
+
+        return '' === $segments[0] ? null : $segments[0];
+    }
+}

--- a/core/lib/Thelia/Api/Resource/Lang.php
+++ b/core/lib/Thelia/Api/Resource/Lang.php
@@ -60,6 +60,11 @@ use Thelia\Model\Map\LangTableMap;
         new GetCollection(
             uriTemplate: '/front/languages',
         ),
+        // The collection is the only front side this resource had, so its
+        // members were named by their admin IRI.
+        new Get(
+            uriTemplate: '/front/languages/{id}',
+        ),
     ],
     normalizationContext: ['groups' => [self::GROUP_FRONT_READ]],
 )]

--- a/core/lib/Thelia/Config/Resources/services/integrations/api_platform.php
+++ b/core/lib/Thelia/Config/Resources/services/integrations/api_platform.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Thelia\Api\Bridge\Propel\MetaData\PropelResourceCollectionMetadataFactory;
+use Thelia\Api\Bridge\Propel\Routing\SurfaceAwareIriConverter;
 
 return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
@@ -23,4 +24,12 @@ return static function (ContainerConfigurator $configurator): void {
     $services->set('thelia.api.propel.resource.metadata_collection_factory', PropelResourceCollectionMetadataFactory::class)
         ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 40)
         ->args([service('thelia.api.propel.resource.metadata_collection_factory.inner')]);
+
+    $services->set('thelia.api.iri_converter.surface_aware', SurfaceAwareIriConverter::class)
+        ->decorate('api_platform.iri_converter')
+        ->args([
+            service('thelia.api.iri_converter.surface_aware.inner'),
+            service('api_platform.metadata.resource.metadata_collection_factory'),
+            service('request_stack'),
+        ]);
 };

--- a/tests/Api/Contract/SurfaceIriContractTest.php
+++ b/tests/Api/Contract/SurfaceIriContractTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Contract;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * An answer names its members and its relations on the surface it was served
+ * from. A resource declares its admin and its front side on the same class, and
+ * the IRI of an item the serializer has no operation for used to fall back to
+ * the first item operation of the class — the admin one — so a front client was
+ * handed links it cannot follow.
+ */
+final class SurfaceIriContractTest extends ApiTestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function frontCollections(): iterable
+    {
+        yield 'languages' => ['/api/front/languages'];
+        yield 'customer titles' => ['/api/front/customer_titles'];
+    }
+
+    #[DataProvider('frontCollections')]
+    public function testAFrontCollectionNamesItsMembersWithFrontIris(string $endpoint): void
+    {
+        $members = $this->members($this->jsonRequest('GET', $endpoint));
+
+        self::assertNotEmpty($members, $endpoint.' returned no member to name');
+
+        foreach ($members as $member) {
+            self::assertStringStartsWith('/api/front/', (string) $member['@id']);
+        }
+    }
+
+    public function testAFrontItemNamesItsRelationsWithFrontIris(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $response = $this->jsonRequest('GET', '/api/front/products/'.$product->getId());
+        self::assertJsonResponseSuccessful($response);
+
+        $data = json_decode((string) $response->getContent(), true);
+
+        self::assertStringStartsWith('/api/front/', (string) $data['@id']);
+        self::assertStringStartsWith('/api/front/', (string) $data['taxRule']['@id']);
+        self::assertStringStartsWith('/api/front/', (string) $data['productCategories'][0]['category']['@id']);
+    }
+
+    public function testAnAdminCollectionKeepsAdminIris(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $members = $this->members($this->jsonRequest('GET', '/api/admin/products', token: $this->authenticateAsAdmin()));
+
+        self::assertNotEmpty($members);
+
+        foreach ($members as $member) {
+            self::assertStringStartsWith('/api/admin/', (string) $member['@id']);
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function members(\Symfony\Component\HttpFoundation\Response $response): array
+    {
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true)['hydra:member'] ?? [];
+    }
+}


### PR DESCRIPTION
Fixes #3732

### The cause

`ApiPlatform\Symfony\Routing\IriConverter::getIriFromResource()` re-resolves an operation whenever the one it is given cannot name an item — none at all, a collection, or the `POST` that just created the resource:

- `vendor/api-platform/symfony/Routing/IriConverter.php:149-151` — with no operation it builds a bare `Get`, which has no name;
- `:160-170` — a nameless operation is then resolved through `resourceMetadataCollectionFactory->create($class)->getOperation(null, false, true)`, the **first item operation of the class**.

Resources declare their admin and their front side in two `#[ApiResource]` blocks on the same class, admin first, so that lookup always lands on the admin operation. Instrumented on `GET /api/front/languages`: the collection `@id` is generated with the front `GetCollection` and is correct, then every member arrives with `operation = null` and no `item_uri_template`, and is named `/api/admin/languages/1`.

The same path names relations, so a front item leaked admin IRIs for everything it embedded: `GET /api/front/products/{id}` returned `"taxRule": {"@id": "/api/admin/tax_rules/1"}`.

### The fix

`SurfaceAwareIriConverter` decorates `api_platform.iri_converter`. When the converter is about to resolve an operation on its own for an item, it looks one up under the first path segment of the operation being served (`_api_operation` on the current request) and hands it over; everything else — a class asked for its collection IRI, an explicit `item_uri_template`, a request outside API Platform — passes straight through. Nothing resource-specific, and no change to the admin surface.

`Lang` was the only resource with a front collection and no front item operation, so its members had nothing else to be named by. It gains `GET /front/languages/{id}` on `front:lang:read`, the group its collection already returns, so no field becomes readable that was not already.

### Consequences, swept before merging

- **Flexy** reads through `resources()` server-side, where no `_api_operation` is set, so the decorator is a no-op there; the theme contains no `/api/admin/` string and never reads `@id` (checked, not modified — the theme is frozen).
- The **Twig back office** calls no `/api/front/` endpoint, and admin answers are unchanged.
- No module and no test parses an `@id` out of a front response; `I18nDenormalizer` resolves IRIs in the read direction, which this decorator passes through untouched.
- A client that stored an admin IRI received from a front answer was storing a URL it could not call in the first place.

### Tests

`tests/Api/Contract/SurfaceIriContractTest.php`, checked failing first — the three failures were `/api/admin/languages/1`, `/api/admin/customer_titles/1` and the embedded `/api/admin/tax_rules/1`. It covers a front collection, the relations of a front item, and an admin collection that must keep its admin IRIs.
