### PR TITLE
fix: annotate boolean returns as bool, not as the true literal

### DIFF
--- a/core/lib/Thelia/Core/Event/Coupon/CouponCreateOrUpdateEvent.php
+++ b/core/lib/Thelia/Core/Event/Coupon/CouponCreateOrUpdateEvent.php
@@ -66,9 +66,6 @@ class CouponCreateOrUpdateEvent extends ActionEvent
         return $this;
     }
 
-    /**
-     * @return true
-     */
     public function getPerCustomerUsageCount(): bool
     {
         return $this->perCustomerUsageCount;

--- a/core/lib/Thelia/Core/Security/SecurityContext.php
+++ b/core/lib/Thelia/Core/Security/SecurityContext.php
@@ -85,7 +85,7 @@ class SecurityContext
     /**
      * Check if an admin user is logged in.
      *
-     * @return true if an admin user is logged in, false otherwise
+     * @return bool true if an admin user is logged in, false otherwise
      */
     public function hasAdminUser(): bool
     {
@@ -105,7 +105,7 @@ class SecurityContext
     /**
      * Check if a customer user is logged in.
      *
-     * @return true if a customer is logged in, false otherwise
+     * @return bool true if a customer is logged in, false otherwise
      */
     public function hasCustomerUser(): bool
     {

--- a/core/lib/Thelia/Model/Module.php
+++ b/core/lib/Thelia/Model/Module.php
@@ -235,7 +235,7 @@ class Module extends BaseModule implements FileModelParentInterface
     }
 
     /**
-     * @return true if this module is a delivery module
+     * @return bool true if this module is a delivery module
      */
     public function isDeliveryModule(): bool
     {


### PR DESCRIPTION
## Problem
Any condition on `SecurityContext::hasCustomerUser()`, `hasAdminUser()` or
`Module::isDeliveryModule()` is reported as always true by static analysis, so
callers cannot write a plain `if`/ternary on them without the analyser
rejecting the branch as unreachable.

## Root cause
Four PHPDoc blocks annotate `@return true` on methods declared `: bool`:

- `core/lib/Thelia/Core/Security/SecurityContext.php:88` — `hasAdminUser()`
- `core/lib/Thelia/Core/Security/SecurityContext.php:108` — `hasCustomerUser()`
- `core/lib/Thelia/Model/Module.php:238` — `isDeliveryModule()`
- `core/lib/Thelia/Core/Event/Coupon/CouponCreateOrUpdateEvent.php:70` — `getPerCustomerUsageCount()`

`true` is a valid literal type (and a native return type since PHP 8.2), so the
annotation is taken at face value and wins over the native `bool` signature.
The prose of the same annotations reads "false otherwise", and two neighbours in
`SecurityContext` already use the correct `@return bool true if …, false otherwise`
form, so the intended type is unambiguous.

## Why this change is needed
These are public API methods that any consumer branches on. With the annotation
as it stands, PHPStan reports `Method … should return true but returns bool` on
the declaring file itself, and `always true` on every caller — the caller has no
clean way around it other than avoiding the method or silencing the rule
globally with `treatPhpDocTypesAsCertain: false`, which would weaken the check
everywhere else.

The project's own analysis runs at level 1, where return types are not checked
against PHPDoc, which is why CI has never surfaced it.

## Fix
Add the missing `bool` to the three annotations that carry a description, and
drop the docblock on `getPerCustomerUsageCount()` entirely — with no
description, `@return bool` duplicates the native type and php-cs-fixer's
`no_superfluous_phpdoc_tags` removes it.

## How to reproduce
No runtime behaviour changes, so this cannot be covered by a functional test.
Analysing any caller at level 6 or above reproduces it:

```php
public function example(SecurityContext $c): string
{
    return $c->hasCustomerUser() ? 'yes' : 'no';
}
```

Before: three `ternary.alwaysTrue` errors (one per method). After: none.

## Compatibility
Documentation only. No signature, behaviour or BC impact.
