### PR TITLE
fix: log the delivery module code, a Module has no name

### DIFF
--- a/core/lib/Thelia/Domain/Shipping/Service/DeliveryPostageQuerier.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/DeliveryPostageQuerier.php
@@ -47,7 +47,7 @@ final readonly class DeliveryPostageQuerier
         try {
             $this->dispatcher->dispatch($deliveryPostageEvent, TheliaEvents::MODULE_DELIVERY_GET_POSTAGE);
         } catch (DeliveryException $e) {
-            Tlog::getInstance()->error(\sprintf('Delivery module %s is not available: %s', $module->getName(), $e->getMessage()));
+            Tlog::getInstance()->error(\sprintf('Delivery module %s is not available: %s', $module->getCode(), $e->getMessage()));
 
             return [
                 'postage' => null,

--- a/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
+++ b/core/lib/Thelia/Domain/Shipping/Service/PostageEstimator.php
@@ -170,7 +170,7 @@ class PostageEstimator
             }
         } catch (DeliveryException) {
             Tlog::getInstance()->error(
-                \sprintf('Delivery module %s is not available', $deliveryModule->getName()),
+                \sprintf('Delivery module %s is not available', $deliveryModule->getCode()),
             );
         }
 


### PR DESCRIPTION
## Problem

Any `DeliveryException` raised by a delivery module turns the checkout into a 500.

Both shipping services build their log message with `$module->getName()`, but `$module` is a `Thelia\Model\Module`. That model has no `getName()`: the `module` table stores `code`, `type`, `activate`, `position`, `full_namespace`, `mandatory` and `hidden`, and the label lives in `module_i18n.title`. Propel's `__call` therefore throws a `BadMethodCallException` from inside the `catch` block, and a perfectly normal situation — this delivery module does not apply to the current cart — becomes fatal.

Seen on a Thelia 3 store at `/checkout/delivery`:

```
An exception has been thrown during the rendering of a template
("Call to undefined method: getName.") in "@UiComponents/Checkout/Delivery/Delivery.html.twig" at line 90.
```

The module that declined the cart was a pickup-point module with no pickup address in session yet. Any module can trigger it: a local delivery module rejecting an out-of-area postcode fails the same way.

## Fix

Log `getCode()` instead. It is the module identity, and it is what the surrounding code already uses.

Two call sites are affected:
- `Domain/Shipping/Service/DeliveryPostageQuerier.php:50`
- `Domain/Shipping/Service/PostageEstimator.php:173`

Both have taken a `Thelia\Model\Module` since the services were introduced in #3346, so the line has never been able to run.

## Notes

The catch blocks are only reached when a delivery module declines the cart, which no test covers today. That is why the bug survived. Worth a functional test on `DeliveryPostageQuerier::query()` with a module that throws.