### PR TITLE
fix: commit the update transaction only when one is still open

### DIFF
--- a/core/lib/Thelia/Install/Update.php
+++ b/core/lib/Thelia/Install/Update.php
@@ -254,7 +254,11 @@ class Update
                 }
             }
 
-            $this->connection->commit();
+            // A DDL statement in an update script (ALTER, CREATE, DROP) implicitly
+            // commits the transaction on MySQL/MariaDB, leaving nothing to commit here.
+            if ($this->connection->inTransaction()) {
+                $this->connection->commit();
+            }
             $this->log('debug', 'update successfully');
         } catch (\Exception $e) {
             // The guard matters here: $this->connection is the raw PDO handle


### PR DESCRIPTION
A DDL statement in an update script (ALTER, CREATE, DROP) implicitly commits the transaction on MySQL/MariaDB. The final `commit()` in `Update::process()` then throws `There is no active transaction`: every statement was in fact applied, but the update reports a failure.

Seen while testing the 2.6.1 → 2.6.2 update (`2.6.2.sql` carries an `ALTER TABLE currency`); the 2.6.0 → 2.6.1 script had 12 DDL statements and hit the same error. The `rollBack()` calls in the catch blocks already carry this `inTransaction()` guard — this applies the same guard to the `commit()`.