### PR TITLE
chore: bump the bundled Tinymce module to 2.6.3

### DIFF
--- a/local/modules/Tinymce/Config/module.xml
+++ b/local/modules/Tinymce/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>Editeur visuel TinyMCE</title>
     </descriptive>
-    <version>2.6.2</version>
+    <version>2.6.3</version>
     <author>
         <name>Manuel Raynaud</name>
         <email>manu@raynaud.io</email>


### PR DESCRIPTION
The standalone `thelia-modules/Tinymce` repository already carries a `2.6.2` tag (an older snapshot that still bundles ResponsiveFilemanager), so the module line with #3469 and #3717 needs the next version number to be taggable.