### PR TITLE
Leave a fresh install able to serve its first page

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -317,6 +317,19 @@ if (isset($options['with-admin'])) {
     ];
 }
 
+// The front-office assets a theme needs at runtime. A theme built on AssetMapper reads
+// its JavaScript from `assets/vendor`, and one built on Tailwind reads a stylesheet that
+// only exists once built: without either, the shop answers 500 on its very first page.
+// Both commands come from packages a theme may or may not require, so they are skipped
+// where nothing provides them. They run last: both read the theme that template:set chose.
+foreach (['importmap:install' => 'Installing front-office asset dependencies', 'tailwind:build' => 'Building the front-office stylesheet'] as $command => $label) {
+    $commands[] = [
+        'label' => $label,
+        'input' => ['command' => $command],
+        'optional' => true,
+    ];
+}
+
 echo "Running kernel commands...\n";
 
 $kernelClass = class_exists(App\Kernel::class) ? App\Kernel::class : Thelia\Core\TheliaKernel::class;
@@ -334,13 +347,20 @@ set_error_handler(static function (int $errno, string $errstr) {
 }, \E_WARNING);
 
 foreach ($commands as $cmd) {
-    echo "  {$cmd['label']}\n";
-
     $kernel = new $kernelClass($_SERVER['APP_ENV'] ?? 'dev', false);
     $kernel->boot();
 
     $app = new Symfony\Bundle\FrameworkBundle\Console\Application($kernel);
     $app->setAutoExit(false);
+
+    // An optional command belongs to a package the active theme may not require.
+    if (($cmd['optional'] ?? false) && !$app->has($cmd['input']['command'])) {
+        $kernel->shutdown();
+
+        continue;
+    }
+
+    echo "  {$cmd['label']}\n";
 
     try {
         $exitCode = $app->run(new Symfony\Component\Console\Input\ArrayInput($cmd['input']), $output);

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -13,7 +13,6 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Symfony\UX\Icons\UXIconsBundle::class => ['all' => true],
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
-    Symfony\UX\React\ReactBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\Translator\UxTranslatorBundle::class => ['all' => true],
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],


### PR DESCRIPTION
A fresh install with the Flexy v4 theme stops before it starts, then serves a 500 on its first page. Two separate causes, both found while installing from an empty directory and an empty database.

### A bundle nothing provides

`config/bundles.php` declares `Symfony\UX\React\ReactBundle`, and `symfony/ux-react` is required neither by this repository nor by the theme. Installing a theme that does not pull it in ends on:

```
Class "Symfony\UX\React\ReactBundle" not found
```

The file stays versioned, as Symfony expects. The line is what has to go: the Flex recipe of the package adds it back on its own wherever the package is installed, so a theme that needs React still gets its bundle registered.

### Assets the shop cannot start without

A theme built on AssetMapper reads its JavaScript from `assets/vendor`, and one built on Tailwind reads a stylesheet that exists only once built. Neither is produced by `bin/install`, so the shop answered:

```
The "@hotwired/stimulus" vendor asset is missing
Built Tailwind CSS file does not exist
```

Both commands now run at the end of the install, after `template:set`, since each reads the theme that was chosen. They belong to packages a theme may not require, so they are skipped where nothing provides them rather than reported as failures.

Verified on a fresh install: `bin/install --with-demo` alone now leaves a shop whose home page, category pages, product pages and checkout answer 200, with no command to type by hand.
