### PR TITLE
fix(test): skip the render assertion when the theme ships no AssetMapper vendors

### DIFF
--- a/core/lib/Thelia/Test/WebIntegrationTestCase.php
+++ b/core/lib/Thelia/Test/WebIntegrationTestCase.php
@@ -117,11 +117,11 @@ abstract class WebIntegrationTestCase extends WebTestCase
      * a failure names the template and the line that broke rather than reporting
      * "failed asserting that 500 is 200".
      *
-     * One outcome is not a defect: a theme installed by Composer ships no
-     * compiled assets, and rendering reads the Encore entrypoints file that
-     * `npm run build` produces in the theme. The core CI never builds them, so
-     * that single failure is reported as a skipped test. Everything else — a
-     * broken template, a controller error, an unexpected status — fails.
+     * One outcome is not a defect: a theme installed by Composer ships no built
+     * assets, and rendering reads them — the Encore entrypoints file, or the
+     * vendor assets AssetMapper expects under the theme. The core CI builds
+     * neither, so that single failure is reported as a skipped test. Everything
+     * else — a broken template, a controller error, an unexpected status — fails.
      */
     protected function assertPageRenders(string $url): void
     {
@@ -135,7 +135,7 @@ abstract class WebIntegrationTestCase extends WebTestCase
             }
 
             self::markTestSkipped(\sprintf(
-                '"%s" cannot be rendered: the theme assets are not built (npm run build in the theme).',
+                '"%s" cannot be rendered: the theme assets are not built (npm run build, importmap:install).',
                 $url,
             ));
         } finally {
@@ -155,9 +155,19 @@ abstract class WebIntegrationTestCase extends WebTestCase
      */
     private static function isMissingAssetBuild(\Throwable $failure): bool
     {
+        // A theme builds its assets with Encore, which reads an entrypoints file, or
+        // with AssetMapper, which reads the vendor assets `importmap:install` writes
+        // into the theme. Both are produced by the theme build, never by the core.
+        $missingBuildMessages = [
+            'Could not find the entrypoints file',
+            'vendor asset is missing',
+        ];
+
         for ($cause = $failure; null !== $cause; $cause = $cause->getPrevious()) {
-            if (str_contains($cause->getMessage(), 'Could not find the entrypoints file')) {
-                return true;
+            foreach ($missingBuildMessages as $missingBuildMessage) {
+                if (str_contains($cause->getMessage(), $missingBuildMessage)) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
The Flexy theme moved from Webpack Encore to AssetMapper (thelia/flexy 1.0.0-beta6), and the core CI installs the theme from Composer without ever building its assets. Rendering now fails on a missing `assets/vendor/` entry instead of a missing Encore entrypoints file, a message `assertPageRenders()` did not recognise — so the four front render smoke tests turned into errors and `main` went red.

`isMissingAssetBuild()` now also matches the AssetMapper message, which restores the documented contract: an unbuilt theme skips the render assertion, everything else still fails.

Checked both ways locally: with `assets/vendor/` removed the four tests error before the fix and skip after it; with the vendors installed the suite stays fully green with no skip.