### PR TITLE
chore: version the Scrutinizer perimeter and index the generated Propel models

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,17 +8,20 @@ build:
 
     nodes:
         analysis:
-            dependencies:
-                before:
+            services:
+                # bin/test-prepare needs a database to build the Propel models; the service
+                # answers on 127.0.0.1:3306 as root with an empty password.
+                mariadb: '10.11'
+            tests:
+                override:
                     # Propel generates its model classes into var/propel/<env>/model when the
                     # kernel boots. Without them every core/lib/Thelia/Model/* stub reports its
                     # own Base class as an unknown type — 310 phantom "bug" issues out of the
-                    # 1670 reported. A failure here only brings those back, so it must not fail
-                    # the inspection.
+                    # 1670 reported. This has to run after the Composer install, hence its place
+                    # here rather than in `dependencies`. A failure only brings those issues
+                    # back, so it must not fail the inspection.
                     - printf 'DATABASE_HOST=127.0.0.1\nDATABASE_PORT=3306\nDATABASE_USER=root\nDATABASE_PASSWORD=\nDATABASE_NAME=test\n' > .env.test.local
                     - php bin/test-prepare || true
-            tests:
-                override:
                     - php-scrutinizer-run
                     - command: composer phpstan
                       use_website_config: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,6 +8,15 @@ build:
 
     nodes:
         analysis:
+            dependencies:
+                before:
+                    # Propel generates its model classes into var/propel/<env>/model when the
+                    # kernel boots. Without them every core/lib/Thelia/Model/* stub reports its
+                    # own Base class as an unknown type — 310 phantom "bug" issues out of the
+                    # 1670 reported. A failure here only brings those back, so it must not fail
+                    # the inspection.
+                    - printf 'DATABASE_HOST=127.0.0.1\nDATABASE_PORT=3306\nDATABASE_USER=root\nDATABASE_PASSWORD=\nDATABASE_NAME=test\n' > .env.test.local
+                    - php bin/test-prepare || true
             tests:
                 override:
                     - php-scrutinizer-run
@@ -15,11 +24,20 @@ build:
                       use_website_config: false
 
 filter:
+    # The analysed perimeter lives here rather than in the website configuration, so that
+    # it is versioned and reviewed like the rest of the build.
+    paths:
+        - 'core/lib/Thelia/*'
+
+    # Indexed so that types resolve, never rated: generated Propel models and dependencies.
+    dependency_paths:
+        - 'var/propel/*'
+        - 'vendor/*'
+
     excluded_paths:
         - 'core/CHANGELOG.md'
         - 'tests/*'
         - 'templates/*'
-        - 'vendor/*'
         - 'var/*'
         - 'public/*'
         - 'local/*'


### PR DESCRIPTION
Two things the current setup gets wrong, both visible in the 1670 issues the last inspection of `main` reports.

**The perimeter was only defined in the website configuration**, written in 2014 and still merged into every inspection: it filters on `core/lib/Thelia/*`, excludes paths that no longer exist (`core/vendor/*`, `cache/*`, `install/*`, `log/*`, `web/*`) and pins `php_cs_fixer` to `level: psr2` while the project is PSR-12 and already runs `composer cs-diff` in CI. The same `paths` now live in this file, so the perimeter is versioned and reviewable, and the website configuration can be emptied without changing what gets analysed.

**The generated Propel models were never indexed.** 310 of the 512 `type_not_found` issues are stubs in `core/lib/Thelia/Model/*` reporting their own `Base` class as an unknown type — those classes are generated into `var/propel/<env>/model`, which `var/*` excluded. `bin/test-prepare` now builds them before the analysis and `dependency_paths` indexes them: types resolve, and the generated code is never rated. The step tolerates its own failure, since not having the models is exactly today's situation.

Note this cannot be verified locally — Scrutinizer only runs on a push. If the models still do not resolve on this branch's inspection, the `before` step is the part to adjust or drop.