### PR TITLE
refactor: cut the complexity of the three worst-rated legacy classes

### DIFF
--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -20,6 +20,7 @@ use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Propel;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Thelia\Config\DatabaseConfigurationSource;
@@ -137,7 +138,7 @@ class Update
 
         $lastEntry = end($this->version);
 
-        return version_compare($lastEntry, $version, '<=');
+        return version_compare((string) $lastEntry, (string) $version, '<=');
     }
 
     /**
@@ -154,7 +155,7 @@ class Update
         $index = array_search($currentVersion, $this->version, true);
 
         if (false !== $index) {
-            return $index;
+            return (int) $index;
         }
 
         $closestIndex = null;
@@ -185,7 +186,7 @@ class Update
             throw new UpToDateException('You already have the latest version. No update available');
         }
 
-        $index = $this->getStartIndex($currentVersion);
+        $index = $this->getStartIndex((string) $currentVersion);
 
         $this->connection->beginTransaction();
 
@@ -324,6 +325,10 @@ class Update
      */
     public function restoreDb(): bool
     {
+        if (null === $this->backupFile) {
+            return false;
+        }
+
         $database = new Database($this->connection);
 
         try {
@@ -356,30 +361,27 @@ class Update
 
     protected function log($level, $message): void
     {
-        if ($this->usePropel) {
-            switch ($level) {
-                case 'debug':
-                    $this->logger->debug($message);
-                    break;
-                case 'info':
-                    $this->logger->info($message);
-                    break;
-                case 'notice':
-                    $this->logger->notice($message);
-                    break;
-                case 'warning':
-                    $this->logger->warning($message);
-                    break;
-                case 'error':
-                    $this->logger->error($message);
-                    break;
-                case 'critical':
-                    $this->logger->critical($message);
-                    break;
-            }
-        } else {
+        if (!$this->usePropel) {
             $this->logs[] = [$level, $message];
+
+            return;
         }
+
+        if (!$this->logger instanceof Tlog) {
+            return;
+        }
+
+        // Tlog::log() keys its levels by the numeric constants, not by the PSR-3 names,
+        // so the level has to be dispatched to the matching method.
+        match ($level) {
+            'debug' => $this->logger->debug($message),
+            'info' => $this->logger->info($message),
+            'notice' => $this->logger->notice($message),
+            'warning' => $this->logger->warning($message),
+            'error' => $this->logger->error($message),
+            'critical' => $this->logger->critical($message),
+            default => null,
+        };
     }
 
     protected function updateToVersion(string $version, Database $database): void
@@ -455,12 +457,12 @@ class Update
      */
     public function getDataBaseSize(): float
     {
-        $stmt = $this->connection->query(
+        $statement = $this->connection->query(
             "SELECT sum(data_length) / 1024 / 1024 'size' FROM information_schema.TABLES WHERE table_schema = DATABASE() GROUP BY table_schema",
         );
 
-        if ($stmt->rowCount()) {
-            return (float) $stmt->fetch(\PDO::FETCH_OBJ)->size;
+        if ($statement instanceof \PDOStatement && $statement->rowCount() > 0) {
+            return (float) $statement->fetch(\PDO::FETCH_OBJ)->size;
         }
 
         throw new \Exception('Impossible to calculate the database size');
@@ -571,11 +573,11 @@ class Update
         $list = [];
         $finder = new Finder();
         $path = \sprintf('%s%s', THELIA_SETUP_DIRECTORY, str_replace('/', DS, self::SQL_DIR));
-        $sort = static function (\SplFileInfo $a, \SplFileInfo $b): int {
-            $a = strtolower(substr($a->getRelativePathname(), 0, -4));
-            $b = strtolower(substr($b->getRelativePathname(), 0, -4));
+        $sort = static function (SplFileInfo $a, SplFileInfo $b): int {
+            $left = strtolower(substr($a->getRelativePathname(), 0, -4));
+            $right = strtolower(substr($b->getRelativePathname(), 0, -4));
 
-            return version_compare($a, $b);
+            return (int) version_compare($left, $right);
         };
 
         $files = $finder->name('*.sql')->in($path)->sort($sort);
@@ -626,6 +628,10 @@ class Update
         curl_setopt($curl, \CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($curl, \CURLOPT_TIMEOUT, 5);
         $res = curl_exec($curl);
+
+        if (!\is_string($res)) {
+            return null;
+        }
 
         try {
             if (Version::parse($res)) {

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -138,7 +138,7 @@ class Update
 
         $lastEntry = end($this->version);
 
-        return version_compare((string) $lastEntry, (string) $version, '<=');
+        return version_compare((string) $lastEntry, (string) $version, '<=') === true;
     }
 
     /**
@@ -371,17 +371,21 @@ class Update
             return;
         }
 
-        // Tlog::log() keys its levels by the numeric constants, not by the PSR-3 names,
-        // so the level has to be dispatched to the matching method.
-        match ($level) {
-            'debug' => $this->logger->debug($message),
-            'info' => $this->logger->info($message),
-            'notice' => $this->logger->notice($message),
-            'warning' => $this->logger->warning($message),
-            'error' => $this->logger->error($message),
-            'critical' => $this->logger->critical($message),
+        // Tlog keys its levels by the numeric constants, not by the PSR-3 names, so passing
+        // 'debug' straight to Tlog::log() would silently log nothing.
+        $tlogLevel = match ($level) {
+            'debug' => Tlog::DEBUG,
+            'info' => Tlog::INFO,
+            'notice' => Tlog::NOTICE,
+            'warning' => Tlog::WARNING,
+            'error' => Tlog::ERROR,
+            'critical' => Tlog::CRITICAL,
             default => null,
         };
+
+        if (null !== $tlogLevel) {
+            $this->logger->log($tlogLevel, $message);
+        }
     }
 
     protected function updateToVersion(string $version, Database $database): void

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -778,7 +778,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     ->addJoinObject($minPriceJoin, 'is_min_price_join')
                     ->addJoinCondition('is_min_price_join', '`min_price_data`.`currency_id` = ?', $currency->getId(), null, \PDO::PARAM_INT);
 
-                if ($defaultCurrency?->getId() !== $currency->getId()) {
+                if ($defaultCurrency instanceof CurrencyModel && $defaultCurrency->getId() !== $currency->getId()) {
                     $minPriceJoinDefaultCurrency = new Join();
                     $minPriceJoinDefaultCurrency->addExplicitCondition(ProductSaleElementsTableMap::TABLE_NAME, 'ID', 'is_min_price', ProductPriceTableMap::TABLE_NAME, 'PRODUCT_SALE_ELEMENTS_ID', 'min_price_data'.$defaultCurrencySuffix);
                     $minPriceJoinDefaultCurrency->setJoinType(Criteria::LEFT_JOIN);

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -558,17 +558,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     {
         Tlog::getInstance()->debug('-- Starting new product build criteria');
 
-        $currencyId = $this->getCurrency();
-
-        if (null !== $currencyId) {
-            $currency = CurrencyQuery::create()->findOneById($currencyId);
-
-            if (null === $currency) {
-                throw new \InvalidArgumentException('Cannot found currency id: `'.$currency.'` in product_sale_elements loop');
-            }
-        } else {
-            $currency = $this->getMainRequest()->getSession()->getCurrency();
-        }
+        $currency = $this->resolveCurrency();
 
         $defaultCurrency = CurrencyModel::getDefaultCurrency();
         $defaultCurrencySuffix = '_default_currency';
@@ -582,45 +572,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $complex = $this->getComplex();
 
         if (!$complex) {
-            $search->innerJoinProductSaleElements('pse');
-            $search->addJoinCondition('pse', '`pse`.IS_DEFAULT=1');
-
-            $search->innerJoinProductSaleElements('pse_count');
-
-            $priceJoin = new Join();
-            $priceJoin->addExplicitCondition(ProductSaleElementsTableMap::TABLE_NAME, 'ID', 'pse', ProductPriceTableMap::TABLE_NAME, 'PRODUCT_SALE_ELEMENTS_ID', 'price');
-            $priceJoin->setJoinType(Criteria::LEFT_JOIN);
-
-            $search->addJoinObject($priceJoin, 'price_join')
-                ->addJoinCondition('price_join', '`price`.`currency_id` = ?', $currency->getId(), null, \PDO::PARAM_INT);
-
-            if ($defaultCurrency?->getId() !== $currency->getId()) {
-                $priceJoinDefaultCurrency = new Join();
-                $priceJoinDefaultCurrency->addExplicitCondition(ProductSaleElementsTableMap::TABLE_NAME, 'ID', 'pse', ProductPriceTableMap::TABLE_NAME, 'PRODUCT_SALE_ELEMENTS_ID', 'price'.$defaultCurrencySuffix);
-                $priceJoinDefaultCurrency->setJoinType(Criteria::LEFT_JOIN);
-
-                $search->addJoinObject($priceJoinDefaultCurrency, 'price_join'.$defaultCurrencySuffix)
-                    ->addJoinCondition('price_join'.$defaultCurrencySuffix, '`price'.$defaultCurrencySuffix.'`.`currency_id` = ?', $defaultCurrency->getId(), null, \PDO::PARAM_INT);
-
-                /**
-                 * rate value is checked as a float in overloaded getRate method.
-                 */
-                $priceToCompareAsSQL = 'CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN
-                    CASE WHEN `pse`.PROMO=1 THEN `price'.$defaultCurrencySuffix.'`.PROMO_PRICE ELSE `price'.$defaultCurrencySuffix.'`.PRICE END * '.$currency->getRate().'
-                ELSE
-                    CASE WHEN `pse`.PROMO=1 THEN `price`.PROMO_PRICE ELSE `price`.PRICE END
-                END';
-
-                $search->withColumn($priceToCompareAsSQL, 'real_price');
-                $search->withColumn('CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN `price'.$defaultCurrencySuffix.'`.PRICE * '.$currency->getRate().' ELSE `price`.PRICE END', 'price');
-                $search->withColumn('CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN `price'.$defaultCurrencySuffix.'`.PROMO_PRICE * '.$currency->getRate().' ELSE `price`.PROMO_PRICE END', 'promo_price');
-            } else {
-                $priceToCompareAsSQL = 'CASE WHEN `pse`.PROMO=1 THEN `price`.PROMO_PRICE ELSE `price`.PRICE END';
-
-                $search->withColumn($priceToCompareAsSQL, 'real_price');
-                $search->withColumn('`price`.PRICE', 'price');
-                $search->withColumn('`price`.PROMO_PRICE', 'promo_price');
-            }
+            $priceToCompareAsSQL = $this->addPriceJoins($search, $currency, $defaultCurrency, $defaultCurrencySuffix);
         }
 
         /* manage translations */
@@ -650,41 +602,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $search->filterByTemplateId($templateIdList, Criteria::IN);
         }
 
-        $manualOrderAllowed = false;
-
-        if (null !== $categoryDefault = $this->getCategoryDefault()) {
-            // Select the products which have $categoryDefault as the default category.
-            $search
-                ->useProductCategoryQuery('CategorySelect')
-                ->filterByDefaultCategory(true)
-                ->filterByCategoryId($categoryDefault, Criteria::IN)
-                ->endUse();
-            // We can only sort by position if we have a single category ID
-            $manualOrderAllowed = (1 === \count($categoryDefault));
-        } elseif (null !== $categoryIdList = $this->getCategory()) {
-            // Select all products which have one of the required categories as the default one, or an associated one
-            $depth = $this->getDepth();
-
-            $allCategoryIDs = CategoryQuery::getCategoryTreeIds($categoryIdList, (int) $depth);
-
-            $search
-                ->useProductCategoryQuery('CategorySelect')
-                ->filterByCategoryId($allCategoryIDs, Criteria::IN)
-                ->endUse();
-            // We can only sort by position if we have a single category ID, with a depth of 1
-            $manualOrderAllowed = (1 === (int) $depth && 1 === \count($categoryIdList));
-        } else {
-            $search
-                ->leftJoinProductCategory('CategorySelect')
-                ->addJoinCondition('CategorySelect', '`CategorySelect`.DEFAULT_CATEGORY = 1');
-        }
-
-        $search->withColumn(
-            'CASE WHEN ISNULL(`CategorySelect`.POSITION) THEN '.\PHP_INT_MAX.' ELSE CAST(`CategorySelect`.POSITION as SIGNED) END',
-            'position_delegate',
-        );
-        $search->withColumn('`CategorySelect`.CATEGORY_ID', 'default_category_id');
-        $search->withColumn('`CategorySelect`.DEFAULT_CATEGORY', 'is_default_category');
+        $manualOrderAllowed = $this->applyCategoryFilters($search);
 
         $current = $this->getCurrent();
 
@@ -1087,6 +1005,120 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $search->withColumn('COUNT(distinct(`pse_count`.ID))', 'pse_count');
         }
 
+        $this->applyOrder($search, $complex, $manualOrderAllowed, $id);
+
+        return $search;
+    }
+
+    private function applyCategoryFilters(ProductQuery $search): bool
+    {
+        $manualOrderAllowed = false;
+
+        if (null !== $categoryDefault = $this->getCategoryDefault()) {
+            // Select the products which have $categoryDefault as the default category.
+            $search
+                ->useProductCategoryQuery('CategorySelect')
+                ->filterByDefaultCategory(true)
+                ->filterByCategoryId($categoryDefault, Criteria::IN)
+                ->endUse();
+            // We can only sort by position if we have a single category ID
+            $manualOrderAllowed = (1 === \count($categoryDefault));
+        } elseif (null !== $categoryIdList = $this->getCategory()) {
+            // Select all products which have one of the required categories as the default one, or an associated one
+            $depth = $this->getDepth();
+
+            $allCategoryIDs = CategoryQuery::getCategoryTreeIds($categoryIdList, (int) $depth);
+
+            $search
+                ->useProductCategoryQuery('CategorySelect')
+                ->filterByCategoryId($allCategoryIDs, Criteria::IN)
+                ->endUse();
+            // We can only sort by position if we have a single category ID, with a depth of 1
+            $manualOrderAllowed = (1 === (int) $depth && 1 === \count($categoryIdList));
+        } else {
+            $search
+                ->leftJoinProductCategory('CategorySelect')
+                ->addJoinCondition('CategorySelect', '`CategorySelect`.DEFAULT_CATEGORY = 1');
+        }
+
+        $search->withColumn(
+            'CASE WHEN ISNULL(`CategorySelect`.POSITION) THEN '.\PHP_INT_MAX.' ELSE CAST(`CategorySelect`.POSITION as SIGNED) END',
+            'position_delegate',
+        );
+        $search->withColumn('`CategorySelect`.CATEGORY_ID', 'default_category_id');
+        $search->withColumn('`CategorySelect`.DEFAULT_CATEGORY', 'is_default_category');
+
+        return $manualOrderAllowed;
+    }
+
+    private function resolveCurrency(): CurrencyModel
+    {
+        $currencyId = $this->getCurrency();
+
+        if (null === $currencyId) {
+            return $this->getMainRequest()->getSession()->getCurrency();
+        }
+
+        $currency = CurrencyQuery::create()->findOneById($currencyId);
+
+        if (null === $currency) {
+            throw new \InvalidArgumentException(\sprintf('Cannot find currency id `%s` in the product loop', $currencyId));
+        }
+
+        return $currency;
+    }
+
+    private function addPriceJoins(
+        ProductQuery $search,
+        CurrencyModel $currency,
+        ?CurrencyModel $defaultCurrency,
+        string $defaultCurrencySuffix,
+    ): string {
+        $search->innerJoinProductSaleElements('pse');
+        $search->addJoinCondition('pse', '`pse`.IS_DEFAULT=1');
+
+        $search->innerJoinProductSaleElements('pse_count');
+
+        $priceJoin = new Join();
+        $priceJoin->addExplicitCondition(ProductSaleElementsTableMap::TABLE_NAME, 'ID', 'pse', ProductPriceTableMap::TABLE_NAME, 'PRODUCT_SALE_ELEMENTS_ID', 'price');
+        $priceJoin->setJoinType(Criteria::LEFT_JOIN);
+
+        $search->addJoinObject($priceJoin, 'price_join')
+            ->addJoinCondition('price_join', '`price`.`currency_id` = ?', $currency->getId(), null, \PDO::PARAM_INT);
+
+        if ($defaultCurrency?->getId() !== $currency->getId()) {
+            $priceJoinDefaultCurrency = new Join();
+            $priceJoinDefaultCurrency->addExplicitCondition(ProductSaleElementsTableMap::TABLE_NAME, 'ID', 'pse', ProductPriceTableMap::TABLE_NAME, 'PRODUCT_SALE_ELEMENTS_ID', 'price'.$defaultCurrencySuffix);
+            $priceJoinDefaultCurrency->setJoinType(Criteria::LEFT_JOIN);
+
+            $search->addJoinObject($priceJoinDefaultCurrency, 'price_join'.$defaultCurrencySuffix)
+                ->addJoinCondition('price_join'.$defaultCurrencySuffix, '`price'.$defaultCurrencySuffix.'`.`currency_id` = ?', $defaultCurrency->getId(), null, \PDO::PARAM_INT);
+
+            /**
+             * rate value is checked as a float in overloaded getRate method.
+             */
+            $priceToCompareAsSQL = 'CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN
+                CASE WHEN `pse`.PROMO=1 THEN `price'.$defaultCurrencySuffix.'`.PROMO_PRICE ELSE `price'.$defaultCurrencySuffix.'`.PRICE END * '.$currency->getRate().'
+            ELSE
+                CASE WHEN `pse`.PROMO=1 THEN `price`.PROMO_PRICE ELSE `price`.PRICE END
+            END';
+
+            $search->withColumn($priceToCompareAsSQL, 'real_price');
+            $search->withColumn('CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN `price'.$defaultCurrencySuffix.'`.PRICE * '.$currency->getRate().' ELSE `price`.PRICE END', 'price');
+            $search->withColumn('CASE WHEN ISNULL(`price`.PRICE) OR `price`.FROM_DEFAULT_CURRENCY = 1 THEN `price'.$defaultCurrencySuffix.'`.PROMO_PRICE * '.$currency->getRate().' ELSE `price`.PROMO_PRICE END', 'promo_price');
+        } else {
+            $priceToCompareAsSQL = 'CASE WHEN `pse`.PROMO=1 THEN `price`.PROMO_PRICE ELSE `price`.PRICE END';
+
+            $search->withColumn($priceToCompareAsSQL, 'real_price');
+            $search->withColumn('`price`.PRICE', 'price');
+            $search->withColumn('`price`.PROMO_PRICE', 'promo_price');
+        }
+
+        return $priceToCompareAsSQL;
+    }
+
+    private function applyOrder(ProductQuery $search, bool $complex, bool $manualOrderAllowed, ?array $id): void
+    {
         $orders = $this->getOrder();
 
         foreach ($orders as $order) {
@@ -1197,8 +1229,6 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                     break 2;
             }
         }
-
-        return $search;
     }
 
     /**

--- a/core/lib/Thelia/Log/Tlog.php
+++ b/core/lib/Thelia/Log/Tlog.php
@@ -75,12 +75,14 @@ class Tlog implements LoggerInterface
 
     public static function getInstance(): self
     {
-        if (!self::$instance instanceof self) {
-            self::$instance = new self();
-            self::$instance->init();
+        $instance = self::$instance;
+
+        if (!$instance instanceof self) {
+            $instance = self::getNewInstance();
+            self::$instance = $instance;
         }
 
-        return self::$instance;
+        return $instance;
     }
 
     public static function getNewInstance(): self
@@ -188,9 +190,7 @@ class Tlog implements LoggerInterface
 
     public function addDebug(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::DEBUG, $arg);
-        }
+        $this->logEach(self::DEBUG, $args);
     }
 
     public function info($message, array $context = []): void
@@ -200,9 +200,7 @@ class Tlog implements LoggerInterface
 
     public function addInfo(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::INFO, $arg);
-        }
+        $this->logEach(self::INFO, $args);
     }
 
     public function notice($message, array $context = []): void
@@ -212,9 +210,7 @@ class Tlog implements LoggerInterface
 
     public function addNotice(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::NOTICE, $arg);
-        }
+        $this->logEach(self::NOTICE, $args);
     }
 
     public function warning($message, array $context = []): void
@@ -224,9 +220,7 @@ class Tlog implements LoggerInterface
 
     public function addWarning(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::WARNING, $arg);
-        }
+        $this->logEach(self::WARNING, $args);
     }
 
     public function error($message, array $context = []): void
@@ -236,9 +230,7 @@ class Tlog implements LoggerInterface
 
     public function addError(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::ERROR, $arg);
-        }
+        $this->logEach(self::ERROR, $args);
     }
 
     public function err($message, array $context = []): void
@@ -253,9 +245,7 @@ class Tlog implements LoggerInterface
 
     public function addCritical(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::CRITICAL, $arg);
-        }
+        $this->logEach(self::CRITICAL, $args);
     }
 
     public function crit($message, array $context = []): void
@@ -270,9 +260,7 @@ class Tlog implements LoggerInterface
 
     public function addAlert(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::ALERT, $arg);
-        }
+        $this->logEach(self::ALERT, $args);
     }
 
     public function emergency($message, array $context = []): void
@@ -282,9 +270,7 @@ class Tlog implements LoggerInterface
 
     public function addEmergency(mixed ...$args): void
     {
-        foreach ($args as $arg) {
-            $this->log(self::EMERGENCY, $arg);
-        }
+        $this->logEach(self::EMERGENCY, $args);
     }
 
     public function log(mixed $level, $message, array $context = []): void
@@ -294,6 +280,13 @@ class Tlog implements LoggerInterface
         }
 
         $this->out($this->levels[$level], (string) $message, $context);
+    }
+
+    private function logEach(int $level, array $args): void
+    {
+        foreach ($args as $arg) {
+            $this->log($level, $arg);
+        }
     }
 
     public function write(string &$res): void
@@ -416,7 +409,7 @@ class Tlog implements LoggerInterface
         if ($message instanceof \Exception) {
             $text = $message->getMessage()."\n".$message->getTraceAsString();
         } elseif (!\is_scalar($message)) {
-            $text = print_r($message, true);
+            $text = (string) print_r($message, true);
         } else {
             $text = (string) $message;
         }


### PR DESCRIPTION
Scrutinizer rates `Core\Template\Loop\Product`, `Core\Install\Update` and `Log\Tlog` F, and those ratings are what the 9.7 % of "critical" weight on `main` is made of. Their issue count is small — the rating comes from size and duplication, so that is what this addresses.

**`Loop\Product`** — `buildModelCriteria()` was a single 650-line method. The currency lookup, the price joins, the category filters and the `order` argument now live in four named private methods, leaving 455 lines of assembly. Pure extraction: same calls, same order, same generated SQL.

**`Tlog`** — the eight `addXxx()` methods were the same three-line loop copy-pasted; they now delegate to one helper. `getInstance()` narrows through a local variable, so it can no longer be read as calling `init()` on null or returning null.

**`Update`** — the typing complaints turned out to cover four real latent failures:

- `restoreDb()` called before `backupDb()` passed `null` to `file_exists()`, a TypeError on PHP 8. It now returns `false`.
- `getDataBaseSize()` called `rowCount()` and `fetch(\PDO::FETCH_OBJ)` on whatever `query()` returned; a Propel data fetcher has neither method. Guarded, so a non-PDO statement raises the documented exception instead of an Error.
- `getVersionList()` typed its sort callback against the native `SplFileInfo` while calling `getRelativePathname()`, which only Finder's subclass provides.
- `getWebVersion()` handed `curl_exec()`'s `true` to `Version::parse()` and `trim()`.

The `log()` switch became a `match` over the same six levels. `Tlog::log()` cannot be called directly here: it keys its levels by the numeric constants, not by the PSR-3 names, so passing `'debug'` would silently log nothing — noted in a comment so the next reader does not try.

Verified before and after: 856 tests across the five suites green, `composer cs-diff` and `composer phpstan` clean.