### PR TITLE
fix: stop handing SVG images to the raster image pipeline

### DIFF
--- a/core/lib/Thelia/Action/Image.php
+++ b/core/lib/Thelia/Action/Image.php
@@ -45,6 +45,9 @@ use Thelia\Tools\URL;
  * A copy (or symbolic link, by default) of the original image is always created in the cache, so that the full
  * resolution image is always available.
  *
+ * SVG images are never rasterized: only their width and height attributes are rewritten, and no Imagine
+ * image object is attached to the event.
+ *
  * Various image processing options are available :
  *
  * - resizing, with border, crop, or by keeping image aspect ratio
@@ -93,11 +96,12 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
     {
         $subdir = $event->getCacheSubdirectory();
         $sourceFile = $event->getSourceFilepath();
-        $imageExt = pathinfo($sourceFile, \PATHINFO_EXTENSION);
 
         if (null === $sourceFile) {
             throw new \InvalidArgumentException('Cache sub-directory and source file path cannot be null');
         }
+
+        $imageExt = pathinfo($sourceFile, \PATHINFO_EXTENSION);
 
         // Find cached file path
         $cacheFilePath = $this->getCacheFilePath($subdir, $sourceFile, $event->isOriginalImage(), $event->getOptionsHash());
@@ -137,7 +141,7 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
 
             // Process image only if we have some transformations to do.
             if (!$event->isOriginalImage()) {
-                if ('svg' === $imageExt) {
+                if ($this->isVectorImage($imageExt)) {
                     $dom = new \DOMDocument('1.0', 'utf-8');
                     $dom->load($originalImagePathInCache);
                     $svg = $dom->documentElement;
@@ -182,9 +186,26 @@ class Image extends BaseCachedFile implements EventSubscriberInterface
         $event->setFileUrl(URL::getInstance()->absoluteUrl($processedImageUrl, null, URL::PATH_TO_FILE, $this->cdnBaseUrl));
         $event->setOriginalFileUrl(URL::getInstance()->absoluteUrl($originalImageUrl, null, URL::PATH_TO_FILE, $this->cdnBaseUrl));
 
+        // The raster pipeline cannot open a vector image: attaching an ImageInterface to the event
+        // would fail on every single render, including when the cached file is already up to date.
+        if ($this->isVectorImage($imageExt)) {
+            $event->setImageObject(null);
+
+            return;
+        }
+
         $imagine = $this->createImagineInstance();
         $image = $imagine->open($cacheFilePath);
         $event->setImageObject($image);
+    }
+
+    /**
+     * A vector image is served from the cache as-is: it is never rasterized, and no
+     * ImageInterface is attached to the event.
+     */
+    private function isVectorImage(string $extension): bool
+    {
+        return 'svg' === strtolower($extension);
     }
 
     private function applyTransformation(

--- a/tests/Integration/Action/ImageActionTest.php
+++ b/tests/Integration/Action/ImageActionTest.php
@@ -17,6 +17,7 @@ namespace Thelia\Tests\Integration\Action;
 use Thelia\Core\Event\File\FileCreateOrUpdateEvent;
 use Thelia\Core\Event\File\FileDeleteEvent;
 use Thelia\Core\Event\File\FileToggleVisibilityEvent;
+use Thelia\Core\Event\Image\ImageEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\ProductImage;
 use Thelia\Model\ProductImageQuery;
@@ -26,6 +27,8 @@ use Thelia\Tests\Support\Trait\CreatesTestFiles;
 final class ImageActionTest extends ActionIntegrationTestCase
 {
     use CreatesTestFiles;
+
+    private const CACHE_SUBDIRECTORY = 'test-image-action';
 
     protected function tearDown(): void
     {
@@ -140,5 +143,64 @@ final class ImageActionTest extends ActionIntegrationTestCase
 
         $reloaded = ProductImageQuery::create()->findPk($savedModel->getId());
         self::assertSame(0, (int) $reloaded->getVisible());
+    }
+
+    public function testProcessImageServesAnSvgWithoutRasterizingIt(): void
+    {
+        $sourceFile = $this->createTestSvg();
+        $this->trackFileForCleanup($sourceFile);
+
+        $event = (new ImageEvent())
+            ->setSourceFilepath($sourceFile)
+            ->setCacheSubdirectory(self::CACHE_SUBDIRECTORY);
+
+        $this->dispatch($event, TheliaEvents::IMAGE_PROCESS);
+
+        $cacheFilePath = $event->getCacheFilepath();
+        self::assertNotNull($cacheFilePath);
+        $this->trackFileForCleanup($cacheFilePath);
+        $this->trackFileForCleanup($event->getCacheOriginalFilepath());
+
+        self::assertFileExists($cacheFilePath);
+        self::assertNotEmpty($event->getFileUrl());
+        self::assertNull($event->getImageObject(), 'A vector image must never be handed to the raster pipeline.');
+    }
+
+    public function testProcessImageRescalesAnSvgWithoutRasterizingIt(): void
+    {
+        $sourceFile = $this->createTestSvg();
+        $this->trackFileForCleanup($sourceFile);
+
+        $event = (new ImageEvent())
+            ->setSourceFilepath($sourceFile)
+            ->setCacheSubdirectory(self::CACHE_SUBDIRECTORY)
+            ->setWidth(64);
+
+        $this->dispatch($event, TheliaEvents::IMAGE_PROCESS);
+
+        $cacheFilePath = $event->getCacheFilepath();
+        self::assertNotNull($cacheFilePath);
+        $this->trackFileForCleanup($cacheFilePath);
+        $this->trackFileForCleanup($event->getCacheOriginalFilepath());
+
+        self::assertStringContainsString('width="64"', (string) file_get_contents($cacheFilePath));
+        self::assertNull($event->getImageObject(), 'A vector image must never be handed to the raster pipeline.');
+    }
+
+    public function testProcessImageStillAttachesAnImageObjectForRasterImages(): void
+    {
+        $sourceFile = $this->createTestPng();
+        $this->trackFileForCleanup($sourceFile);
+
+        $event = (new ImageEvent())
+            ->setSourceFilepath($sourceFile)
+            ->setCacheSubdirectory(self::CACHE_SUBDIRECTORY);
+
+        $this->dispatch($event, TheliaEvents::IMAGE_PROCESS);
+
+        $this->trackFileForCleanup((string) $event->getCacheFilepath());
+        $this->trackFileForCleanup($event->getCacheOriginalFilepath());
+
+        self::assertNotNull($event->getImageObject());
     }
 }

--- a/tests/Support/Trait/CreatesTestFiles.php
+++ b/tests/Support/Trait/CreatesTestFiles.php
@@ -38,6 +38,19 @@ trait CreatesTestFiles
         return $tmpFile;
     }
 
+    protected function createTestSvg(string $prefix = 'thelia_test_svg_'): string
+    {
+        $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid($prefix).'.svg';
+        file_put_contents(
+            $path,
+            '<?xml version="1.0" encoding="utf-8"?>'
+            .'<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40">'
+            .'<rect width="120" height="40" fill="#000000"/></svg>',
+        );
+
+        return $path;
+    }
+
     protected function createTestTextFile(string $content = 'test content', string $prefix = 'thelia_test_doc_'): string
     {
         $tmpFile = tempnam(sys_get_temp_dir(), $prefix);


### PR DESCRIPTION
Fixes #3754

## Diagnostic

`Thelia\Action\Image::processImage()` ends with an unconditional

```php
$imagine = $this->createImagineInstance();
$image = $imagine->open($cacheFilePath);
$event->setImageObject($image);
```

GD (and Imagick) cannot decode an SVG, so `Imagine\Gd\Imagine::open()` throws
`RuntimeException("Unable to open image <path>")`. Two details make it a permanent
log leak rather than a one-off:

* the call sits **after** the `if (!file_exists($cacheFilePath))` block, so it runs on
  every render even once the cache file is up to date;
* `processImage()` already handles SVG explicitly a few lines above (the `viewBox` /
  `width` / `height` rewrite) — the method knows the file is a vector image and then
  hands it to the raster pipeline anyway.

The store logo shipped by default is `local/media/images/store/thelia.svg`, so a stock
install hits this on every page that resolves a store image.

## What changed

* the vector case is named once (`isVectorImage()`) and used by both the write branch
  and the new guard;
* for a vector image the event gets no `ImageInterface` and the cached file is served
  as-is. `ImageEvent::getImageObject()` is already nullable and its only consumer
  (`Core/Template/Loop/Image.php`) already reads it with `?->`;
* the `pathinfo($sourceFile, …)` call was moved below the `null === $sourceFile` guard
  that used to sit right after it (it fed `pathinfo()` a null and raised a deprecation).

## Why passthrough rather than rejecting SVG at upload

Rejecting SVG in the store configuration form would not fix this issue: the default
logo Thelia ships *is* an SVG, and the store-media resolver falls back to it when no
logo is configured. It would also leave the core pipeline broken for every other caller
and contradict the SVG support already written into `processImage()`.

Other non-raster formats were considered and deliberately left out. `.svgz` needs a
`Content-Encoding: gzip` the image cache does not control, no Thelia upload path
produces one, and nothing in the tree references it — a passthrough there would only
look supported. For a genuinely unreadable file the exception is the right answer and
still surfaces.

## Security note (not addressed here)

An SVG is an executable XML document. Serving an uploaded one from the public image
cache is an XSS vector, and #3555 records that back-office uploads have no MIME or
extension constraint at all. This patch does not widen that exposure — the copy or
symlink into `public/cache/images/` is created today, before the exception — but it does
make the resulting URL usable, so the point is worth stating: a proper fix for #3555
should pair an upload allow-list with SVG sanitising.

## Also noticed, left alone

* `processImage()` sets the SVG `height` attribute from `$event->getWidth()`
  (`core/lib/Thelia/Action/Image.php`, in the SVG branch) — squashes the aspect ratio.
* when `ImageEvent::setFormat('webp')` is combined with an SVG source, the cache path
  extension is rewritten to `.webp` although nothing ever writes that file.

## Tests

`tests/Integration/Action/ImageActionTest.php`:

* `testProcessImageServesAnSvgWithoutRasterizingIt` — original-size SVG, the exact
  demo.thelia.net case;
* `testProcessImageRescalesAnSvgWithoutRasterizingIt` — SVG with a width, exercising the
  `viewBox` branch;
* `testProcessImageStillAttachesAnImageObjectForRasterImages` — raster control, so the
  guard cannot silently swallow bitmaps.

Both SVG tests error on `Unable to open image` without the patch.
