### PR TITLE
fix: answer 404 instead of 500 for a front-office path matching no view

### DIFF
--- a/core/lib/Thelia/Core/Template/Parser/ParserResolver.php
+++ b/core/lib/Thelia/Core/Template/Parser/ParserResolver.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\Template\Assets\AssetResolverInterface;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Core\Template\TemplateHelperInterface;
@@ -39,7 +40,14 @@ class ParserResolver
     }
 
     /**
-     * @throws \Exception
+     * No parser able to render the named template means the template does not exist in the
+     * active theme: an unknown view, not a broken installation. It is reported as a missing
+     * resource, the same way a parser reports a template file it cannot load, so that callers
+     * decide what it means for them - the front-office view chain answers 404, the back-office
+     * catch-all does the same, and the mail and PDF renderers, which also run from the command
+     * line, are free to treat it as the misconfiguration it is for them.
+     *
+     * @throws ResourceNotFoundException when no registered parser can render the template
      */
     public function getParser(string $pathTemplate, ?string $templateName): ParserInterface
     {
@@ -56,11 +64,11 @@ class ParserResolver
             }
         }
 
-        throw new \Exception(\sprintf('Parser for template %s not found', $templateName));
+        throw new ResourceNotFoundException(\sprintf('Parser for template %s not found', $templateName));
     }
 
     /**
-     * @throws \Exception
+     * @throws ResourceNotFoundException when no registered parser can render the requested view
      */
     public function getParserByCurrentRequest(): ?ParserInterface
     {

--- a/tests/Unit/Core/Template/Parser/ParserResolverTest.php
+++ b/tests/Unit/Core/Template/Parser/ParserResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Template\Parser;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
+use Thelia\Core\Template\Parser\ParserFallback;
+use Thelia\Core\Template\Parser\ParserResolver;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Template\TemplateHelperInterface;
+use Thelia\Core\View\ViewRenderer;
+
+/**
+ * A view name no registered parser can render is a page the shop does not have.
+ *
+ * The front-office catch-all route reads the last segment of any URL as a view name, so a
+ * service worker probe, a mistyped page or a URL left over from a previous site all reach
+ * the view chain naming a view no theme ships. The outcome has to be a 404: a 500 hides
+ * real failures in the noise and writes a CRITICAL entry per probe in the production log.
+ *
+ * These tests build the resolver with parsers that render nothing, which is the situation
+ * of a shop whose theme is served by a single engine — the Twig parser and a theme that
+ * does not ship the template. A shop that also runs the Smarty parser never gets here:
+ * that parser claims every template name and reports the missing file from render()
+ * instead, which the view chain already turns into a 404.
+ */
+final class ParserResolverTest extends TestCase
+{
+    public static function unknownViewProvider(): iterable
+    {
+        yield 'service worker probed by browsers' => ['sw.js'];
+        yield 'service worker, the other conventional name' => ['service-worker.js'];
+        yield 'view name no theme declares' => ['brand'];
+        yield 'another view name no theme declares' => ['currency'];
+        yield 'page of a site the shop replaced' => ['mentions-legales.html'];
+    }
+
+    #[DataProvider('unknownViewProvider')]
+    public function testAViewNoParserCanRenderIsReportedAsAMissingResource(string $view): void
+    {
+        $resolver = new ParserResolver([new ParserFallback()], [], new RequestStack(), $this->templateHelper());
+
+        $this->expectException(ResourceNotFoundException::class);
+        $this->expectExceptionMessage(\sprintf('Parser for template %s not found', $view));
+
+        $resolver->getParser('/themes/flexy', $view);
+    }
+
+    /**
+     * The whole point of reporting it that way: the front-office view chain already turns a
+     * missing template resource into a 404, so it needs no case of its own for this one.
+     */
+    #[DataProvider('unknownViewProvider')]
+    public function testTheViewChainAnswersNotFoundForAViewNoParserCanRender(string $view): void
+    {
+        $request = Request::create('/'.$view);
+        $request->attributes->set('_view', $view);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $renderer = new ViewRenderer(
+            new ParserResolver([new ParserFallback()], [], $requestStack, $this->templateHelper()),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(RouterInterface::class),
+        );
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $renderer->render($request);
+    }
+
+    private function templateHelper(): TemplateHelperInterface
+    {
+        $templateDefinition = $this->createMock(TemplateDefinition::class);
+        $templateDefinition->method('getAbsolutePath')->willReturn('/themes/flexy');
+
+        $templateHelper = $this->createMock(TemplateHelperInterface::class);
+        $templateHelper->method('isAdmin')->willReturn(false);
+        $templateHelper->method('getActiveFrontTemplate')->willReturn($templateDefinition);
+
+        return $templateHelper;
+    }
+}


### PR DESCRIPTION
Fixes #3753

A front-office path that matches no view answers 500 with `Exception: "Parser for template sw.js not found"` and writes a `request.CRITICAL` entry for every probe of `/sw.js`, `/service-worker.js`, `/brand`, a mistyped page, or a URL left over from a previous site.

### Where it comes from

`/sw.js` is matched by the theme's catch-all route `/{_view}`, after the rewriting router has reported the URL as unknown. `_view` is then `sw.js`, and `ViewRenderer` asks `ParserResolver` for a parser able to render it. When no registered parser supports a template the theme does not ship, `ParserResolver::getParser()` raised a bare `\Exception` — an error the view chain has no way to recognise, so it reached the kernel as a server failure.

That chain already knows how to answer a missing template: `ViewRenderer` catches `Thelia\Core\Template\Exception\ResourceNotFoundException`, the exception a parser raises for a template file it cannot load, and turns it into a `NotFoundHttpException`, which `Thelia\Action\HttpException::display404()` renders as the theme's 404 page. `BaseAdminController` treats the same exception the same way on the admin side.

### Why it does not show on every shop

The Smarty parser answers `supportTemplateRender()` with `checkTemplate()`, which only verifies that the resolved path stays inside the template directory — it never checks that the file exists, so it claims *every* view name. On a shop where it is active it therefore takes the unknown view, reports the missing file from `render()`, and the chain answers a 404. The 500 needs a shop where no parser claims the name: a theme served by Twig alone, which is what a Flexy front-office without the Smarty module is.

That is worth a look on its own, in the `TheliaSmarty` module: a parser claiming names it cannot render is also what makes the order of the parser list load-bearing.

### The fix

`ParserResolver::getParser()` now reports a template no parser can render as that same missing resource, so the existing 404 handling takes over whatever the set of installed parsers: the visitor gets the theme's 404 page with a 404 status, and the exception listeners stop before the CRITICAL logging.

Throwing a `NotFoundHttpException` from `ParserResolver` was the other option and was not kept: the same method serves `Command\PdfRender` and `MailerFactory`, which also run from the command line, where an HTTP exception means nothing — and where a genuinely missing mail or PDF template would silently become a 404 page instead of surfacing as the misconfiguration it is. Only `ViewRenderer`, the HTTP layer, decides that a missing template is a 404.

`ResourceNotFoundException` extends `\RuntimeException`, so the existing `catch (\Exception)` around these calls keep working.

### Test

`tests/Unit/Core/Template/Parser/ParserResolverTest.php` builds the resolver with parsers that render nothing — the single-engine shop the bug needs — and covers both halves over the five paths from the issue: `getParser()` reports a missing resource, and a real `ViewRenderer` over that resolver answers `NotFoundHttpException`. Both fail without the change, with the exact `Exception: "Parser for template sw.js not found"` of the issue.

An HTTP-level test would not do: the test container has the Smarty parser, which claims the view and makes the case pass with or without the fix.