### PR TITLE
Keep deprecation logs out of the production error log

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,0 +1,60 @@
+monolog:
+    channels:
+        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+
+when@dev:
+    monolog:
+        handlers:
+            main:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+                channels: ["!event"]
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine", "!console"]
+
+when@test:
+    monolog:
+        handlers:
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                excluded_http_codes: [404, 405]
+                channels: ["!event"]
+            nested:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+
+when@prod:
+    monolog:
+        handlers:
+            # The "deprecation" channel is deliberately left without a handler in prod.
+            #
+            # The stock Symfony recipe ships a dedicated "deprecation" handler writing to
+            # php://stderr. On a shop, stderr is the FPM error log, and a single deprecated
+            # call site reached on every request writes one line per request: a low-traffic
+            # demo shop produced tens of MB of deprecation lines per day that way.
+            #
+            # Deprecations are surfaced where they can be acted upon — the dev log above and
+            # the CI test run — not in the production error log. Keep this file when the
+            # monolog recipe is updated.
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                excluded_http_codes: [404, 405]
+                channels: ["!deprecation"]
+                buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            nested:
+                type: stream
+                path: php://stderr
+                level: debug
+                formatter: monolog.formatter.json
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine"]


### PR DESCRIPTION
Fixes #3755

## What floods the log

The stock Symfony monolog recipe ships this in its `when@prod` block, and Thelia carries it verbatim — the file committed on demo.thelia.net is byte-identical:

```yaml
deprecation:
    type: stream
    channels: [deprecation]
    path: php://stderr
    formatter: monolog.formatter.json
```

Worth being precise about the diagnosis in the issue: the `main` handler **already** carries `channels: ["!deprecation"]`, so excluding the channel there changes nothing. The volume comes from that second, dedicated `deprecation` handler. On a shop, `php://stderr` is the FPM error log, and any deprecated call site reached on every request writes one line per request — which is how a low-traffic demo shop reached 39 MB in a day.

## The change

Drop the prod `deprecation` handler, and leave a comment explaining why so a future recipe update does not quietly restore it. `dev` and `test` are untouched: deprecations stay visible where they can be acted upon.

`nested` is referenced by `main` via `handler: nested`, so monolog marks it a nested handler and never pushes it onto a logger directly (`MonologExtension.php:94`) — dropping the `deprecation` handler leaves the channel with no handler in prod, which is the intent.

## Scope

`/config/` is gitignored in this repo; this file is force-added, as `config/packages/api_platform.yaml` and `config/packages/liip_imagine.yaml` already are.

That fixes this repository and sets the reference, **but it does not reach a real shop**: a project gets `config/packages/monolog.yaml` from the upstream Flex recipe at `composer create-project`, and `thelia/thelia-project` tracks no `config/` at all. The same change needs to land in the skeleton to actually fix deployed shops — filed separately.