### PR TITLE
Guard the core against deprecated Request::get() call sites

### DIFF
--- a/tests/Unit/Core/ExplicitRequestBagTest.php
+++ b/tests/Unit/Core/ExplicitRequestBagTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Request::get() is deprecated since Symfony 7.4 and searches the attributes, the query
+ * string and the request body in that order, so a call site that meant to read one of
+ * them silently accepts the other two. The core reads every request value from an
+ * explicit bag instead; this test keeps it that way.
+ *
+ * A single reachable call site also writes one deprecation line per request into the
+ * production error log, which is how a low-traffic shop reached tens of MB a day.
+ */
+final class ExplicitRequestBagTest extends TestCase
+{
+    private const CORE_LIBRARY_DIRECTORY = __DIR__.'/../../../core/lib';
+
+    private const REQUEST_ACCESSORS = ['getRequest', 'getCurrentRequest', 'getMainRequest'];
+
+    public function testRequestGetIsStillDeprecatedUpstream(): void
+    {
+        $method = new \ReflectionMethod(Request::class, 'get');
+
+        self::assertStringContainsString(
+            '@deprecated',
+            (string) $method->getDocComment(),
+            'Request::get() is no longer deprecated upstream, this guard can be dropped.',
+        );
+    }
+
+    public function testCoreReadsRequestValuesFromAnExplicitBag(): void
+    {
+        $callSites = [];
+
+        foreach ($this->coreSourceFiles() as $file) {
+            foreach ($this->findRequestGetCalls($file) as $line) {
+                $callSites[] = $file->getPathname().':'.$line;
+            }
+        }
+
+        self::assertSame(
+            [],
+            $callSites,
+            "Request::get() is deprecated since Symfony 7.4. Read from the bag the value actually\n"
+            ."comes from — query->get(), request->get() or attributes->get() — at:\n"
+            .implode("\n", $callSites),
+        );
+    }
+
+    /**
+     * @return iterable<\SplFileInfo>
+     */
+    private function coreSourceFiles(): iterable
+    {
+        $directory = realpath(self::CORE_LIBRARY_DIRECTORY);
+
+        self::assertIsString($directory, 'The core library directory was not found.');
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+        );
+
+        /** @var \SplFileInfo $file */
+        foreach ($files as $file) {
+            if ('php' === $file->getExtension()) {
+                yield $file;
+            }
+        }
+    }
+
+    /**
+     * Walks the token stream so that comments and strings mentioning the call cannot
+     * trip the guard, and reports the line of every `->get(` whose receiver is a
+     * request: a `$…request` variable, or one of the usual request accessors.
+     *
+     * @return list<int>
+     */
+    private function findRequestGetCalls(\SplFileInfo $file): array
+    {
+        $tokens = array_values(array_filter(
+            token_get_all((string) file_get_contents($file->getPathname())),
+            static fn (array|string $token): bool => !\is_array($token)
+                || !\in_array($token[0], [\T_WHITESPACE, \T_COMMENT, \T_DOC_COMMENT], true),
+        ));
+
+        $lines = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!\is_array($token) || \T_STRING !== $token[0] || 'get' !== $token[1]) {
+                continue;
+            }
+
+            if (($tokens[$index + 1] ?? null) !== '(') {
+                continue;
+            }
+
+            $operator = $tokens[$index - 1] ?? null;
+
+            if (!\is_array($operator)
+                || !\in_array($operator[0], [\T_OBJECT_OPERATOR, \T_NULLSAFE_OBJECT_OPERATOR], true)) {
+                continue;
+            }
+
+            if ($this->isRequestReceiver($tokens, $index - 2)) {
+                $lines[] = $token[2];
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The receiver sits just before the `->`. Two shapes count as a request:
+     * a `$…request` variable, and a `getRequest()`-style accessor call. Anything
+     * else — `$request->query`, `$this->request`, `$container` — does not, so the
+     * explicit bags and the unrelated `get()` methods stay untouched.
+     *
+     * @param list<array{int, string, int}|string> $tokens
+     */
+    private function isRequestReceiver(array $tokens, int $index): bool
+    {
+        $token = $tokens[$index] ?? null;
+
+        if (\is_array($token) && \T_VARIABLE === $token[0]) {
+            return str_ends_with(strtolower($token[1]), 'request');
+        }
+
+        if (')' !== $token || '(' !== ($tokens[$index - 1] ?? null)) {
+            return false;
+        }
+
+        $accessor = $tokens[$index - 2] ?? null;
+
+        return \is_array($accessor)
+            && \T_STRING === $accessor[0]
+            && \in_array($accessor[1], self::REQUEST_ACCESSORS, true);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/thelia/thelia/issues/3755

## Measurement first

The issue reads "finish migrating the remaining `Request::get()` call sites ... in the core". On `main` there are none left to migrate. Scanning the token stream of all 1597 PHP files under `core/lib` finds **zero** call sites; every request value is already read from an explicit bag:

```
25  $request->attributes->get(     19  $request->request->get(
18  $request->query->get(          14  getMainRequest()->query->get(
14  getMainRequest()->attributes->get(   2  getRequest()->attributes->get(
 2  $request->headers->get(         2  $request->files->get(
 1  $request->cookies->get(
```

The 419 deprecation lines in the report are a log volume, not a call-site count: a handful of call sites in the installed modules, each reached on every request. Those live in `thelia-modules/*`, outside this repository.

So the useful contribution here is not a migration, it is keeping the migration from silently regressing.

## The guard

`tests/Unit/Core/ExplicitRequestBagTest.php` walks the PHP token stream of `core/lib` and fails on any `->get(` whose receiver is a request — a `$…request` variable or a `getRequest()` / `getCurrentRequest()` / `getMainRequest()` accessor, including the nullsafe form.

Token-based rather than a grep, so comments, docblocks and strings mentioning the call cannot trip it. Receivers that are not a request — `$request->query`, `$container`, `$form`, `$session` — are deliberately not matched, and neither is `$this->request->get()`, which is indistinguishable from a bag read at token level.

A second test asserts `Request::get()` is still marked `@deprecated` upstream, so the guard gets removed rather than silently kept once Symfony drops the method.

## Verified red

Injecting one `$request->get("injected")` into `ModuleXmlLoader.php` takes the scan from 0 to 1 call site and fails the assertion; removing it returns to 0.

## Why it matters beyond the log

`Request::get()` searches attributes, then query, then body, and returns whichever hits first — so a call site that meant to read a route parameter silently accepts a query string or a POST body value. Keeping the core on explicit bags is a correctness property, not only a deprecation cleanup.