### PR TITLE
fix: abort setup/update.php when stdin gives no answer, and exit non-zero on failure

### DIFF
--- a/setup/update.php
+++ b/setup/update.php
@@ -18,6 +18,9 @@ if (\PHP_SAPI != 'cli') {
     throw new \Exception('this script can only be launched with cli sapi');
 }
 
+// How many times an unusable answer is asked again before the script gives up.
+const UPDATE_MAX_INPUT_ATTEMPTS = 3;
+
 $bootstrapToggle = false;
 $bootstraped = false;
 
@@ -93,57 +96,38 @@ $current = $update->getCurrentVersion();
 $files = $update->getLatestVersion();
 $web = $update->getWebVersion();
 
-while (1) {
-    if ($web !== null && $files != $web) {
-        cliOutput(sprintf(
-            'Thelia server is reporting the current stable release version is %s ',
-            $web
-        ), 'warning');
-    }
-
+if ($web !== null && $files != $web) {
     cliOutput(sprintf(
-        'You are going to update Thelia from version %s to version %s.',
-        $current,
+        'Thelia server is reporting the current stable release version is %s ',
+        $web
+    ), 'warning');
+}
+
+cliOutput(sprintf(
+    'You are going to update Thelia from version %s to version %s.',
+    $current,
+    $files
+), 'info');
+
+if ($web !== null && $files < $web) {
+    cliOutput(sprintf(
+        'Your files belongs to version %s, which is not the latest stable release.',
         $files
-    ), 'info');
-
-    if ($web !== null && $files < $web) {
-        cliOutput(sprintf(
-            'Your files belongs to version %s, which is not the latest stable release.',
-            $files
-        ), 'warning');
-        cliOutput(
-            'It is recommended to upgrade your files first then run this script again.'.\PHP_EOL
-            .'The latest version is available at http://thelia.net/#download .', 'warning');
-        cliOutput('Continue update process anyway ? (Y/n)');
-    } else {
-        cliOutput('Continue update process ? (Y/n)');
-    }
-
-    $rep = readStdin(true);
-    if ($rep == 'y') {
-        break;
-    }
-    if ($rep == 'n') {
-        cliOutput('Update aborted', 'warning');
-        exit(0);
-    }
+    ), 'warning');
+    cliOutput(
+        'It is recommended to upgrade your files first then run this script again.'.\PHP_EOL
+        .'The latest version is available at http://thelia.net/#download .', 'warning');
+    $question = 'Continue update process anyway ? (Y/n)';
+} else {
+    $question = 'Continue update process ? (Y/n)';
 }
 
-$backup = false;
-while (1) {
-    cliOutput('Would you like to backup the current database before proceeding ? (Y/n)');
-
-    $rep = readStdin(true);
-    if ($rep == 'y') {
-        $backup = true;
-        break;
-    }
-    if ($rep == 'n') {
-        $backup = false;
-        break;
-    }
+if (!askConfirmation($question)) {
+    cliOutput('Update aborted', 'warning');
+    exit(0);
 }
+
+$backup = askConfirmation('Would you like to backup the current database before proceeding ? (Y/n)');
 
 /***************************************************
  * Update
@@ -187,28 +171,18 @@ if (null === $updateError) {
         cliOutput(sprintf('[%s] %s'.\PHP_EOL, $log[0], $log[1]), 'error');
     }
 
-    if (true === $backup) {
-        while (1) {
-            cliOutput('Would you like to restore the backup database ? (Y/n)');
+    if (true === $backup && askConfirmation('Would you like to restore the backup database ? (Y/n)')) {
+        cliOutput('Database restore started. Wait, it could take a while...');
 
-            $rep = readStdin(true);
-            if ($rep == 'y') {
-                cliOutput('Database restore started. Wait, it could take a while...');
-
-                if (false === $update->restoreDb()) {
-                    cliOutput(sprintf(
-                        'Sorry, your database can\'t be restore. Try to do it manually : %s',
-                        $update->getBackupFile()
-                    ), 'error');
-                    exit(5);
-                }
-                cliOutput('Database successfully restore.');
-                exit(5);
-            }
-            if ($rep == 'n') {
-                exit(0);
-            }
+        if (false === $update->restoreDb()) {
+            cliOutput(sprintf(
+                'Sorry, your database can\'t be restore. Try to do it manually : %s',
+                $update->getBackupFile()
+            ), 'error');
+            exit(5);
         }
+        cliOutput('Database successfully restore.');
+        exit(5);
     }
 }
 
@@ -238,24 +212,74 @@ if (true === $hasDeleteError) {
 }
 
 cliOutput('Update process finished.', 'info');
-exit(0);
+exit(null === $updateError ? 0 : 7);
 
 /***************************************************
  * Utils
  ***************************************************/
 
+/**
+ * @return string|false the answer, or false when standard input is exhausted
+ */
 function readStdin($normalize = false)
 {
-    $fr = fopen('php://stdin', 'r');
-    $input = fgets($fr, 128);
+    // Opened once and never closed: reopening php://stdin for every question
+    // discards the input PHP has already buffered, so every piped answer but
+    // the first one was lost.
+    static $stream = null;
+
+    if (null === $stream) {
+        $stream = fopen('php://stdin', 'r');
+    }
+
+    if (false === $stream) {
+        return false;
+    }
+
+    $input = fgets($stream, 128);
+
+    if (false === $input) {
+        return false;
+    }
+
     $input = rtrim($input);
-    fclose($fr);
 
     if ($normalize) {
         $input = strtolower(trim($input));
     }
 
     return $input;
+}
+
+function askConfirmation($question): bool
+{
+    for ($attempt = 0; $attempt < UPDATE_MAX_INPUT_ATTEMPTS; ++$attempt) {
+        cliOutput($question);
+
+        $answer = readStdin(true);
+
+        if (false === $answer) {
+            abortUpdate('standard input is exhausted or is not a terminal, no answer can be read.');
+        }
+
+        if ($answer === 'y') {
+            return true;
+        }
+
+        if ($answer === 'n') {
+            return false;
+        }
+
+        cliOutput('Please answer y or n.', 'warning');
+    }
+
+    abortUpdate(sprintf('no valid answer after %d attempts.', UPDATE_MAX_INPUT_ATTEMPTS));
+}
+
+function abortUpdate($reason): never
+{
+    cliOutput('Update aborted : '.$reason, 'error');
+    exit(6);
 }
 
 function joinPaths()


### PR DESCRIPTION
Fixes the two defects reported in https://github.com/thelia/thelia/issues/3746 on the 2.6 line.

### 1. Infinite loop when stdin is not a terminal

`readStdin()` reopened `php://stdin` for every question and never told EOF apart from an
empty answer, so the `while (1)` confirmation loops could not exit: the prompt was
reprinted forever and the process pinned a CPU core.

```
$ timeout 10 php setup/update.php < /dev/null
... "Continue update process ? (Y/n)" printed ~18 million times, exit 124
```

Closing the stream also threw away the input PHP had already buffered, so piped answers
after the first one were lost:

```
$ printf 'y\nn\n' | timeout 10 php setup/update.php
... loops forever on the backup question, exit 124
```

The stream is now opened once and kept open, `readStdin()` returns `false` on EOF, and
the confirmation prompts go through `askConfirmation()`, which aborts on EOF and gives up
after three unusable answers instead of looping.

### 2. Exit code 0 when the update failed

When `Update::process()` threw, the script printed the error, cleared the cache, printed
`Update process finished.` and exited 0, leaving a deployment pipeline no way to notice.
The script now exits 7 in that case.

New exit codes: `6` = aborted, no usable answer on stdin; `7` = update failed.
The existing codes (1 to 5) are unchanged.

### Verified

| case | before | after |
| --- | --- | --- |
| `php setup/update.php < /dev/null` | loops forever (124) | `Update aborted : ...` / 6 |
| `printf 'y\nn\n' \| php setup/update.php` | loops forever (124) | runs, 0 |
| update fails | `Update process finished.` / 0 | 7 |
| three unusable answers | loops forever | `no valid answer after 3 attempts.` / 6 |
| answering `n` | 0 | 0 |
| interactive tty: typo then `y` then `Ctrl-D` | n/a | re-prompts, then aborts with 6 |

Interactive use was checked over a real pty: a wrong answer is still re-prompted, `Ctrl-D`
aborts cleanly.
