### PR TITLE
fix: run the update loop on the connection Propel hands out

### DIFF
--- a/core/lib/Thelia/Core/Install/Database.php
+++ b/core/lib/Thelia/Core/Install/Database.php
@@ -258,7 +258,13 @@ class Database
         );
     }
 
-    public function getConnection(): \PDO
+    /**
+     * The handle the update scripts of setup/update/php are given. Propel hands out a
+     * PdoConnection, which speaks the same query(), prepare() and exec() as \PDO but
+     * does not extend it and keeps its own \PDO private, so a \PDO return type turns
+     * every update script into a TypeError.
+     */
+    public function getConnection(): ConnectionInterface|\PDO
     {
         return $this->connection;
     }

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -75,8 +75,10 @@ class Update
                 ProductTableMap::DATABASE_NAME,
             );
 
-            // Unwrap before assigning: the property is typed \PDO, so the wrapper
-            // cannot transit through it.
+            // Unwrap the wrapper Propel returns, so that the update runs on the one
+            // connection it opened rather than through its transaction bookkeeping.
+            // What comes out is a PdoConnection, not a \PDO: it exposes the same
+            // query(), prepare() and exec(), and keeps its own \PDO private.
             if ($connection instanceof ConnectionWrapper) {
                 $connection = $connection->getWrappedConnection();
             }
@@ -254,7 +256,7 @@ class Update
         } catch (\Throwable $throwable) {
             // An Error is not turned into an UpdateException — the installer keeps
             // seeing it as it is today — but the update transaction is closed.
-            // The guard matters here: $this->connection is the raw PDO handle
+            // The guard matters here: $this->connection is the unwrapped handle
             // (see __construct()), whose rollBack() throws when no transaction is open.
             if ($this->connection->inTransaction()) {
                 $this->connection->rollBack();
@@ -442,15 +444,16 @@ class Update
 
     public function setCurrentVersion($version): void
     {
-        if ($this->connection instanceof \PDO) {
-            try {
-                $stmt = $this->connection->prepare('UPDATE config set value = ? where name = ?');
-                $stmt->execute([$version, 'thelia_version']);
-            } catch (\PDOException $e) {
-                $this->log('error', \sprintf('Error setting current version : %s', $e->getMessage()));
+        // No instanceof \PDO guard here: the connection Propel hands out is a
+        // PdoConnection, so the guard silently skipped the only write that records
+        // how far the update went, and every run started over from the same version.
+        try {
+            $stmt = $this->connection->prepare('UPDATE config set value = ? where name = ?');
+            $stmt->execute([$version, 'thelia_version']);
+        } catch (\PDOException $e) {
+            $this->log('error', \sprintf('Error setting current version : %s', $e->getMessage()));
 
-                throw $e;
-            }
+            throw $e;
         }
     }
 

--- a/tests/Integration/Install/UpdateConnectionTest.php
+++ b/tests/Integration/Install/UpdateConnectionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Install;
+
+use Propel\Runtime\Propel;
+use Thelia\Core\Install\Database;
+use Thelia\Core\Install\Update;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The update loop runs on the connection Propel opened, and Propel opens a
+ * PdoConnection: it speaks the same query(), prepare() and exec() as \PDO, but it
+ * does not extend it and keeps its own \PDO private.
+ *
+ * Everything the loop does with that connection is exercised here, because both
+ * places that assumed a \PDO failed silently or late: the handle given to the PHP
+ * update scripts, and the write of the version marker that records how far the
+ * update went.
+ */
+final class UpdateConnectionTest extends IntegrationTestCase
+{
+    public function testAnUpdateScriptGetsAUsableConnection(): void
+    {
+        $connection = $this->database()->getConnection();
+
+        // What setup/update/php/3.0.0-beta3.php does on its first line.
+        $version = $connection
+            ->query("SELECT `value` FROM `config` WHERE `name` = 'thelia_version'")
+            ->fetchColumn();
+
+        self::assertIsString($version);
+    }
+
+    public function testAnUpdateScriptCanWriteThroughAPreparedStatement(): void
+    {
+        $connection = $this->database()->getConnection();
+
+        $statement = $connection->prepare('UPDATE `config` SET `value` = :value WHERE `name` = :name');
+        $statement->execute(['value' => 'written by an update script', 'name' => 'thelia_version']);
+
+        self::assertSame('written by an update script', $this->readVersionMarker());
+    }
+
+    public function testTheVersionMarkerIsWritten(): void
+    {
+        $update = new Update(false);
+
+        $update->setCurrentVersion('3.0.0-marker');
+
+        self::assertSame('3.0.0-marker', $this->readVersionMarker());
+        self::assertSame('3.0.0-marker', $update->getCurrentVersion());
+    }
+
+    private function database(): Database
+    {
+        return new Database(Propel::getConnection(ProductTableMap::DATABASE_NAME));
+    }
+
+    private function readVersionMarker(): string
+    {
+        return (string) Propel::getConnection(ProductTableMap::DATABASE_NAME)
+            ->query("SELECT `value` FROM `config` WHERE `name` = 'thelia_version'")
+            ->fetchColumn();
+    }
+}


### PR DESCRIPTION
Fixes #3751.

The update loop runs on the connection Propel opened. Propel opens a `PdoConnection`: it exposes the same `query()`, `prepare()` and `exec()` as `\PDO`, but it does not extend it and keeps its own `\PDO` private. Two places assumed the opposite.

**`Database::getConnection()` declared `: \PDO`**, so the first PHP update script of the 3.0 line brought the loop down:

```
TypeError: Thelia\Core\Install\Database::getConnection(): Return value must be of type PDO,
Propel\Runtime\Connection\PdoConnection returned
```

The order of the failure is what hurts: `update/sql/3.0.0-beta3.sql` runs first, its DDL commits itself, and the script then throws before the version marker is written. The shop is left with a beta3 schema and a `thelia_version` still on beta2.

**`Update::setCurrentVersion()` was guarded by `instanceof \PDO`**, a test that is always false with a Propel connection, so the one write that records how far the update went never happened. The `thelia_major_version` / `thelia_minus_version` block right above it has no such guard and works.

Both are widened to the connection the loop actually holds rather than unwrapped down to a `\PDO`: `PdoConnection` offers no way to reach the `\PDO` it wraps — the property is protected, there is no accessor, and `__call` only forwards method calls. Nothing is lost by keeping it: the update scripts and `setCurrentVersion()` use `query()`, `prepare()` and `exec()`, `PdoConnection::query()` and `::prepare()` return real `\PDOStatement`s, and the arguments `execute()` takes are the ones #3510 settled.

Upgrading a 3.0.0-beta2 shop to beta3 now applies the SQL script, runs the PHP script and moves `thelia_version` to `3.0.0-beta3`, on a `thelia/thelia` checkout and on a `composer create-project` install alike.

`tests/Integration/Install/UpdateConnectionTest.php` covers the handle an update script is given and the write of the marker. Both fail on `main`, the first as the TypeError above.

### Still open, not addressed here

`Update::process()` opens a transaction, and the DDL of any update script commits it implicitly, so `commit()` then raises `PDOException: There is no active transaction`. Every migration that succeeds is reported as an error, and a run started with a backup offers to restore it — over a database that was in fact migrated. Worth its own issue.
