### PR TITLE
fix: keep the query parameters when a rewritten url switches language

### DIFF
--- a/core/lib/Thelia/Core/Routing/RewritingRouter.php
+++ b/core/lib/Thelia/Core/Routing/RewritingRouter.php
@@ -137,8 +137,31 @@ class RewritingRouter implements RouterInterface, RequestMatcherInterface
                 ->retrieve($resolver->view, $resolver->viewId, $requestedLang->getLocale())
                 ->toString();
 
-            $this->redirect(URL::getInstance()->absoluteUrl($localizedUrl), 301);
+            $this->redirect(
+                URL::getInstance()->absoluteUrl($localizedUrl, $this->requestedQueryParameters($request)),
+                301,
+            );
         }
+    }
+
+    /**
+     * The page has to survive the language switch, and so does its state: a paginated
+     * listing, a sort order, a filter are all carried by the query string.
+     *
+     * They are read from the query string of the request and not from the query bag, which
+     * applyRewritingAttributes() fills with the view id and with the parameters encoded in
+     * the rewritten url. Those are internal to the rewriting and have no business being
+     * written back into a public url. "lang" is dropped as well: it has been consumed here,
+     * and the url it points to already is the one of the requested language.
+     */
+    private function requestedQueryParameters(Request $request): array
+    {
+        $parameters = [];
+        parse_str((string) $request->getQueryString(), $parameters);
+
+        unset($parameters['lang']);
+
+        return $parameters;
     }
 
     protected function ensureActiveLocaleOrRedirect(RewritingResolver $resolver): void

--- a/tests/Integration/Core/Routing/RewritingRouterTest.php
+++ b/tests/Integration/Core/Routing/RewritingRouterTest.php
@@ -186,6 +186,68 @@ final class RewritingRouterTest extends IntegrationTestCase
         }
     }
 
+    /**
+     * @return array{0: string, 1: string} the french then the english url of the same category
+     */
+    private function createTranslatedCategory(string $title): array
+    {
+        $category = $this->createCategory($title);
+        $category->setLocale('fr_FR')->setTitle($title.' en francais')->save();
+
+        return [$category->getRewrittenUrl('fr_FR'), $category->getRewrittenUrl('en_US')];
+    }
+
+    private static function queryParametersOf(string $url): array
+    {
+        $parameters = [];
+        parse_str((string) parse_url($url, \PHP_URL_QUERY), $parameters);
+        ksort($parameters);
+
+        return $parameters;
+    }
+
+    public function testMatchRequestKeepsTheQueryParametersWhenSwitchingLanguage(): void
+    {
+        [$frenchUrl, $englishUrl] = $this->createTranslatedCategory('Category read in another language');
+
+        try {
+            $this->router->matchRequest(
+                $this->request($frenchUrl, ['page' => '2', 'order' => 'price', 'lang' => 'en_US']),
+            );
+            self::fail('Asking for another language must redirect to the url of that language.');
+        } catch (RedirectException $redirectException) {
+            $target = $redirectException->getUrl();
+
+            // The state of the page - here the page of a paginated listing and its sort order -
+            // used to be dropped, sending the visitor back to the top of the first page.
+            self::assertStringEndsWith('/'.$englishUrl, (string) parse_url($target, \PHP_URL_PATH));
+            self::assertSame(['order' => 'price', 'page' => '2'], self::queryParametersOf($target));
+        }
+    }
+
+    public function testMatchRequestDoesNotCarryRewritingParametersOverWhenSwitchingLanguage(): void
+    {
+        [$frenchUrl, $englishUrl] = $this->createTranslatedCategory('Category read with rewriting parameters');
+
+        $request = $this->request($frenchUrl, ['page' => '2', 'lang' => 'en_US']);
+
+        // What applyRewritingAttributes() writes into the query bag: the view id, and the
+        // parameters encoded in the rewritten url. They are internal to the rewriting and
+        // must never be handed back to the visitor as part of a public url.
+        $request->query->set('category_id', '4242');
+        $request->query->set('folder_id', '7');
+
+        try {
+            $this->router->matchRequest($request);
+            self::fail('Asking for another language must redirect to the url of that language.');
+        } catch (RedirectException $redirectException) {
+            $target = $redirectException->getUrl();
+
+            self::assertStringEndsWith('/'.$englishUrl, (string) parse_url($target, \PHP_URL_PATH));
+            self::assertSame(['page' => '2'], self::queryParametersOf($target));
+        }
+    }
+
     public function testMatchRequestRedirectsAReplacedUrlToTheCurrentOne(): void
     {
         $category = $this->createCategory('Replaced category');


### PR DESCRIPTION
## The defect

`RewritingRouter::maybeRedirectForRequestedLocale()` rebuilds the redirect target from the
`view` / `viewId` pair alone, so every other query parameter is dropped:

```
/fr/ma-categorie?page=2&order=price&lang=en_US   ->   /en/my-category
```

The visitor asked for the same page in another language and lands back on page one of the
listing, unsorted. It affects any theme and any link carrying `?lang=`, hence the fix in the
core rather than in a theme.

Reported for the Flexy theme: https://github.com/thelia-templates/flexy/issues/128

## The fix

The parameters of the request are appended to the translated url, `lang` excluded: it has
been consumed by the redirect, and the target url already is the one of the requested
language. Keeping it would not loop - the next pass compares the requested locale with the
locale of the resolved url and finds them equal - it would only leave a spent parameter in a
url meant to be shared and indexed.

## Not reading the query bag

The router pollutes the query bag itself: `applyRewritingAttributes()` writes
`<view>_id` into it and re-injects the `otherParameters` encoded in the rewritten url.
Copying `$request->query->all()` would publish `category_id=42` in the redirect url.

In the current flow the pollution happens after the redirect - `matchRequest()` calls
`maybeRedirectForRequestedLocale()` before `applyRewritingAttributes()` - so the bag is
clean at that point today, and only stays clean as long as nobody reorders those two calls
or runs the matcher twice on the same request. The parameters are therefore read from
`Request::getQueryString()`, which comes from the `QUERY_STRING` server value and is
untouched by the bag writes, so the guarantee does not depend on the call order. A test
covers it.

## Left alone

The redirect stays a `301`, as the two other redirects of the class. A permanent redirect
whose target depends on data the merchant can change (the rewritten url of the object in the
target language) is worth a discussion, but that is a behaviour change of its own and does
not belong in this fix.

## Tests

`tests/Integration/Core/Routing/RewritingRouterTest.php`:

- `testMatchRequestKeepsTheQueryParametersWhenSwitchingLanguage` - `page` and `order` survive
  the switch, `lang` does not.
- `testMatchRequestDoesNotCarryRewritingParametersOverWhenSwitchingLanguage` - a request whose
  query bag already carries `category_id` / `folder_id` does not leak them into the target url.

Both fail on the current code and pass with the fix.
