### PR TITLE
chore: declare the PHPStan level and paths of the BO Twig gate in its config

### DIFF
--- a/.github/workflows/phpstan-botwig.yml
+++ b/.github/workflows/phpstan-botwig.yml
@@ -53,5 +53,5 @@ jobs:
           rm -rf templates/backOffice/default-twig
           git clone --depth 1 --branch main https://github.com/thelia-templates/default-twig.git templates/backOffice/default-twig
 
-      - name: PHPStan (level 5 + dedicated baseline)
-        run: ./vendor/bin/phpstan analyse -c phpstan-botwig.neon --level=5 --no-progress --error-format=github templates/backOffice/default-twig/src
+      - name: PHPStan (level and paths come from phpstan-botwig.neon)
+        run: ./vendor/bin/phpstan analyse -c phpstan-botwig.neon --no-progress --error-format=github

--- a/phpstan-botwig.neon
+++ b/phpstan-botwig.neon
@@ -3,9 +3,17 @@ includes:
     - phpstan-baseline-botwig.neon
 parameters:
     # Level-5 guard-rail for the BO Twig bundle (thelia/backoffice-default-twig-template).
+    # The level and the analysed paths are declared here, not in the CI command, so that
+    # running `vendor/bin/phpstan analyse -c phpstan-botwig.neon` locally reproduces the
+    # phpstan-botwig workflow exactly.
+    #
+    # `paths!` replaces the `core` entry inherited from phpstan.neon instead of merging
+    # with it: core is already covered by `composer phpstan`.
+    #
     # The baseline absorbs the defensive Propel/event narrowing false positives; tolerate
     # unmatched baseline entries so a phpstan patch bump can't turn the gate red on
     # already-known items — it still fails on NEW errors, which is the point.
+    level: 5
     reportUnmatchedIgnoredErrors: false
-    paths:
+    paths!:
         - templates/backOffice/default-twig/src


### PR DESCRIPTION
## Why

`phpstan-botwig.neon` did not declare the level or restrict the paths it analyses.
The real level and the real path lived only in the workflow command
(`--level=5 … templates/backOffice/default-twig/src`), so the two disagreed:

```
$ vendor/bin/phpstan dump-parameters -c phpstan-botwig.neon
level: 1
paths:
    - /var/www/html/core
    - /var/www/html/templates/backOffice/default-twig/src
```

CI was fine — the CLI arguments override both — but anyone reproducing the gate
locally with the documented config got **level 1 on core + the bundle**, i.e. a
false green. The config also inherited `paths: core` from `phpstan.neon` through
`includes:`, which merges instead of replacing.

## What changed

* `level: 5` and `paths!:` (the `!` replaces the inherited `core` entry instead of
  merging with it) are now declared in `phpstan-botwig.neon`.
* The workflow command drops the now-redundant `--level=5` and positional path, so
  `vendor/bin/phpstan analyse -c phpstan-botwig.neon` reproduces CI exactly.

`phpstan.neon` is untouched: `composer phpstan` still analyses `core` at level 1.

## Measurements

Bundle only (`templates/backOffice/default-twig/src`, 198 files), against
`thelia-templates/default-twig@main`:

| level | errors without the baseline | errors with `phpstan-baseline-botwig.neon` |
|------:|----------------------------:|-------------------------------------------:|
| 2     | 4                           | 0 |
| 3     | 4                           | 0 |
| 4     | 33                          | 0 |
| 5     | **36**                      | **0** |
| 6     | 66                          | 30 |

Level 5 is already fully covered by the existing baseline, so the gate becomes
honest without adding a single baseline entry: 23 entries / 35 errors before and
after. Level 6 would need 30 new entries and is out of scope here.

## Verification

```
$ vendor/bin/phpstan dump-parameters -c phpstan-botwig.neon
level: 5
paths:
    - …/templates/backOffice/default-twig/src

$ vendor/bin/phpstan analyse -c phpstan-botwig.neon
 [OK] No errors
```
