### PR TITLE
fix: deliver the redirect to the domain of the requested language

### DIFF
--- a/core/lib/Thelia/Core/EventListener/KernelListener.php
+++ b/core/lib/Thelia/Core/EventListener/KernelListener.php
@@ -90,10 +90,14 @@ class KernelListener
     }
 
     #[AsEventListener(event: KernelEvents::REQUEST, priority: 128)]
-    public function initializeLanguageAndAdmin(RequestEvent $event): ?Response
+    public function initializeLanguageAndAdmin(RequestEvent $event): void
     {
+        // Everything a language redirect must not answer to is decided here: a sub request,
+        // an api or a stateless route, a preflight OPTIONS, a request whose headers are
+        // already on the wire. There is no console case to guard: this listener is only
+        // ever called on a kernel request.
         if (!$this->sessionManager->sessionIsStartable($event)) {
-            return null;
+            return;
         }
         /** @var Request $request */
         $request = $event->getRequest();
@@ -106,12 +110,17 @@ class KernelListener
 
         $response = $this->langService->handleLang($session, $request);
 
+        // Symfony discards what a listener returns and reads only what setResponse() puts
+        // on the event. This response used to be returned, a habit kept from the stack
+        // middleware this listener was made of, whose handle() did answer with it: the
+        // redirect to the domain of the requested language has been computed and thrown
+        // away on every request ever since.
         if ($response instanceof Response) {
-            return $response;
+            $event->setResponse($response);
+
+            return;
         }
 
         $this->langService->syncMultiDomainLanguage($request);
-
-        return null;
     }
 }

--- a/core/lib/Thelia/Domain/Localization/Service/LangService.php
+++ b/core/lib/Thelia/Domain/Localization/Service/LangService.php
@@ -179,6 +179,14 @@ readonly class LangService
             return $lang;
         }
 
+        // A language switch is a navigation, and a redirect is the only way to answer one.
+        // Answering anything else with a redirect is not: a browser replays a 301 as a GET
+        // and drops the body, so a checkout posted with a "lang" parameter in its action
+        // url would be silently thrown away instead of being taken.
+        if (!$request->isMethodSafe()) {
+            return $lang;
+        }
+
         $domainUrl = $lang->getUrl();
 
         if (empty($domainUrl)) {
@@ -190,16 +198,52 @@ readonly class LangService
             return Lang::getDefaultLanguage();
         }
 
-        // If the language domain differs from the current one, redirect to it, keeping the
-        // current page when a translation of it exists for the target language.
-        if (rtrim($domainUrl, '/') !== $request->getSchemeAndHttpHost()) {
-            return new RedirectResponse(
-                $this->getTranslatedDomainUrl($request, $domainUrl, $lang),
-                Response::HTTP_MOVED_PERMANENTLY,
-            );
+        // Already on the domain of the requested language: nothing to redirect to.
+        if (rtrim($domainUrl, '/') === $request->getSchemeAndHttpHost()) {
+            return $lang;
         }
 
-        return $lang;
+        // The current page is kept when a translation of it exists for the target language.
+        $targetUrl = $this->withRequestedQueryString(
+            $request,
+            $this->translatedDomainUrl($request, $domainUrl, $lang),
+        );
+
+        // The check above compares two strings, and a domain written with a different case
+        // or with its default port spelled out does not match the one being browsed. Such a
+        // shop would be answered with a redirect to the very url it asked for, which tells
+        // the browser nothing but to ask again.
+        if ($this->isCurrentUrl($request, $targetUrl)) {
+            return $lang;
+        }
+
+        return new RedirectResponse($targetUrl, Response::HTTP_MOVED_PERMANENTLY);
+    }
+
+    /**
+     * A redirect to the url being served is never a useful answer: it only tells the browser
+     * to ask the same question again. Queries are ignored on purpose, since dropping them
+     * still lands on the same page, and so still loops.
+     */
+    private function isCurrentUrl(Request $request, string $url): bool
+    {
+        $target = parse_url($url);
+
+        if (false === $target) {
+            return false;
+        }
+
+        // A host-less target is relative to the host being browsed. getHost() and getScheme()
+        // both answer in lower case, which is what a host and a scheme are compared in.
+        $sameHost = !isset($target['host'])
+            || (
+                strtolower($target['host']) === $request->getHost()
+                && strtolower($target['scheme'] ?? $request->getScheme()) === $request->getScheme()
+                && ($target['port'] ?? $request->getPort()) === $request->getPort()
+            );
+
+        return $sameHost
+            && trim($target['path'] ?? '', '/') === trim($request->getRealPathInfo(), '/');
     }
 
     /**
@@ -208,7 +252,7 @@ readonly class LangService
      * when rewriting is disabled, when the current page has no rewritten URL, or when it has
      * no translation in the target language.
      */
-    private function getTranslatedDomainUrl(Request $request, string $domainUrl, Lang $lang): string
+    private function translatedDomainUrl(Request $request, string $domainUrl, Lang $lang): string
     {
         if (!ConfigQuery::isRewritingEnable()) {
             return $domainUrl;
@@ -238,6 +282,31 @@ readonly class LangService
         }
 
         return rtrim($domainUrl, '/').'/'.$translatedUrl->getUrl();
+    }
+
+    /**
+     * The page has to survive the language switch, and so does its state: a paginated
+     * listing, a sort order, a campaign tag are all carried by the query string. They are
+     * read from the query string of the request rather than from the query bag, which any
+     * listener running before this one is free to write into.
+     *
+     * "lang" and "locale" are dropped: they have been consumed here, and the url they point
+     * to already is the one of the requested language. Carrying them over would also turn a
+     * domain the shop cannot match - written http:// on a shop served in https, say - into
+     * an endless redirect, each hop asking for the same switch again.
+     */
+    private function withRequestedQueryString(Request $request, string $url): string
+    {
+        $parameters = [];
+        parse_str((string) $request->getQueryString(), $parameters);
+
+        unset($parameters['lang'], $parameters['locale']);
+
+        if ([] === $parameters) {
+            return $url;
+        }
+
+        return $url.(str_contains($url, '?') ? '&' : '?').http_build_query($parameters);
     }
 
     private function getLanguageByDomain(Request $request): ?Lang

--- a/tests/Integration/Core/EventListener/KernelListenerLanguageRedirectTest.php
+++ b/tests/Integration/Core/EventListener/KernelListenerLanguageRedirectTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\EventListener;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\EventListener\KernelListener;
+use Thelia\Core\HttpFoundation\Request as TheliaRequest;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Core\HttpFoundation\Session\SessionFactory;
+use Thelia\Core\HttpFoundation\Session\SessionManager;
+use Thelia\Core\Translation\Translator;
+use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\LangQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A listener answers with a response by putting it on the event: what it returns is
+ * discarded. The redirect to the domain of the requested language is the only response
+ * this listener produces, and it has to reach the visitor.
+ */
+final class KernelListenerLanguageRedirectTest extends IntegrationTestCase
+{
+    private const CURRENT_DOMAIN = 'http://en.example.com';
+    private const TARGET_DOMAIN = 'http://fr.example.com';
+
+    private KernelListener $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->listener = new KernelListener(
+            self::$kernel,
+            Translator::getInstance(),
+            $this->getService(EventDispatcherInterface::class),
+            $this->getService(LangService::class),
+            $this->getService(SessionManager::class),
+            $this->getService(SessionFactory::class),
+            self::$kernel->getCacheDir(),
+            false,
+            'test',
+        );
+
+        ConfigQuery::write('one_domain_foreach_lang', '1');
+        LangQuery::create()
+            ->findOneByLocale('fr_FR')
+            ->setActive(true)
+            ->setUrl(self::TARGET_DOMAIN)
+            ->save();
+    }
+
+    protected function tearDown(): void
+    {
+        // Both outlive the transaction rollback: ConfigQuery memoizes what it reads, and
+        // the admin flag is a static the listener writes on every request.
+        ConfigQuery::resetCache();
+        TheliaRequest::$isAdminEnv = false;
+
+        parent::tearDown();
+    }
+
+    private function event(string $uri, string $method = 'GET', int $type = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        $request = TheliaRequest::create($uri, $method);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return new RequestEvent(self::$kernel, $request, $type);
+    }
+
+    public function testTheRedirectToTheLanguageDomainReachesTheVisitor(): void
+    {
+        $event = $this->event(self::CURRENT_DOMAIN.'/?lang=fr');
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        $response = $event->getResponse();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(301, $response->getStatusCode());
+        self::assertSame(self::TARGET_DOMAIN, $response->getTargetUrl());
+    }
+
+    public function testAFormPostIsNotAnsweredWithARedirect(): void
+    {
+        // A browser replays a 301 as a GET without the body: redirecting a post would
+        // throw away what the visitor submitted.
+        $event = $this->event(self::CURRENT_DOMAIN.'/?lang=fr', 'POST');
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testAnApiRequestIsLeftAlone(): void
+    {
+        $event = $this->event(self::CURRENT_DOMAIN.'/api/front/products?lang=fr');
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testASubRequestIsLeftAlone(): void
+    {
+        $event = $this->event(self::CURRENT_DOMAIN.'/?lang=fr', 'GET', HttpKernelInterface::SUB_REQUEST);
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testAnAdminRequestIsLeftAlone(): void
+    {
+        $event = $this->event(self::CURRENT_DOMAIN.'/admin/categories?lang=fr');
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testASingleDomainShopIsLeftAlone(): void
+    {
+        ConfigQuery::write('one_domain_foreach_lang', '0');
+
+        $event = $this->event(self::CURRENT_DOMAIN.'/?lang=fr');
+
+        $this->listener->initializeLanguageAndAdmin($event);
+
+        self::assertNull($event->getResponse());
+    }
+}

--- a/tests/Integration/Domain/Localization/LangServiceMultiDomainTest.php
+++ b/tests/Integration/Domain/Localization/LangServiceMultiDomainTest.php
@@ -111,10 +111,95 @@ final class LangServiceMultiDomainTest extends IntegrationTestCase
         self::assertSame(self::TARGET_DOMAIN, $response->getTargetUrl());
     }
 
-    private function switchToFrench(string $path): Lang|Response
+    public function testRedirectKeepsTheQueryParametersOfThePageBeingRead(): void
     {
+        $this->frenchLangOnTargetDomain();
+
+        $category = $this->createFixtureFactory()->category();
+        $englishUrl = $this->rewrittenUrl($category, 'en_US', 'Paginated category');
+        $frenchUrl = $this->rewrittenUrl($category, 'fr_FR', 'Categorie paginee');
+
+        $response = $this->switchToFrench('/'.$englishUrl, ['page' => '2', 'order' => 'price']);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(
+            self::TARGET_DOMAIN.'/'.$frenchUrl,
+            strtok($response->getTargetUrl(), '?'),
+        );
+        self::assertSame(
+            ['order' => 'price', 'page' => '2'],
+            self::queryParametersOf($response->getTargetUrl()),
+        );
+    }
+
+    /**
+     * The language parameters have been consumed here, and the url they point to already is
+     * the one of the requested language. Carrying them over would also make a domain the
+     * shop cannot match redirect to itself for as long as the browser follows.
+     */
+    public function testRedirectDropsTheLanguageParameters(): void
+    {
+        $this->frenchLangOnTargetDomain();
+
+        $category = $this->createFixtureFactory()->category();
+        $englishUrl = $this->rewrittenUrl($category, 'en_US', 'Category asked in two ways');
+        $this->rewrittenUrl($category, 'fr_FR', 'Categorie demandee de deux facons');
+
+        $response = $this->switchToFrench('/'.$englishUrl, ['locale' => 'fr_FR', 'utm_source' => 'newsletter']);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(
+            ['utm_source' => 'newsletter'],
+            self::queryParametersOf($response->getTargetUrl()),
+        );
+    }
+
+    public function testNoRedirectWhenTheTargetIsThePageBeingServed(): void
+    {
+        // The domain of the language is the one being browsed, written in another case: the
+        // string comparison on the host sees two different domains, and the redirect it
+        // builds points at the very url that was asked for.
+        $this->frenchLangOnTargetDomain()->setUrl('http://EN.EXAMPLE.COM')->save();
+
+        $category = $this->createFixtureFactory()->category();
+        $this->rewrittenUrl($category, 'en_US', 'Category on a shouted domain');
+        $frenchUrl = $this->rewrittenUrl($category, 'fr_FR', 'Categorie sur un domaine crie');
+
+        $lang = $this->switchToFrench('/'.$frenchUrl);
+
+        self::assertInstanceOf(Lang::class, $lang);
+        self::assertSame('fr_FR', $lang->getLocale());
+    }
+
+    public function testNoRedirectOnAFormPost(): void
+    {
+        // A browser replays a 301 as a GET without the body: redirecting the post of a
+        // checkout would throw away the order instead of taking it.
+        $this->frenchLangOnTargetDomain();
+
+        $request = Request::create(self::CURRENT_DOMAIN.'/order/delivery?lang=fr', 'POST');
+
+        $lang = $this->langService->resolveFrontLanguageFromRequest($request);
+
+        self::assertInstanceOf(Lang::class, $lang);
+        self::assertSame('fr_FR', $lang->getLocale());
+    }
+
+    private static function queryParametersOf(string $url): array
+    {
+        $parameters = [];
+        parse_str((string) parse_url($url, \PHP_URL_QUERY), $parameters);
+        ksort($parameters);
+
+        return $parameters;
+    }
+
+    private function switchToFrench(string $path, array $query = []): Lang|Response
+    {
+        $query['lang'] = 'fr';
+
         return $this->langService->resolveFrontLanguageFromRequest(
-            Request::create(self::CURRENT_DOMAIN.$path.'?lang=fr'),
+            Request::create(self::CURRENT_DOMAIN.$path.'?'.http_build_query($query)),
         );
     }
 


### PR DESCRIPTION
## The defect

`KernelListener::initializeLanguageAndAdmin()` answered the switch to another language domain by **returning** a `RedirectResponse`. Symfony discards what a listener returns and reads only what `setResponse()` puts on the event, so the redirect was computed on every such request and thrown away.

The habit comes from the code this listener was made of: the redirect used to live in `Thelia\Core\Stack\ParamInitMiddleware::handle()`, whose return value *was* the answer sent to the visitor. "Migrate to SF 6" (37f451d0, 2022-03-28) turned that middleware into `KernelListener::paramInit()` and kept `return $response;` as it was. It has been inert ever since, through the rename to `initializeLanguageAndAdmin()` and through the move of the logic into `LangService`.

### When it fires

Only when all of these hold — it is the language switcher, not ordinary browsing:

- `one_domain_foreach_lang` is on (`ConfigQuery::isMultiDomainActivated()`)
- the request is a front one (`Request::$isAdminEnv` is false — `LangService::handleLang()` never builds a response for the admin)
- it carries `?lang=` or `?locale=` resolving to an active language
- that language has a `url`, and it is not the domain being browsed

### What changes for a shop with one domain per language

Not as much as it looks, because `RewritingRouter::manageLocale()` has been catching most of it. Today the Flexy switcher (`?lang=fr_FR` on the current path) is answered in **two hops**: `RewritingRouter::maybeRedirectForRequestedLocale()` sends the visitor to the French url *on the current domain*, and `manageLocale()` then sends them to the French domain. With this change the first hop already points at the French domain. Same destination, one redirect instead of two, and it no longer goes through `URL::absoluteUrl()` — which falls back on `router.default_uri` when the host is not what the shop expects.

What genuinely changes is the case `RewritingRouter` never covered, because it only ever looks at rewritten urls:

- **rewriting disabled**: `?lang=fr` did nothing at all; it now sends the visitor to the French domain.
- **a page that is not a rewritten url** (a checkout step, a module route): `?lang=fr` did nothing; it now sends the visitor to the **root** of the French domain. The page is lost. With one domain per language the session and the cart are per domain anyway, so there is nothing to carry over — but shops should know the switcher stops being a no-op mid-tunnel. Keeping the path in that case is a separate change and is not made here.

## The guards

Enabling a redirect that never left means the checks nobody had to write are missing. What `SessionManager::sessionIsStartable()` already covers is left alone — sub request, `/api/`, `_wdt`, `_profiler`, `_stateless`, preflight `OPTIONS`, headers already sent, non-Thelia request. There is no console case: the listener only runs on a kernel request.

Added in `LangService::handleLanguageWithDomainRedirect()`:

- **safe methods only.** A browser replays a 301 as a GET without the body. A form posted to a url carrying `lang` would have been silently dropped instead of taken.
- **never redirect to the url being served.** The domain comparison is a string comparison, so a `lang.url` written in another case, or with its default port spelled out, does not match the host being browsed and the redirect it builds points back at the same page. Same check, and same reason, as `RewritingRouter::isCurrentUrl()`.

## The query string

`LangService` built its target as `rtrim($domainUrl, '/').'/'.$translatedUrl->getUrl()` and dropped everything after the `?`, exactly as `RewritingRouter` did before #3771. The Flexy switcher carries the current query into its link (`currentQuery|merge({lang: lang.locale})`), so a paginated listing, a sort order or a campaign tag was lost on the way to the other domain. The parameters are now carried over, read from `Request::getQueryString()` rather than from the query bag, as in #3771.

`lang` and `locale` are dropped: they have been consumed, and the url they point to already is the one of the requested language. That is also what keeps a shop whose `lang.url` can never match its host — written `http://` on a site served in `https`, say — from redirecting to itself for as long as the browser follows.

## Tests

`tests/Integration/Core/EventListener/KernelListenerLanguageRedirectTest.php` — the redirect reaches the visitor, and is not produced for a post, an api route, a sub request, an admin page, or a single domain shop.

`tests/Integration/Domain/Localization/LangServiceMultiDomainTest.php` — the query parameters survive the switch, the language parameters do not, the target that is the current page is not redirected to, and a post is not answered with a redirect.
