### PR TITLE
fix: report an update run for what it did instead of a phantom transaction error

### DIFF
--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -190,8 +190,13 @@ class Update
 
         $index = $this->getStartIndex((string) $currentVersion);
 
-        $this->connection->beginTransaction();
-
+        // The loop runs outside any transaction. MariaDB commits implicitly on every
+        // CREATE, ALTER and DROP, so a transaction spanning a schema migration ends at
+        // the first one and leaves everything written before it committed: it promises
+        // all-or-nothing and delivers neither. What makes an interrupted run recoverable
+        // is the version marker updateToVersion() writes after each version, so the next
+        // run resumes where this one stopped, and the backup update.php offers
+        // beforehand, the only thing that can undo a schema change.
         $database = new Database($this->connection);
         $version = null;
 
@@ -240,29 +245,20 @@ class Update
                 }
             }
 
-            $this->connection->commit();
             $this->log('debug', 'update successfully');
         } catch (\Exception $exception) {
-            if ($this->connection->inTransaction()) {
-                $this->connection->rollBack();
-            }
-
             $this->log('error', \sprintf('error during update process with message : %s', $exception->getMessage()));
 
-            $ex = new UpdateException($exception->getMessage(), $exception->getCode(), $exception->getPrevious());
+            // A failing statement reaches here as a PDOException, whose getCode() is the
+            // SQLSTATE string ('42S02'). Exception only takes an int, so wrapping it
+            // raised a TypeError of its own and no SQL failure ever reached update.php:
+            // the operator got a fatal error instead of the offer to restore the backup.
+            $code = $exception->getCode();
+
+            $ex = new UpdateException($exception->getMessage(), \is_int($code) ? $code : 0, $exception);
             $ex->setVersion($version);
 
             throw $ex;
-        } catch (\Throwable $throwable) {
-            // An Error is not turned into an UpdateException — the installer keeps
-            // seeing it as it is today — but the update transaction is closed.
-            // The guard matters here: $this->connection is the unwrapped handle
-            // (see __construct()), whose rollBack() throws when no transaction is open.
-            if ($this->connection->inTransaction()) {
-                $this->connection->rollBack();
-            }
-
-            throw $throwable;
         }
 
         $this->log('debug', 'end of update processing');

--- a/setup/update.php
+++ b/setup/update.php
@@ -184,18 +184,39 @@ if (null === $updateError) {
         cliOutput(sprintf('[%s] %s'.\PHP_EOL, $log[0], $log[1]), 'error');
     }
 
-    if (true === $backup && askConfirmation('Would you like to restore the backup database ? (Y/n)')) {
-        cliOutput('Database restore started. Wait, it could take a while...');
+    if (true === $backup) {
+        // Say what the restore does before asking. It rewrites every table from the
+        // backup, so it undoes the versions the run did manage to apply and drops
+        // everything written since the backup was taken.
+        $appliedVersions = $update->getUpdatedVersions();
 
-        if (false === $update->restoreDb()) {
+        if ([] !== $appliedVersions) {
             cliOutput(sprintf(
-                'Sorry, your database can\'t be restore. Try to do it manually : %s',
-                $update->getBackupFile(),
-            ), 'error');
+                'Applied to the database before the failure: %s.',
+                implode(', ', $appliedVersions),
+            ), 'warning');
+        }
+
+        cliOutput(
+            'Restoring rewrites every table from the backup: those versions, and anything '
+            .'written since the backup was taken, are lost.',
+            'warning',
+        );
+
+        if (askConfirmation('Would you like to restore the backup database ? (Y/n)')) {
+            cliOutput('Database restore started. Wait, it could take a while...');
+
+            if (false === $update->restoreDb()) {
+                cliOutput(sprintf(
+                    'Sorry, your database can\'t be restore. Try to do it manually : %s',
+                    $update->getBackupFile(),
+                ), 'error');
+                exit(5);
+            }
+
+            cliOutput('Database successfully restore.');
             exit(5);
         }
-        cliOutput('Database successfully restore.');
-        exit(5);
     }
 }
 

--- a/tests/Integration/Install/UpdateTransactionTest.php
+++ b/tests/Integration/Install/UpdateTransactionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Install;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Thelia\Core\Install\Database;
+use Thelia\Core\Install\Exception\UpdateException;
+use Thelia\Core\Install\Update;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * What the update loop reports has to match what it did, because update.php offers to
+ * restore the backup on a failure, and that restore rewrites every table.
+ *
+ * Two things made it lie. The loop ran inside a transaction, and MariaDB commits
+ * implicitly on every CREATE, ALTER and DROP, so the transaction ended at the first
+ * schema change and the commit closing the loop raised "There is no active
+ * transaction" on a migration that had succeeded. And a failing statement arrives as a
+ * PDOException whose code is the SQLSTATE string, which Exception refuses, so wrapping
+ * a real failure raised a TypeError and never reached update.php at all.
+ *
+ * The loop is driven here by steps written for the test. The shipped scripts are no
+ * use for this: their statements are guarded and skip the DDL on a database that
+ * already carries it.
+ */
+final class UpdateTransactionTest extends IntegrationTestCase
+{
+    private const PROBE_DDL = 'CREATE TABLE IF NOT EXISTS `update_transaction_probe` (`id` INTEGER) ENGINE=InnoDB';
+
+    protected bool $useTransaction = false;
+
+    private string $initialVersion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initialVersion = $this->readVersionMarker();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection()->exec('DROP TABLE IF EXISTS `update_transaction_probe`');
+        $this->writeVersionMarker($this->initialVersion);
+
+        parent::tearDown();
+    }
+
+    public function testARunCrossingASchemaChangeIsNotReportedAsAFailure(): void
+    {
+        $update = $this->updateRunning(
+            static fn (string $version, Database $database) => $database->execute(self::PROBE_DDL),
+        );
+        $this->startAt($this->nthFromLast(1));
+
+        $applied = $update->process();
+
+        self::assertSame([$update->getLatestVersion()], $applied);
+        self::assertSame($update->getLatestVersion(), $this->readVersionMarker());
+    }
+
+    public function testAVersionThatWentThroughKeepsItsMarkerWhenALaterOneFails(): void
+    {
+        $lastVersion = $this->nthFromLast(0);
+        $versionBefore = $this->nthFromLast(1);
+
+        // Data only, and the failure comes before any schema change: this is the case
+        // where a transaction was still open when the loop gave up. Rolling back there
+        // erased the marker of the version that had already been applied, so the next
+        // run replayed it from the start.
+        $update = $this->updateRunning(
+            static function (string $version) use ($lastVersion): void {
+                if ($version === $lastVersion) {
+                    throw new \RuntimeException('the update script blew up');
+                }
+            },
+        );
+        $this->startAt($this->nthFromLast(2));
+
+        try {
+            $update->process();
+            self::fail('A failing update script must be reported.');
+        } catch (UpdateException) {
+        }
+
+        self::assertSame($versionBefore, $this->readVersionMarker());
+    }
+
+    public function testASqlErrorIsReportedAsAnUpdateFailure(): void
+    {
+        $update = $this->updateRunning(
+            static fn (string $version, Database $database) => $database->execute('SELECT * FROM `a_table_that_does_not_exist`'),
+        );
+        $this->startAt($this->nthFromLast(1));
+
+        try {
+            $update->process();
+            self::fail('A failing update script must be reported.');
+        } catch (UpdateException $exception) {
+            // Reported, rather than raising a TypeError on the way out, so that
+            // update.php can print it and offer the backup it took beforehand.
+            self::assertStringContainsString('a_table_that_does_not_exist', $exception->getMessage());
+            self::assertSame($this->nthFromLast(0), $exception->getVersion());
+        }
+    }
+
+    private function updateRunning(\Closure $step): Update
+    {
+        return new class(false, $step) extends Update {
+            public function __construct(bool $usePropel, private readonly \Closure $step)
+            {
+                parent::__construct($usePropel);
+            }
+
+            protected function updateToVersion(string $version, Database $database): void
+            {
+                ($this->step)($version, $database);
+
+                $this->setCurrentVersion($version);
+            }
+        };
+    }
+
+    /**
+     * The version $offset places before the last one on the list the loop walks.
+     */
+    private function nthFromLast(int $offset): string
+    {
+        $versions = (new Update(false))->getVersions();
+
+        return $versions[\count($versions) - 1 - $offset];
+    }
+
+    private function startAt(string $version): void
+    {
+        $this->writeVersionMarker($version);
+    }
+
+    private function readVersionMarker(): string
+    {
+        return (string) $this->connection()
+            ->query("SELECT `value` FROM `config` WHERE `name` = 'thelia_version'")
+            ->fetchColumn();
+    }
+
+    private function writeVersionMarker(string $version): void
+    {
+        $statement = $this->connection()->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'thelia_version'");
+        $statement->execute([$version]);
+    }
+
+    private function connection(): ConnectionInterface
+    {
+        return Propel::getConnection(ProductTableMap::DATABASE_NAME);
+    }
+}


### PR DESCRIPTION
Fixes #3774.

An update run has to report what it actually did, because `setup/update.php` offers to restore the backup on a failure, and that restore rewrites every table. It reported the opposite in both directions.

### A successful migration was reported as a failure

`Update::process()` opened a transaction before the loop and committed it after. MariaDB commits implicitly on every `CREATE`, `ALTER` and `DROP`, so the transaction ended at the first schema change and the closing `commit()` raised `There is no active transaction` — on a migration that had applied everything and moved `thelia_version` correctly. The operator was then offered a restore that would drop the migrated schema and replay the pre-update dump over it.

**The transaction is removed rather than guarded.** Probing the connection the loop uses:

```
after beginTransaction  : inTransaction=true
after DDL               : inTransaction=false
rollBack()              : PDOException: There is no active transaction
rows surviving rollBack : 2      <- both, including the one written before the DDL
```

The row written *before* the DDL survives, so once a script touches the schema the transaction protects nothing — not even the statements preceding the DDL in the same file. 33 of the 76 shipped `update/sql/*.sql` files contain DDL, and the two most recent add more through guarded `PREPARE`/`EXECUTE`, so every path reaching 3.0 crosses it. Guarding the `commit()` would have silenced the symptom while keeping a promise the engine cannot keep.

It also worked against the marker. `updateToVersion()` writes `thelia_version` after **each** version so an interrupted run resumes where it stopped; a rollback that fired erased the markers of versions whose DDL was already committed and irreversible, forcing a full replay. That case is now covered by a test: a data-only script failing after an earlier version succeeded used to leave the marker on the version *before* the one that had gone through.

What makes a run recoverable is the marker, and the backup `update.php` takes beforehand — the only thing that can undo a schema change.

### A real failure never reached the operator at all

A failing statement arrives as a `PDOException` whose `getCode()` is the SQLSTATE **string** (`'42S02'`), and `Exception::__construct()` takes an `int`. Wrapping it therefore raised a `TypeError` of its own:

```
PHP Fatal error: Uncaught TypeError: Exception::__construct(): Argument #2 ($code)
must be of type int, string given in Update.php:252
```

So `update.php` never caught an `UpdateException`, never printed the logs, and never offered the backup it had just taken. The offer to restore appeared on the false error and was unreachable on the real one — exactly inverted. The code is now passed through only when it is an int, and the original exception is chained as the previous one instead of being dropped.

### The restore prompt says what it does

On a genuine failure the offer is worth taking, so it now names the versions that did go through and states that restoring rewrites every table, before asking.

### Verified

Upgrading a 3.0.0-beta2 shop to beta3 now reports success, offers no restore, and a second run exits 3 as already up to date. Before the fix the same run reported an error and, on accepting the restore, dropped and rebuilt tables from the dump until it failed partway and left `address` empty.

The three tests in `tests/Integration/Install/UpdateTransactionTest.php` fail on `main` for three distinct reasons: `There is no active transaction`, the `TypeError` above, and the marker rolled back to the wrong version.
