### PR TITLE
fix: make the backup taken before an update restorable

### DIFF
--- a/core/lib/Thelia/Core/Install/Database.php
+++ b/core/lib/Thelia/Core/Install/Database.php
@@ -27,6 +27,9 @@ use Thelia\Log\Tlog;
  */
 class Database
 {
+    /** The statement backupDb() closes a dump with, and restoreDb() looks for to tell a whole file from a truncated one. */
+    private const DUMP_TERMINATOR = 'SET foreign_key_checks=1;';
+
     protected ConnectionInterface|\PDO $connection;
 
     /**
@@ -122,7 +125,15 @@ class Database
      */
     protected function prepareSql($sql): array
     {
-        $sql = str_replace(";',", '-CODE-', $sql);
+        // Both substitutions below hide a semicolon from the splitter and put it back
+        // once the file is cut. The tokens are drawn per call and checked against the
+        // file, so nothing in the data can be mistaken for one on the way back. Fixed
+        // markers could be: the placeholder was '|', so every pipe a shop had written
+        // came out of a dump as a semicolon.
+        $quotedSemicolon = $this->placeholderAbsentFrom($sql);
+        $blockSemicolon = $this->placeholderAbsentFrom($sql);
+
+        $sql = str_replace(";',", $quotedSemicolon, $sql);
         $sql = trim($sql);
         preg_match_all('#DELIMITER (.+?)\n(.+?)DELIMITER ;#s', $sql, $m);
 
@@ -131,20 +142,30 @@ class Database
                 throw new \RuntimeException('You can not use "|" as delimiter: '.$v);
             }
 
-            $stored = str_replace([';', $m[1][$k]], ['|', ";\n"], $m[2][$k]);
+            $stored = str_replace([';', $m[1][$k]], [$blockSemicolon, ";\n"], $m[2][$k]);
             $sql = str_replace($v, $stored, $sql);
         }
 
         $query = [];
 
-        $tab = explode(";\n", $sql);
-
-        foreach ($tab as $iValue) {
-            $queryTemp = str_replace(['-CODE-', '|'], [";',", ';'], $iValue);
-            $query[] = $queryTemp;
+        foreach (explode(";\n", $sql) as $iValue) {
+            $query[] = str_replace([$quotedSemicolon, $blockSemicolon], [";',", ';'], $iValue);
         }
 
         return $query;
+    }
+
+    /**
+     * A token the file does not already contain, so that putting it back cannot alter
+     * a value that happened to look like it.
+     */
+    private function placeholderAbsentFrom(string $sql): string
+    {
+        do {
+            $placeholder = '{{thelia-sql-'.bin2hex(random_bytes(8)).'}}';
+        } while (str_contains($sql, $placeholder));
+
+        return $placeholder;
     }
 
     /**
@@ -202,9 +223,7 @@ class Database
                     $data[] = 'INSERT INTO `'.$table.'` VALUES(';
 
                     for ($j = 0; $j < $fieldCount; ++$j) {
-                        $row[$j] = addslashes((string) $row[$j]);
-                        $row[$j] = str_replace("\n", '\\n', $row[$j]);
-                        $data[] = '"'.$row[$j].'"';
+                        $data[] = $this->quoteForDump($row[$j]);
 
                         if ($j < ($fieldCount - 1)) {
                             $data[] = ',';
@@ -218,10 +237,37 @@ class Database
             $data[] = "\n\n\n";
         }
 
-        $data[] = 'SET foreign_key_checks=1;';
+        $data[] = self::DUMP_TERMINATOR;
 
         // save filename
         $this->writeFilename($filename, $data);
+    }
+
+    /**
+     * A value as it goes back in through a plain SQL file.
+     *
+     * NULL stays NULL. Writing it as an empty string is what made a restore die on the
+     * first nullable non-string column it met, after having already dropped and rebuilt
+     * every table before that one.
+     *
+     * Everything else is quoted by the connection, which knows the charset it talks in
+     * and the escaping mode of the server; addslashes() knew neither.
+     *
+     * That also settles the newlines, which used to be substituted by hand afterwards:
+     * the connection escapes CR, LF and CTRL-Z itself, so no raw newline can reach the
+     * file and split a statement in two when prepareSql() cuts the dump on ";\n".
+     */
+    private function quoteForDump(int|float|string|bool|null $value): string
+    {
+        if (null === $value) {
+            return 'NULL';
+        }
+
+        if (\is_bool($value)) {
+            $value = $value ? '1' : '0';
+        }
+
+        return $this->connection->quote((string) $value);
     }
 
     /**
@@ -231,7 +277,65 @@ class Database
      */
     public function restoreDb(string $filename): void
     {
-        $this->insertSql(null, [$filename]);
+        $statements = $this->prepareSql($this->readCompleteDump($filename));
+
+        try {
+            $this->replay($statements);
+        } finally {
+            // A dump turns foreign key checks off so it can be replayed in any order,
+            // and turns them back on at its end. A restore that stops before that must
+            // not leave them off on a connection the caller goes on using.
+            $this->connection->exec('SET foreign_key_checks=1');
+        }
+    }
+
+    /**
+     * @param list<string> $statements
+     */
+    private function replay(array $statements): void
+    {
+        $table = null;
+
+        foreach ($statements as $statement) {
+            if ('' === trim($statement)) {
+                continue;
+            }
+
+            if (1 === preg_match('/^\s*DROP TABLE `([^`]+)`/i', $statement, $matches)) {
+                $table = $matches[1];
+            }
+
+            try {
+                $this->execute($statement);
+            } catch (\Throwable $throwable) {
+                // Say where it stopped. A dump is a DROP, a CREATE and the rows of one
+                // table after another, and DDL cannot be rolled back, so what is left
+                // is the backup up to this table and the previous content after it.
+                throw new \RuntimeException(\sprintf('The restore stopped while rebuilding `%s`. The tables restored before it now hold the backup, the ones after it still hold what they held: %s', $table ?? 'the first statement', $throwable->getMessage()), 0, $throwable);
+            }
+        }
+    }
+
+    /**
+     * Reads a dump only if it is whole.
+     *
+     * The check happens before a single table is dropped: a file cut short by a full
+     * disk or a killed process would otherwise be replayed until it runs out, and leave
+     * the database part backup, part what it was, with nothing to say so.
+     */
+    private function readCompleteDump(string $filename): string
+    {
+        $dump = file_get_contents($filename);
+
+        if (false === $dump || '' === trim($dump)) {
+            throw new \RuntimeException(\sprintf('The backup file %s is empty. Nothing was restored.', $filename));
+        }
+
+        if (!str_ends_with(rtrim($dump), self::DUMP_TERMINATOR)) {
+            throw new \RuntimeException(\sprintf('The backup file %s is truncated: it does not end the way a complete dump ends. Nothing was restored.', $filename));
+        }
+
+        return $dump;
     }
 
     /**

--- a/core/lib/Thelia/Core/Install/Database.php
+++ b/core/lib/Thelia/Core/Install/Database.php
@@ -138,10 +138,8 @@ class Database
         preg_match_all('#DELIMITER (.+?)\n(.+?)DELIMITER ;#s', $sql, $m);
 
         foreach ($m[0] as $k => $v) {
-            if ('|' === $m[1][$k]) {
-                throw new \RuntimeException('You can not use "|" as delimiter: '.$v);
-            }
-
+            // A '|' delimiter used to be rejected here, because '|' was the placeholder
+            // above and the two would have collided. Nothing is reserved any more.
             $stored = str_replace([';', $m[1][$k]], [$blockSemicolon, ";\n"], $m[2][$k]);
             $sql = str_replace($v, $stored, $sql);
         }

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -54,6 +54,7 @@ class Update
     protected array $updatedVersions = [];
     protected ConnectionInterface|\PDO $connection;
     protected ?string $backupFile = null;
+    protected ?string $restoreFailure = null;
     protected string $backupDir = 'local/backup/';
     protected array $messages = [];
     protected Translator $translator;
@@ -338,13 +339,25 @@ class Update
 
             $database->restoreDb($this->backupFile);
         } catch (\Exception $exception) {
+            // Kept for the caller to print: it names the table the restore stopped on,
+            // and what the database holds now. Written on the object rather than echoed,
+            // so the caller decides where it goes.
+            $this->restoreFailure = $exception->getMessage();
+
             $this->log('error', \sprintf('error during restore process with message : %s', $exception->getMessage()));
-            echo $exception->getMessage();
 
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Why the last restore failed, or null if none did.
+     */
+    public function getRestoreFailure(): ?string
+    {
+        return $this->restoreFailure;
     }
 
     public function getBackupFile(): ?string

--- a/setup/update.php
+++ b/setup/update.php
@@ -207,6 +207,7 @@ if (null === $updateError) {
             cliOutput('Database restore started. Wait, it could take a while...');
 
             if (false === $update->restoreDb()) {
+                cliOutput($update->getRestoreFailure() ?? 'The backup could not be restored.', 'error');
                 cliOutput(sprintf(
                     'Sorry, your database can\'t be restore. Try to do it manually : %s',
                     $update->getBackupFile(),

--- a/tests/Integration/Install/DatabaseBackupTest.php
+++ b/tests/Integration/Install/DatabaseBackupTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Install;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Thelia\Core\Install\Database;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The backup taken before an update is the only thing that can undo a schema migration,
+ * so it has to be restorable. It was not: every value went through addslashes() and was
+ * written between double quotes, which turned NULL into an empty string. The restore
+ * then died on the first nullable non-string column it met — and because a dump is a
+ * DROP, a CREATE and the rows of one table after another, it died having already
+ * rebuilt the tables before that one and emptied the one it was on.
+ *
+ * A dump is worth nothing unless what comes back is what went in, so the round trip is
+ * what is asserted here, over the values that break naive escaping.
+ */
+final class DatabaseBackupTest extends IntegrationTestCase
+{
+    private const TABLE = 'backup_round_trip';
+
+    protected bool $useTransaction = false;
+
+    private string $dumpFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dumpFile = tempnam(sys_get_temp_dir(), 'thelia-backup-').'.sql';
+        $this->createTable();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection()->exec('DROP TABLE IF EXISTS `'.self::TABLE.'`');
+        @unlink($this->dumpFile);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return iterable<string, array{int|null, string}>
+     */
+    public static function trapValues(): iterable
+    {
+        yield 'null in a nullable integer column' => [null, 'the value that used to break the whole restore'];
+        yield 'literal backslashes' => [1, 'C:\\path\\to\\file, and a lone \\ here'];
+        yield 'a backslash-n that is not a newline' => [2, 'not a newline: \\n \\r \\t'];
+        yield 'real newlines' => [3, "line one\nline two\r\nline three"];
+        yield 'quotes of both kinds' => [4, "l'apostrophe et \"les guillemets\""];
+        yield 'a semicolon before a newline' => [5, "a statement separator lives here;\nand the value goes on"];
+        yield 'multibyte utf8' => [6, 'accentué — ligature œ, cyrillique Мехико, 漢字'];
+        yield 'four-byte utf8mb4 emoji' => [7, 'panier 🛒 validé ✅ 👍🏽'];
+        yield 'sql that would run if it escaped its quotes' => [8, "'); DROP TABLE `victim`; --"];
+        yield 'control characters' => [9, "tab\there, ctrl-z \x1a, and a NUL-free tail"];
+        yield 'the empty string, which is not null' => [10, ''];
+        // A pipe is an ordinary character in data, and it was the placeholder the
+        // statement splitter used internally: every one of them came back a semicolon.
+        yield 'pipes, as a rich text toolbar or a csv field holds them' => [11, 'undo,redo,|,bold,italic,|,link'];
+        // Text that looks like the markers the splitter uses internally.
+        yield 'text shaped like an internal marker' => [12, "a -CODE- b -SEMICOLON- c ;', d"];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('trapValues')]
+    public function testAValueComesBackAsItWentIn(?int $nullableInt, string $payload): void
+    {
+        $this->insert($nullableInt, $payload);
+        $before = $this->rows();
+
+        $this->database()->backupDb($this->dumpFile, [self::TABLE]);
+        $this->database()->restoreDb($this->dumpFile);
+
+        self::assertSame($before, $this->rows());
+    }
+
+    public function testEveryTrapValueSurvivesTheSameDump(): void
+    {
+        foreach (self::trapValues() as $case) {
+            $this->insert($case[0], $case[1]);
+        }
+        $before = $this->rows();
+        self::assertCount(iterator_count(self::trapValues()), $before);
+
+        $this->database()->backupDb($this->dumpFile, [self::TABLE]);
+        $this->database()->restoreDb($this->dumpFile);
+
+        self::assertSame($before, $this->rows());
+    }
+
+    public function testANullIsDumpedAsNullRatherThanAnEmptyString(): void
+    {
+        $this->insert(null, 'anything');
+
+        $this->database()->backupDb($this->dumpFile, [self::TABLE]);
+
+        // Read on the file itself: an empty string here is what MariaDB rejects for an
+        // integer column under STRICT_TRANS_TABLES, and it rejects it mid-restore.
+        self::assertStringContainsString(',NULL,', (string) file_get_contents($this->dumpFile));
+    }
+
+    public function testATruncatedDumpIsRefusedBeforeAnythingIsDropped(): void
+    {
+        $this->insert(1, 'a row worth keeping');
+        $before = $this->rows();
+
+        $this->database()->backupDb($this->dumpFile, [self::TABLE]);
+        $dump = (string) file_get_contents($this->dumpFile);
+        file_put_contents($this->dumpFile, substr($dump, 0, (int) (\strlen($dump) / 2)));
+
+        // self::fail() raises a RuntimeException of its own, so the outcome is recorded
+        // and asserted outside the catch rather than from inside it.
+        $message = null;
+
+        try {
+            $this->database()->restoreDb($this->dumpFile);
+        } catch (\RuntimeException $exception) {
+            $message = $exception->getMessage();
+        }
+
+        self::assertNotNull($message, 'A truncated dump must not be replayed.');
+        self::assertStringContainsString('truncated', $message);
+
+        // The point of checking first: the table is still there, with its rows.
+        self::assertSame($before, $this->rows());
+    }
+
+    public function testAFailedRestoreSaysWhichTableItStoppedOn(): void
+    {
+        $this->insert(1, 'a row');
+        $this->database()->backupDb($this->dumpFile, [self::TABLE]);
+
+        // Narrow the column the dump recreates, so its own INSERT no longer fits it:
+        // the same rejection, mid-restore, that an empty string for an integer produced.
+        $dump = (string) file_get_contents($this->dumpFile);
+        file_put_contents($this->dumpFile, str_replace('`payload` longtext', '`payload` int(11)', $dump));
+
+        $message = null;
+
+        try {
+            $this->database()->restoreDb($this->dumpFile);
+        } catch (\RuntimeException $exception) {
+            $message = $exception->getMessage();
+        }
+
+        self::assertNotNull($message, 'A dump that cannot apply must be reported.');
+        self::assertStringContainsString(self::TABLE, $message);
+        self::assertStringContainsString('the ones after it still hold what they held', $message);
+    }
+
+    private function createTable(): void
+    {
+        $this->connection()->exec('DROP TABLE IF EXISTS `'.self::TABLE.'`');
+        $this->connection()->exec(
+            'CREATE TABLE `'.self::TABLE.'` (
+                `id` INTEGER NOT NULL AUTO_INCREMENT,
+                `nullable_int` INTEGER NULL,
+                `payload` LONGTEXT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB CHARACTER SET=\'utf8mb4\' COLLATE=\'utf8mb4_general_ci\'',
+        );
+    }
+
+    private function insert(?int $nullableInt, string $payload): void
+    {
+        $statement = $this->connection()->prepare(
+            'INSERT INTO `'.self::TABLE.'` (`nullable_int`, `payload`) VALUES (?, ?)',
+        );
+        $statement->execute([$nullableInt, $payload]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rows(): array
+    {
+        return $this->connection()
+            ->query('SELECT * FROM `'.self::TABLE.'` ORDER BY `id`')
+            ->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function testADelimiterBlockStillKeepsItsOwnSemicolons(): void
+    {
+        // The placeholder exists for this: thelia.sql ships DELIMITER blocks, whose
+        // inner semicolons must not cut the statement in two.
+        $file = "DELIMITER //\nCREATE TRIGGER t BEGIN SET @a = 1; SET @b = 2; END//\nDELIMITER ;\nSELECT 1;\n";
+
+        $statements = $this->database()->statementsOf($file);
+        $trigger = implode('', array_filter($statements, static fn (string $s) => str_contains($s, 'TRIGGER')));
+
+        self::assertStringContainsString('SET @a = 1; SET @b = 2;', $trigger);
+    }
+
+    private function database(): DatabaseExposingItsParser
+    {
+        return new DatabaseExposingItsParser($this->connection());
+    }
+
+    private function connection(): ConnectionInterface
+    {
+        return Propel::getConnection(ProductTableMap::DATABASE_NAME);
+    }
+}
+
+/**
+ * prepareSql() is protected, and how it cuts a file into statements is exactly what the
+ * pipe regression was about, so it is reached here rather than inferred.
+ */
+final class DatabaseExposingItsParser extends Database
+{
+    /**
+     * @return list<string>
+     */
+    public function statementsOf(string $sql): array
+    {
+        return array_values($this->prepareSql($sql));
+    }
+}

--- a/tests/Integration/Install/DatabaseBackupTest.php
+++ b/tests/Integration/Install/DatabaseBackupTest.php
@@ -35,6 +35,9 @@ final class DatabaseBackupTest extends IntegrationTestCase
 {
     private const TABLE = 'backup_round_trip';
 
+    /** Mirrors the statement backupDb() closes a dump with; the assertion below catches a drift. */
+    private const DUMP_TERMINATOR = 'SET foreign_key_checks=1;';
+
     protected bool $useTransaction = false;
 
     private string $dumpFile;
@@ -146,10 +149,19 @@ final class DatabaseBackupTest extends IntegrationTestCase
         $this->insert(1, 'a row');
         $this->database()->backupDb($this->dumpFile, [self::TABLE]);
 
-        // Narrow the column the dump recreates, so its own INSERT no longer fits it:
-        // the same rejection, mid-restore, that an empty string for an integer produced.
+        // A row carrying the wrong number of values. Every server refuses that, in any
+        // sql_mode and any version. Narrowing a column and feeding it a string instead
+        // only failed where STRICT_TRANS_TABLES is on: Thelia takes that mode off on
+        // MySQL, so the restore went through and the test had nothing to catch.
         $dump = (string) file_get_contents($this->dumpFile);
-        file_put_contents($this->dumpFile, str_replace('`payload` longtext', '`payload` int(11)', $dump));
+        $broken = str_replace(
+            self::DUMP_TERMINATOR,
+            'INSERT INTO `'.self::TABLE."` VALUES('one value for three columns');\n".self::DUMP_TERMINATOR,
+            $dump,
+        );
+
+        self::assertNotSame($dump, $broken, 'A dump no longer ends the way this test breaks it.');
+        file_put_contents($this->dumpFile, $broken);
 
         $message = null;
 

--- a/tests/Integration/Install/DatabaseBackupTest.php
+++ b/tests/Integration/Install/DatabaseBackupTest.php
@@ -207,6 +207,17 @@ final class DatabaseBackupTest extends IntegrationTestCase
         self::assertStringContainsString('SET @a = 1; SET @b = 2;', $trigger);
     }
 
+    public function testAPipeIsAcceptableAsADelimiter(): void
+    {
+        // It used to be rejected, because '|' was the placeholder the splitter used.
+        $file = "DELIMITER |\nCREATE TRIGGER t BEGIN SET @a = 1; SET @b = 2; END|\nDELIMITER ;\n";
+
+        $statements = $this->database()->statementsOf($file);
+        $trigger = implode('', array_filter($statements, static fn (string $s) => str_contains($s, 'TRIGGER')));
+
+        self::assertStringContainsString('SET @a = 1; SET @b = 2;', $trigger);
+    }
+
     private function database(): DatabaseExposingItsParser
     {
         return new DatabaseExposingItsParser($this->connection());


### PR DESCRIPTION
Fixes #3777.

The update loop no longer wraps itself in a transaction MariaDB cannot honour (#3774), which leaves the backup taken before the run as the only way back. It could not be restored. Two independent causes, both silent.

### NULL was dumped as an empty string

Every value went through `addslashes((string) $value)` and was written between double quotes, so a NULL became `""`. Under `STRICT_TRANS_TABLES` that is rejected for any non-string column, and the restore died on the first one it met — having already dropped and rebuilt the tables before it, and emptied the one it was on:

```
SQLSTATE[22007]: Incorrect integer value: '' for column `address`.`state_id` at row 1
```

A full dump and restore of a demo shop lost the whole `address` table, 12 rows, and stopped there.

Values are now quoted by the connection, which knows the charset it talks in and the escaping mode of the server, and NULL is written as `NULL`. That also settles the newlines: the connection escapes CR, LF and CTRL-Z itself, so the hand-rolled `str_replace("\n", '\n', …)` that used to follow `addslashes()` is gone rather than repaired — nothing can reach the file as a raw newline and split a statement. For the record, that substitution was *not* broken: `addslashes()` ran first, so a backslash already in the data was doubled before the newline escape was inserted, and both round-tripped. The claim to the contrary in the issue was wrong; the tests below pin the behaviour either way.

### Every pipe in the data came back a semicolon

`prepareSql()` hides the semicolons inside a `DELIMITER` block behind a placeholder while it cuts the file into statements on `";\n"`, then puts them back. The placeholder was `|`, and the reverse substitution ran over **every** statement, not only the ones that came from such a block. So any pipe a shop had written was turned into a semicolon on the way in.

The demo data alone hits it — the rich text toolbar in `config` is a pipe-separated list, and it came back with semicolons. This affects `insertSql()` in general, so it also applies to any seed file whose data holds a pipe.

The placeholders are now drawn per call and checked against the file, so no value can be mistaken for one on the way back. The same treatment covers the older `-CODE-` marker, which had the same flaw for text containing `-CODE-`. `thelia.sql` ships `DELIMITER` blocks, and a fresh install still creates its routine — there is a test for that too.

### A restore that stops no longer stops in silence

A dump is a `DROP`, a `CREATE` and the rows of one table after another, and DDL cannot be rolled back, so a restore that fails halfway leaves a database that is neither the backup nor what it was. True atomicity is out of reach here — it would mean restoring into a scratch schema and swapping it in with a single `RENAME TABLE`, which is a different design and not this fix. What is in reach, and is what this does:

- **the dump is checked before anything is dropped.** A file that does not end the way a complete dump ends is refused outright, so a backup cut short by a full disk or a killed process is never replayed. Nothing is touched.
- **a failure says where it stopped:** `The restore stopped while rebuilding \`address\`. The tables restored before it now hold the backup, the ones after it still hold what they held: …`, surfaced through `Update::getRestoreFailure()` and printed by `update.php`, which used to swallow it in an `echo` from inside the domain class.
- **foreign key checks are put back** whatever happens. A dump turns them off to be replayable in any order and on again at its end; a restore that stopped in between used to leave them off on the connection.

### Verified

A dump and restore of a demo install — 162 tables, 15,074 rows — now comes back identical, compared row by row rather than by `CHECKSUM TABLE`, which is not a content-only function and disagreed while every cell matched. On `main` the same run dies on `address`.

End to end: an update that fails now offers the backup, and accepting it brings the shop back — 12 addresses, 10 customers, 30 products, the marker on its previous version, and the pipes intact.

`tests/Integration/Install/DatabaseBackupTest.php` round-trips the values that break naive escaping, one per case: NULL in a nullable integer column, literal backslashes, a `\n` that is not a newline, real newlines and CRLF, both kinds of quote, a semicolon before a newline, multibyte UTF-8, four-byte emoji, SQL that would run if its quotes escaped, control characters, the empty string, pipes, and text shaped like the internal markers. Seven of the eighteen tests fail on `main`.
