### PR TITLE
chore: allow composer/installers 2.x

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -17,7 +17,7 @@
         "ext-pdo": "*",
 
         "composer/composer": "^2.9",
-        "composer/installers": "~1.0",
+        "composer/installers": "^1.0 || ^2.0",
 
         "api-platform/symfony": "^4.3",
         "lexik/jwt-authentication-bundle": "^3.0",


### PR DESCRIPTION
Fixes #3780

`core/composer.json` pinned `composer/installers` to `~1.0`. The last release on that line, `v1.12.0`, declares five implicitly nullable parameters, which PHP 8.4 reports at compile time. Every Composer command run on a Thelia 3 project therefore prints deprecation notices before its own output.

```
"composer/installers": "~1.0"   ->   "composer/installers": "^1.0 || ^2.0"
```

`^1.0 || ^2.0` lets Composer pick `v2.3.0`, which has none.

### Install locations are unchanged

`composer/installers` decides where modules and templates land, so the four Thelia locations were compared in the source of both versions rather than trusted from documentation. `src/Composer/Installers/TheliaInstaller.php` is byte-identical apart from a PHPDoc line:

| type | v1.12.0 | v2.3.0 |
|---|---|---|
| `thelia-module` | `local/modules/{$name}/` | `local/modules/{$name}/` |
| `thelia-frontoffice-template` | `templates/frontOffice/{$name}/` | `templates/frontOffice/{$name}/` |
| `thelia-backoffice-template` | `templates/backOffice/{$name}/` | `templates/backOffice/{$name}/` |
| `thelia-email-template` | `templates/email/{$name}/` | `templates/email/{$name}/` |

The surrounding machinery is equally unchanged: `Installer::supports()` is character-for-character identical, and `BaseInstaller::getInstallPath()` still consults `extra.installer-paths` before its own table and still honours `extra.installer-name`. The 2.x diff is type declarations plus the removal of a `$this->composer->getPackage()` null guard that cannot be null under Composer 2.

`thelia-pdf-template`, `thelia-local` and `thelia-core` are not in that table and are matched by neither version — `supports()` builds the pattern `thelia-(module|frontoffice-template|backoffice-template|email-template)` from the locations above. They are handled by the `thelia/installer` plugin, which is untouched. `thelia/setup` (type `thelia-local`, `extra.installer-name: setup`) keeps landing in `local/setup/`.

### Verified by installing

Two clean `composer install` runs in the same sandbox, one per constraint, then the resolved path of every `thelia-*` package read back from `vendor/composer/installed.json`. All 24 packages across the six Thelia types land at the same path under both versions:

```
thelia/backoffice-default-template        thelia-backoffice-template     templates/backOffice/default
thelia/backoffice-default-twig-template   thelia-backoffice-template     templates/backOffice/default-twig
thelia/flexy                              thelia-frontoffice-template    templates/frontOffice/flexy
thelia/email-default-template             thelia-email-template          templates/email/default
thelia/pdf-default-template               thelia-pdf-template            templates/pdf/default
thelia/setup                              thelia-local                   local/setup
thelia/config                             thelia-local                   local/config
thelia/core                               thelia-core                    core
thelia/cheque-module                      thelia-module                  vendor/thelia/modules/Cheque
... 15 further thelia-module packages, all under vendor/thelia/modules/
```

`bin/install --with-demo --with-admin` then completed on the 2.3.0 tree, front office and `/admin/login` both answer 200, and `module:list` reports the same 16 modules active, all resolved from `vendor/thelia/modules/`. `composer test` is green.

### Measured gain

PHP 8.4.24, Composer 2.10.2, loading `BaseInstaller`, `Installer` and `TheliaInstaller`:

| | deprecations |
|---|---|
| `composer/installers` v1.12.0 | 5 |
| `composer/installers` v2.3.0 | 0 |

Three come from `BaseInstaller::__construct()` (`$package`, `$composer`, `$io`) and two from `Installer::__construct()` (`$filesystem`, `$binaryInstaller`). On a plain `composer install` the visible output goes from

```
  - Installing composer/installers (v1.12.0): Extracting archive
Deprecation Notice: Composer\Installers\Installer::__construct(): Implicitly marking parameter $filesystem as nullable is deprecated, the explicit nullable type must be used instead in .../Installer.php:136
More deprecation notices were hidden, run again with `-v` to show them.
```

to no notice at all.

### Composer 1

`v2.3.0` still declares `composer-plugin-api: ^1.0 || ^2.0`, so nothing is dropped by this bump. Composer 1 is in any case already out of reach for Thelia 3: `symfony/flex` requires `composer-plugin-api ^2.1`. `thelia/core` is the only package in the installed tree that requires `composer/installers` at all.

The 2.6 line does not require the package and is left alone.
