### PR TITLE
fix: keep STRICT_TRANS_TABLES in the session sql_mode on MySQL and MariaDB

### DIFF
--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -268,13 +268,6 @@ class TheliaKernel extends Kernel
                             $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
                         }
 
-                        // remove STRICT_TRANS_TABLES
-                        if (($key = array_search('STRICT_TRANS_TABLES', $sessionSqlMode, true)) !== false) {
-                            unset($sessionSqlMode[$key]);
-                            $canUpdate = true;
-                            $logs[] = 'Remove sql_mode STRICT_TRANS_TABLES. Please configure your MySQL server.';
-                        }
-
                         // remove ONLY_FULL_GROUP_BY
                         if (($key = array_search('ONLY_FULL_GROUP_BY', $sessionSqlMode, true)) !== false) {
                             unset($sessionSqlMode[$key]);
@@ -283,14 +276,7 @@ class TheliaKernel extends Kernel
                         }
                     }
                 } else {
-                    // MariaDB 10.2.4+ compatibility
-                    // remove STRICT_TRANS_TABLES
-                    if (version_compare($data['version'], '10.2.4', '>=') && $key = \in_array('STRICT_TRANS_TABLES', $sessionSqlMode, true)) {
-                        unset($sessionSqlMode[$key]);
-                        $canUpdate = true;
-                        $logs[] = 'Remove sql_mode STRICT_TRANS_TABLES. Please configure your MySQL server.';
-                    }
-
+                    // MariaDB 10.1.7+ compatibility
                     if (version_compare($data['version'], '10.1.7', '>=') && !\in_array('NO_ENGINE_SUBSTITUTION', $sessionSqlMode, true)) {
                         $sessionSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
                         $canUpdate = true;

--- a/tests/Unit/Core/TheliaKernelSqlModeTest.php
+++ b/tests/Unit/Core/TheliaKernelSqlModeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\PDODataFetcher;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\TheliaKernel;
+use Thelia\Log\Tlog;
+
+/**
+ * The server engine is faked through VERSION(), so both the MySQL and the
+ * MariaDB branch are exercised whatever the database the suite runs against.
+ */
+final class TheliaKernelSqlModeTest extends TestCase
+{
+    private string $cacheDir;
+
+    protected function setUp(): void
+    {
+        $this->cacheDir = sys_get_temp_dir().'/thelia-sql-mode-'.bin2hex(random_bytes(8));
+        (new Filesystem())->mkdir($this->cacheDir);
+
+        // Tlog::getInstance() would read its configuration from the database.
+        // A bare instance keeps its default ERROR level, so warnings are dropped.
+        $this->setTlogInstance((new \ReflectionClass(Tlog::class))->newInstanceWithoutConstructor());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setTlogInstance(null);
+        (new Filesystem())->remove($this->cacheDir);
+    }
+
+    public function testMariaDbKeepsStrictTransTablesAndEveryOtherMode(): void
+    {
+        $serverModes = ['STRICT_TRANS_TABLES', 'ERROR_FOR_DIVISION_BY_ZERO', 'NO_AUTO_CREATE_USER', 'NO_ENGINE_SUBSTITUTION'];
+
+        $modes = $this->resolveSessionSqlMode('10.11.11-MariaDB-log', $serverModes);
+
+        self::assertContains('STRICT_TRANS_TABLES', $modes);
+        self::assertSame($serverModes, $modes);
+    }
+
+    public function testMySqlKeepsStrictTransTablesAndOnlyDropsOnlyFullGroupBy(): void
+    {
+        $serverModes = ['ONLY_FULL_GROUP_BY', 'STRICT_TRANS_TABLES', 'NO_ZERO_IN_DATE', 'NO_ZERO_DATE', 'ERROR_FOR_DIVISION_BY_ZERO', 'NO_ENGINE_SUBSTITUTION'];
+
+        $modes = $this->resolveSessionSqlMode('8.0.40', $serverModes);
+
+        self::assertContains('STRICT_TRANS_TABLES', $modes);
+        self::assertNotContains('ONLY_FULL_GROUP_BY', $modes);
+        self::assertSame(array_values(array_diff($serverModes, ['ONLY_FULL_GROUP_BY'])), $modes);
+    }
+
+    /**
+     * @param string[] $serverModes
+     *
+     * @return string[] the sql_mode the kernel settles on for the session
+     */
+    private function resolveSessionSqlMode(string $version, array $serverModes): array
+    {
+        $fetcher = $this->createMock(PDODataFetcher::class);
+        $fetcher->method('fetch')->willReturn([
+            'version' => $version,
+            'session_sql_mode' => implode(',', $serverModes),
+        ]);
+
+        $appliedModes = $serverModes;
+
+        $connection = $this->createMock(ConnectionInterface::class);
+        $connection->method('query')->willReturnCallback(
+            static function (string $statement) use ($fetcher, &$appliedModes) {
+                if (str_starts_with($statement, 'SELECT VERSION()')) {
+                    return $fetcher;
+                }
+
+                self::assertSame(1, preg_match("/^SET SESSION sql_mode='(.*)';$/", $statement, $matches));
+                $appliedModes = explode(',', $matches[1]);
+
+                return $fetcher;
+            }
+        );
+
+        $kernel = new class($this->cacheDir) extends TheliaKernel {
+            public function __construct(private readonly string $sqlModeCacheDir)
+            {
+            }
+
+            public function getCacheDir(): string
+            {
+                return $this->sqlModeCacheDir;
+            }
+
+            public function resolveSqlMode(ConnectionInterface $con): void
+            {
+                $this->checkMySQLConfigurations($con);
+            }
+        };
+
+        $kernel->resolveSqlMode($connection);
+
+        return $appliedModes;
+    }
+
+    private function setTlogInstance(?Tlog $instance): void
+    {
+        $property = new \ReflectionProperty(Tlog::class, 'instance');
+        $property->setValue(null, $instance);
+    }
+}


### PR DESCRIPTION
Fixes #3779

## Three defects in one branch

`TheliaKernel::checkMySQLConfigurations()` adjusted the session `sql_mode` at boot, with one branch for MySQL and one for MariaDB. The MariaDB branch read:

```php
if (version_compare($data['version'], '10.2.4', '>=') && $key = \in_array('STRICT_TRANS_TABLES', $sessionSqlMode, true)) {
    unset($sessionSqlMode[$key]);
```

`in_array()` returns a boolean, so `unset($modes[true])` is `unset($modes[1])`: the element at index 1 is removed, whatever it happens to be. Measured on MariaDB 10.11:

```
server sql_mode : STRICT_TRANS_TABLES, ERROR_FOR_DIVISION_BY_ZERO, NO_AUTO_CREATE_USER, NO_ENGINE_SUBSTITUTION
Thelia applied  : STRICT_TRANS_TABLES,                             NO_AUTO_CREATE_USER, NO_ENGINE_SUBSTITUTION
log emitted     : "Remove sql_mode STRICT_TRANS_TABLES"
```

So on every MariaDB shop: division-by-zero protection was silently switched off, the mode the code meant to drop stayed on, and the log said the opposite of what happened.

## Why the removal is dropped rather than repaired

The bug ran the experiment for us. Because the removal never worked on MariaDB — the engine DDEV ships, so the engine most Thelia development happens on — MariaDB shops have been running in strict mode for years without the incompatibility the removal was guarding against. Keeping the mode is therefore the behaviour already validated on half the ecosystem.

Measured on the other half, MySQL 8.0.40, with `STRICT_TRANS_TABLES` active:

- fresh install with `--with-demo`: succeeds, no SQL error
- all five test suites: 1174 tests green
- front walkthrough (product page, add to cart, registration, delivery, payment, order placed) and back office (product create and edit, order status change, customer edit, module configuration): no rejected write, no `SQLSTATE` in the logs

`ONLY_FULL_GROUP_BY` is a separate concern with a different risk profile and is untouched, as is `NO_ENGINE_SUBSTITUTION`. With the removal gone from the MariaDB branch, the faulty `unset` disappears with it. `grep` confirms no other `$key = in_array(...)` remains in the core.

## Test

`tests/Unit/Core/TheliaKernelSqlModeTest.php` fakes `VERSION()` through a mocked connection, so both engine branches are exercised whatever database the suite runs against, and asserts that `STRICT_TRANS_TABLES` survives and that no mode present at the start disappears. Without the fix both cases fail: the MariaDB one on the dropped `ERROR_FOR_DIVISION_BY_ZERO`, the MySQL one on the dropped `STRICT_TRANS_TABLES`.
