### PR TITLE
docs: update Readme for the AssetMapper front-office asset build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ Thelia is open source software. See the [LICENSE](LICENSE) file for details.
 - PHP 8.3 with these extensions: pdo_mysql, openssl, intl, gd, curl, dom, mbstring, zip
 - MariaDB 10.11 or MySQL 8
 - Composer 2.7+
-- Node.js 20 and npm, to build the front-office and back-office assets
+- Node.js 20 and npm, to build the back-office assets
 - Nginx or Apache, with the document root set to `public/`
 
 ## Setting up a development environment
@@ -59,10 +59,16 @@ Without DDEV, export the database variables (or put them in `.env.local`) and ru
 
 ### Build the assets
 
-`bin/install` sets up the database and templates but does not compile front-end assets. Build them for each active template that has a `package.json`, otherwise the pages return HTTP 500 with a missing Webpack entrypoints file:
+`bin/install` compiles the front-office assets itself: it runs `importmap:install` and `tailwind:build` for the active front-office theme. To rebuild them later, run both commands from the application root:
 
 ```bash
-ddev exec bash -c "cd templates/frontOffice/flexy && npm install && npm run build"
+ddev exec php bin/console importmap:install
+ddev exec php bin/console tailwind:build
+```
+
+The back-office theme still builds with npm:
+
+```bash
 ddev exec bash -c "cd templates/backOffice/default-twig && npm install && npm run build"
 ```
 


### PR DESCRIPTION
The Readme still documented an npm build for the Flexy front-office theme (`npm install && npm run build`) and claimed `bin/install` does not compile front-end assets. Since the move to AssetMapper + Tailwind v4, Flexy has no `package.json` anymore and `bin/install` runs `importmap:install` and `tailwind:build` itself.

- Rewrite the "Build the assets" section: front-office assets are compiled by `bin/install`, with the two `bin/console` commands for a later manual rebuild.
- Keep the back-office (`default-twig`) npm build as is.
- Adjust the requirements: Node.js and npm are only needed for the back-office assets.

Fixes #3787