### PR TITLE
fix: declare the branch alias on the setup and config packages

### DIFF
--- a/local/config/composer.json
+++ b/local/config/composer.json
@@ -5,6 +5,9 @@
         "thelia/installer": "~1.1"
     },
     "extra": {
-        "installer-name": "config"
+        "installer-name": "config",
+        "branch-alias": {
+            "dev-main": "3.0.x-dev"
+        }
     }
 }

--- a/setup/composer.json
+++ b/setup/composer.json
@@ -5,6 +5,9 @@
         "thelia/installer": "~1.1"
     },
     "extra": {
-        "installer-name": "setup"
+        "installer-name": "setup",
+        "branch-alias": {
+            "dev-main": "3.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Without a branch alias, Composer reads `dev-main` of `thelia/setup` and `thelia/config` as plain branch names, so they never satisfy the `^3.0.0-beta1` constraints declared by `thelia/core` and the development line cannot be installed without a manual inline alias.

This adds the same alias `thelia/core` already carries (`"dev-main": "3.0.x-dev"`) to `setup/composer.json` and `local/config/composer.json`. Both files are byte-identical to their read-only subtree splits (`thelia/setup`, `thelia/config`), so the splits will pick the alias up on the next split run.

Verified with a throwaway project requiring `thelia/setup ^3.0.0-beta1` through a path repository: resolution fails before the change and locks `thelia/setup (dev-main)` after it.

Fixes #3785