### PR TITLE
fix: create var/translations during install so the first page does not 500

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -92,9 +92,11 @@ if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $dbName)) {
 
 // ── Phase 1: Check permissions ───────────────────────────────────────
 
-// Ensure required directories exist (may be missing after a fresh clone)
+// Ensure required directories exist (may be missing after a fresh clone).
+// var/translations is registered as an AssetMapper path by symfony/ux-translator,
+// which never creates it at boot: without it, the first page answers 500.
 $fs = new Symfony\Component\Filesystem\Filesystem();
-foreach (['var', 'public', 'local/media', 'local/config'] as $dir) {
+foreach (['var', 'public', 'local/media', 'local/config', 'var/translations'] as $dir) {
     $fs->mkdir(THELIA_ROOT.$dir);
 }
 


### PR DESCRIPTION
On a fresh install, the very first front-office page answers 500:

> The asset mapper directory "var/translations" does not exist.

`symfony/ux-translator` unconditionally registers `%kernel.project_dir%/var/translations` as an AssetMapper path, but only its optional cache warmer creates the directory — and optional warmers never run at kernel boot here (build_dir == cache_dir). Nothing in `bin/install` creates it or runs an explicit `cache:warmup`, so the directory is missing until a manual `cache:clear`.

This adds `var/translations` to the directories `bin/install` already ensures exist (phase 1). The creation is idempotent, independent of the active front-office theme, and harmless when `symfony/ux-translator` is not installed.

Verified on a fresh install (empty directory + empty database): first front page went from 500 to 200 with no manual cache clear.

Fixes #3784