### PR TITLE
Let the pre-update backup run when memory_limit is unlimited

### DIFF
--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -486,26 +486,43 @@ class Update
 
     /**
      * Checks whether it is possible to make a data base backup.
+     *
+     * The backup accumulates the whole dump in memory, so a finite memory_limit
+     * caps the database size the backup can handle. A negative memory_limit
+     * means unlimited memory: the backup is always possible.
      */
     public function checkBackupIsPossible(): bool
     {
-        $size = 0;
+        $memoryLimit = self::parseMemoryLimit(\ini_get('memory_limit'));
 
-        if (preg_match('/^(\d+)(.)$/', \ini_get('memory_limit'), $matches)) {
-            switch (strtolower($matches[2])) {
-                case 'k':
-                    $size = $matches[1] / 1024;
-                    break;
-                case 'm':
-                    $size = $matches[1];
-                    break;
-                case 'g':
-                    $size = $matches[1] * 1024;
-                    break;
-            }
+        if ($memoryLimit < 0) {
+            return true;
         }
 
-        return !($this->getDataBaseSize() > ($size - 64) / 8);
+        $memoryLimitInMegabytes = $memoryLimit / (1024 ** 2);
+
+        return !($this->getDataBaseSize() > ($memoryLimitInMegabytes - 64) / 8);
+    }
+
+    /**
+     * Converts a php.ini shorthand-byte value to bytes, following the PHP
+     * semantics: the leading integer part is kept (a fractional prefix such as
+     * "0.5G" truncates to 0), the k/m/g suffix is case-insensitive, and a value
+     * without a suffix is already in bytes. A negative result means unlimited.
+     *
+     * @internal exposed for tests
+     */
+    public static function parseMemoryLimit(string $memoryLimit): int
+    {
+        $memoryLimit = trim($memoryLimit);
+        $bytes = (int) $memoryLimit;
+
+        return match (strtolower(substr($memoryLimit, -1))) {
+            'k' => $bytes * 1024,
+            'm' => $bytes * 1024 ** 2,
+            'g' => $bytes * 1024 ** 3,
+            default => $bytes,
+        };
     }
 
     public function getLatestVersion(): mixed

--- a/tests/Unit/Install/UpdateBackupMemoryLimitTest.php
+++ b/tests/Unit/Install/UpdateBackupMemoryLimitTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Install;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Thelia\Core\Install\Update;
+
+/**
+ * `Update::checkBackupIsPossible()` sizes the pre-update backup against
+ * `memory_limit`, so its parsing has to follow the php.ini shorthand-byte
+ * semantics: a negative value means unlimited, k/m/g suffixes are
+ * case-insensitive, a bare number is bytes, and a fractional prefix such
+ * as "0.5G" is truncated to its integer part exactly as PHP truncates it.
+ */
+final class UpdateBackupMemoryLimitTest extends TestCase
+{
+    #[DataProvider('memoryLimitProvider')]
+    public function testParseMemoryLimitFollowsPhpShorthandByteSemantics(string $iniValue, int $expectedBytes): void
+    {
+        self::assertSame($expectedBytes, Update::parseMemoryLimit($iniValue));
+    }
+
+    public static function memoryLimitProvider(): iterable
+    {
+        yield 'unlimited' => ['-1', -1];
+        yield 'megabytes, uppercase suffix' => ['128M', 134217728];
+        yield 'megabytes, lowercase suffix' => ['64m', 67108864];
+        yield 'gigabytes' => ['1G', 1073741824];
+        yield 'kilobytes' => ['512k', 524288];
+        yield 'bare bytes' => ['134217728', 134217728];
+        yield 'surrounding whitespace' => [' 256M ', 268435456];
+        yield 'fractional prefix truncated to int, as PHP does' => ['0.5G', 0];
+        yield 'fractional prefix keeps its integer part' => ['1.9G', 1073741824];
+        yield 'any negative value is unlimited' => ['-2G', -2147483648];
+        yield 'unknown suffix falls back to bytes' => ['1x', 1];
+        yield 'no leading digits' => ['abc', 0];
+    }
+
+    public function testBackupIsAlwaysPossibleWhenMemoryIsUnlimited(): void
+    {
+        $update = $this->updateWithDatabaseSize(100000.0);
+
+        self::assertTrue($this->checkBackupWithMemoryLimit($update, '-1'));
+    }
+
+    public function testBackupIsPossibleWhenTheDatabaseFitsUnderTheFiniteLimit(): void
+    {
+        $update = $this->updateWithDatabaseSize(10.0);
+
+        // (512 - 64) / 8 = 56 MB allowed
+        self::assertTrue($this->checkBackupWithMemoryLimit($update, '512M'));
+    }
+
+    public function testBackupIsRefusedWhenTheDatabaseExceedsTheFiniteLimit(): void
+    {
+        $update = $this->updateWithDatabaseSize(100.0);
+
+        self::assertFalse($this->checkBackupWithMemoryLimit($update, '512M'));
+    }
+
+    public function testBackupIsPossibleWhenTheLimitIsGivenAsBareBytes(): void
+    {
+        $update = $this->updateWithDatabaseSize(5.0);
+
+        // 134217728 bytes = 128 MB, (128 - 64) / 8 = 8 MB allowed
+        self::assertTrue($this->checkBackupWithMemoryLimit($update, '134217728'));
+    }
+
+    public function testBackupIsRefusedWhenTheLimitIsTooSmallForTheDump(): void
+    {
+        $update = $this->updateWithDatabaseSize(5.0);
+
+        // (96 - 64) / 8 = 4 MB allowed, the 5 MB database does not fit
+        self::assertFalse($this->checkBackupWithMemoryLimit($update, '96M'));
+    }
+
+    private function checkBackupWithMemoryLimit(Update $update, string $memoryLimit): bool
+    {
+        $initialLimit = \ini_get('memory_limit');
+        ini_set('memory_limit', $memoryLimit);
+
+        try {
+            return $update->checkBackupIsPossible();
+        } finally {
+            ini_set('memory_limit', $initialLimit);
+        }
+    }
+
+    private function updateWithDatabaseSize(float $sizeInMegabytes): Update
+    {
+        return new class($sizeInMegabytes) extends Update {
+            public function __construct(private readonly float $databaseSize)
+            {
+            }
+
+            public function getDataBaseSize(): float
+            {
+                return $this->databaseSize;
+            }
+        };
+    }
+}


### PR DESCRIPTION
`Update::checkBackupIsPossible()` parsed `memory_limit` with `preg_match('/^(\d+)(.)$/', ...)`, which matches neither `-1` nor a bare byte count. The parsed size stayed at 0, the allowance became `(0 - 64) / 8` = -8 MB, and every pre-update backup was refused — `setup/update.php` exits with code 4 precisely on the setups (unlimited memory) where the backup is the safest to run.

This PR extracts the parsing into `Update::parseMemoryLimit()`, following PHP's own shorthand-byte semantics:

- a negative value (`-1`) means unlimited, so the backup is always allowed;
- `k`/`m`/`g` suffixes are case-insensitive;
- a value without a suffix is bytes;
- a fractional prefix such as `0.5G` truncates to its integer part, exactly as PHP truncates it (checked against `ini_parse_quantity()`).

The proportional cap for finite limits is kept as it is: the backup still accumulates the whole dump in memory (`Database::backupDb()` builds an array and `implode()`s it), so the `(limit - 64) / 8` allowance still has a reason to exist. Streaming the dump to the file as it is produced would remove that cap altogether and let large shops back up too; that is left for a follow-up.

Fixes #3783
