### PR TITLE
fix: base the cached sql_mode verdict on the server-configured sql_mode

### DIFF
--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -244,17 +244,23 @@ class TheliaKernel extends Kernel
     protected function checkMySQLConfigurations(ConnectionInterface $con): void
     {
         if (!file_exists($this->getCacheDir().DS.'check_mysql_configurations.php')) {
-            $sessionSqlMode = [];
+            $serverSqlMode = [];
             $canUpdate = false;
             $logs = [];
+            // The verdict is cached across requests, so it must describe the
+            // server-configured sql_mode (@@GLOBAL, what every fresh connection
+            // inherits), never the current session: bin/install boots several
+            // kernels over one shared connection, and a session corrected by a
+            // previous kernel would cache a "nothing to do" verdict that every
+            // later web request would then run with.
             /** @var PDODataFetcher $result */
-            $result = $con->query('SELECT VERSION() as version, @@SESSION.sql_mode as session_sql_mode');
+            $result = $con->query('SELECT VERSION() as version, @@GLOBAL.sql_mode as global_sql_mode');
 
             if ($result && $data = $result->fetch(\PDO::FETCH_ASSOC)) {
-                $sessionSqlMode = explode(',', (string) $data['session_sql_mode']);
+                $serverSqlMode = explode(',', (string) $data['global_sql_mode']);
 
-                if (empty($sessionSqlMode[0])) {
-                    unset($sessionSqlMode[0]);
+                if (empty($serverSqlMode[0])) {
+                    unset($serverSqlMode[0]);
                 }
 
                 // MariaDB is not impacted by this problem
@@ -262,23 +268,23 @@ class TheliaKernel extends Kernel
                     // MySQL 5.6+ compatibility
                     if (version_compare($data['version'], '5.6.0', '>=')) {
                         // add NO_ENGINE_SUBSTITUTION
-                        if (!\in_array('NO_ENGINE_SUBSTITUTION', $sessionSqlMode, true)) {
-                            $sessionSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
+                        if (!\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
+                            $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
                             $canUpdate = true;
                             $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
                         }
 
                         // remove ONLY_FULL_GROUP_BY
-                        if (($key = array_search('ONLY_FULL_GROUP_BY', $sessionSqlMode, true)) !== false) {
-                            unset($sessionSqlMode[$key]);
+                        if (($key = array_search('ONLY_FULL_GROUP_BY', $serverSqlMode, true)) !== false) {
+                            unset($serverSqlMode[$key]);
                             $canUpdate = true;
                             $logs[] = 'Remove sql_mode ONLY_FULL_GROUP_BY. Please configure your MySQL server.';
                         }
                     }
                 } else {
                     // MariaDB 10.1.7+ compatibility
-                    if (version_compare($data['version'], '10.1.7', '>=') && !\in_array('NO_ENGINE_SUBSTITUTION', $sessionSqlMode, true)) {
-                        $sessionSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
+                    if (version_compare($data['version'], '10.1.7', '>=') && !\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
+                        $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
                         $canUpdate = true;
                         $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
                     }
@@ -294,7 +300,7 @@ class TheliaKernel extends Kernel
             (new Filesystem())->dumpFile(
                 $this->getCacheDir().DS.'check_mysql_configurations.php',
                 '<?php return '.VarExporter::export([
-                    'modes' => array_values($sessionSqlMode),
+                    'modes' => array_values($serverSqlMode),
                     'canUpdate' => $canUpdate,
                     'logs' => $logs,
                 ]).';',

--- a/tests/Integration/Core/TheliaKernelSqlModeVerdictTest.php
+++ b/tests/Integration/Core/TheliaKernelSqlModeVerdictTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\TheliaKernel;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The sql_mode verdict is cached across requests, so it must describe the
+ * server configuration (what a fresh connection inherits), never the current
+ * session: bin/install boots several kernels over one shared connection, and
+ * a session already corrected by a previous kernel would otherwise cache a
+ * "nothing to do" verdict that every later web request inherits.
+ *
+ * The test puts the current session in the state OPPOSITE to the server
+ * configuration (whichever direction that is on the engine at hand), then
+ * checks that the cached verdict still reflects the server configuration.
+ */
+final class TheliaKernelSqlModeVerdictTest extends IntegrationTestCase
+{
+    protected bool $useTransaction = false;
+
+    public function testVerdictReflectsServerConfigurationNotCurrentSession(): void
+    {
+        $con = $this->getPropelConnection();
+
+        $row = $con
+            ->query('SELECT VERSION() AS version, @@GLOBAL.sql_mode AS global_mode, @@SESSION.sql_mode AS session_mode')
+            ->fetch(\PDO::FETCH_ASSOC);
+
+        $isMariaDb = str_contains((string) $row['version'], 'MariaDB');
+        $globalModes = $this->parseModes((string) $row['global_mode']);
+        $correctedModes = $this->applyTheliaCorrections($globalModes, $isMariaDb);
+        $serverNeedsCorrection = $correctedModes !== $globalModes;
+
+        // Diverge the session from the server configuration, flipping the
+        // verdict a session-based check would reach: a server that needs
+        // correcting gets an already-corrected session (the bin/install
+        // scenario), a compliant server gets a session that needs correcting.
+        $divergentSessionModes = $serverNeedsCorrection
+            ? $correctedModes
+            : array_values(array_diff($globalModes, ['NO_ENGINE_SUBSTITUTION']));
+
+        $originalSessionMode = (string) $row['session_mode'];
+        $cacheDir = sys_get_temp_dir().'/thelia-sql-mode-verdict-'.bin2hex(random_bytes(8));
+        (new Filesystem())->mkdir($cacheDir);
+
+        try {
+            $con->query("SET SESSION sql_mode='".implode(',', $divergentSessionModes)."'");
+
+            // Prove the sabotage took before asserting anything about the
+            // verdict: the session really diverges from the server
+            // configuration, in a verdict-flipping way.
+            $sessionModes = $this->parseModes(
+                (string) $con->query('SELECT @@SESSION.sql_mode')->fetchColumn(),
+            );
+            self::assertSame($divergentSessionModes, $sessionModes, 'sanity: SET SESSION sql_mode was not applied');
+            self::assertNotSame($globalModes, $sessionModes, 'sanity: the session must diverge from the server configuration');
+            self::assertNotSame(
+                $serverNeedsCorrection,
+                $this->applyTheliaCorrections($sessionModes, $isMariaDb) !== $sessionModes,
+                'sanity: session state and server configuration must call for opposite verdicts',
+            );
+
+            $this->runSqlModeCheckWithFreshCache($con, $cacheDir);
+
+            $cache = require $cacheDir.\DIRECTORY_SEPARATOR.'check_mysql_configurations.php';
+
+            self::assertSame(
+                $serverNeedsCorrection,
+                (bool) $cache['canUpdate'],
+                'The cached verdict must reflect the server-configured sql_mode, not the state of the current session',
+            );
+
+            if ($serverNeedsCorrection) {
+                self::assertSame($correctedModes, $cache['modes']);
+            }
+        } finally {
+            $con->query("SET SESSION sql_mode='".$originalSessionMode."'");
+            (new Filesystem())->remove($cacheDir);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function parseModes(string $sqlMode): array
+    {
+        return array_values(array_filter(explode(',', $sqlMode)));
+    }
+
+    /**
+     * The corrections Thelia applies, mirroring checkMySQLConfigurations():
+     * ensure NO_ENGINE_SUBSTITUTION, and on MySQL drop ONLY_FULL_GROUP_BY.
+     *
+     * @param string[] $modes
+     *
+     * @return string[]
+     */
+    private function applyTheliaCorrections(array $modes, bool $isMariaDb): array
+    {
+        if (!\in_array('NO_ENGINE_SUBSTITUTION', $modes, true)) {
+            $modes[] = 'NO_ENGINE_SUBSTITUTION';
+        }
+
+        if (!$isMariaDb) {
+            $modes = array_diff($modes, ['ONLY_FULL_GROUP_BY']);
+        }
+
+        return array_values($modes);
+    }
+
+    private function runSqlModeCheckWithFreshCache(ConnectionInterface $con, string $cacheDir): void
+    {
+        $kernel = new class($cacheDir) extends TheliaKernel {
+            public function __construct(private readonly string $sqlModeCacheDir)
+            {
+            }
+
+            public function getCacheDir(): string
+            {
+                return $this->sqlModeCacheDir;
+            }
+
+            public function runSqlModeCheck(ConnectionInterface $con): void
+            {
+                $this->checkMySQLConfigurations($con);
+            }
+        };
+
+        $kernel->runSqlModeCheck($con);
+    }
+}

--- a/tests/Unit/Core/TheliaKernelSqlModeTest.php
+++ b/tests/Unit/Core/TheliaKernelSqlModeTest.php
@@ -76,7 +76,7 @@ final class TheliaKernelSqlModeTest extends TestCase
         $fetcher = $this->createMock(PDODataFetcher::class);
         $fetcher->method('fetch')->willReturn([
             'version' => $version,
-            'session_sql_mode' => implode(',', $serverModes),
+            'global_sql_mode' => implode(',', $serverModes),
         ]);
 
         $appliedModes = $serverModes;


### PR DESCRIPTION
Fixes #3786

`checkMySQLConfigurations()` decided whether the sql_mode needs correcting by looking at `@@SESSION.sql_mode`, then cached that verdict in `var/cache/<env>/check_mysql_configurations.php`. The verdict outlives the session it was computed from: `bin/install` boots several kernels in one PHP process over one shared Propel connection, and `template:set` clears the cache after the first kernel has already corrected the session. The next kernel then reads an already-corrected session and caches `canUpdate => false`. On MySQL, every web request inherits that verdict and runs with `ONLY_FULL_GROUP_BY`.

The check now reads `@@GLOBAL.sql_mode` — the server configuration every fresh connection inherits — so the cached verdict stays valid whatever the state of the connection that computed it. The current session is still corrected with `SET SESSION` when needed. Reading `@@GLOBAL.sql_mode` needs no privilege (verified with a user holding only `USAGE` globally), and on MariaDB with a default configuration the verdict stays `false` as before.

The new integration test pins the current session in the state opposite to the server configuration (whichever direction that is on the engine at hand), proves the divergence took, and asserts the cached verdict still reflects the server configuration — so it is conclusive on both MySQL and MariaDB, whatever their default sql_mode.

Verified on MySQL 8.0: before the fix, a fresh `bin/install` cached `canUpdate => false` and HTTP requests ran with `ONLY_FULL_GROUP_BY`; after the fix, a fresh install caches `canUpdate => true` and HTTP requests run with the corrected sql_mode.