### PR TITLE
feat: build the back-office Sass stylesheet during install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -319,12 +319,18 @@ if (isset($options['with-admin'])) {
     ];
 }
 
-// The front-office assets a theme needs at runtime. A theme built on AssetMapper reads
-// its JavaScript from `assets/vendor`, and one built on Tailwind reads a stylesheet that
-// only exists once built: without either, the shop answers 500 on its very first page.
-// Both commands come from packages a theme may or may not require, so they are skipped
-// where nothing provides them. They run last: both read the theme that template:set chose.
-foreach (['importmap:install' => 'Installing front-office asset dependencies', 'tailwind:build' => 'Building the front-office stylesheet'] as $command => $label) {
+// The assets a theme needs at runtime. A theme built on AssetMapper reads its
+// JavaScript from `assets/vendor`, one built on Tailwind reads a stylesheet that only
+// exists once built, and one built on Sass (the Twig back-office) reads a stylesheet
+// compiled by sass:build: without them, the first page of the shop or of the admin
+// answers 500. Each command comes from a package a theme may or may not require, so it
+// is skipped where nothing provides it. They run last: all read the themes that
+// template:set chose.
+foreach ([
+    'importmap:install' => 'Installing front-office asset dependencies',
+    'tailwind:build' => 'Building the front-office stylesheet',
+    'sass:build' => 'Building the Sass stylesheets',
+] as $command => $label) {
     $commands[] = [
         'label' => $label,
         'input' => ['command' => $command],

--- a/core/lib/Thelia/Test/WebIntegrationTestCase.php
+++ b/core/lib/Thelia/Test/WebIntegrationTestCase.php
@@ -135,7 +135,7 @@ abstract class WebIntegrationTestCase extends WebTestCase
             }
 
             self::markTestSkipped(\sprintf(
-                '"%s" cannot be rendered: the theme assets are not built (npm run build, importmap:install).',
+                '"%s" cannot be rendered: the theme assets are not built (importmap:install, tailwind:build, sass:build).',
                 $url,
             ));
         } finally {
@@ -155,12 +155,14 @@ abstract class WebIntegrationTestCase extends WebTestCase
      */
     private static function isMissingAssetBuild(\Throwable $failure): bool
     {
-        // A theme builds its assets with Encore, which reads an entrypoints file, or
-        // with AssetMapper, which reads the vendor assets `importmap:install` writes
-        // into the theme. Both are produced by the theme build, never by the core.
+        // A theme builds its assets with Encore, which reads an entrypoints file; with
+        // AssetMapper, which reads the vendor assets `importmap:install` writes into the
+        // theme; or with sass-bundle, which serves a stylesheet that only exists once
+        // `sass:build` ran. All are produced by the theme build, never by the core.
         $missingBuildMessages = [
             'Could not find the entrypoints file',
             'vendor asset is missing',
+            'run php bin/console sass:build',
         ];
 
         for ($cause = $failure; null !== $cause; $cause = $cause->getPrevious()) {


### PR DESCRIPTION
The back-office theme is moving from Webpack Encore to AssetMapper (thelia-templates/default-twig#53). Its stylesheet is now compiled by symfonycasts/sass-bundle, so a fresh install must run `sass:build` the same way it already runs `importmap:install` and `tailwind:build` for the front office.

- `bin/install`: add `sass:build` to the optional post-install asset commands. Like the two existing ones, it is skipped when no installed package provides the command, so an application without the sass-bundle (today's default) installs exactly as before.
- `WebIntegrationTestCase`: recognize the sass-bundle "run php bin/console sass:build" error as a missing theme build, reported as a skipped smoke test — same treatment as a missing Encore entrypoints file or missing AssetMapper vendors. Verified red/green: with the migrated theme and no built stylesheet, the http-backoffice suite reports 8 errors without this change and 8 skips with it; with the stylesheet built it is 10 passed.

Cohabitation: nothing Encore-related changes, so this works with the current Webpack-based theme as well. **Merge this before the theme PR** — the migrated theme needs `sass:build` at install time.

The matching `bin/install` sync for the skeleton is in thelia/thelia-project (its parity check stays red until this PR merges).