### PR TITLE
fix: let the dev repo install fresh again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "url": "core/",
             "options": {
                 "versions": {
-                    "thelia/core": "3.0.0-beta3"
+                    "thelia/core": "3.0.0-beta4"
                 }
             }
         }

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -16,7 +16,6 @@ return [
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\Translator\UxTranslatorBundle::class => ['all' => true],
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
-    Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     BackOfficeDefaultBundle\BackOfficeDefaultBundle::class => ['all' => true],
     BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle::class => ['all' => true],


### PR DESCRIPTION
Two leftovers broke a fresh install of the dev repo (empty directory, `composer install`, `bin/install`):

- The `core/` path repository still declared `thelia/core` as `3.0.0-beta3`. The back-office theme requires `^3.0.0-beta4` since 1.0.0-beta8, and the path repository is canonical, so Composer refused to resolve:
  ```
  thelia/core[3.0.0-beta4] from composer repo but thelia/core[3.0.0-beta3] from path repo (core/) has higher repository priority
  ```
- `config/bundles.php` still registered `WebpackEncoreBundle`, which nothing installs since both themes moved to AssetMapper (the back-office theme dropped the requirement in 1.0.0-beta9). The kernel then crashed on the missing class at first boot.

Verified on a fresh PHP 8.4 install: resolution passes, `bin/install --with-demo --with-admin` completes, and both offices render.