### PR TITLE
fix: point front controllers at a router service and routes that exist

### DIFF
--- a/core/lib/Thelia/Controller/Front/BaseFrontController.php
+++ b/core/lib/Thelia/Controller/Front/BaseFrontController.php
@@ -26,12 +26,16 @@ class BaseFrontController extends BaseController
 {
     public const CONTROLLER_TYPE = 'front';
 
-    protected string $currentRouter = 'router.front';
+    /**
+     * The front-office routes live in the default router: the theme declares them with
+     * #[Route], and so do the modules. Only the back office runs a router of its own.
+     */
+    protected string $currentRouter = 'router';
 
     public function checkAuth(): void
     {
         if (false === $this->getSecurityContext()->hasCustomerUser()) {
-            throw new RedirectException($this->retrieveUrlFromRouteId('customer.login.process'));
+            throw new RedirectException($this->retrieveUrlFromRouteId('customer_login'));
         }
     }
 
@@ -45,7 +49,7 @@ class BaseFrontController extends BaseController
         $cart = $this->getSession()->getSessionCart($eventDispatcher);
 
         if (null === $cart || 0 === $cart->countCartItems()) {
-            throw new RedirectException($this->retrieveUrlFromRouteId('cart.view'));
+            throw new RedirectException($this->retrieveUrlFromRouteId('checkout_cart'));
         }
     }
 
@@ -58,7 +62,7 @@ class BaseFrontController extends BaseController
             || null === $order->getDeliveryModuleId()
             || null === AddressQuery::create()->findPk($order->getChoosenDeliveryAddress())
             || null === ModuleQuery::create()->findPk($order->getDeliveryModuleId())) {
-            throw new RedirectException($this->retrieveUrlFromRouteId('order.delivery'));
+            throw new RedirectException($this->retrieveUrlFromRouteId('checkout_delivery'));
         }
     }
 
@@ -71,7 +75,7 @@ class BaseFrontController extends BaseController
             || null === $order->getPaymentModuleId()
             || null === AddressQuery::create()->findPk($order->getChoosenInvoiceAddress())
             || null === ModuleQuery::create()->findPk($order->getPaymentModuleId())) {
-            throw new RedirectException($this->retrieveUrlFromRouteId('order.invoice'));
+            throw new RedirectException($this->retrieveUrlFromRouteId('checkout_payment'));
         }
     }
 

--- a/tests/Integration/Controller/Front/BaseFrontControllerTest.php
+++ b/tests/Integration/Controller/Front/BaseFrontControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Controller\Front;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Thelia\Controller\Front\BaseFrontController;
+use Thelia\Core\HttpKernel\Exception\RedirectException;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The router service and the route identifiers BaseFrontController redirects to are plain
+ * strings, resolved only when a redirect is actually issued. Nothing reports a stale one
+ * until a visitor walks into it, so they are pinned here against the running container.
+ */
+final class BaseFrontControllerTest extends IntegrationTestCase
+{
+    public function testARedirectToAFrontRouteGoesThroughARouterTheContainerProvides(): void
+    {
+        $response = $this->controller()->redirectToCustomerLogin();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringEndsWith('/customer/login', $response->getTargetUrl());
+    }
+
+    public function testAnAnonymousVisitorIsSentToTheLoginPage(): void
+    {
+        $this->assertRedirectsTo('/customer/login', static fn (FrontControllerUnderTest $controller) => $controller->checkAuth());
+    }
+
+    public function testAnEmptyCartIsSentBackToTheCartPage(): void
+    {
+        $eventDispatcher = static::getContainer()->get('event_dispatcher');
+        self::assertInstanceOf(EventDispatcherInterface::class, $eventDispatcher);
+
+        $this->assertRedirectsTo(
+            '/checkout/cart',
+            static fn (FrontControllerUnderTest $controller) => $controller->guardCartNotEmpty($eventDispatcher),
+        );
+    }
+
+    public function testAnOrderWithoutADeliveryChoiceIsSentBackToTheDeliveryStep(): void
+    {
+        $this->assertRedirectsTo('/checkout/delivery', static fn (FrontControllerUnderTest $controller) => $controller->guardValidDelivery());
+    }
+
+    public function testAnOrderWithoutAPaymentChoiceIsSentBackToThePaymentStep(): void
+    {
+        $this->assertRedirectsTo('/checkout/payment', static fn (FrontControllerUnderTest $controller) => $controller->guardValidInvoice());
+    }
+
+    private function assertRedirectsTo(string $expectedPath, callable $guard): void
+    {
+        try {
+            $guard($this->controller());
+        } catch (RedirectException $redirect) {
+            self::assertStringEndsWith($expectedPath, $redirect->getUrl());
+
+            return;
+        }
+
+        self::fail(\sprintf('Expected a RedirectException towards "%s".', $expectedPath));
+    }
+
+    private function controller(): FrontControllerUnderTest
+    {
+        $container = static::getContainer();
+
+        $controller = new FrontControllerUnderTest();
+        $controller->container = $container;
+        $controller->securityContext = $container->get(SecurityContext::class);
+        $controller->requestStack = $container->get('request_stack');
+
+        return $controller;
+    }
+}
+
+/**
+ * Stands in for the front controller of a module: it inherits the wiring under test
+ * and only widens the visibility of what it exercises.
+ */
+final class FrontControllerUnderTest extends BaseFrontController
+{
+    public function redirectToCustomerLogin(): RedirectResponse
+    {
+        return $this->generateRedirectFromRoute('customer_login');
+    }
+
+    public function guardCartNotEmpty(EventDispatcherInterface $eventDispatcher): void
+    {
+        $this->checkCartNotEmpty($eventDispatcher);
+    }
+
+    public function guardValidDelivery(): void
+    {
+        $this->checkValidDelivery();
+    }
+
+    public function guardValidInvoice(): void
+    {
+        $this->checkValidInvoice();
+    }
+}


### PR DESCRIPTION
`Thelia\Controller\Front\BaseFrontController` still named identifiers from the Thelia 2
front-office wiring. None of them exists on a Thelia 3 install, and each one is resolved
by string at call time, so the container compiles and the routes build without complaint:
the failure only surfaces when a visitor reaches the redirect.

- `$currentRouter` pointed at `router.front`. Thelia 3 registers `router` (the default
  router, where the theme and the modules declare their `#[Route]` front routes) and
  `router.admin`. Every `generateRedirectFromRoute()` and `retrieveUrlFromRouteId()` call
  from a front controller therefore threw `ServiceNotFoundException`. `router` is the
  right target: the chain router is private and inlined, and the admin router only carries
  `/admin` routes.
- `checkAuth()` redirected to `customer.login.process`; the route is `customer_login`.
- `checkCartNotEmpty()`, `checkValidDelivery()` and `checkValidInvoice()` redirected to
  `cart.view`, `order.delivery` and `order.invoice`; the checkout steps are
  `checkout_cart`, `checkout_delivery` and `checkout_payment`.

This is a base class, so the defects were not specific to one module, and both paths are
easy to miss: a redirect issued after a form is processed, and the "please log in first"
branch an anonymous visitor takes. `BasePaymentModuleController` extends this class and
gets the router fix with it.

## How it was tested

`tests/Integration/Controller/Front/BaseFrontControllerTest.php` drives a stand-in module
front controller against the running container and pins the five redirects. Each test was
checked failing before the fix: all five on `ServiceNotFoundException: router.front`, then
— with the router service alone repaired — one per stale route id
(`RouteNotFoundException` for `customer.login.process`, `cart.view`, `order.delivery`,
`order.invoice`).

Also verified over HTTP on a fresh install with demo data: a controller extending
`BaseFrontController` answered 500 on both an anonymous `checkAuth()` and a
`generateRedirectFromRoute()`, and answers 302 to `/customer/login` with the fix.

`composer cs-diff` and `composer phpstan` are clean. The suites are unchanged apart from
the five added tests; three failures on `main` at `e00296004` are pre-existing and
unrelated (the `local/config` schema release lag, which also has CI red, and two company
address validation tests).

Fixes #3797
