### PR TITLE
fix: render a mail message that has no template file with the default parser

### DIFF
--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -172,7 +172,7 @@ class MailerFactory
         // that existence test miss the real file and fall back to the wrong engine.
         $templateFileName = (string) ($message->getHtmlTemplateFileName() ?: $message->getTextTemplateFileName());
         $parser = $this->getParser(
-            '' !== $templateFileName ? pathinfo($templateFileName, \PATHINFO_FILENAME) : $messageCode
+            '' !== $templateFileName ? pathinfo($templateFileName, \PATHINFO_FILENAME) : null
         );
         // Assign parameters
         foreach ($messageParameters as $name => $value) {
@@ -316,10 +316,16 @@ class MailerFactory
     /**
      * @throws \Exception
      */
-    protected function getParser(string $template): ParserInterface
+    protected function getParser(?string $template): ParserInterface
     {
+        // A message with no template file at all renders from its database-stored body,
+        // so there is no file for a parser to claim: asking the resolver for one would
+        // report a missing resource, and sendEmailMessage() would swallow it — the mail
+        // silently lost. The default parser renders the stored body instead.
         $path = $this->templateHelper->getActiveMailTemplate()->getAbsolutePath();
-        $parser = $this->parserResolver->getParser($path, $template);
+        $parser = null === $template
+            ? $this->parserResolver->getDefaultParser()
+            : $this->parserResolver->getParser($path, $template);
 
         $parser->setTemplateDefinition(
             $parser->getTemplateDefinition() ?: $this->templateHelper->getActiveMailTemplate()

--- a/tests/Integration/Mailer/MailerFactoryTest.php
+++ b/tests/Integration/Mailer/MailerFactoryTest.php
@@ -17,6 +17,7 @@ namespace Thelia\Tests\Integration\Mailer;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\MailerInterface;
 use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Template\Exception\ResourceNotFoundException;
 use Thelia\Core\Template\Parser\ParserResolver;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateHelperInterface;
@@ -231,6 +232,43 @@ final class MailerFactoryTest extends IntegrationTestCase
         self::assertSame('fr_FR', $session->getLang()->getLocale());
     }
 
+    public function testAMessageWithoutATemplateFileRendersItsStoredBody(): void
+    {
+        // No template file at all: the message renders from its database-stored body, so
+        // there is no file for a parser to claim. Resolving a parser from the message code
+        // reports a missing resource, and sendEmailMessage() would swallow it: the mail is
+        // silently lost. The default parser has to render the stored body instead.
+        $message = new Message();
+        $message->setName('test_body_only_message');
+        $message->setLocale('en_US');
+        $message->setSubject('Subject');
+        $message->setHtmlMessage('<p>Stored body</p>');
+        $message->setTextMessage('Stored body');
+        $message->save();
+
+        $parser = $this->createMock(ParserInterface::class);
+        $parser->method('getRequest')->willReturn($this->getService(RequestStack::class)->getMainRequest());
+        $parser->method('getTemplateHelper')->willReturn($this->getService(TemplateHelperInterface::class));
+        $parser->method('renderString')->willReturnArgument(0);
+
+        $mailerFactory = new MailerFactory(
+            $this->getService(TemplateHelperInterface::class),
+            $this->createParserResolverWhereNoParserClaimsAView($parser),
+            $this->getService(MailerInterface::class),
+        );
+
+        $email = $mailerFactory->createEmailMessage(
+            'test_body_only_message',
+            ['sender@example.com' => 'Sender'],
+            ['recipient@example.com' => 'Recipient'],
+            [],
+            'en_US',
+        );
+
+        self::assertSame('<p>Stored body</p>', $email->getHtmlBody());
+        self::assertSame('Stored body', $email->getTextBody());
+    }
+
     public function testSendDoesNotThrowWithNullTransport(): void
     {
         $email = $this->mailerFactory->createSimpleEmailMessage(
@@ -247,6 +285,34 @@ final class MailerFactoryTest extends IntegrationTestCase
         self::assertTrue(true);
     }
 
+    /**
+     * The situation of an install whose parsers all verify that a template file exists
+     * (the Twig parser always did, the Smarty parser does since TheliaSmarty 3.0.1): a
+     * view no theme ships is claimed by nobody, and only getDefaultParser() answers.
+     */
+    private function createParserResolverWhereNoParserClaimsAView(ParserInterface $defaultParser): ParserResolver
+    {
+        return new class($this->getService(RequestStack::class), $this->getService(TemplateHelperInterface::class), $defaultParser) extends ParserResolver {
+            public function __construct(
+                RequestStack $requestStack,
+                TemplateHelperInterface $templateHelper,
+                private readonly ParserInterface $defaultParser,
+            ) {
+                parent::__construct([], [], $requestStack, $templateHelper);
+            }
+
+            public function getParser(string $pathTemplate, ?string $templateName): ParserInterface
+            {
+                throw new ResourceNotFoundException(\sprintf('Parser for template %s not found', $templateName));
+            }
+
+            public function getDefaultParser(): ParserInterface
+            {
+                return $this->defaultParser;
+            }
+        };
+    }
+
     private function createParserResolverReturning(ParserInterface $parser): ParserResolver
     {
         return new class($this->getService(RequestStack::class), $this->getService(TemplateHelperInterface::class), $parser) extends ParserResolver {
@@ -259,6 +325,11 @@ final class MailerFactoryTest extends IntegrationTestCase
             }
 
             public function getParser(string $pathTemplate, ?string $templateName): ParserInterface
+            {
+                return $this->parser;
+            }
+
+            public function getDefaultParser(): ParserInterface
             {
                 return $this->parser;
             }


### PR DESCRIPTION
## What

A mail message may carry no template file at all and render from its database-stored body — the demo data ships one (`order_confirmation_cheque`). `MailerFactory::createEmailMessage()` resolved a parser from the message code in that case, asking the parser resolver for a view no theme ships.

On an install whose parsers all verify that a template file exists — the Twig parser always did, the Smarty parser does since thelia-modules/TheliaSmarty#12 — no parser claims the code, the resolver reports a missing resource, `sendEmailMessage()` swallows it, and the mail is silently lost.

## Fix

When the message has no template file, use `ParserResolver::getDefaultParser()` to render the stored body instead of resolving a parser from a view name that cannot exist. Messages with a template file keep resolving the engine from the file name, unchanged.

## Tests

- New integration test proving a body-only message builds its Email through the default parser; verified failing before the fix with `ResourceNotFoundException: Parser for template test_body_only_message not found`.
- `MailerFactoryTest` 7/7 green, integration suite 627 green, unit 383 green, `composer cs-diff` and `composer phpstan` at 0.

Note: the api suite currently fails on 4 pre-existing `AddressApiTest` cases introduced by #3798, unrelated to this change.

Related to #3788.