### PR TITLE
fix: keep the separators of a rewritten url that spells out a path

### DIFF
--- a/core/lib/Thelia/Model/RewritingUrl.php
+++ b/core/lib/Thelia/Model/RewritingUrl.php
@@ -98,12 +98,20 @@ class RewritingUrl extends BaseRewritingUrl
         return preg_replace('/-+/', $replacement, $string) ?? $string;
     }
 
+    /**
+     * A rewritten url is a path, not a single segment: the slash separates the
+     * levels a shop nests its content under, and dropping it silently welds two
+     * segments into one, so the url the visitor and the sitemap were given
+     * answers 404 while an address nobody asked for takes its place. Kept out of
+     * the default character class for that reason; a project that wants flat
+     * urls can still forbid it through the configuration key.
+     */
     protected function replaceSpecialCharacter(string $string, string $replacement = ''): string
     {
         return preg_replace(
             '/'.ConfigQuery::read(
                 self::SPECIAL_CHARS_REGEXP_CONFIG_KEY,
-                '[^a-zA-Z0-9-\.]'
+                '[^a-zA-Z0-9-\.\/]'
             ).'/',
             $replacement,
             $string

--- a/tests/Integration/Core/Routing/UrlRewritingTest.php
+++ b/tests/Integration/Core/Routing/UrlRewritingTest.php
@@ -235,4 +235,17 @@ final class UrlRewritingTest extends IntegrationTestCase
             ->count();
         self::assertSame(0, $countAfter);
     }
+
+    public function testAHierarchicalUrlKeepsItsSeparators(): void
+    {
+        // A shop nesting its content answers on a path, and the address it was
+        // given has to be the address it is stored under: dropping the slash
+        // welds "guides/summer" into "guidessummer", so the url handed to the
+        // visitor, the sitemap and the search engine answers 404.
+        $category = $this->createCategoryWithTitle('Summer Guide');
+        $category->setRewrittenUrl('en_US', 'guides/summer');
+
+        self::assertSame('guides/summer', $category->getRewrittenUrl('en_US'));
+        self::assertNotNull(RewritingUrlQuery::create()->findOneByUrl('guides/summer'));
+    }
 }


### PR DESCRIPTION
`RewritingUrl::preInsert()` sanitises the url before storing it, and the default character class it applies (`[^a-zA-Z0-9-\.]`) removes the slash. Every url that spells out a path therefore lost its separators on the way in.

Measured on a content site: a page answering on `guides/summer` was stored as `guidessummer`. The url given back to the visitor, written into the sitemap and handed to the search engine answers 404, while an address nobody asked for takes its place. Moving or renaming a parent renames the whole branch the same way, so a single save flattens a subtree.

The slash joins the character class. Nothing else of the sanitiser changes: accents are still folded, spaces still become hyphens, and the result is still lowercased. A project that wants flat urls can still forbid the slash through `admin.url.sanitizer.special.chars.regexp.config.key`.

`testAHierarchicalUrlKeepsItsSeparators` covers it, and was checked red against the current code (`guidessummer`).
