### PR TITLE
fix: widen a feature filter when several of its values are checked

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
@@ -44,22 +44,29 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
     public function filter(ModelCriteria $query, $value, bool $isMinOrMaxFilter = false, ?int $categoryDepth = null): void
     {
         if (!$isMinOrMaxFilter) {
-            foreach ($value as $featureId => $childValue) {
-                foreach ($childValue as $type => $featureAvId) {
-                    $count = FeatureAvQuery::create()
-                        ->filterById($featureAvId, Criteria::IN)
-                        ->withColumn('COUNT(DISTINCT feature_id)', 'distinct_feature_count')
-                        ->select(['distinct_feature_count'])
-                        ->findOne();
+            $featureAvIds = $this->flattenSelectedValues($value);
 
-                    $query
-                        ->useFeatureProductQuery()
-                        ->filterByFeatureAvId($featureAvId, Criteria::IN)
-                        ->endUse()
-                        ->groupBy(FeatureProductTableMap::COL_PRODUCT_ID)
-                        ->having('COUNT(DISTINCT '.FeatureProductTableMap::COL_FEATURE_ID.') = ?', $count);
-                }
+            if ($featureAvIds === []) {
+                return;
             }
+
+            // Every identifier selected across every feature goes into a single IN, and the
+            // HAVING then asks a product to carry as many distinct features as were selected.
+            // Two values of the same feature widen the match (they count as one feature), values
+            // of two different features narrow it. Applying one IN per value instead would put
+            // two mutually exclusive conditions on the same join and match nothing.
+            $count = FeatureAvQuery::create()
+                ->filterById($featureAvIds, Criteria::IN)
+                ->withColumn('COUNT(DISTINCT feature_id)', 'distinct_feature_count')
+                ->select(['distinct_feature_count'])
+                ->findOne();
+
+            $query
+                ->useFeatureProductQuery()
+                ->filterByFeatureAvId($featureAvIds, Criteria::IN)
+                ->endUse()
+                ->groupBy(FeatureProductTableMap::COL_PRODUCT_ID)
+                ->having('COUNT(DISTINCT '.FeatureProductTableMap::COL_FEATURE_ID.') = ?', $count);
 
             return;
         }
@@ -78,6 +85,29 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
                     ->endUse();
             }
         }
+    }
+
+    /**
+     * The feature availability identifiers held by a [featureId => values] selection, whatever
+     * the depth the query string nested them at.
+     *
+     * @return array<int, int|string>
+     */
+    private function flattenSelectedValues(mixed $value): array
+    {
+        $featureAvIds = [];
+
+        foreach ((array) $value as $childValue) {
+            foreach ((array) $childValue as $featureAvId) {
+                if (\is_array($featureAvId) || $featureAvId === null || $featureAvId === '') {
+                    continue;
+                }
+
+                $featureAvIds[] = $featureAvId;
+            }
+        }
+
+        return array_values(array_unique($featureAvIds));
     }
 
     public function getValue(ActiveRecordInterface $activeRecord, string $locale, $valueSearched = null, ?int $depth = 1): ?array

--- a/tests/Integration/Api/FeatureFilterSelectionTest.php
+++ b/tests/Integration/Api/FeatureFilterSelectionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Model\Feature;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Two values checked inside one feature ask for either of them; values checked across two
+ * features ask for both. A shopper who checks "Blue" and then "Red" expects more products,
+ * never an empty list.
+ */
+final class FeatureFilterSelectionTest extends IntegrationTestCase
+{
+    private const BLUE_PRODUCT = 'FEAT-BLUE';
+    private const RED_PRODUCT = 'FEAT-RED';
+    private const BLUE_FRENCH_PRODUCT = 'FEAT-BLUE-FRENCH';
+    private const FRENCH_PRODUCT = 'FEAT-FRENCH';
+
+    private FilterService $filterService;
+
+    /** @var array<string, int> */
+    private array $featureAvIds = [];
+
+    /** @var array<string, int> product reference => id, in creation order */
+    private array $productIds = [];
+
+    private int $colourId = 0;
+    private int $originId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filterService = static::getContainer()->get(FilterService::class);
+        $this->createCatalogue();
+    }
+
+    public function testOneCheckedValueKeepsTheProductsHoldingIt(): void
+    {
+        self::assertSame(
+            [self::BLUE_PRODUCT, self::BLUE_FRENCH_PRODUCT],
+            $this->matchingReferences([$this->colourId => [$this->featureAvIds['blue']]]),
+        );
+    }
+
+    public function testTwoCheckedValuesOfTheSameFeatureWidenTheSelection(): void
+    {
+        self::assertSame(
+            [self::BLUE_PRODUCT, self::RED_PRODUCT, self::BLUE_FRENCH_PRODUCT],
+            $this->matchingReferences([
+                $this->colourId => [
+                    $this->featureAvIds['blue'],
+                    $this->featureAvIds['red'],
+                ],
+            ]),
+        );
+    }
+
+    public function testCheckedValuesOfTwoFeaturesNarrowTheSelection(): void
+    {
+        self::assertSame(
+            [self::BLUE_FRENCH_PRODUCT],
+            $this->matchingReferences([
+                $this->colourId => [$this->featureAvIds['blue']],
+                $this->originId => [$this->featureAvIds['french']],
+            ]),
+        );
+    }
+
+    /**
+     * @param array<int, list<int>> $selection feature id => checked value ids
+     *
+     * @return list<string> the references of the matching products, in creation order
+     */
+    private function matchingReferences(array $selection): array
+    {
+        // Restricted to the products this test created: the filter is what is under test,
+        // not whatever else the database holds.
+        $query = ProductQuery::create()->filterById(array_values($this->productIds), Criteria::IN);
+
+        $filtered = $this->filterService->filterWithTFilter(
+            tfilters: ['feature' => $selection],
+            resource: 'products',
+            query: $query,
+        );
+
+        $matched = [];
+
+        foreach ($filtered->find($this->getPropelConnection()) as $product) {
+            $matched[] = (int) $product->getId();
+        }
+
+        return array_keys(array_filter(
+            $this->productIds,
+            static fn (int $id): bool => \in_array($id, $matched, true),
+        ));
+    }
+
+    private function createCatalogue(): void
+    {
+        $factory = $this->createFixtureFactory();
+
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $colour = $factory->feature(['title' => 'Colour']);
+        $origin = $factory->feature(['title' => 'Origin']);
+        $this->colourId = (int) $colour->getId();
+        $this->originId = (int) $origin->getId();
+
+        $blue = $factory->featureAv($colour, ['title' => 'Blue']);
+        $red = $factory->featureAv($colour, ['title' => 'Red']);
+        $french = $factory->featureAv($origin, ['title' => 'France']);
+
+        $this->featureAvIds = [
+            'blue' => (int) $blue->getId(),
+            'red' => (int) $red->getId(),
+            'french' => (int) $french->getId(),
+        ];
+
+        $catalogue = [
+            self::BLUE_PRODUCT => [[$colour, $blue]],
+            self::RED_PRODUCT => [[$colour, $red]],
+            self::BLUE_FRENCH_PRODUCT => [[$colour, $blue], [$origin, $french]],
+            self::FRENCH_PRODUCT => [[$origin, $french]],
+        ];
+
+        foreach ($catalogue as $reference => $heldValues) {
+            $product = $factory->product($category, $taxRule, $currency, ['ref' => $reference]);
+            $this->productIds[$reference] = (int) $product->getId();
+
+            foreach ($heldValues as [$feature, $featureAv]) {
+                $this->holdValue($product, $feature, (int) $featureAv->getId());
+            }
+        }
+    }
+
+    private function holdValue(Product $product, Feature $feature, int $featureAvId): void
+    {
+        $featureProduct = new FeatureProduct();
+        $featureProduct->setProductId($product->getId());
+        $featureProduct->setFeatureId($feature->getId());
+        $featureProduct->setFeatureAvId($featureAvId);
+        $featureProduct->save($this->getPropelConnection());
+    }
+}


### PR DESCRIPTION
## Problem

On a product listing, checking two values of the same feature empties the list instead of
widening it. Checking one value in each of two features empties it too.

`FeatureAvFilter::filter()` walks the selection value by value and adds one condition per
value, all of them on the same `feature_product` join. Two conditions on one join are
`AND`-ed, so the query asks a single `feature_product` row to hold two different
`feature_av_id` at once, and no row can.

## Reproduction

Catalogue: feature *Colour* with values *Blue* and *Red*, feature *Origin* with value
*France*. Four products: one Blue, one Red, one Blue + France, one France.

```
GET /api/front/products?tfilters[feature][<colour>][]=<blue>&tfilters[feature][<colour>][]=<red>
```

| selection | expected | before |
|---|---|---|
| Blue | Blue, Blue+France | Blue, Blue+France |
| Blue, Red | Blue, Red, Blue+France | *(empty)* |
| Blue + France (two features) | Blue+France | *(empty)* |

The generated SQL, before:

```sql
... INNER JOIN feature_product ON (product.id = feature_product.product_id)
WHERE feature_product.feature_av_id IN (40) AND feature_product.feature_av_id IN (42)
GROUP BY feature_product.product_id, feature_product.product_id, product.id
HAVING COUNT(DISTINCT feature_product.feature_id) = 1
```

The `HAVING` count also came from the last value visited only, and the `GROUP BY` gained a
duplicate column per value.

## Fix

Collect every checked identifier, all features together, into a single `IN`, and let the
`HAVING COUNT(DISTINCT feature_id)` already in place arbitrate: the count is the number of
distinct features the selection spans, so two values of one feature count as one feature and
widen the match, while values of two features narrow it.

```sql
WHERE feature_product.feature_av_id IN (43, 45)
GROUP BY feature_product.product_id, product.id
HAVING COUNT(DISTINCT feature_product.feature_id) = 2
```

This is the semantics Thelia 2 exposed through the `product` loop's
`feature_availability="7:53,54"` argument: `OR` inside a feature, `AND` between features.

The helper that flattens the selection tolerates the shapes a query string can produce
(nested one or two levels deep, empty strings, unexpected arrays) and drops duplicates.

## Test

`tests/Integration/Api/FeatureFilterSelectionTest.php` covers the three rows of the table
above. Two of its three cases fail on `main` without the fix; all three pass with it.

## Limitation, unchanged by this PR

`FilterService::isMinOrMaxFilter()` decides the bound mode (`min`/`max`) for the whole
feature batch as soon as one feature carries a bound. Mixing a slider feature and a checkbox
feature in the same request is therefore still wrong, before and after this change. Left
alone here: it is a separate decision about how the batch is split.

## Not to be confused with #3648

Issue #3648 (closed by #3653) was the cost of *building* the facet list on a large catalogue.
This PR changes the query the *checked* values produce. Facet aggregation is untouched, and
the query count measured by `TFiltersQueryCountTest` does not move.

## Checks

`composer cs-diff` 0 · `composer phpstan` 0 · `composer test` green on the five suites
(unit, integration, api with its single pre-existing skip, http-flexy, http-backoffice with
its two pre-existing deprecations).
