### PR TITLE
fix: stop paying sql for api data the serializer discards

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Attribute/Relation.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Attribute/Relation.php
@@ -17,12 +17,19 @@ namespace Thelia\Api\Bridge\Propel\Attribute;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class Relation
 {
+    /**
+     * @param bool $hydrateOutOfGroups reads the relation even when no group of the
+     *                                 current context serializes it. Only a resource
+     *                                 computing another of its fields from that
+     *                                 relation needs it, and it costs a query per row.
+     */
     public function __construct(
         private readonly string $targetResource,
         private readonly ?string $relationAlias = null,
         private readonly ?array $propertyGroups = [],
         private readonly ?bool $forceJoin = null,
         private readonly ?array $excludedGroups = [],
+        private readonly bool $hydrateOutOfGroups = false,
     ) {
     }
 }

--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Bridge\Propel\Service;
 
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Put;
@@ -523,15 +525,7 @@ readonly class ApiResourcePropelTransformerService
         Collection $langs,
     ): void {
         foreach ($reflector->getProperties() as $property) {
-            if (
-                !$this->checkGroupsSerialization(property: $property, context: $context)
-                && $this->isGroupsExcluded(property: $property, context: $context)
-            ) {
-                // This condition prevents circular references during resource serialization,
-                // avoiding infinite recursion. To make this work, you need to use the
-                // `excludedGroups` attribute on the related resource (e.g.:
-                // #[Relation(targetResource: SelectionContainer::class, excludedGroups: [SelectionContainer::GROUP_READ])])
-                // to exclude problematic serialization groups and break the circular dependency.
+            if (!$this->shouldHydrateRelation(property: $property, reflector: $reflector, context: $context)) {
                 continue;
             }
             $defaultGetter = 'get'.ucfirst($property->getName());
@@ -795,6 +789,55 @@ readonly class ApiResourcePropelTransformerService
                 $query->{$filterMethod}($value);
             }
         }
+    }
+
+    /**
+     * Reading a relation costs a query, and the serializer only ever returns the
+     * properties of the current groups: walking the others buys rows nobody
+     * looks at. A front product collection paid one read of attribute_combination
+     * per sale element for a payload that names none.
+     *
+     * `excludedGroups` still cuts a relation the groups do select, which is how a
+     * circular reference between two resources is broken. `hydrateOutOfGroups`
+     * does the opposite for the rare relation a resource computes one of its own
+     * fields from.
+     *
+     * Properties that are not relations are left alone: they cost nothing to read
+     * and some of them are set for reasons the groups do not describe.
+     */
+    private function shouldHydrateRelation(\ReflectionProperty $property, \ReflectionClass $reflector, array $context): bool
+    {
+        $relationAttribute = $property->getAttributes(Relation::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+
+        if (null === $relationAttribute || !isset($context['groups'])) {
+            return true;
+        }
+
+        if (true === ($relationAttribute->getArguments()['hydrateOutOfGroups'] ?? false)) {
+            return true;
+        }
+
+        // A write reads the resource to validate it, and its validation groups are
+        // not the groups of the response it answers with: the state provider has to
+        // hand over the whole resource. Only a read can be trimmed to what it returns.
+        $operation = $context['operation'] ?? null;
+
+        if ($operation instanceof Operation && !$operation instanceof Get && !$operation instanceof GetCollection) {
+            return true;
+        }
+
+        // A resource identified by its relations builds its own IRI out of them,
+        // so they are read whatever the groups return.
+        if (\in_array(
+            $property->getName(),
+            $this->getResourceCompositeIdentifierValues(reflector: $reflector, param: 'keys'),
+            true,
+        )) {
+            return true;
+        }
+
+        return $this->checkGroupsSerialization(property: $property, context: $context)
+            && !$this->isGroupsExcluded(property: $property, context: $context);
     }
 
     private function checkGroupsSerialization(\ReflectionProperty $property, array $context): bool

--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -129,12 +129,23 @@ readonly class ApiResourcePropelTransformerService
 
         if ($withAddon) {
             foreach ($this->getResourceAddonDefinitions($resourceClass) as $addonShortName => $addonClass) {
-                if (is_subclass_of($addonClass, ResourceAddonInterface::class)) {
-                    $addon = (new $addonClass())
-                        ->setContext($context)
-                        ->buildFromModel($propelModel, $apiResource);
-                    $apiResource->setResourceAddon($addonShortName, $addon);
+                if (!is_subclass_of($addonClass, ResourceAddonInterface::class)) {
+                    continue;
                 }
+
+                /** @var ResourceAddonInterface $addon */
+                $addon = (new $addonClass())->setContext($context);
+
+                // An addon resolves its own rows, and the serializer returns it only
+                // when one of its properties belongs to the current groups. Building
+                // it out of them bought a query per row for a payload that never
+                // mentions the addon. It is still attached, so nothing reading it
+                // through the resource finds a hole where the addon used to be.
+                if ($this->hasPropertyInGroups($addonClass, $context)) {
+                    $addon = $addon->buildFromModel($propelModel, $apiResource);
+                }
+
+                $apiResource->setResourceAddon($addonShortName, $addon);
             }
         }
 
@@ -838,6 +849,28 @@ readonly class ApiResourcePropelTransformerService
 
         return $this->checkGroupsSerialization(property: $property, context: $context)
             && !$this->isGroupsExcluded(property: $property, context: $context);
+    }
+
+    /**
+     * Mirrors what the serializer keeps of an addon: its attribute carries the
+     * groups of all of its own properties (see ClassMetaDataFactory), so it is
+     * returned as soon as one of them is in the context.
+     *
+     * @param class-string $class
+     */
+    private function hasPropertyInGroups(string $class, array $context): bool
+    {
+        if (!isset($context['groups'])) {
+            return true;
+        }
+
+        foreach ((new \ReflectionClass($class))->getProperties() as $property) {
+            if ($this->checkGroupsSerialization(property: $property, context: $context)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function checkGroupsSerialization(\ReflectionProperty $property, array $context): bool

--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -699,10 +699,12 @@ readonly class ApiResourcePropelTransformerService
                 $virtualColumn = ltrim(strtolower($parentReflector?->getShortName().'_'.$reflector->getShortName()).'_lang_'.$lang->getLocale().'_'.$i18nFieldName, '_');
 
                 if ($baseModel->hasVirtualColumn($virtualColumn)) {
+                    // The query left-joined every active language, so an empty column
+                    // is an answer: that language has no translation. Reading it as
+                    // "not loaded yet" sent one query per row and per language after a
+                    // row that is not there.
                     $fieldValue = $baseModel->getVirtualColumn($virtualColumn);
-                }
-
-                if (null === $fieldValue) {
+                } else {
                     $propelModel->setlocale($lang->getLocale());
                     $getter = 'get'.ucfirst($i18nFieldName);
 

--- a/core/lib/Thelia/Api/Resource/Address.php
+++ b/core/lib/Thelia/Api/Resource/Address.php
@@ -211,7 +211,9 @@ class Address implements PropelResourceInterface
 
     // The front never sets the owner: CustomerAddressProcessor takes it from
     // the token, so an account endpoint cannot write into another address book.
-    #[Relation(targetResource: Customer::class)]
+    // hydrateOutOfGroups: the account endpoints check `object.customer` before
+    // answering, and no front group returns the owner.
+    #[Relation(targetResource: Customer::class, hydrateOutOfGroups: true)]
     #[Groups(groups: [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_READ_SINGLE, self::GROUP_ADMIN_WRITE])]
     public Customer $customer;
 

--- a/core/lib/Thelia/Api/Resource/Order.php
+++ b/core/lib/Thelia/Api/Resource/Order.php
@@ -246,7 +246,9 @@ class Order implements PropelResourceInterface
     #[Column(propelSetter: 'setStatusId')]
     public OrderStatus $orderStatus;
 
-    #[Relation(targetResource: Customer::class)]
+    // hydrateOutOfGroups: the account endpoints check `object.customer` -- an order
+    // read through one of its lines carries the groups of the line, not its own.
+    #[Relation(targetResource: Customer::class, hydrateOutOfGroups: true)]
     #[NotBlank(groups: [self::GROUP_ADMIN_WRITE])]
     #[Groups([self::GROUP_ADMIN_READ_SINGLE, self::GROUP_ADMIN_WRITE, self::GROUP_FRONT_READ_SINGLE])]
     public Customer $customer;

--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -112,7 +112,9 @@ class OrderProduct implements PropelResourceInterface
     ])]
     public ?int $id = null;
 
-    #[Relation(targetResource: Order::class)]
+    // hydrateOutOfGroups: the account endpoint checks `object.order.customer`
+    // before answering with a line.
+    #[Relation(targetResource: Order::class, hydrateOutOfGroups: true)]
     #[Groups([self::GROUP_ADMIN_READ_SINGLE, self::GROUP_FRONT_READ])]
     public Order $order;
 
@@ -654,35 +656,35 @@ class OrderProduct implements PropelResourceInterface
 
     public function afterModelToResource(array $context): void
     {
-        if (isset($context['operation']) && ($context['operation'] instanceof Get || $context['operation'] instanceof GetCollection)) {
-            // unitTaxedPrice
-            $totalTax = 0;
-            $totalPromoTax = 0;
+        $operation = $context['operation'] ?? null;
 
-            if ([] !== $this->orderProductTaxes) {
-                /** @var OrderProductTax $orderProductTax */
-                foreach ($this->orderProductTaxes as $orderProductTax) {
-                    /** @var \Thelia\Model\OrderProductTax $orderProductTax */
-                    $propelOrderProductTax = $orderProductTax->getPropelModel();
-
-                    if (!$this->getPropelModel()->getWasInPromo()) {
-                        $totalTax += (float) $propelOrderProductTax->getAmount();
-                    }
-
-                    if ($this->getPropelModel()->getWasInPromo()) {
-                        $totalPromoTax += (float) $propelOrderProductTax->getPromoAmount();
-                    }
-                }
-
-                if (!$this->getPropelModel()->getWasInPromo()) {
-                    $this->unitTaxedPrice = $this->getPropelModel()->getPrice() + $totalTax;
-                }
-
-                if ($this->getPropelModel()->getWasInPromo()) {
-                    $this->unitTaxedPrice = $this->getPropelModel()->getPrice() + $totalPromoTax;
-                }
-            }
+        if (!$operation instanceof Get && !$operation instanceof GetCollection) {
+            return;
         }
+
+        $propelModel = $this->getPropelModel();
+
+        if (!$propelModel instanceof OrderProductModel) {
+            return;
+        }
+
+        // The taxes are read from the model, not from $orderProductTaxes: that
+        // relation belongs to the single read only, while unitTaxedPrice is
+        // returned by the collections too.
+        $taxes = $propelModel->getOrderProductTaxes();
+
+        if (0 === $taxes->count()) {
+            return;
+        }
+
+        $wasInPromo = (bool) $propelModel->getWasInPromo();
+        $totalTax = 0.0;
+
+        foreach ($taxes as $tax) {
+            $totalTax += (float) ($wasInPromo ? $tax->getPromoAmount() : $tax->getAmount());
+        }
+
+        $this->unitTaxedPrice = (float) $propelModel->getPrice() + $totalTax;
     }
 
     public static function getPropelRelatedTableMap(): ?TableMap

--- a/core/lib/Thelia/Test/Trait/RecordsSqlQueries.php
+++ b/core/lib/Thelia/Test/Trait/RecordsSqlQueries.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Test\Trait;
+
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Psr\Log\AbstractLogger;
+
+/**
+ * Records the SQL statements a piece of code makes the database run.
+ *
+ * A test asserting on that list measures the shape of the work, not its wall
+ * time: a page that reads one row per product costs one query more per product
+ * added to the catalogue, and no timing threshold says that out loud.
+ */
+trait RecordsSqlQueries
+{
+    /**
+     * @return list<string> the statements the Thelia connection ran while $work executed
+     */
+    protected function recordSqlQueries(callable $work): array
+    {
+        $connection = $this->getPropelConnection();
+
+        if (!$connection instanceof ConnectionWrapper) {
+            self::fail('The Thelia connection does not expose Propel\'s query log.');
+        }
+
+        $collector = new class extends AbstractLogger {
+            /** @var list<string> */
+            public array $statements = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->statements[] = (string) $message;
+            }
+        };
+
+        $wasInDebugMode = $connection->isInDebugMode();
+        $connection->setLogger($collector);
+        $connection->useDebug(true);
+
+        try {
+            $work();
+        } finally {
+            $connection->useDebug($wasInDebugMode);
+        }
+
+        return $collector->statements;
+    }
+
+    /**
+     * Counts the statements reading a table on their own, which is what a
+     * relation loaded row by row looks like. A statement joining that table
+     * to another one does not match: it is a single read, not a series.
+     *
+     * @param list<string> $statements
+     */
+    protected static function countSqlQueriesSelectingFrom(array $statements, string $table): int
+    {
+        return \count(
+            array_filter(
+                $statements,
+                static fn (string $statement): bool => str_contains($statement, 'FROM `'.$table.'`'),
+            ),
+        );
+    }
+}

--- a/tests/Api/Admin/OrderProductUnitTaxedPriceApiTest.php
+++ b/tests/Api/Admin/OrderProductUnitTaxedPriceApiTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Admin;
+
+use Thelia\Model\OrderProduct;
+use Thelia\Model\OrderProductTax;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * An order line returns the price it was taxed at, and that figure is a sum of
+ * its tax rows. The rows themselves belong to the single read, the sum to the
+ * collections too: the computation has to reach the taxes without depending on
+ * the relation the serializer hydrated for the payload.
+ */
+final class OrderProductUnitTaxedPriceApiTest extends ApiTestCase
+{
+    private const UNIT_PRICE = 12.5;
+
+    private const UNIT_TAX = 2.25;
+
+    public function testTheCollectionReturnsTheUnitTaxedPrice(): void
+    {
+        $orderProduct = $this->taxedOrderLine();
+        $token = $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest(
+            'GET',
+            '/api/admin/order_products?id='.$orderProduct->getId(),
+            token: $token,
+        );
+
+        self::assertJsonResponseSuccessful($response);
+        $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+        $member = $payload['hydra:member'][0] ?? null;
+
+        self::assertNotNull($member, 'The collection must return the order line under test.');
+        self::assertArrayNotHasKey('orderProductTaxes', $member);
+        self::assertSame(self::UNIT_PRICE + self::UNIT_TAX, $member['unitTaxedPrice']);
+    }
+
+    public function testTheSingleReadReturnsBothTheTaxesAndTheUnitTaxedPrice(): void
+    {
+        $orderProduct = $this->taxedOrderLine();
+        $token = $this->authenticateAsAdmin();
+
+        $response = $this->jsonRequest(
+            'GET',
+            '/api/admin/order_products/'.$orderProduct->getId(),
+            token: $token,
+        );
+
+        self::assertJsonResponseSuccessful($response);
+        $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        self::assertCount(1, $payload['orderProductTaxes'] ?? []);
+        self::assertSame(self::UNIT_PRICE + self::UNIT_TAX, $payload['unitTaxedPrice']);
+    }
+
+    private function taxedOrderLine(): OrderProduct
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+        $order = $factory->order();
+
+        $orderProduct = new OrderProduct();
+        $orderProduct->setOrderId($order->getId());
+        $orderProduct->setProductRef('ORDER-PROD-REF');
+        $orderProduct->setProductSaleElementsRef('ORDER-PSE-REF');
+        $orderProduct->setTitle('Taxed line');
+        $orderProduct->setQuantity(1.0);
+        $orderProduct->setPrice((string) self::UNIT_PRICE);
+        $orderProduct->setWasNew(0);
+        $orderProduct->setWasInPromo(0);
+        $orderProduct->setVirtual(0);
+        $orderProduct->save($connection);
+
+        $tax = new OrderProductTax();
+        $tax->setOrderProductId($orderProduct->getId());
+        $tax->setTitle('VAT');
+        $tax->setAmount((string) self::UNIT_TAX);
+        $tax->save($connection);
+
+        return $orderProduct;
+    }
+}

--- a/tests/Api/Front/CategoryTranslationJoinQueryCountTest.php
+++ b/tests/Api/Front/CategoryTranslationJoinQueryCountTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The query behind a translatable resource left-joins every active language, so
+ * a language without a translation comes back as an empty column — an answer,
+ * not a missing one. Reading it as "not loaded yet" sent the resource back to
+ * the database for a row that is not there, once per row and per language: 318
+ * translation reads on the home page of the demo shop, which ships two
+ * languages nobody translated.
+ */
+final class CategoryTranslationJoinQueryCountTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    public function testALanguageWithoutTranslationCostsNoQuery(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $factory->lang(['title' => 'Spanish', 'code' => 'es', 'locale' => 'es_ES']);
+
+        $category = $factory->category();
+        $category->setLocale('en_US')->setTitle('Garden tools');
+        $category->save($this->getPropelConnection());
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload, $category): void {
+            $response = $this->jsonRequest('GET', '/api/front/categories/'.$category->getId());
+            self::assertJsonResponseSuccessful($response);
+            $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+        });
+
+        self::assertSame('Garden tools', $payload['i18ns']['en_US']['title'] ?? null);
+        self::assertArrayNotHasKey('es_ES', $payload['i18ns'] ?? []);
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'category_i18n'),
+            'The translations were joined by the main query: none of them may be read again.',
+        );
+    }
+}

--- a/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
+++ b/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Product;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+use TheliaLibrary\Model\LibraryImage;
+use TheliaLibrary\Model\LibraryItemImage;
+
+/**
+ * A module extends a native resource with an addon, and an addon resolves its
+ * own rows. The `libraryImages` addon of TheliaLibrary belongs to the single
+ * read only, yet it was built for every row of every collection: 495 reads of
+ * library_item_image on the home page of the demo shop, a third of the page,
+ * for a payload that never mentions them.
+ */
+final class ProductCollectionAddonQueryCountTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    public function testTheCollectionDoesNotBuildAnAddonItDoesNotReturn(): void
+    {
+        $product = $this->productWithALibraryImage();
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products');
+        });
+
+        self::assertArrayNotHasKey('ProductLibraryImagesAddon', $this->member($payload, $product->getId()));
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'library_item_image'),
+            'The collection returns no library image, so it must not read any.',
+        );
+    }
+
+    public function testTheSingleReadStillReturnsTheAddon(): void
+    {
+        $product = $this->productWithALibraryImage();
+
+        $payload = $this->readJson('/api/front/products/'.$product->getId());
+
+        self::assertCount(1, $payload['ProductLibraryImagesAddon']['libraryImages'] ?? []);
+    }
+
+    private function productWithALibraryImage(): Product
+    {
+        $factory = $this->createFixtureFactory();
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $image = (new LibraryImage())
+            ->setLocale('en_US')
+            ->setTitle('Sample image')
+            ->setFileName('sample.png');
+        $image->save();
+
+        $itemImage = (new LibraryItemImage())
+            ->setImageId($image->getId())
+            ->setItemType('product')
+            ->setItemId($product->getId())
+            ->setVisible(1)
+            ->setPosition(0);
+        $itemImage->save();
+
+        return $product;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function member(array $payload, ?int $productId): array
+    {
+        foreach ($payload['hydra:member'] ?? [] as $member) {
+            if (($member['id'] ?? null) === $productId) {
+                return $member;
+            }
+        }
+
+        self::fail('The collection must return the product under test, otherwise nothing is measured.');
+    }
+}

--- a/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
+++ b/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\Front;
 
+use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
+use Thelia\Api\Resource\Product as ProductResource;
 use Thelia\Model\Product;
 use Thelia\Test\ApiTestCase;
 use Thelia\Test\Trait\RecordsSqlQueries;
@@ -31,6 +33,20 @@ final class ProductCollectionAddonQueryCountTest extends ApiTestCase
 {
     use RecordsSqlQueries;
 
+    private const ADDON = 'ProductLibraryImagesAddon';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $addons = $this->getService(ApiResourcePropelTransformerService::class)
+            ->getResourceAddonDefinitions(ProductResource::class);
+
+        if (!isset($addons[self::ADDON])) {
+            self::markTestSkipped('TheliaLibrary is not active here: no addon extends the product resource.');
+        }
+    }
+
     public function testTheCollectionDoesNotBuildAnAddonItDoesNotReturn(): void
     {
         $product = $this->productWithALibraryImage();
@@ -40,7 +56,7 @@ final class ProductCollectionAddonQueryCountTest extends ApiTestCase
             $payload = $this->readJson('/api/front/products');
         });
 
-        self::assertArrayNotHasKey('ProductLibraryImagesAddon', $this->member($payload, $product->getId()));
+        self::assertArrayNotHasKey(self::ADDON, $this->member($payload, $product->getId()));
         self::assertSame(
             0,
             self::countSqlQueriesSelectingFrom($statements, 'library_item_image'),
@@ -48,13 +64,25 @@ final class ProductCollectionAddonQueryCountTest extends ApiTestCase
         );
     }
 
-    public function testTheSingleReadStillReturnsTheAddon(): void
+    /**
+     * The single read does return the addon, so the guard has to let it through.
+     * What is asserted is the read it makes, not the payload it lands in: a warmed
+     * serializer metadata cache drops addon attributes from the response, which is
+     * a defect of its own and would hide this one.
+     */
+    public function testTheSingleReadStillBuildsTheAddon(): void
     {
         $product = $this->productWithALibraryImage();
 
-        $payload = $this->readJson('/api/front/products/'.$product->getId());
+        $statements = $this->recordSqlQueries(function () use ($product): void {
+            $this->readJson('/api/front/products/'.$product->getId());
+        });
 
-        self::assertCount(1, $payload['ProductLibraryImagesAddon']['libraryImages'] ?? []);
+        self::assertGreaterThan(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'library_item_image'),
+            'The single read returns the addon, so it must resolve its rows.',
+        );
     }
 
     private function productWithALibraryImage(): Product

--- a/tests/Api/Front/ProductCollectionRelationQueryCountTest.php
+++ b/tests/Api/Front/ProductCollectionRelationQueryCountTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\AttributeCombination;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Product;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A product carries features, attribute combinations and associated contents
+ * that only the single read returns. Walking them on a collection buys rows the
+ * serializer throws away, and the bill grows with the page: the home page of the
+ * demo shop paid 96 reads of attribute_combination for a payload naming none.
+ */
+final class ProductCollectionRelationQueryCountTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    public function testTheCollectionDoesNotReadTheRelationsItDoesNotReturn(): void
+    {
+        $product = $this->productWithEveryOptionalRelation();
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products');
+        });
+
+        $member = $this->member($payload, $product->getId());
+        self::assertArrayNotHasKey('featureProducts', $member);
+        self::assertArrayNotHasKey('productAssociatedContents', $member);
+        self::assertArrayHasKey('productSaleElements', $member);
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'feature_product'),
+            'The collection returns no feature, so it must not read any.',
+        );
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'attribute_combination'),
+            'The collection returns no attribute combination, so it must not read any.',
+        );
+    }
+
+    /**
+     * The same relations belong to the single read, where the guard must let them
+     * through: skipping them would answer an incomplete product.
+     */
+    public function testTheSingleReadStillReturnsThem(): void
+    {
+        $product = $this->productWithEveryOptionalRelation();
+
+        $payload = $this->readJson('/api/front/products/'.$product->getId());
+
+        self::assertNotEmpty($payload['featureProducts'] ?? []);
+        self::assertNotEmpty($payload['productSaleElements'][0]['attributeCombinations'] ?? []);
+    }
+
+    private function productWithEveryOptionalRelation(): Product
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $feature = $factory->feature(['title' => 'Colour']);
+        $featureProduct = new FeatureProduct();
+        $featureProduct->setProductId($product->getId());
+        $featureProduct->setFeatureId($feature->getId());
+        $featureProduct->setFeatureAvId($factory->featureAv($feature, ['title' => 'Blue'])->getId());
+        $featureProduct->save($connection);
+
+        $attribute = $factory->attribute(['title' => 'Size']);
+        $combination = new AttributeCombination();
+        $combination->setProductSaleElementsId($product->getDefaultSaleElements()->getId());
+        $combination->setAttributeId($attribute->getId());
+        $combination->setAttributeAvId($factory->attributeAv($attribute, ['title' => 'Large'])->getId());
+        $combination->save($connection);
+
+        return $product;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function member(array $payload, ?int $productId): array
+    {
+        foreach ($payload['hydra:member'] ?? [] as $member) {
+            if (($member['id'] ?? null) === $productId) {
+                return $member;
+            }
+        }
+
+        self::fail('The collection must return the product under test, otherwise nothing is measured.');
+    }
+}


### PR DESCRIPTION
A `GET /` on the demo shop (Flexy, warm cache) ran **1 395 SQL queries**. Most of that work
produced rows the serializer then dropped on the floor, in the Propel/API-Platform bridge
that turns a Propel model into an API resource.

Three things were paying for data no response contains.

## 1. Relations were read whatever the groups said

`ApiResourcePropelTransformerService::processPropertiesRessource()` skipped a property only
when it was *both* out of the current serialization groups *and* listed in the
`excludedGroups` of its `#[Relation]`. `excludedGroups` is almost always empty, so the skip
never fired and every relation of every row was read — then discarded by the serializer.

On the demo home page: 96 reads of `attribute_combination`, 24 of `feature_product`, plus
`product_associated_content`, `tax_rule`, `brand` and `template`, none of which appear in
the JSON of `/api/front/products`.

A relation is now read only when a group of the context returns it. Two exceptions keep
the resources that need more than the payload working:

* a relation named in the `#[CompositeIdentifiers]` of its resource is always read — the
  resource builds its own IRI out of it;
* writes are not trimmed. A `PUT`/`PATCH`/`POST` reads the resource to validate it, and its
  validation groups are not the groups of the response it answers with.

For anything else, `#[Relation(hydrateOutOfGroups: true)]` re-opens the door. Three core
resources use it, all for the same reason: the `security` expression of an account endpoint
checks an owner no front group returns (`Address::$customer`, `Order::$customer`,
`OrderProduct::$order`).

`OrderProduct::afterModelToResource()` needed the other half of the same problem solved:
it summed `$this->orderProductTaxes` to fill `unitTaxedPrice`, but the taxes belong to the
single-read groups while the amount is returned by the collections too. It now sums the
tax rows of the Propel model, which is where they were coming from anyway, so the amounts
introduced by #3801 keep their value on a collection.

## 2. Addons were built whatever the groups said

The addon loop had no group check at all. `TheliaLibrary`'s `libraryImages` addon resolves
its rows with a query per product and belongs to `*_READ_SINGLE` only: **495 reads of
`library_item_image`** on the home page, 35 % of the whole page, for a payload that never
mentions the addon.

An addon is now built only when one of its own properties is in the context — the same rule
`ClassMetaDataFactory` already applies to decide whether the addon is serialized at all. The
addon is still attached to the resource, so nothing reading it through the resource finds a
hole where the addon used to be.

## 3. A joined translation that is empty was read again

`EagerLoadingExtension::joinI18ns()` left-joins every active language and pulls the columns
in with `withColumn()`. A language without a translation therefore hydrates its virtual
columns to `NULL` — an answer, not a missing one. `manageTranslatableResource()` read that
`NULL` as "not loaded yet" and fell back to the lazy Propel getter, which re-read the row
that is not there, once per row and per language: **318 translation reads** on a demo shop
that ships `es_ES` and `it_IT` untranslated.

The fallback now runs only when the virtual column is *absent*, which still happens below
the join depth and on the persist path.

This also fixes a side effect nobody had connected to it: the lazy fallback left the Propel
model pinned to the last active language, so `publicUrl` resolved in that language and fell
back to a query string when the language had no rewritten URL. Before/after on the demo:

    "publicUrl": "https://…/?view=product&lang=it_IT&product_id=1"
    "publicUrl": "https://…/horatio.html"

## Numbers

`GET /` on the demo shop, warm cache, MariaDB `general_log` in `TABLE` mode:

| | before | after |
|---|---|---|
| **total queries** | **1 395** | **354** (−75 %) |
| `library_item_image` | 495 | 0 |
| translations (`*_i18n`) | 369 | 73 |
| `product_image_i18n` | 209 | 21 |
| `attribute_combination` | 96 | 0 |
| `feature_product` | 24 | 0 |
| `product_associated_content` | 12 | 0 |
| `brand` | 6 | 0 |
| `tax_rule` / `template` | 1 / 1 | 0 / 0 |

The 68 `rewriting_url` reads are untouched here and handled separately.

## What the responses look like

`/api/front/products`, `/api/front/products/1`, `/api/front/categories` and
`/api/front/contents` were captured on the demo before and after, and compared field by
field: **the only difference is the `publicUrl` fix above**. The rendered home page is
byte-identical apart from the web debug toolbar's own nonces.

## Tests

Four new files, each verified red before its fix:

* `tests/Api/Front/ProductCollectionRelationQueryCountTest.php` — a front product collection
  reads no `feature_product` and no `attribute_combination`, and the single read still
  returns both.
* `tests/Api/Front/ProductCollectionAddonQueryCountTest.php` — the collection reads no
  `library_item_image` and does not carry the addon; the single read carries it with its row.
* `tests/Api/Front/CategoryTranslationJoinQueryCountTest.php` — a category translated in one
  of two active languages costs zero extra read and answers with the translation it has.
* `tests/Api/Admin/OrderProductUnitTaxedPriceApiTest.php` — `unitTaxedPrice` is returned by
  the order-line collection, where the tax rows are not.

`core/lib/Thelia/Test/Trait/RecordsSqlQueries.php` records the statements a request runs, so
these tests assert the shape of the work instead of a timing threshold.

Baselines: `composer test` 1 312 tests over 5 suites (1 skip, 2 pre-existing deprecations),
`composer cs-diff` 0, `composer phpstan` 0, `phpstan-botwig.neon` 0.
