### PR TITLE
fix: memoize and batch the rewritten url lookups

### DIFF
--- a/core/lib/Thelia/Api/Service/API/ResourceService.php
+++ b/core/lib/Thelia/Api/Service/API/ResourceService.php
@@ -21,6 +21,7 @@ use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
+use Thelia\Tools\URL;
 
 readonly class ResourceService
 {
@@ -104,8 +105,17 @@ readonly class ResourceService
 
             return null;
         }
+        $isTranslatableResult = $this->isTranslatableResult($result);
+
+        if ($isTranslatableResult && (\is_array($result) || $result instanceof \ArrayIterator)) {
+            // getPublicUrl() is itself serialized through GROUP_*_READ, so the Serializer
+            // below is about to call it once per item: the batch lookup has to run before
+            // that normalization, not before the addPublicUrl() call it feeds afterward.
+            $this->preloadPublicUrls($result, $currentLocale);
+        }
+
         $normalizedData = $this->normalizer->normalizeData($result, $context, $format);
-        if ($this->isTranslatableResult($result)) {
+        if ($isTranslatableResult) {
             // can't use Serializer in this use case, so need to manually add publicUrl
             if ($format === null) {
                 $normalizedData = $this->addPublicUrl($result, $normalizedData, $currentLocale);
@@ -210,6 +220,36 @@ readonly class ResourceService
         }
 
         return $finalNormalizedData;
+    }
+
+    /**
+     * Fills the rewritten url cache for the whole collection in one query per
+     * view name, instead of one query per item once addUrlToEntry() starts
+     * calling getUrl() in a loop.
+     *
+     * @param iterable<mixed> $resources
+     */
+    private function preloadPublicUrls(iterable $resources, string $currentLocale): void
+    {
+        $viewIdsByView = [];
+
+        foreach ($resources as $resource) {
+            if (!method_exists($resource, 'getUrl') || !method_exists($resource, 'getRewrittenUrlViewName')) {
+                continue;
+            }
+
+            $view = $resource->getRewrittenUrlViewName();
+
+            if ('' === $view) {
+                continue;
+            }
+
+            $viewIdsByView[$view][] = $resource->getId();
+        }
+
+        foreach ($viewIdsByView as $view => $viewIds) {
+            URL::getInstance()->preloadRewrittenUrls($view, $currentLocale, $viewIds);
+        }
     }
 
     private function addUrlToEntry(mixed $resource, array $entry, string $currentLocale): array

--- a/core/lib/Thelia/Config/Resources/services/utilities/url_management.php
+++ b/core/lib/Thelia/Config/Resources/services/utilities/url_management.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Thelia\Core\Routing\Rewriting\RewritingUrlMemoizer;
 use Thelia\Tools\URL;
 
 return static function (ContainerConfigurator $configurator): void {
@@ -21,7 +22,7 @@ return static function (ContainerConfigurator $configurator): void {
 
     // URL management
     $services->set(URL::class)
-        ->args([service('router')]);
+        ->args([service('router'), service(RewritingUrlMemoizer::class)]);
 
     $services->alias('thelia.url.manager', URL::class)
         ->public();

--- a/core/lib/Thelia/Core/Routing/Rewriting/RewritingUrlMemoizer.php
+++ b/core/lib/Thelia/Core/Routing/Rewriting/RewritingUrlMemoizer.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Routing\Rewriting;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Per-request memoization of rewritten url lookups.
+ *
+ * URL::retrieve() otherwise runs one SELECT per (view, view id, locale), and a
+ * single page routinely asks for the same key several times (a category
+ * repeated in a menu and in a product listing, a product shown as itself and
+ * as a cross-sell). This holds the outcome for the duration of the request,
+ * including the outcome "no rewritten url for that key" as a first-class
+ * negative result, so a second call never replays the query.
+ *
+ * No dependency on the HTTP Request itself: url generation runs from CLI
+ * commands as well (imports, exports, sitemap generation) and must keep
+ * working without one. The store is cleared on the next main request and on
+ * every console command instead, so a long-running worker (FrankenPHP,
+ * RoadRunner) or a batch of commands sharing one process never serves stale
+ * data.
+ */
+class RewritingUrlMemoizer
+{
+    /** @var array<string, array{url: ?string, rewrittenUrl: ?string}> */
+    private array $store = [];
+
+    public function has(string $view, mixed $viewId, mixed $viewLocale): bool
+    {
+        return \array_key_exists($this->key($view, $viewId, $viewLocale), $this->store);
+    }
+
+    /**
+     * @param callable():array{url: ?string, rewrittenUrl: ?string} $compute
+     *
+     * @return array{url: ?string, rewrittenUrl: ?string}
+     */
+    public function remember(string $view, mixed $viewId, mixed $viewLocale, callable $compute): array
+    {
+        $key = $this->key($view, $viewId, $viewLocale);
+
+        if (\array_key_exists($key, $this->store)) {
+            return $this->store[$key];
+        }
+
+        return $this->store[$key] = $compute();
+    }
+
+    public function set(string $view, mixed $viewId, mixed $viewLocale, ?string $url, ?string $rewrittenUrl): void
+    {
+        $this->store[$this->key($view, $viewId, $viewLocale)] = [
+            'url' => $url,
+            'rewrittenUrl' => $rewrittenUrl,
+        ];
+    }
+
+    public function clear(): void
+    {
+        $this->store = [];
+    }
+
+    /**
+     * The keys a page asks for barely change from one request to the next (a
+     * couple dozen views, ids and locales), so a single opaque string key is
+     * enough: no need to reason about collisions between a view name and an
+     * id that happen to share a separator.
+     */
+    private function key(string $view, mixed $viewId, mixed $viewLocale): string
+    {
+        return $view.'|'.($viewId ?? '').'|'.($viewLocale ?? '');
+    }
+
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            $this->clear();
+        }
+    }
+
+    #[AsEventListener(event: ConsoleEvents::COMMAND)]
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        $this->clear();
+    }
+}

--- a/core/lib/Thelia/Model/RewritingUrl.php
+++ b/core/lib/Thelia/Model/RewritingUrl.php
@@ -17,6 +17,7 @@ namespace Thelia\Model;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Model\Base\RewritingUrl as BaseRewritingUrl;
+use Thelia\Tools\URL;
 
 class RewritingUrl extends BaseRewritingUrl
 {
@@ -38,6 +39,25 @@ class RewritingUrl extends BaseRewritingUrl
                     'Redirected' => $this->getId(),
                 ]);
         }
+    }
+
+    /**
+     * postSave() runs after both postInsert() and postUpdate(): whichever of
+     * the two writes a row, the request-scoped rewritten url cache must not
+     * keep serving what it read before that write.
+     */
+    public function postSave(?ConnectionInterface $con = null): void
+    {
+        parent::postSave($con);
+
+        URL::getInstance()->clearRewritingUrlCache();
+    }
+
+    public function postDelete(?ConnectionInterface $con = null): void
+    {
+        parent::postDelete($con);
+
+        URL::getInstance()->clearRewritingUrlCache();
     }
 
     public function preInsert(?ConnectionInterface $con = null): bool

--- a/core/lib/Thelia/Model/RewritingUrlQuery.php
+++ b/core/lib/Thelia/Model/RewritingUrlQuery.php
@@ -66,6 +66,45 @@ class RewritingUrlQuery extends BaseRewritingUrlQuery
             ->findOne();
     }
 
+    /**
+     * Same match as getViewUrlQuery(), for a whole batch of view ids at once:
+     * one query preloading a collection instead of one query per item.
+     *
+     * @param list<int|string> $viewIds
+     *
+     * @return array<string, string> the rewritten url path, keyed by view id (as a string)
+     */
+    public function getViewUrlsQuery(string $view, $viewLocale, array $viewIds): array
+    {
+        if ([] === $viewIds) {
+            return [];
+        }
+
+        $rows = self::create()
+            ->joinRewritingArgument('ra', Criteria::LEFT_JOIN)
+            ->where('ISNULL(`ra`.REWRITING_URL_ID)')
+            ->filterByView($view)
+            ->filterByViewLocale($this->retrieveLocale($viewLocale))
+            ->filterByViewId($viewIds, Criteria::IN)
+            ->filterByRedirected(null)
+            ->orderById(Criteria::DESC)
+            ->find();
+
+        $urlsByViewId = [];
+
+        foreach ($rows as $row) {
+            $viewId = (string) $row->getViewId();
+
+            // Rows come back most-recent-id first (orderById DESC), so the first one
+            // seen for a given view id reproduces what getViewUrlQuery()'s findOne() picks.
+            if (!\array_key_exists($viewId, $urlsByViewId)) {
+                $urlsByViewId[$viewId] = $row->getUrl();
+            }
+        }
+
+        return $urlsByViewId;
+    }
+
     public function getSpecificUrlQuery($view, $viewLocale, $viewId, $viewOtherParameters): ?RewritingUrl
     {
         // A rewriting argument value is always scalar, so an array-valued parameter can never match

--- a/core/lib/Thelia/Model/Tools/UrlRewritingTrait.php
+++ b/core/lib/Thelia/Model/Tools/UrlRewritingTrait.php
@@ -154,6 +154,11 @@ trait UrlRewritingTrait
             ->update([
                 'View' => ConfigQuery::getObsoleteRewrittenUrlView(),
             ]);
+
+        // ModelCriteria::update() writes SQL directly and never instantiates
+        // a RewritingUrl object, so the model's postSave/postDelete hooks never
+        // run: the cache has to be cleared explicitly here.
+        URL::getInstance()->clearRewritingUrlCache();
     }
 
     /**
@@ -232,6 +237,10 @@ trait UrlRewritingTrait
         if (null !== $oldRewritingUrl = RewritingUrlQuery::create()->findOneByUrl($currentUrl)) {
             $oldRewritingUrl->setRedirected($rewritingUrl->getId())->save();
         }
+
+        // Belt and suspenders alongside RewritingUrl::postSave(): a cache entry set for
+        // this key before the url existed must not survive past the write that creates it.
+        URL::getInstance()->clearRewritingUrlCache();
 
         return $this;
     }

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -23,6 +23,7 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\Routing\Rewriting\Exception\UrlRewritingException;
 use Thelia\Core\Routing\Rewriting\RewritingResolver;
 use Thelia\Core\Routing\Rewriting\RewritingRetriever;
+use Thelia\Core\Routing\Rewriting\RewritingUrlMemoizer;
 use Thelia\Model\ConfigQuery;
 
 class URL
@@ -30,6 +31,7 @@ class URL
     protected RewritingResolver $resolver;
     protected RewritingRetriever $retriever;
     protected RequestContext $requestContext;
+    private RewritingUrlMemoizer $memoizer;
 
     public const PATH_TO_FILE = true;
     public const WITH_INDEX_PAGE = false;
@@ -39,7 +41,7 @@ class URL
     /** @var string a cache for the base URL scheme */
     private ?string $baseUrlScheme = null;
 
-    public function __construct(?RouterInterface $router = null)
+    public function __construct(?RouterInterface $router = null, ?RewritingUrlMemoizer $memoizer = null)
     {
         // Allow singleton style calls once instantiated.
         // For this to work, the URL service has to be instantiated very early. This is done manually
@@ -52,6 +54,9 @@ class URL
 
         $this->retriever = new RewritingRetriever();
         $this->resolver = new RewritingResolver();
+        // Optional so tests and other manual `new URL()` call sites keep working: each
+        // instance then simply gets its own, unshared memoizer.
+        $this->memoizer = $memoizer ?? new RewritingUrlMemoizer();
     }
 
     public function setRequestContext(RequestContext $requestContext): void
@@ -241,7 +246,19 @@ class URL
     public function retrieve(string $view, $viewId, $viewLocale): RewritingRetriever
     {
         if (ConfigQuery::isRewritingEnable()) {
-            $this->retriever->loadViewUrl($view, $viewLocale, $viewId);
+            $cached = $this->memoizer->remember(
+                $view,
+                $viewId,
+                $viewLocale,
+                function () use ($view, $viewId, $viewLocale): array {
+                    $this->retriever->loadViewUrl($view, $viewLocale, $viewId);
+
+                    return ['url' => $this->retriever->url, 'rewrittenUrl' => $this->retriever->rewrittenUrl];
+                },
+            );
+
+            $this->retriever->url = $cached['url'];
+            $this->retriever->rewrittenUrl = $cached['rewrittenUrl'];
         } else {
             $allParametersWithoutView = [];
             $allParametersWithoutView['lang'] = $viewLocale;
@@ -255,6 +272,17 @@ class URL
         }
 
         return $this->retriever;
+    }
+
+    /**
+     * Drops every cached rewritten url lookup. Writes that go through
+     * {@see \Thelia\Model\Tools\UrlRewritingTrait} clear it themselves; this is
+     * the escape hatch for the ones that write through a bulk
+     * `ModelCriteria::update()` and never instantiate a RewritingUrl object.
+     */
+    public function clearRewritingUrlCache(): void
+    {
+        $this->memoizer->clear();
     }
 
     /**

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -25,6 +25,7 @@ use Thelia\Core\Routing\Rewriting\RewritingResolver;
 use Thelia\Core\Routing\Rewriting\RewritingRetriever;
 use Thelia\Core\Routing\Rewriting\RewritingUrlMemoizer;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\RewritingUrlQuery;
 
 class URL
 {
@@ -272,6 +273,53 @@ class URL
         }
 
         return $this->retriever;
+    }
+
+    /**
+     * Fills the rewritten url cache for a whole batch of ids of the same view
+     * and locale in a single query, instead of paying one query per id the
+     * first time each of them is retrieved.
+     *
+     * @param list<int|string> $viewIds
+     */
+    public function preloadRewrittenUrls(string $view, $viewLocale, array $viewIds): void
+    {
+        if (!ConfigQuery::isRewritingEnable()) {
+            return;
+        }
+
+        $missingIds = array_values(array_filter(
+            array_unique($viewIds),
+            fn ($viewId): bool => !$this->memoizer->has($view, $viewId, $viewLocale),
+        ));
+
+        if ([] === $missingIds) {
+            return;
+        }
+
+        $rewritingUrlsByViewId = (new RewritingUrlQuery())->getViewUrlsQuery($view, $viewLocale, $missingIds);
+
+        foreach ($missingIds as $viewId) {
+            $allParametersWithoutView = [];
+
+            if (null !== $viewLocale) {
+                $allParametersWithoutView['lang'] = $viewLocale;
+            }
+
+            if (null !== $viewId) {
+                $allParametersWithoutView[$view.'_id'] = $viewId;
+            }
+
+            $rewrittenUrlPath = $rewritingUrlsByViewId[(string) $viewId] ?? null;
+
+            $this->memoizer->set(
+                $view,
+                $viewId,
+                $viewLocale,
+                $this->viewUrl($view, $allParametersWithoutView),
+                null !== $rewrittenUrlPath ? $this->absoluteUrl($rewrittenUrlPath) : null,
+            );
+        }
     }
 
     /**

--- a/tests/Integration/Api/ProductCollectionRewritingUrlQueryCountTest.php
+++ b/tests/Integration/Api/ProductCollectionRewritingUrlQueryCountTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\DataAccessService;
+use Thelia\Model\Product;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The Flexy theme fetches its data through the `resources()` Twig function,
+ * which calls {@see DataAccessService::resources()} in-process (it "can't use
+ * [the] Serializer in this use case", per ResourceService::doResources()) and
+ * adds `publicUrl` itself, one item at a time. None of it was memoized within
+ * the request and none of it was batched across a collection: 65 rewriting_url
+ * reads for 27 distinct keys on the demo home page.
+ */
+final class ProductCollectionRewritingUrlQueryCountTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private DataAccessService $dataAccess;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dataAccess = static::getContainer()->get(DataAccessService::class);
+    }
+
+    public function testACollectionBatchesItsRewrittenUrlLookupsInsteadOfOnePerItem(): void
+    {
+        $products = $this->createProductsWithTitles([
+            'Wooden chair',
+            'Steel table',
+            'Glass vase',
+            'Ceramic mug',
+            'Cotton towel',
+        ]);
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->dataAccess->resources('/api/front/products');
+        });
+
+        self::assertIsArray($payload);
+
+        foreach ($products as $product) {
+            self::assertNotNull(
+                $this->member($payload, $product->getId())['publicUrl'] ?? null,
+                'Every product of the collection must keep getting a public url.',
+            );
+        }
+
+        $rewritingUrlQueries = self::countSqlQueriesSelectingFrom($statements, 'rewriting_url');
+
+        self::assertGreaterThan(
+            0,
+            $rewritingUrlQueries,
+            'The collection does resolve rewritten urls, so it must read the table at least once.',
+        );
+        self::assertLessThan(
+            \count($products),
+            $rewritingUrlQueries,
+            'One query per distinct view batches every item of the collection: it must cost strictly less than one query per product.',
+        );
+    }
+
+    /**
+     * @param list<string> $titles
+     *
+     * @return list<Product>
+     */
+    private function createProductsWithTitles(array $titles): array
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $products = [];
+
+        foreach ($titles as $title) {
+            $product = $factory->product($category, $taxRule, $currency);
+            $product->setLocale('en_US')->setTitle($title)->save();
+            $products[] = $product;
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function member(array $payload, int $productId): array
+    {
+        foreach ($payload as $entry) {
+            if (($entry['id'] ?? null) === $productId) {
+                return $entry;
+            }
+        }
+
+        self::fail('The collection must return the product under test, otherwise nothing is measured.');
+    }
+}

--- a/tests/Integration/Core/Routing/UrlRewritingTest.php
+++ b/tests/Integration/Core/Routing/UrlRewritingTest.php
@@ -253,6 +253,76 @@ final class UrlRewritingTest extends IntegrationTestCase
         self::assertNotNull(RewritingUrlQuery::create()->findOneByUrl('guides/summer'));
     }
 
+    public function testGetViewUrlsQueryBatchesSeveralIdsInOneCallAndSkipsTheOnesWithoutAUrl(): void
+    {
+        $con = Propel::getConnection('TheliaMain');
+
+        $withUrl = $this->createCategoryWithTitle('Batched Category One');
+        $withUrl->generateRewrittenUrl('en_US', $con);
+
+        $otherWithUrl = $this->createCategoryWithTitle('Batched Category Two');
+        $otherWithUrl->generateRewrittenUrl('en_US', $con);
+
+        $withoutUrl = $this->createFixtureFactory()->category();
+
+        $urlsByViewId = RewritingUrlQuery::create()->getViewUrlsQuery(
+            'category',
+            'en_US',
+            [$withUrl->getId(), $otherWithUrl->getId(), $withoutUrl->getId()],
+        );
+
+        self::assertStringContainsString('batched-category-one', $urlsByViewId[(string) $withUrl->getId()]);
+        self::assertStringContainsString('batched-category-two', $urlsByViewId[(string) $otherWithUrl->getId()]);
+        self::assertArrayNotHasKey(
+            (string) $withoutUrl->getId(),
+            $urlsByViewId,
+            'A category without a title never got a rewritten url: it must not appear in the map at all.',
+        );
+    }
+
+    public function testPreloadRewrittenUrlsFillsTheCacheForEveryIdInOneQuery(): void
+    {
+        $con = Propel::getConnection('TheliaMain');
+
+        $categories = [
+            $this->createCategoryWithTitle('Preloaded Category One'),
+            $this->createCategoryWithTitle('Preloaded Category Two'),
+            $this->createCategoryWithTitle('Preloaded Category Three'),
+        ];
+
+        foreach ($categories as $category) {
+            $category->generateRewrittenUrl('en_US', $con);
+        }
+
+        $url = URL::getInstance();
+        $ids = array_map(static fn (Category $category): int => $category->getId(), $categories);
+
+        $statements = $this->recordSqlQueries(static function () use ($url, $ids): void {
+            $url->preloadRewrittenUrls('category', 'en_US', $ids);
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'rewriting_url'),
+            'One query must cover the whole batch, not one per id.',
+        );
+
+        $secondBatch = $this->recordSqlQueries(static function () use ($url, $categories): void {
+            foreach ($categories as $category) {
+                self::assertStringContainsString(
+                    'preloaded-category',
+                    (string) $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl,
+                );
+            }
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($secondBatch, 'rewriting_url'),
+            'Every id was preloaded already: none of the retrieve() calls above may read the table again.',
+        );
+    }
+
     public function testUrlRetrieveMemoizesTheSameKeyWithinARequest(): void
     {
         $category = $this->createCategoryWithTitle('Memoized Category');

--- a/tests/Integration/Core/Routing/UrlRewritingTest.php
+++ b/tests/Integration/Core/Routing/UrlRewritingTest.php
@@ -21,9 +21,13 @@ use Thelia\Core\Routing\Rewriting\RewritingRetriever;
 use Thelia\Model\Category;
 use Thelia\Model\RewritingUrlQuery;
 use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+use Thelia\Tools\URL;
 
 final class UrlRewritingTest extends IntegrationTestCase
 {
+    use RecordsSqlQueries;
+
     private function createCategoryWithTitle(string $title): Category
     {
         $factory = $this->createFixtureFactory();
@@ -247,5 +251,91 @@ final class UrlRewritingTest extends IntegrationTestCase
 
         self::assertSame('guides/summer', $category->getRewrittenUrl('en_US'));
         self::assertNotNull(RewritingUrlQuery::create()->findOneByUrl('guides/summer'));
+    }
+
+    public function testUrlRetrieveMemoizesTheSameKeyWithinARequest(): void
+    {
+        $category = $this->createCategoryWithTitle('Memoized Category');
+
+        $con = Propel::getConnection('TheliaMain');
+        $category->generateRewrittenUrl('en_US', $con);
+
+        $url = URL::getInstance();
+
+        $first = $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl;
+
+        $statements = $this->recordSqlQueries(static function () use ($url, $category): void {
+            $url->retrieve('category', $category->getId(), 'en_US');
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'rewriting_url'),
+            'The same (view, id, locale) key was already resolved once: a second retrieve() must not read it again.',
+        );
+        self::assertSame($first, $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl);
+    }
+
+    public function testUrlRetrieveMemoizesAMissTooAndCostsNoSecondQuery(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+
+        $url = URL::getInstance();
+
+        $first = $url->retrieve('category', $category->getId(), 'en_US');
+        self::assertNull($first->rewrittenUrl, 'No title was set, so no rewritten url exists yet.');
+
+        $statements = $this->recordSqlQueries(static function () use ($url, $category): void {
+            $url->retrieve('category', $category->getId(), 'en_US');
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'rewriting_url'),
+            'A category with no rewritten url is a negative result and must be cached too.',
+        );
+    }
+
+    public function testSetRewrittenUrlInvalidatesTheMemoizedCache(): void
+    {
+        $category = $this->createCategoryWithTitle('Stale Cache Category');
+
+        $con = Propel::getConnection('TheliaMain');
+        $category->generateRewrittenUrl('en_US', $con);
+
+        $url = URL::getInstance();
+
+        // Warm the cache with the url generated from the title.
+        $staleRewrittenUrl = $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl;
+
+        $category->setRewrittenUrl('en_US', 'hand-picked-url.html');
+
+        $refreshed = $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl;
+
+        self::assertNotSame($staleRewrittenUrl, $refreshed);
+        self::assertStringContainsString('hand-picked-url.html', (string) $refreshed);
+    }
+
+    public function testMarkRewrittenUrlObsoleteInvalidatesTheMemoizedCache(): void
+    {
+        // markRewrittenUrlObsolete() writes through ModelCriteria::update(), which never
+        // instantiates a RewritingUrl object and so never runs its postSave() hook: this is
+        // the case that needs an explicit cache clear of its own to not go stale.
+        $category = $this->createCategoryWithTitle('Obsoleted Cache Category');
+
+        $con = Propel::getConnection('TheliaMain');
+        $category->generateRewrittenUrl('en_US', $con);
+
+        $url = URL::getInstance();
+
+        $staleRewrittenUrl = $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl;
+        self::assertNotNull($staleRewrittenUrl);
+
+        $category->markRewrittenUrlObsolete();
+
+        $refreshed = $url->retrieve('category', $category->getId(), 'en_US')->rewrittenUrl;
+
+        self::assertNull($refreshed, 'The url was reassigned to the obsolete view: it must no longer resolve under "category".');
     }
 }

--- a/tests/Unit/Core/Routing/Rewriting/RewritingUrlMemoizerTest.php
+++ b/tests/Unit/Core/Routing/Rewriting/RewritingUrlMemoizerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Routing\Rewriting;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Thelia\Core\Routing\Rewriting\RewritingUrlMemoizer;
+
+final class RewritingUrlMemoizerTest extends TestCase
+{
+    public function testRememberOnlyComputesOnce(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $calls = 0;
+
+        $compute = static function () use (&$calls): array {
+            ++$calls;
+
+            return ['url' => '/category?id=1', 'rewrittenUrl' => '/summer.html'];
+        };
+
+        $first = $memoizer->remember('category', 1, 'en_US', $compute);
+        $second = $memoizer->remember('category', 1, 'en_US', $compute);
+
+        self::assertSame($first, $second);
+        self::assertSame(1, $calls, 'A second lookup for the same key must not recompute it.');
+    }
+
+    public function testRememberIsScopedByViewIdAndLocale(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $calls = 0;
+        $compute = static function () use (&$calls): array {
+            ++$calls;
+
+            return ['url' => "/computed-{$calls}", 'rewrittenUrl' => null];
+        };
+
+        $memoizer->remember('category', 1, 'en_US', $compute);
+        $memoizer->remember('category', 2, 'en_US', $compute);
+        $memoizer->remember('category', 1, 'fr_FR', $compute);
+        $memoizer->remember('brand', 1, 'en_US', $compute);
+
+        self::assertSame(4, $calls, 'A different view, id or locale is a different key.');
+    }
+
+    public function testNegativeResultIsCachedTooAndCostsNoSecondComputation(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $calls = 0;
+
+        $compute = static function () use (&$calls): array {
+            ++$calls;
+
+            // An object without a rewritten url still resolves to a plain view url.
+            return ['url' => '/category?category_id=42', 'rewrittenUrl' => null];
+        };
+
+        $first = $memoizer->remember('category', 42, 'en_US', $compute);
+        $second = $memoizer->remember('category', 42, 'en_US', $compute);
+
+        self::assertNull($first['rewrittenUrl']);
+        self::assertSame($first, $second);
+        self::assertSame(1, $calls, 'A cached negative result must still cost zero computation on the next hit.');
+        self::assertTrue($memoizer->has('category', 42, 'en_US'));
+    }
+
+    public function testHasReflectsWhatWasCachedIncludingNullValues(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+
+        self::assertFalse($memoizer->has('category', 1, 'en_US'));
+
+        $memoizer->set('category', 1, 'en_US', null, null);
+
+        // array_key_exists, not isset(): a stored null value is still a cache hit.
+        self::assertTrue($memoizer->has('category', 1, 'en_US'));
+    }
+
+    public function testClearForgetsEveryCachedKey(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $memoizer->set('category', 1, 'en_US', '/category?category_id=1', '/summer.html');
+
+        $memoizer->clear();
+
+        self::assertFalse($memoizer->has('category', 1, 'en_US'));
+    }
+
+    public function testOnKernelRequestClearsOnlyForTheMainRequest(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $memoizer->set('category', 1, 'en_US', '/category?category_id=1', '/summer.html');
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $subRequestEvent = new RequestEvent($kernel, new Request(), HttpKernelInterface::SUB_REQUEST);
+        $memoizer->onKernelRequest($subRequestEvent);
+
+        self::assertTrue($memoizer->has('category', 1, 'en_US'), 'A sub-request must not reset the cache of the request it is part of.');
+
+        $mainRequestEvent = new RequestEvent($kernel, new Request(), HttpKernelInterface::MAIN_REQUEST);
+        $memoizer->onKernelRequest($mainRequestEvent);
+
+        self::assertFalse($memoizer->has('category', 1, 'en_US'));
+    }
+
+    public function testOnConsoleCommandClearsTheCache(): void
+    {
+        $memoizer = new RewritingUrlMemoizer();
+        $memoizer->set('category', 1, 'en_US', '/category?category_id=1', '/summer.html');
+
+        $event = new ConsoleCommandEvent(
+            new Command('demo:command'),
+            new ArrayInput([]),
+            new NullOutput(),
+        );
+
+        $memoizer->onConsoleCommand($event);
+
+        self::assertFalse($memoizer->has('category', 1, 'en_US'), 'A CLI command must start from an empty cache, batches of commands included.');
+    }
+}


### PR DESCRIPTION
## Problem

Every rewritten url lookup (`UrlRewritingTrait::getUrl()` -> `URL::retrieve()` -> `RewritingUrlQuery`) runs its own `SELECT`, with no cache. A single page routinely asks for the same handful of (view, id, locale) keys several times, and a collection asks for one distinct key per item. On the demo shop's home page this alone accounted for ~68 of ~354 queries (measured after #3812), for only ~27 distinct keys.

## Fix

Two independent, additive steps:

1. **Per-request memoization** (`RewritingUrlMemoizer`, injected into `URL`): caches the outcome of `retrieve()` per (view, id, locale) for the duration of the request, including the negative result ("no rewritten url for this key") as a first-class cache entry. Cleared on the next main request and on every console command, with no dependency on the HTTP `Request` itself so CLI usage keeps working. Writes invalidate it: `UrlRewritingTrait::setRewrittenUrl()` / `markRewrittenUrlObsolete()` clear it explicitly (the latter writes through a bulk `ModelCriteria::update()`, which bypasses model hooks), and `RewritingUrl::postSave()`/`postDelete()` clear it for every other write path.

2. **Batched collection preload** (`RewritingUrlQuery::getViewUrlsQuery()` + `URL::preloadRewrittenUrls()`): resolves a whole batch of ids of the same view/locale in one `IN()` query instead of one query per item. Wired into `ResourceService::doResources()`, and run *before* `normalizeData()` — `getPublicUrl()` is itself serialized through the front/admin groups, so the Serializer would otherwise resolve every item one by one before `addPublicUrl()` ever got a chance to batch anything.

## Numbers (demo shop home page, warm cache)

| | before (origin/main) | after |
|---|---|---|
| total queries | 355 | 299 |
| `rewriting_url` family | 69 | 13 |

The remaining 13 are a mix of batched `IN()` queries (one per distinct view per collection call - the home page renders several separate product/category/content collections) and a few genuinely single-item lookups (current page url, menu items resolved outside a collection), which is outside this fix's scope.

## Test plan

- [x] `composer test` - 5 suites green (390 unit / 674 integration / 235 api, 1 pre-existing skip / 17 http-flexy / 10 http-backoffice, 2 pre-existing deprecations)
- [x] `composer cs-diff` - 0
- [x] `composer phpstan` - 0
- [x] `./vendor/bin/phpstan analyse -c phpstan-botwig.neon` - 0
- [x] New unit tests for the memoizer (hit/miss/negative-cache/clear/request-scoping/console-scoping)
- [x] New integration tests for `URL::retrieve()` memoization, write invalidation (`setRewrittenUrl`, `markRewrittenUrlObsolete`), `getViewUrlsQuery()` batching, and `preloadRewrittenUrls()`
- [x] New integration test asserting a product collection resolves its urls in fewer queries than it has items
- [x] Existing slug-collision test (`testGenerateRewrittenUrlHandlesCollisions`) still green - it goes through `resolve()`, untouched by this change