### PR TITLE
fix: stop rereading the config table and the default country within a request

### DIFF
--- a/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
@@ -197,7 +197,9 @@ class AttributeAccessService
         return $this->dataAccessWithI18n(
             'defaultCountry',
             $attributeName,
-            CountryQuery::create()->filterByByDefault(1)->limit(1)
+            // Filtering by the already memoized default country's id, rather than
+            // by_default=1 again, skips a redundant lookup of which country that is.
+            CountryQuery::create()->filterById(Country::getDefaultCountry()->getId())->limit(1)
         );
     }
 

--- a/core/lib/Thelia/Core/Cache/ConfigCacheService.php
+++ b/core/lib/Thelia/Core/Cache/ConfigCacheService.php
@@ -50,12 +50,6 @@ class ConfigCacheService
      */
     private static function loadConfigs(): array
     {
-        $configs = [];
-
-        foreach (ConfigQuery::create()->find() as $config) {
-            $configs[$config->getName()] = $config->getValue();
-        }
-
-        return $configs;
+        return ConfigQuery::findAllAsMap();
     }
 }

--- a/core/lib/Thelia/Core/EventListener/DefaultCountryCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/DefaultCountryCacheListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Model\Country;
+use Thelia\Model\Event\CountryEvent;
+
+/**
+ * Keeps {@see Country::getDefaultCountry()}'s static memo honest.
+ *
+ * The lookup it wraps is read constantly (once per product card that falls
+ * back to the shop's default delivery country) and almost never written, so
+ * a plain static holding the resolved model is the right cache. It still
+ * needs two safety nets: a write to the row that carries `by_default` must
+ * not leave the memo stale for the rest of the request, and a persistent
+ * worker runtime (FrankenPHP, RoadRunner) must not carry it over from one
+ * request, or one console command, to the next.
+ */
+readonly class DefaultCountryCacheListener
+{
+    #[AsEventListener(event: CountryEvent::POST_SAVE)]
+    #[AsEventListener(event: CountryEvent::POST_DELETE)]
+    public function onCountryWrite(): void
+    {
+        Country::resetDefaultCountryCache();
+    }
+
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            Country::resetDefaultCountryCache();
+        }
+    }
+
+    #[AsEventListener(event: ConsoleEvents::COMMAND)]
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        Country::resetDefaultCountryCache();
+    }
+}

--- a/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxEngine.php
+++ b/core/lib/Thelia/Domain/Taxation/TaxEngine/TaxEngine.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Thelia\Model\Cart;
 use Thelia\Model\Country;
-use Thelia\Model\CountryQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\State;
 
@@ -66,7 +65,7 @@ class TaxEngine
         $customer = $this->getSession()?->getCustomerUser();
 
         if (!$customer) {
-            $this->taxCountry = CountryQuery::create()->findOneByByDefault(1);
+            $this->taxCountry = Country::getDefaultCountry();
             $this->taxState = null;
 
             return $this->taxCountry;
@@ -79,7 +78,7 @@ class TaxEngine
             return $this->taxCountry;
         }
 
-        $this->taxCountry = CountryQuery::create()->findOneByByDefault(1);
+        $this->taxCountry = Country::getDefaultCountry();
         $this->taxState = null;
 
         return $this->taxCountry;

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -63,21 +63,56 @@ class ConfigQuery extends BaseConfigQuery
     }
 
     /**
+     * @internal
+     *
+     * The whole table, name => value. It is small enough to load in one go
+     * and to hand to {@see initCache()} as an authoritative snapshot: every
+     * name absent from the result has no row in the table at all.
+     *
+     * @return array<string, string>
+     */
+    public static function findAllAsMap(): array
+    {
+        $configs = [];
+
+        foreach (self::create()->find() as $config) {
+            $configs[$config->getName()] = $config->getValue();
+        }
+
+        return $configs;
+    }
+
+    /**
      * Find a config variable and return the value or default value if not founded.
      *
      * Use this method for better performance, a cache is created for each variable already searched
      */
     public static function read(string $search, $default = null, bool $ignoreCache = false)
     {
-        if ($ignoreCache || !self::$booted || !\array_key_exists($search, self::$cache)) {
+        if ($ignoreCache) {
             $model = self::create()->filterByName($search)->findOneOrCreate();
 
             // The default only applies to a variable that does not exist yet: a stored
             // '0' or '' is a value, and the cached path returns it as such.
-            self::$cache[$search] = $model->getValue() ?? $default;
+            return self::$cache[$search] = $model->getValue() ?? $default;
         }
 
-        return self::$cache[$search];
+        if (!self::$booted) {
+            // Nothing warmed the cache yet (this can run before
+            // ConfigCacheService gets a chance to, e.g. a debug logger reading
+            // its own config while Propel itself is still being wired up).
+            // Load the whole table once instead of paying for every distinct
+            // name read from here on, one row at a time.
+            self::initCache(self::findAllAsMap());
+        }
+
+        if (!\array_key_exists($search, self::$cache)) {
+            // The snapshot above is exhaustive: a name missing from it has no
+            // row in the table, it is not a lookup that has not run yet.
+            return $default;
+        }
+
+        return self::$cache[$search] ?? $default;
     }
 
     public static function write($configName, $value, $secured = null, $hidden = null): void

--- a/core/lib/Thelia/Model/Country.php
+++ b/core/lib/Thelia/Model/Country.php
@@ -154,6 +154,14 @@ class Country extends BaseCountry
     }
 
     /**
+     * @internal
+     */
+    public static function resetDefaultCountryCache(): void
+    {
+        self::$defaultCountry = null;
+    }
+
+    /**
      * Return the shop country.
      *
      * @throws \LogicException if no shop country is defined

--- a/tests/Integration/Domain/Taxation/TaxEngineDefaultCountryQueryCountTest.php
+++ b/tests/Integration/Domain/Taxation/TaxEngineDefaultCountryQueryCountTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Taxation;
+
+use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
+use Thelia\Model\Country;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A product listing asks {@see TaxEngine::getDeliveryCountry()} for every
+ * card on the page. With no cart address and no customer to fall back to
+ * (an anonymous visitor, the common case), that used to re-read the
+ * `country` row holding `by_default=1` on every single call.
+ */
+final class TaxEngineDefaultCountryQueryCountTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    public function testRepeatedFallbackToTheDefaultCountryCostsAtMostOneQuery(): void
+    {
+        Country::resetDefaultCountryCache();
+
+        $taxEngine = $this->getService(TaxEngine::class);
+
+        $statements = $this->recordSqlQueries(static function () use ($taxEngine): void {
+            $first = $taxEngine->getDeliveryCountry();
+            $second = $taxEngine->getDeliveryCountry();
+            $third = $taxEngine->getDeliveryCountry();
+
+            self::assertSame($first->getId(), $second->getId());
+            self::assertSame($first->getId(), $third->getId());
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'country'),
+            'Three calls with no cart address and no customer must still cost a single country lookup.',
+        );
+    }
+
+    /**
+     * The memo must not survive a change of which country is the default:
+     * an admin flipping it must be visible to the rest of the very same
+     * request, not just to the next one.
+     */
+    public function testChangingTheDefaultCountryInvalidatesTheMemoImmediately(): void
+    {
+        $originalDefault = Country::getDefaultCountry();
+
+        $newDefault = $this->createFixtureFactory()->country([
+            'isocode' => 'ZZ',
+            'isoalpha2' => 'ZZ',
+            'isoalpha3' => 'ZZZ',
+        ]);
+        $newDefault->toggleDefault();
+
+        self::assertNotSame($originalDefault->getId(), $newDefault->getId());
+        self::assertSame(
+            $newDefault->getId(),
+            Country::getDefaultCountry()->getId(),
+            'A write to by_default must invalidate the memoized default country within the same request.',
+        );
+    }
+}

--- a/tests/Integration/Model/ConfigQueryTest.php
+++ b/tests/Integration/Model/ConfigQueryTest.php
@@ -16,9 +16,58 @@ namespace Thelia\Tests\Integration\Model;
 
 use Thelia\Model\ConfigQuery;
 use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
 
 final class ConfigQueryTest extends IntegrationTestCase
 {
+    use RecordsSqlQueries;
+
+    /**
+     * Locks the falsy-value pitfall together with the query count: a stored
+     * '0' read twice must still be served from the cache the second time,
+     * not just return the right value at the cost of a query per call.
+     */
+    public function testReadingAStoredZeroTwiceCostsOneQuery(): void
+    {
+        ConfigQuery::write('test_read_falsy_zero_query_count', '0');
+        ConfigQuery::resetCache();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            self::assertSame('0', ConfigQuery::read('test_read_falsy_zero_query_count', 1));
+            self::assertSame('0', ConfigQuery::read('test_read_falsy_zero_query_count', 1));
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'Reading the same name twice must load the table once, not query per call.',
+        );
+    }
+
+    /**
+     * The snapshot loaded on the first uncached read is exhaustive: a name
+     * that was never written has no row in the table at all, so every read
+     * of it after the first one must be free, and several distinct never
+     * written names must still share the same single bulk load.
+     */
+    public function testReadingSeveralNeverWrittenNamesCostsAtMostOneQuery(): void
+    {
+        ConfigQuery::resetCache();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            self::assertSame('a', ConfigQuery::read('test_never_written_one', 'a'));
+            self::assertSame('b', ConfigQuery::read('test_never_written_two', 'b'));
+            self::assertSame('b', ConfigQuery::read('test_never_written_two', 'b'));
+            self::assertSame('c', ConfigQuery::read('test_never_written_three', 'c'));
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'Four reads across three never-written names must still cost a single bulk load.',
+        );
+    }
+
     public function testReadReturnsAStoredZeroInsteadOfTheDefault(): void
     {
         ConfigQuery::write('test_read_falsy_zero', '0');


### PR DESCRIPTION
## Summary

Lot 3 of the front N+1 SQL campaign (config + default delivery country), following lots 1 (#3812) and 2 (#3813). Measured on the demo home page render, cache warm: **295 → 251 SELECT queries (-44)**.

### `config` (21 → 2)

`ConfigQuery::read()` already had an `array_key_exists`-based cache, correct on the falsy-value pitfall ('0'/''), but it only helped once `ConfigCacheService` had booted it via `TheliaBundle::boot()`. Two gaps let it bypass the cache anyway:

1. **Timing**: Propel wires its own debug logger to `Tlog::getInstance()` while the connection is still being set up, before Thelia's bundle boots. `Tlog::init()` reads 10 distinct config names at that point, each paying its own query, one row at a time.
2. **Missing rows**: the bulk snapshot (`SELECT * FROM config`) only lists rows that exist. Any name that was never explicitly written (a "virtual" default, most `ConfigQuery::read()` call sites) is absent from it forever, so `array_key_exists` fails and the code queried the row again on every single call, every single request — 10 more distinct queries on the home page.

Fix: `read()` now boots the cache itself with one bulk load the first time it is needed (regardless of who calls it first), and treats a name missing from that exhaustive snapshot as a negative result (return the default) instead of a reason to query. `ConfigCacheService::loadConfigs()` now delegates to the same snapshot method instead of duplicating it.

The remaining 2 `config` queries are the one bulk load plus `TheliaKernel::isInstalled()`'s raw PDO install check, unrelated and out of scope.

### `country` (26 → 2)

`TaxEngine::getDeliveryCountry()` re-reads the row flagged `by_default=1` on every call whenever there is no cart delivery address and no customer default address — the common anonymous-visitor case. Flexy's `ProductCard` calls it twice per card, so a listing of a dozen products cost two dozen identical queries. `Country::getDefaultCountry()` already memoizes that exact lookup in a static, unused by `TaxEngine`. Converged both `TaxEngine` fallback branches and `AttributeAccessService::attributeCountry()`'s naked `filterByByDefault(1)` query onto it. Session-scoped delivery countries are untouched and still take priority; only the fallback is memoized.

Added `Country::resetDefaultCountryCache()` plus a new `DefaultCountryCacheListener` clearing it on a write to the country table (immediate, same-request visibility if an admin flips the default) and on the next main request / console command (persistent-worker and CLI safety, same pattern as lot 2's `RewritingUrlMemoizer`).

The remaining 2 `country` queries are the one default-country lookup plus `Country::getShopLocation()`'s unrelated by-id lookup of the configured shop country.

## Test plan

- [x] New unit-style query-count tests added RED first, confirmed failing against origin/main, then GREEN against the fix (`tests/Integration/Model/ConfigQueryTest.php`, `tests/Integration/Domain/Taxation/TaxEngineDefaultCountryQueryCountTest.php`)
- [x] Locks the falsy-value pitfall together with the query count (a stored `'0'` read twice costs one query, not two)
- [x] Locks write-invalidation for both the config cache (pre-existing coverage) and the new default-country memo (same-request visibility)
- [x] `composer test` — all 5 suites green (unit 390, integration 678, api 235/1 skip, http-flexy 17, http-backoffice 10/2 pre-existing deprecations)
- [x] `composer cs-diff` — 0
- [x] `composer phpstan` — 0
- [x] `./vendor/bin/phpstan analyse -c phpstan-botwig.neon` — 0
- [x] Measured before/after on a fresh cache render: 295 → 251 SELECT queries