### PR TITLE
chore: CRA compliance groundwork

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,57 @@
+name: sbom
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sbom:
+    name: CycloneDX SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, ctype, iconv, intl, gd, zip
+
+      # composer.lock is not committed (library-type repository): resolve the
+      # dependency tree first, without installing or running anything.
+      - name: Resolve the dependency tree
+        run: composer update --no-install --no-scripts --no-plugins --no-progress --prefer-dist
+
+      - name: Install the CycloneDX Composer plugin
+        run: |
+          composer global config --no-plugins allow-plugins.cyclonedx/cyclonedx-php-composer true
+          composer global require --no-progress cyclonedx/cyclonedx-php-composer
+
+      - name: Generate the SBOM from composer.lock
+        run: composer CycloneDX:make-sbom --omit=dev --output-format=JSON --output-file="$PWD/sbom.cdx.json"
+
+      - name: Audit the locked dependencies for known advisories
+        # Findings must be visible in the run but must not block the SBOM publication.
+        continue-on-error: true
+        run: composer audit --locked | tee composer-audit.txt
+
+      - name: Upload the SBOM as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: |
+            sbom.cdx.json
+            composer-audit.txt
+
+      - name: Attach the SBOM to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" sbom.cdx.json --clobber

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,74 @@
-# Security policy
+# Security Policy
+
+Thelia is free and open source software stewarded by [OpenStudio](https://www.openstudio.fr).
+This policy explains how to report a vulnerability, what happens after a report, and
+which versions receive security fixes.
 
 ## Reporting a vulnerability
 
-Report security vulnerabilities privately. Do not open a public issue for them.
+**Never report a security problem through a public issue, discussion or pull request.**
 
-You can report a vulnerability in two ways:
+Report it privately, in one of two ways:
 
-- Open a private report from the "Security" tab of this repository ("Report a vulnerability").
-- Or email contact@thelia.net.
+- Preferred: open a private report from this repository's
+  [Security tab](https://github.com/thelia/thelia/security/advisories/new)
+  ("Report a vulnerability").
+- Or email [contact@thelia.net](mailto:contact@thelia.net) with `[SECURITY]` in the
+  subject line.
 
-Please include a description of the problem, the steps to reproduce it, and the affected version or branch. We will confirm that we received your report, work on a fix, and keep you informed. Give us a reasonable time to publish a patch before disclosing the issue publicly.
+A useful report includes:
+
+- the affected component and version (or branch and commit),
+- a description of the vulnerability and its impact,
+- steps to reproduce, or a proof of concept,
+- a suggested fix or mitigation, if you have one.
+
+We practice coordinated disclosure: please keep the details confidential until a fixed
+release is available. We credit reporters in the advisory unless they prefer to stay
+anonymous.
+
+## Scope
+
+In scope:
+
+- the Thelia core: this repository and the packages published from it
+  (`thelia/thelia`, `thelia/core`, `thelia/setup`, `thelia/config`),
+- the official modules published under [thelia-modules](https://github.com/thelia-modules),
+- the official themes published under [thelia-templates](https://github.com/thelia-templates).
+
+Out of scope:
+
+- third-party modules and themes — report them to their maintainers,
+- vulnerabilities in upstream dependencies — report them upstream; we ship a fixed
+  release once a patched version is available,
+- issues specific to a website running Thelia — report them to the site owner.
+
+## What to expect
+
+| Step | Target |
+|------|--------|
+| Acknowledgement of your report | 72 hours |
+| Triage and first assessment | 7 days |
+| Fix for a confirmed vulnerability | 90 days |
+| Public disclosure | Coordinated with you, once a fixed release is available |
+
+These targets can shift for particularly complex issues; if they do, we keep you
+informed.
+
+## Advisories and CVEs
+
+Confirmed vulnerabilities are published as
+[GitHub Security Advisories](https://github.com/thelia/thelia/security/advisories) on
+the affected repository once a fixed release is available. We request CVE identifiers
+through GitHub for vulnerabilities affecting released versions.
 
 ## Supported versions
 
-Security fixes go to the version of Thelia 3 under active development and to the latest Thelia 2 release. Older versions do not receive fixes.
+| Series | Branch | Supported | End of support |
+|--------|--------|-----------|----------------|
+| 3.0 | `main` | Yes — active development | — |
+| 2.6 | `2.6` | Yes — security fixes | To be announced |
+| 2.5 and older | — | No | Ended |
+
+Security fixes are released for the latest 3.0 and 2.6 versions only: keep your
+installation on the most recent release of its series.

--- a/docs/security/cra-incident-response.md
+++ b/docs/security/cra-incident-response.md
@@ -1,0 +1,85 @@
+# CRA incident response process
+
+This document describes how OpenStudio, acting as the open-source software steward of
+Thelia, handles the notification obligations of the EU Cyber Resilience Act
+([Regulation (EU) 2024/2847](https://eur-lex.europa.eu/eli/reg/2024/2847/oj), "CRA").
+The reporting obligations apply from **11 September 2026**.
+
+## Role and obligations
+
+Thelia is made available for free as open source software. OpenStudio qualifies as an
+**open-source software steward** (CRA Article 24), not as a manufacturer: no CE marking
+and no conformity assessment are required. The steward obligations are:
+
+- maintain a coordinated vulnerability disclosure policy — see
+  [SECURITY.md](../../SECURITY.md),
+- cooperate with market surveillance authorities on request,
+- notify actively exploited vulnerabilities and severe incidents (Article 24(3),
+  applying Article 14 insofar as the steward is involved in the development of the
+  product).
+
+## What triggers a notification
+
+A notification is due when the Thelia security team becomes aware of either:
+
+1. An **actively exploited vulnerability** in Thelia — the core, an official module or
+   an official theme — meaning exploitation observed in the wild, not a theoretical
+   report;
+2. A **severe incident having an impact on the security** of Thelia's development or
+   distribution infrastructure — for example a compromise of the GitHub organizations
+   (`thelia`, `thelia-modules`, `thelia-templates`), of the release pipeline, or of the
+   packages published on Packagist.
+
+Record the exact time of awareness: every deadline below counts from it.
+
+## Who notifies
+
+The OpenStudio security lead (reachable at [contact@thelia.net](mailto:contact@thelia.net))
+owns the notification. If unavailable, any OpenStudio maintainer with release rights on
+`thelia/thelia` takes over. One person drives the notification timeline; the fix work
+happens in parallel and never waits for the notifications.
+
+## Where to notify
+
+Notifications are submitted through the **single reporting platform** established by
+ENISA (CRA Article 16). The platform dispatches each notification to the CSIRT
+designated as coordinator of the relevant Member State — for France, **CERT-FR** — and
+to ENISA.
+
+- ENISA — single reporting platform entry point: <https://www.enisa.europa.eu/>
+- CERT-FR (French coordinator CSIRT): <https://www.cert.ssi.gouv.fr/>
+
+## Timeline (Article 14)
+
+For an **actively exploited vulnerability**:
+
+| Deadline | Notification | Content |
+|----------|--------------|---------|
+| 24 hours after awareness | Early warning | The vulnerability is actively exploited; the Member States where affected users are located, if known. |
+| 72 hours after awareness | Vulnerability notification | General information about the product, the nature of the exploit, severity and impact, corrective or mitigating measures taken or available, and how users can respond. |
+| 14 days after a corrective or mitigating measure is available | Final report | Description of the vulnerability, its severity and impact; where available, information about the malicious actor; the corrective measure and how it reached users. |
+
+For a **severe incident**: the same 24-hour early warning and 72-hour incident
+notification, then a final report **one month** after the incident notification.
+
+## Checklist
+
+1. **Assess, immediately** — confirm the active exploitation or the severe incident and
+   record the time of awareness.
+2. **T+24 h** — submit the early warning on the reporting platform.
+3. **T+72 h** — submit the full notification on the platform.
+4. **Fix** — develop, review and release the correction following
+   [SECURITY.md](../../SECURITY.md); publish a GitHub Security Advisory and request a
+   CVE.
+5. **T+14 days after the fix is available** — submit the final report on the platform.
+6. **Inform users** — GitHub Security Advisory on the affected repository, release
+   notes of the fixed versions on every supported series, announcement on the Thelia
+   channels.
+
+## References
+
+- [Regulation (EU) 2024/2847](https://eur-lex.europa.eu/eli/reg/2024/2847/oj) —
+  Articles 14 (notification), 16 (single reporting platform) and 24 (stewards).
+- [ENISA](https://www.enisa.europa.eu/) — operator of the single reporting platform.
+- [CERT-FR](https://www.cert.ssi.gouv.fr/) — French coordinator CSIRT.
+- [SECURITY.md](../../SECURITY.md) — coordinated vulnerability disclosure policy.


### PR DESCRIPTION
Prepares Thelia for the EU Cyber Resilience Act (open-source steward regime, reporting obligations applying from 11 September 2026):

- expand SECURITY.md into a full coordinated vulnerability disclosure policy (scope, response targets, advisories/CVE process, supported versions)
- document the CRA incident response process (docs/security/cra-incident-response.md)
- generate a CycloneDX SBOM from composer.lock on every release and attach it to the GitHub release

Documentation and CI only, no application code touched.