### PR TITLE
fix: redirect the admin login submit when a session is already open

### DIFF
--- a/core/lib/Thelia/Controller/Admin/SessionController.php
+++ b/core/lib/Thelia/Controller/Admin/SessionController.php
@@ -83,7 +83,7 @@ class SessionController extends BaseAdminController
             return $response;
         }
 
-        return $this->render('login');
+        return $this->renderLoginPage();
     }
 
     public function showLostPasswordAction(): Response|RedirectResponse
@@ -237,6 +237,13 @@ class SessionController extends BaseAdminController
 
     public function checkLoginAction(EventDispatcherInterface $eventDispatcher): RedirectResponse|Response|null
     {
+        // A login form submitted while a session is already open (browser back
+        // button, second tab) carries a stale CSRF token and would always be
+        // rejected: go straight to the home page instead.
+        if (($response = $this->checkAdminLoggedIn()) instanceof RedirectResponse) {
+            return $response;
+        }
+
         $request = $this->getRequest();
 
         /** @var AdminLogin $adminLoginForm */
@@ -302,7 +309,19 @@ class SessionController extends BaseAdminController
         $this->setupFormErrorContext('Login process', $message, $adminLoginForm, $ex);
 
         // Display the login form again
-        return $this->render('login');
+        return $this->renderLoginPage();
+    }
+
+    protected function renderLoginPage(): Response
+    {
+        $response = $this->render('login');
+
+        // Keep the login form out of the browser back-forward cache: once
+        // logged in, navigating back must fetch the page again and be
+        // redirected to the home page, not restore a stale form.
+        $response->headers->set('Cache-Control', 'no-store');
+
+        return $response;
     }
 
     /**

--- a/tests/Http/BackOffice/AdminPagesSmokeTest.php
+++ b/tests/Http/BackOffice/AdminPagesSmokeTest.php
@@ -65,6 +65,11 @@ final class AdminPagesSmokeTest extends WebIntegrationTestCase
     public function testAdminLoginPageIsPublic(): void
     {
         $this->assertPageRenders('/admin/login');
+
+        self::assertTrue(
+            $this->client->getResponse()->headers->hasCacheControlDirective('no-store'),
+            'The login page must not enter the browser back-forward cache',
+        );
     }
 
     public function testAdminHomeRedirectsToLoginWhenNotLoggedIn(): void
@@ -134,5 +139,34 @@ final class AdminPagesSmokeTest extends WebIntegrationTestCase
         $this->loginAdmin();
 
         $this->assertPageRenders('/admin/tools');
+    }
+
+    public function testAdminLoginPageRedirectsToHomeWhenLoggedIn(): void
+    {
+        $this->loginAdmin();
+
+        $this->client->request('GET', '/admin/login');
+
+        $response = $this->client->getResponse();
+        self::assertSame(302, $response->getStatusCode());
+        self::assertStringEndsWith('/admin', (string) $response->headers->get('Location'));
+    }
+
+    public function testAdminCheckLoginRedirectsToHomeWhenLoggedIn(): void
+    {
+        $this->loginAdmin();
+
+        // A stale login form submitted from the browser cache must lead to the
+        // home page, whatever credentials it carries.
+        $this->client->request('POST', '/admin/checklogin', [
+            'thelia_admin_login' => [
+                'username' => 'wrong-user',
+                'password' => 'wrong-password',
+            ],
+        ]);
+
+        $response = $this->client->getResponse();
+        self::assertSame(302, $response->getStatusCode());
+        self::assertStringEndsWith('/admin', (string) $response->headers->get('Location'));
     }
 }


### PR DESCRIPTION
Submitting the login form while an admin session is already open (browser back button, second tab) always failed with "invalid credentials": the cached form carries a stale CSRF token, and `checkLoginAction` tried to authenticate anyway.

- `/admin/checklogin` now redirects to the home page when an admin session is already open, whatever the submitted credentials.
- The login page is served with `Cache-Control: no-store`, so navigating back after login fetches the page again and redirects to the home page instead of restoring a stale form.