### PR TITLE
fix: read the active languages once per request in the api bridge

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Extension/EagerLoadingExtension.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Extension/EagerLoadingExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Resource\I18n;
 use Thelia\Api\Resource\TranslatableResourceInterface;
-use Thelia\Model\LangQuery;
+use Thelia\Model\Lang;
 
 final readonly class EagerLoadingExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
@@ -243,7 +243,7 @@ final readonly class EagerLoadingExtension implements QueryCollectionExtensionIn
             return;
         }
 
-        $langs = LangQuery::create()->filterByActive(1)->find();
+        $langs = Lang::getActiveLangs();
         $i18nResource = new ($resourceClass::getI18nResourceClass());
 
         if (!$i18nResource instanceof I18n) {

--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -35,7 +35,7 @@ use Thelia\Api\Bridge\Propel\Event\ModelToResourceEvent;
 use Thelia\Api\Resource\PropelResourceInterface;
 use Thelia\Api\Resource\ResourceAddonInterface;
 use Thelia\Api\Resource\TranslatableResourceInterface;
-use Thelia\Model\LangQuery;
+use Thelia\Model\Lang;
 
 readonly class ApiResourcePropelTransformerService
 {
@@ -67,7 +67,7 @@ readonly class ApiResourcePropelTransformerService
         bool $withAddon = true,
     ): PropelResourceInterface {
         if (!$langs instanceof Collection) {
-            $langs = LangQuery::create()->filterByActive(1)->find();
+            $langs = Lang::getActiveLangs();
         }
 
         // Init internal recursion-control context

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
@@ -23,7 +23,7 @@ use Thelia\Api\Bridge\Propel\Extension\QueryResultCollectionExtensionInterface;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 use Thelia\Api\Bridge\Propel\State\Pagination\PropelPaginator;
 use Thelia\Api\Resource\PropelResourceInterface;
-use Thelia\Model\LangQuery;
+use Thelia\Model\Lang;
 
 readonly class PropelCollectionProvider implements ProviderInterface
 {
@@ -69,7 +69,7 @@ readonly class PropelCollectionProvider implements ProviderInterface
             $results = $query->find();
         }
 
-        $langs = LangQuery::create()->filterByActive(1)->find();
+        $langs = Lang::getActiveLangs();
 
         if ($results instanceof PropelModelPager) {
             $resources = array_map(

--- a/core/lib/Thelia/Core/EventListener/ActiveLangsCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/ActiveLangsCacheListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Model\Event\LangEvent;
+use Thelia\Model\Lang;
+
+/**
+ * Keeps {@see Lang::getActiveLangs()} honest: the memoized list never outlives a request or
+ * a console command, and a write on a language drops it at once.
+ */
+readonly class ActiveLangsCacheListener
+{
+    #[AsEventListener(event: LangEvent::POST_SAVE)]
+    #[AsEventListener(event: LangEvent::POST_DELETE)]
+    public function onLangWrite(): void
+    {
+        Lang::resetActiveLangsCache();
+    }
+
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            Lang::resetActiveLangsCache();
+        }
+    }
+
+    #[AsEventListener(event: ConsoleEvents::COMMAND)]
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        Lang::resetActiveLangsCache();
+    }
+}

--- a/core/lib/Thelia/Model/Lang.php
+++ b/core/lib/Thelia/Model/Lang.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Model;
 
+use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Propel;
 use Thelia\Model\Base\Lang as BaseLang;
@@ -26,6 +27,8 @@ class Lang extends BaseLang
     public const REPLACE_BY_DEFAULT_LANGUAGE = 1;
 
     protected static $defaultLanguage;
+
+    protected static ?ObjectCollection $activeLangs = null;
 
     /**
      * Return the default language object, using a local variable to cache it.
@@ -45,6 +48,26 @@ class Lang extends BaseLang
         }
 
         return self::$defaultLanguage;
+    }
+
+    /**
+     * The active languages, read once per request.
+     *
+     * The API bridge asks for them every time it transforms a model or eager-loads a
+     * collection: a page rendering a dozen resources reread the same rows a dozen times.
+     * Reset by {@see \Thelia\Core\EventListener\ActiveLangsCacheListener} at the start of
+     * every request and console command, and whenever a language is saved or deleted.
+     *
+     * @return ObjectCollection<Lang>
+     */
+    public static function getActiveLangs(): ObjectCollection
+    {
+        return self::$activeLangs ??= LangQuery::create()->filterByActive(1)->find();
+    }
+
+    public static function resetActiveLangsCache(): void
+    {
+        self::$activeLangs = null;
     }
 
     public function toggleDefault(): void


### PR DESCRIPTION
## What

Three places in the API bridge run `LangQuery::create()->filterByActive(1)->find()` on their own: `ApiResourcePropelTransformerService::modelToResource()` whenever it is called without a `$langs` collection, `PropelCollectionProvider::provide()` and `EagerLoadingExtension::joinI18ns()`. A front page that renders a dozen resources through `resources()` — the header menu, a listing, its filters, the footer — reads the same `lang` rows a dozen times: 13 to 20 identical queries per page on a Flexy theme.

## Fix

Same shape as #3814 for the config table and the default country:

- `Lang::getActiveLangs()` memoizes the collection for the request, `Lang::resetActiveLangsCache()` drops it.
- `ActiveLangsCacheListener` resets it at the start of every main request and console command, and on `LangEvent::POST_SAVE` / `POST_DELETE`, so a change to the languages is visible at once.
- The three call sites read through it.

## Measured

Flexy category page: 13 `lang` queries before, 1 after. Product page: 17 to 1. Rendered HTML identical.