### PR TITLE
feat: let BaseForm use stateless CSRF tokens for cacheable forms

### DIFF
--- a/core/lib/Thelia/Core/Form/TheliaFormFactory.php
+++ b/core/lib/Thelia/Core/Form/TheliaFormFactory.php
@@ -20,6 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryBuilderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 use Symfony\Component\Validator\ValidatorBuilder;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -42,6 +43,7 @@ class TheliaFormFactory
         protected TokenStorageInterface $tokenStorage,
         #[Autowire(param: 'Thelia.parser.forms')]
         protected array $formDefinition,
+        protected ?CsrfTokenManagerInterface $csrfTokenManager = null,
     ) {
     }
 
@@ -74,6 +76,7 @@ class TheliaFormFactory
             $type,
             $data,
             $options,
+            $this->csrfTokenManager,
         );
 
         return $form;

--- a/core/lib/Thelia/Form/BaseForm.php
+++ b/core/lib/Thelia/Form/BaseForm.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\ValidatorBuilder;
@@ -69,6 +70,7 @@ abstract class BaseForm implements FormInterface
         string $type = FormType::class,
         array $data = [],
         array $options = [],
+        ?CsrfTokenManagerInterface $csrfTokenManager = null,
     ): void {
         $this->request = $request;
         $this->type = $type;
@@ -81,10 +83,14 @@ abstract class BaseForm implements FormInterface
         $this->initFormWithRequest($type, $data, $options);
 
         if (!isset($options['csrf_protection']) || false !== $options['csrf_protection']) {
+            // The framework manager keeps session-bound tokens for the default token id (the
+            // form name) and switches to stateless, origin-based validation for the ids listed
+            // in framework.csrf_protection.stateless_token_ids, so a form rendered inside a
+            // cache can opt in through the 'csrf_token_id' option or its own name.
             $this->formFactoryBuilder
                 ->addExtension(
                     new CsrfExtension(
-                        new CsrfTokenManager(null, $tokenStorage),
+                        $csrfTokenManager ?? new CsrfTokenManager(null, $tokenStorage),
                     ),
                 );
         }

--- a/tests/Integration/Form/BaseFormCsrfTokenTest.php
+++ b/tests/Integration/Form/BaseFormCsrfTokenTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Form;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Core\Form\TheliaFormFactory;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Form\CouponCode;
+use Thelia\Test\IntegrationTestCase;
+
+final class BaseFormCsrfTokenTest extends IntegrationTestCase
+{
+    private RequestStack $requestStack;
+    private int $pushed = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->requestStack = $this->getService('request_stack');
+    }
+
+    protected function tearDown(): void
+    {
+        while ($this->pushed-- > 0) {
+            $this->requestStack->pop();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testTheDefaultTokenIsBoundToTheSessionAndRoundTrips(): void
+    {
+        $this->pushRequest();
+
+        $rendered = $this->tokenValueOf($this->createForm());
+        self::assertNotSame('csrf-token', $rendered, 'a session token is a random value, never the stateless marker');
+
+        self::assertFalse($this->hasCsrfError($this->submit($this->createForm(), $rendered)));
+        self::assertTrue($this->hasCsrfError($this->submit($this->createForm(), 'not-the-session-token')));
+    }
+
+    public function testAStatelessTokenIdRendersAConstantMarkerAndValidatesOnTheOrigin(): void
+    {
+        $this->pushRequest(['HTTP_SEC_FETCH_SITE' => 'same-origin']);
+
+        $stateless = ['csrf_token_id' => 'submit'];
+
+        self::assertSame('csrf-token', $this->tokenValueOf($this->createForm($stateless)));
+        self::assertFalse($this->hasCsrfError($this->submit($this->createForm($stateless), 'csrf-token')));
+    }
+
+    public function testAStatelessTokenIsRejectedWhenTheRequestComesFromAnotherSite(): void
+    {
+        $this->pushRequest(['HTTP_SEC_FETCH_SITE' => 'cross-site']);
+
+        $form = $this->submit($this->createForm(['csrf_token_id' => 'submit']), 'csrf-token');
+
+        self::assertTrue($this->hasCsrfError($form));
+    }
+
+    public function testAStatelessTokenIsRejectedWithoutAnyOriginInformation(): void
+    {
+        $this->pushRequest();
+
+        $form = $this->submit($this->createForm(['csrf_token_id' => 'submit']), 'csrf-token');
+
+        self::assertTrue($this->hasCsrfError($form));
+    }
+
+    private function pushRequest(array $server = []): void
+    {
+        $request = Request::create('http://localhost/cart', 'POST', server: $server);
+        $request->setSession($this->requestStack->getCurrentRequest()->getSession());
+
+        $this->requestStack->push($request);
+        ++$this->pushed;
+    }
+
+    private function createForm(array $options = []): \Symfony\Component\Form\FormInterface
+    {
+        /** @var TheliaFormFactory $factory */
+        $factory = $this->getService(TheliaFormFactory::class);
+
+        return $factory->createForm(CouponCode::getName(), options: $options)->getForm();
+    }
+
+    private function tokenValueOf(\Symfony\Component\Form\FormInterface $form): string
+    {
+        return (string) $form->createView()->children['_token']->vars['value'];
+    }
+
+    private function hasCsrfError(\Symfony\Component\Form\FormInterface $form): bool
+    {
+        foreach ($form->getErrors() as $error) {
+            if (str_contains($error->getMessage(), 'CSRF')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function submit(\Symfony\Component\Form\FormInterface $form, string $token): \Symfony\Component\Form\FormInterface
+    {
+        $form->submit(['coupon-code' => 'ANY', '_token' => $token]);
+
+        return $form;
+    }
+}


### PR DESCRIPTION
Closes #3824

`BaseForm` used to build its own `CsrfTokenManager` on top of the session token storage, so every form got a session-bound token and `framework.csrf_protection.stateless_token_ids` had no effect on Thelia forms. A form rendered inside a cache (Turbo snapshot, Varnish, fragment cache, ESI) then replays a token from another session and the submit fails with `The CSRF token is invalid`.

`TheliaFormFactory` now hands the framework's `CsrfTokenManagerInterface` to `BaseForm::init()`. For the default token id (the form name) that manager falls back to the same session storage as before, so existing forms and tokens already stored in sessions behave exactly as today. Token ids listed in `stateless_token_ids` (either through the `csrf_token_id` option or by listing the form name) switch to Symfony's same-origin validation and render a constant token, which is safe to cache.

`init()` keeps accepting a call without the manager and falls back to the previous session-only behaviour.

Checked on a fresh install: a product page fetched without any cookie renders `csrf-token` once `thelia_cart_add` is declared stateless, the LiveComponent add-to-cart replayed without a cookie returns 200 with a same-origin header, 422 from another site or without any origin information. Full suite, cs and phpstan green.