### PR TITLE
fix: let a parser report no request when rendering outside HTTP

### DIFF
--- a/core/lib/Thelia/Core/Template/ParserTemplateTrait.php
+++ b/core/lib/Thelia/Core/Template/ParserTemplateTrait.php
@@ -35,9 +35,20 @@ trait ParserTemplateTrait
     #[Required]
     public RequestStack $requestStack;
 
-    public function getRequest(): Request
+    /**
+     * The request the template is rendered for, or null when there is none: a template
+     * rendered from the command line - an email sent by a scheduled task, a PDF built by a
+     * console command - has no request to read from, and the callers already treat the
+     * request as optional.
+     */
+    public function getRequest(): ?Request
     {
         $request = $this->requestStack->getMainRequest();
+
+        if (null === $request) {
+            return null;
+        }
+
         if (!$request instanceof Request) {
             return Request::createFromBase($request);
         }

--- a/tests/Unit/Core/Template/ParserTemplateTraitRequestTest.php
+++ b/tests/Unit/Core/Template/ParserTemplateTraitRequestTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Template;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\Template\ParserTemplateTrait;
+use Thelia\Core\Template\TemplateDefinition;
+
+/**
+ * A parser may render outside any HTTP request: an email sent by a scheduled task, a PDF
+ * built by a console command. Asking it for the request then has to answer null, as the
+ * ParserInterface contract says, not fail on converting a request that does not exist.
+ */
+class ParserTemplateTraitRequestTest extends TestCase
+{
+    public function testThereIsNoRequestOutsideAnHttpRequest(): void
+    {
+        $parser = $this->createParser(new RequestStack());
+
+        $this->assertNull($parser->getRequest());
+    }
+
+    public function testTheMainRequestIsReturnedAsAsTheliaRequest(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(SymfonyRequest::create('/some-page'));
+
+        $request = $this->createParser($requestStack)->getRequest();
+
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertSame('/some-page', $request->getPathInfo());
+    }
+
+    public function testATheliaRequestIsReturnedUntouched(): void
+    {
+        $requestStack = new RequestStack();
+        $theliaRequest = Request::create('/some-page');
+        $requestStack->push($theliaRequest);
+
+        $this->assertSame($theliaRequest, $this->createParser($requestStack)->getRequest());
+    }
+
+    private function createParser(RequestStack $requestStack): object
+    {
+        $parser = new class {
+            use ParserTemplateTrait;
+
+            public function setTemplateDefinition(TemplateDefinition|string $templateDefinition, bool $fallbackToDefaultTemplate = false): void
+            {
+            }
+        };
+
+        $parser->requestStack = $requestStack;
+
+        return $parser;
+    }
+}


### PR DESCRIPTION
## Problem

`ParserTemplateTrait::getRequest()` is declared `?Request` by `ParserInterface`, but the trait converts whatever the request stack holds with `Request::createFromBase()`. Outside an HTTP request — an email sent by a scheduled task, a PDF built by a console command, any script booting the kernel — the stack is empty and the call dies with a `TypeError` (`createFromBase(): Argument #1 must be of type Request, null given`), so a template cannot be rendered from the CLI at all.

## Fix

Return `null` when there is no main request, as the interface says. Callers already treat the request as optional (`MailerFactory`, `BaseHook`, the Twig parser use `?->` / `instanceof` checks).

## Tests

`tests/Unit/Core/Template/ParserTemplateTraitRequestTest.php`: no request → `null` (fails with the `TypeError` before this change); a Symfony request → wrapped as a Thelia `Request`; a Thelia request → returned as is.

Baselines: `composer test` 5 suites green (393 / 682 / 235 + 1 skip / 17 / 12 + 2 pre-existing deprecations), `composer cs-diff` 0, `composer phpstan` 0.

## Out of scope

`TheliaSmarty`'s `SmartyParser` dereferences `getRequest()` without a null check (l.393-404); it already failed with the `TypeError` in that situation and now gets a null-dereference instead — to be handled in that module if CLI rendering through Smarty is wanted.