### PR TITLE
fix: read the tfilters facets from the products the visible filter keeps

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
@@ -157,11 +157,15 @@ readonly class FilterService
 
         if ($isApiRoute) {
             $tfilters = $request->query->all('tfilters');
+            $visible = $request->query->get('visible');
             $query = $this->filterTFilterWithRequest(request: $request);
         } else {
             $tfilters = $context['filters']['tfilters'] ?? [];
+            $visible = $context['filters']['visible'] ?? null;
             $query = $this->filterTFilterWithContext(context: $context);
         }
+
+        $this->restrictToVisibility($query, $visible);
 
         $filterObjects = [];
         $locale = $context['filters']['locale'] ?? $request->query->get('locale');
@@ -256,6 +260,20 @@ readonly class FilterService
         }
 
         return $this->managePosition($filterObjects);
+    }
+
+    /**
+     * The facets follow the listing: a `visible` parameter narrows the set they are read from
+     * the way the collection's own filter narrows the products, so a value held only by hidden
+     * products is not offered to filter a list that will never show them.
+     */
+    private function restrictToVisibility(ModelCriteria $query, mixed $visible): void
+    {
+        if ($visible === null || $visible === '' || !method_exists($query, 'filterByVisible')) {
+            return;
+        }
+
+        $query->filterByVisible(filter_var($visible, \FILTER_VALIDATE_BOOL) ? 1 : 0);
     }
 
     private function managePosition(array $filterObjects): array

--- a/tests/Integration/Api/TFiltersVisibleProductsTest.php
+++ b/tests/Integration/Api/TFiltersVisibleProductsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Api\Resource\Filter;
+use Thelia\Api\Resource\FilterValue;
+use Thelia\Model\ChoiceFilter;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Product;
+use Thelia\Model\Template;
+use Thelia\Test\IntegrationTestCase;
+
+final class TFiltersVisibleProductsTest extends IntegrationTestCase
+{
+    private FilterService $filterService;
+
+    private int $categoryId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filterService = static::getContainer()->get(FilterService::class);
+        $this->createCatalogue();
+    }
+
+    public function testWithoutVisibilityEveryProductFeedsTheFacets(): void
+    {
+        self::assertSame(
+            [
+                'brand/Brand' => ['Hidden brand', 'Shown brand'],
+                'feature/Colour' => ['Blue', 'Red'],
+            ],
+            $this->facets([]),
+        );
+    }
+
+    public function testVisibleProductsAloneFeedTheFacets(): void
+    {
+        self::assertSame(
+            [
+                'brand/Brand' => ['Shown brand'],
+                'feature/Colour' => ['Blue'],
+            ],
+            $this->facets(['visible' => 'true']),
+        );
+    }
+
+    public function testHiddenProductsAloneFeedTheFacetsWhenAsked(): void
+    {
+        self::assertSame(
+            [
+                'brand/Brand' => ['Hidden brand'],
+                'feature/Colour' => ['Red'],
+            ],
+            $this->facets(['visible' => '0']),
+        );
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<string, list<string>>
+     */
+    private function facets(array $filters): array
+    {
+        $filterObjects = $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    'tfilters' => ['category' => [['eq' => $this->categoryId]]],
+                    'locale' => 'en_US',
+                    ...$filters,
+                ],
+            ],
+            'products',
+        );
+
+        $facets = [];
+
+        /** @var Filter $filter */
+        foreach ($filterObjects as $filter) {
+            if ($filter->getType() === 'category') {
+                continue;
+            }
+
+            $titles = array_map(
+                static fn (FilterValue $value): string => (string) $value->getTitle(),
+                $filter->getValues(),
+            );
+            sort($titles);
+            $facets[$filter->getType().'/'.$filter->getTitle()] = $titles;
+        }
+
+        ksort($facets);
+
+        return $facets;
+    }
+
+    private function createCatalogue(): void
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        // Without a template on the category the service offers no filter at all.
+        $template = new Template();
+        $template->setLocale('en_US');
+        $template->setName('Filtered template');
+        $template->save($connection);
+
+        $category = $factory->category();
+        $category->setDefaultTemplateId($template->getId());
+        $category->save($connection);
+        $this->categoryId = (int) $category->getId();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $colour = $factory->feature(['title' => 'Colour']);
+
+        $choiceFilter = new ChoiceFilter();
+        $choiceFilter->setCategoryId($category->getId());
+        $choiceFilter->setTemplateId($template->getId());
+        $choiceFilter->setFeatureId($colour->getId());
+        $choiceFilter->setPosition(1);
+        $choiceFilter->setVisible(true);
+        $choiceFilter->setType('checkbox');
+        $choiceFilter->save($connection);
+        $blue = $factory->featureAv($colour, ['title' => 'Blue']);
+        $red = $factory->featureAv($colour, ['title' => 'Red']);
+
+        $shown = $factory->product($category, $taxRule, $currency, ['ref' => 'SHOWN', 'visible' => 1]);
+        $shown->setBrandId($factory->brand(['title' => 'Shown brand'])->getId())->save($connection);
+        $this->holdValue($shown, (int) $colour->getId(), (int) $blue->getId());
+
+        $hidden = $factory->product($category, $taxRule, $currency, ['ref' => 'HIDDEN', 'visible' => 0]);
+        $hidden->setBrandId($factory->brand(['title' => 'Hidden brand'])->getId())->save($connection);
+        $this->holdValue($hidden, (int) $colour->getId(), (int) $red->getId());
+    }
+
+    private function holdValue(Product $product, int $featureId, int $featureAvId): void
+    {
+        $featureProduct = new FeatureProduct();
+        $featureProduct->setProductId($product->getId());
+        $featureProduct->setFeatureId($featureId);
+        $featureProduct->setFeatureAvId($featureAvId);
+        $featureProduct->save($this->getPropelConnection());
+    }
+}


### PR DESCRIPTION
`/api/front/tfilters/products` reads its facet values from every product of the category, whether visible or not, while a front listing asks the products collection with `visible=1`. A brand or a feature value carried only by hidden products is therefore offered as a filter, and checking it yields an empty list.

`FilterService::getFilters()` now honours a `visible` parameter the same way the collection does: when the caller passes it, the facets are read from the products it keeps. Without the parameter nothing changes.

Covered by `TFiltersVisibleProductsTest`: a category holding a visible product (brand A, colour blue) and a hidden one (brand B, colour red) exposes both values without the parameter, only A/blue with `visible=true`, only B/red with `visible=0`.
