### PR TITLE
fix: widen the brand filter when several brands are checked

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
@@ -40,11 +40,38 @@ class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterf
 
     public function filter(ModelCriteria $query, $value, bool $isMinOrMaxFilter = false, ?int $categoryDepth = null): void
     {
-        foreach ($value as $id => $childValue) {
-            foreach ($childValue as $type => $brandId) {
-                $query->filterByBrandId($brandId);
+        $brandIds = $this->flattenSelectedValues($value);
+
+        if ($brandIds === []) {
+            return;
+        }
+
+        // A product has one brand, so two checked brands can only be asked for as one IN:
+        // one equality per brand would AND two exclusive conditions and match nothing.
+        $query->filterByBrandId($brandIds, Criteria::IN);
+    }
+
+    /**
+     * The selection arrives as `tfilters[brand][brand][] = id`, one or two levels deep
+     * depending on the client. Keeps the identifiers, whatever the nesting, without duplicates.
+     *
+     * @return list<int|string>
+     */
+    private function flattenSelectedValues(mixed $value): array
+    {
+        $brandIds = [];
+
+        foreach ((array) $value as $childValue) {
+            foreach ((array) $childValue as $brandId) {
+                if (\is_array($brandId) || $brandId === null || $brandId === '') {
+                    continue;
+                }
+
+                $brandIds[] = $brandId;
             }
         }
+
+        return array_values(array_unique($brandIds));
     }
 
     public function getValue(ActiveRecordInterface $activeRecord, string $locale, $valueSearched = null, ?int $depth = 1): ?array

--- a/tests/Integration/Api/BrandFilterSelectionTest.php
+++ b/tests/Integration/Api/BrandFilterSelectionTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Model\ProductQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A product carries a single brand, so two brands checked in the filter column ask for
+ * either of them. A shopper who checks a second brand expects more products, never an
+ * empty list.
+ */
+final class BrandFilterSelectionTest extends IntegrationTestCase
+{
+    private const FIRST_BRAND_PRODUCT = 'BRAND-FIRST';
+    private const SECOND_BRAND_PRODUCT = 'BRAND-SECOND';
+    private const THIRD_BRAND_PRODUCT = 'BRAND-THIRD';
+    private const UNBRANDED_PRODUCT = 'BRAND-NONE';
+
+    private FilterService $filterService;
+
+    /** @var array<string, int> */
+    private array $brandIds = [];
+
+    /** @var array<string, int> product reference => id, in creation order */
+    private array $productIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filterService = static::getContainer()->get(FilterService::class);
+        $this->createCatalogue();
+    }
+
+    public function testOneCheckedBrandKeepsItsProducts(): void
+    {
+        self::assertSame(
+            [self::FIRST_BRAND_PRODUCT],
+            $this->matchingReferences([$this->brandIds['first']]),
+        );
+    }
+
+    public function testTwoCheckedBrandsWidenTheSelection(): void
+    {
+        self::assertSame(
+            [self::FIRST_BRAND_PRODUCT, self::SECOND_BRAND_PRODUCT],
+            $this->matchingReferences([$this->brandIds['first'], $this->brandIds['second']]),
+        );
+    }
+
+    public function testACheckedBrandRepeatedByTheQueryStringCountsOnce(): void
+    {
+        self::assertSame(
+            [self::FIRST_BRAND_PRODUCT],
+            $this->matchingReferences([$this->brandIds['first'], (string) $this->brandIds['first']]),
+        );
+    }
+
+    /**
+     * @param list<int|string> $selection the checked brand ids, as the query string carries them
+     *
+     * @return list<string> the references of the matching products, in creation order
+     */
+    private function matchingReferences(array $selection): array
+    {
+        // Restricted to the products this test created: the filter is what is under test,
+        // not whatever else the database holds.
+        $query = ProductQuery::create()->filterById(array_values($this->productIds), Criteria::IN);
+
+        $filtered = $this->filterService->filterWithTFilter(
+            tfilters: ['brand' => ['brand' => $selection]],
+            resource: 'products',
+            query: $query,
+        );
+
+        $matched = [];
+
+        foreach ($filtered->find($this->getPropelConnection()) as $product) {
+            $matched[] = (int) $product->getId();
+        }
+
+        return array_keys(array_filter(
+            $this->productIds,
+            static fn (int $id): bool => \in_array($id, $matched, true),
+        ));
+    }
+
+    private function createCatalogue(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $connection = $this->getPropelConnection();
+
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        foreach (['first', 'second', 'third'] as $name) {
+            $this->brandIds[$name] = (int) $factory->brand()->getId();
+        }
+
+        $catalogue = [
+            self::FIRST_BRAND_PRODUCT => $this->brandIds['first'],
+            self::SECOND_BRAND_PRODUCT => $this->brandIds['second'],
+            self::THIRD_BRAND_PRODUCT => $this->brandIds['third'],
+            self::UNBRANDED_PRODUCT => null,
+        ];
+
+        foreach ($catalogue as $reference => $brandId) {
+            $product = $factory->product($category, $taxRule, $currency, ['ref' => $reference]);
+            $product->setBrandId($brandId);
+            $product->save($connection);
+            $this->productIds[$reference] = (int) $product->getId();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On a product listing, checking two brands empties the list instead of widening it.

`BrandFilter::filter()` walks the selection value by value and calls `filterByBrandId()` once per
brand. A product has one `brand_id`, so the two equalities are `AND`-ed on the same column and no
row can satisfy both.

## Reproduction

```
GET /api/front/products?tfilters[brand][brand][0]=58&tfilters[brand][brand][1]=20
```

| selection | expected | before |
|---|---|---|
| brand 58 | its products | its products |
| brands 58, 20 | products of either | *(empty)* |

Generated SQL, before:

```sql
WHERE product.brand_id = 58 AND product.brand_id = 20
```

## Fix

Collect the checked identifiers into a single `IN`, the way `FeatureAvFilter` does since #3810.
The flattening tolerates the shapes a query string can produce (one or two levels of nesting,
empty strings, unexpected arrays) and drops duplicates.

```sql
WHERE product.brand_id IN (58, 20)
```

This is the semantics Thelia 2 exposed through the `product` loop's `brand="58,20"` argument.

## Test

`tests/Integration/Api/BrandFilterSelectionTest.php`: one brand, two brands, one brand repeated by
the query string. The two-brands case fails on `main` without the fix; all three pass with it.

## Checks

`composer cs-diff` 0 · `composer phpstan` 0 · `composer test:integration` 688 OK ·
`composer test:api` 235 OK (single pre-existing skip).
