### PR TITLE
feat(api): count and relax the tfilters facets, read each feature and attribute in its own mode

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\Request;
@@ -150,7 +151,8 @@ readonly class FilterService
      * from the set narrowed by every other filter but itself, so a checked value keeps its
      * siblings on offer (checking one brand must not hide the other brands); a filter that is
      * not selected reads it from the fully narrowed set. The category filter is the browsing
-     * scope, never relaxed.
+     * scope, never relaxed. A collection restricted to a set of ids (`id[]=…`, the products a
+     * search engine ranked) gets its facets from that set, category or not.
      */
     public function getFilters(array $context, string $resource): array
     {
@@ -165,25 +167,31 @@ readonly class FilterService
         if ($isApiRoute) {
             $tfilters = $request->query->all('tfilters');
             $visible = $request->query->get('visible');
+            $scopeIds = $request->query->all('id');
             $categoryDepth = (int) $request->query->get(CategoryFilter::CATEGORY_DEPTH_NAME);
         } else {
             $tfilters = $context['filters']['tfilters'] ?? [];
             $visible = $context['filters']['visible'] ?? null;
+            $scopeIds = $context['filters']['id'] ?? [];
             $categoryDepth = (int) ($context['filters'][CategoryFilter::CATEGORY_DEPTH_NAME] ?? null);
         }
 
-        // createFilterDto() drops every filter when no category is being browsed,
-        // so the facet values would be computed only to be thrown away.
-        if (!$this->hasFilter(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters)) {
+        $scopeIds = $this->scopeIds($scopeIds);
+        $browsesCategory = $this->hasFilter(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters);
+
+        // Without a browsed category nor an explicit set of ids the facets would describe the
+        // whole catalogue, which no listing shows.
+        if (!$browsesCategory && $scopeIds === null) {
             return [];
         }
 
         $locale = $context['filters']['locale'] ?? $request->query->get('locale');
         $locale ??= $this->langService->getLocale();
 
-        $resolveIds = function (array $selection) use ($resource, $visible, $categoryDepth): array {
+        $resolveIds = function (array $selection) use ($resource, $visible, $categoryDepth, $scopeIds): array {
             $query = $this->filterWithTFilter(tfilters: $selection, resource: $resource, categoryDepth: $categoryDepth);
             $this->restrictToVisibility($query, $visible);
+            $this->restrictToScope($query, $scopeIds);
 
             return $this->resolveResourceIds($query);
         };
@@ -206,7 +214,7 @@ readonly class FilterService
                 if ($narrowedIds === []) {
                     continue;
                 }
-                $narrowedQuery ??= $this->restrictedQuery($tfilters, $resource, $visible, $categoryDepth);
+                $narrowedQuery ??= $this->restrictedQuery($tfilters, $resource, $visible, $categoryDepth, $scopeIds);
                 $values = $this->getValues(query: $narrowedQuery, filter: $filter, tfilters: $tfilters, locale: $locale);
             }
 
@@ -228,12 +236,49 @@ readonly class FilterService
         return $this->managePosition($filterObjects);
     }
 
-    private function restrictedQuery(array $tfilters, string $resource, mixed $visible, int $categoryDepth): ModelCriteria
+    /**
+     * @param array<int>|null $scopeIds
+     */
+    private function restrictedQuery(array $tfilters, string $resource, mixed $visible, int $categoryDepth, ?array $scopeIds): ModelCriteria
     {
         $query = $this->filterWithTFilter(tfilters: $tfilters, resource: $resource, categoryDepth: $categoryDepth);
         $this->restrictToVisibility($query, $visible);
+        $this->restrictToScope($query, $scopeIds);
 
         return $query;
+    }
+
+    /**
+     * The `id` parameter of the collection, as a search page sends it: the facets then describe
+     * the products the search engine ranked, not the catalogue. Null when the request sends none.
+     *
+     * @return array<int>|null
+     */
+    private function scopeIds(mixed $ids): ?array
+    {
+        if ($ids === null || $ids === '' || $ids === []) {
+            return null;
+        }
+
+        if (\is_string($ids)) {
+            $ids = explode(',', $ids);
+        }
+
+        $ids = array_values(array_unique(array_map('intval', array_filter((array) $ids, 'is_scalar'))));
+
+        return $ids === [] ? null : $ids;
+    }
+
+    /**
+     * @param array<int>|null $scopeIds
+     */
+    private function restrictToScope(ModelCriteria $query, ?array $scopeIds): void
+    {
+        if ($scopeIds === null) {
+            return;
+        }
+
+        $query->filterById($scopeIds, Criteria::IN);
     }
 
     /**
@@ -342,6 +387,12 @@ readonly class FilterService
      */
     private function choiceFiltersOfBrowsedCategory(array $tfilters): ?array
     {
+        if (!$this->hasFilter(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters)) {
+            // A listing outside any category (a search) has no choice_filter rows to obey: every
+            // filter is offered, as a checkbox list.
+            return ['rows' => [], 'template_id' => null];
+        }
+
         $categoryId = $this->retrieveFilterValue(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters);
         $category = CategoryQuery::create()->findPk(key: $categoryId);
 

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/FilterService.php
@@ -145,6 +145,13 @@ readonly class FilterService
         return $query->groupById();
     }
 
+    /**
+     * The facets of the browsed set. A filter that is part of the selection reads its facet
+     * from the set narrowed by every other filter but itself, so a checked value keeps its
+     * siblings on offer (checking one brand must not hide the other brands); a filter that is
+     * not selected reads it from the fully narrowed set. The category filter is the browsing
+     * scope, never relaxed.
+     */
     public function getFilters(array $context, string $resource): array
     {
         $request = $this->requestStack->getMainRequest();
@@ -158,19 +165,12 @@ readonly class FilterService
         if ($isApiRoute) {
             $tfilters = $request->query->all('tfilters');
             $visible = $request->query->get('visible');
-            $query = $this->filterTFilterWithRequest(request: $request);
+            $categoryDepth = (int) $request->query->get(CategoryFilter::CATEGORY_DEPTH_NAME);
         } else {
             $tfilters = $context['filters']['tfilters'] ?? [];
             $visible = $context['filters']['visible'] ?? null;
-            $query = $this->filterTFilterWithContext(context: $context);
+            $categoryDepth = (int) ($context['filters'][CategoryFilter::CATEGORY_DEPTH_NAME] ?? null);
         }
-
-        $this->restrictToVisibility($query, $visible);
-
-        $filterObjects = [];
-        $locale = $context['filters']['locale'] ?? $request->query->get('locale');
-        $locale ??= $this->langService->getLocale();
-        $filters = $this->getAvailableFilters($resource);
 
         // createFilterDto() drops every filter when no category is being browsed,
         // so the facet values would be computed only to be thrown away.
@@ -178,88 +178,189 @@ readonly class FilterService
             return [];
         }
 
-        $resourceIds = $this->resolveResourceIds($query);
+        $locale = $context['filters']['locale'] ?? $request->query->get('locale');
+        $locale ??= $this->langService->getLocale();
 
-        if ($resourceIds === []) {
-            return [];
-        }
+        $resolveIds = function (array $selection) use ($resource, $visible, $categoryDepth): array {
+            $query = $this->filterWithTFilter(tfilters: $selection, resource: $resource, categoryDepth: $categoryDepth);
+            $this->restrictToVisibility($query, $visible);
 
-        foreach ($filters as $filter) {
-            $values = $filter instanceof TheliaAggregatedFilterInterface
-                ? $this->getAggregatedValues(
+            return $this->resolveResourceIds($query);
+        };
+
+        $narrowedIds = $resolveIds($tfilters);
+        $narrowedQuery = null;
+        $choiceFilters = $this->choiceFiltersOfBrowsedCategory($tfilters);
+        $filterObjects = [];
+
+        foreach ($this->getAvailableFilters($resource) as $filter) {
+            if ($filter instanceof TheliaAggregatedFilterInterface) {
+                $values = $this->aggregatedFacet(
                     filter: $filter,
-                    resourceIds: $resourceIds,
                     tfilters: $tfilters,
-                    locale: $locale
-                )
-                : $this->getValues(
-                    query: $query,
-                    filter: $filter,
-                    tfilters: $tfilters,
-                    locale: $locale
+                    narrowedIds: $narrowedIds,
+                    resolveIds: $resolveIds,
+                    locale: $locale,
                 );
+            } else {
+                if ($narrowedIds === []) {
+                    continue;
+                }
+                $narrowedQuery ??= $this->restrictedQuery($tfilters, $resource, $visible, $categoryDepth);
+                $values = $this->getValues(query: $narrowedQuery, filter: $filter, tfilters: $tfilters, locale: $locale);
+            }
+
             if ($values === []) {
                 continue;
             }
-            $hasMainResource = $this->hasMainResource($values);
-            if ($hasMainResource) {
-                $values = array_intersect_key(
-                    $values, array_unique(
-                        array_map(
-                            static fn (FilterValue $filterValue): string => $filterValue->getId().'-'.$filterValue->getMainId(),
-                            $values,
-                        )
-                    )
-                );
 
-                $splitValues = [];
-
-                /** @var FilterValue $value */
-                foreach ($values as $value) {
-                    $splitValues[$value->getMainId()][] = $value;
-                }
-
-                foreach ($splitValues as $value) {
-                    $filterDto = $this->createFilterDto(
-                        tfilters: $tfilters,
-                        filter: $filter,
-                        values: $value,
-                        locale: $locale
-                    );
-                    if (!$filterDto || !$filterDto->isVisible()) {
-                        continue;
-                    }
-                    $filterObjects[] = $filterDto;
-                }
-            }
-            if (!$hasMainResource) {
-                $values = array_values(
-                    array_reduce(
-                        $values,
-                        static function ($carry, $item) {
-                            $carry[$item->getId()] = $item;
-
-                            return $carry;
-                        },
-                        []
-                    )
-                );
-
-                $filterDto = $this->createFilterDto(
-                    tfilters: $tfilters,
-                    filter: $filter,
-                    values: $values,
-                    locale: $locale,
-                );
+            foreach ($this->groupByMainResource($values) as $group) {
+                $filterDto = $this->createFilterDto(filter: $filter, values: $group, locale: $locale, choiceFilters: $choiceFilters);
 
                 if (!$filterDto || !$filterDto->isVisible()) {
                     continue;
                 }
+
                 $filterObjects[] = $filterDto;
             }
         }
 
         return $this->managePosition($filterObjects);
+    }
+
+    private function restrictedQuery(array $tfilters, string $resource, mixed $visible, int $categoryDepth): ModelCriteria
+    {
+        $query = $this->filterWithTFilter(tfilters: $tfilters, resource: $resource, categoryDepth: $categoryDepth);
+        $this->restrictToVisibility($query, $visible);
+
+        return $query;
+    }
+
+    /**
+     * The facet values of one aggregated filter. When the filter is selected, the values of
+     * each selected group (a feature, an attribute, or the filter as a whole for a brand) are
+     * read from the set narrowed by everything but that group; the other groups keep the fully
+     * narrowed set.
+     *
+     * @param array<int>                  $narrowedIds
+     * @param callable(array): array<int> $resolveIds
+     *
+     * @return array<FilterValue>
+     */
+    private function aggregatedFacet(TheliaAggregatedFilterInterface $filter, array $tfilters, array $narrowedIds, callable $resolveIds, string $locale): array
+    {
+        if ($filter instanceof CategoryFilter) {
+            return $narrowedIds === [] ? [] : $this->getAggregatedValues($filter, $narrowedIds, $tfilters, $locale);
+        }
+
+        $selectedKeys = array_values(array_filter(
+            $filter::getFilterName(),
+            static fn (string $name): bool => isset($tfilters[$name]) && $tfilters[$name] !== [] && $tfilters[$name] !== '',
+        ));
+
+        if ($selectedKeys === []) {
+            return $narrowedIds === [] ? [] : $this->getAggregatedValues($filter, $narrowedIds, $tfilters, $locale);
+        }
+
+        if (!$filter instanceof TheliaChoiceFilterInterface) {
+            $relaxed = $tfilters;
+            foreach ($selectedKeys as $key) {
+                unset($relaxed[$key]);
+            }
+
+            $relaxedIds = $resolveIds($relaxed);
+
+            return $relaxedIds === [] ? [] : $this->getAggregatedValues($filter, $relaxedIds, $tfilters, $locale);
+        }
+
+        $values = $narrowedIds === [] ? [] : $this->getAggregatedValues($filter, $narrowedIds, $tfilters, $locale);
+
+        foreach ($selectedKeys as $key) {
+            foreach (array_keys((array) $tfilters[$key]) as $group) {
+                $relaxed = $tfilters;
+                unset($relaxed[$key][$group]);
+
+                if ($relaxed[$key] === []) {
+                    unset($relaxed[$key]);
+                }
+
+                $relaxedIds = $resolveIds($relaxed);
+                $values = array_values(array_filter(
+                    $values,
+                    static fn (FilterValue $value): bool => (string) $value->getMainId() !== (string) $group,
+                ));
+
+                if ($relaxedIds === []) {
+                    continue;
+                }
+
+                foreach ($this->getAggregatedValues($filter, $relaxedIds, $tfilters, $locale) as $value) {
+                    if ((string) $value->getMainId() === (string) $group) {
+                        $values[] = $value;
+                    }
+                }
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Splits the values by the entity they hang from (a feature, an attribute), deduplicated;
+     * values without one (a brand, a category) form a single group.
+     *
+     * @param array<FilterValue> $values
+     *
+     * @return array<array<FilterValue>>
+     */
+    private function groupByMainResource(array $values): array
+    {
+        if (!$this->hasMainResource($values)) {
+            $unique = [];
+
+            foreach ($values as $value) {
+                $unique[$value->getId()] ??= $value;
+            }
+
+            return [array_values($unique)];
+        }
+
+        $groups = [];
+
+        foreach ($values as $value) {
+            $groups[$value->getMainId()][$value->getId()] ??= $value;
+        }
+
+        return array_map('array_values', array_values($groups));
+    }
+
+    /**
+     * The choice_filter rows that rule the browsed category, read once for every filter of
+     * the page rather than once per facet.
+     *
+     * @return array{rows: array<ChoiceFilter>, template_id: int|null}|null null when nothing rules them
+     */
+    private function choiceFiltersOfBrowsedCategory(array $tfilters): ?array
+    {
+        $categoryId = $this->retrieveFilterValue(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters);
+        $category = CategoryQuery::create()->findPk(key: $categoryId);
+
+        if (!$category) {
+            return null;
+        }
+
+        $templateId = null;
+        $rows = ChoiceFilterQuery::findChoiceFilterByCategory(category: $category, templateId: $templateId)->getData();
+
+        if ($rows === [] && $templateId) {
+            $rows = ChoiceFilterQuery::create()->filterByTemplateId($templateId)->find()->getData();
+        }
+
+        if ($rows === [] && $templateId === null) {
+            return null;
+        }
+
+        return ['rows' => $rows, 'template_id' => $templateId];
     }
 
     /**
@@ -382,77 +483,43 @@ readonly class FilterService
         return $ids;
     }
 
-    private function createFilterDto(array $tfilters, TheliaFilterInterface $filter, array $values, string $locale): ?Filter
+    /**
+     * @param array<FilterValue>                                           $values
+     * @param array{rows: array<ChoiceFilter>, template_id: int|null}|null $choiceFilters
+     */
+    private function createFilterDto(TheliaFilterInterface $filter, array $values, string $locale, ?array $choiceFilters): ?Filter
     {
-        if (!$this->hasFilter(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters)) {
-            return null;
-        }
-
-        $categoryId = $this->retrieveFilterValue(theliaFilterNames: CategoryFilter::getFilterName(), tfilters: $tfilters);
-        $category = CategoryQuery::create()->findPk(key: $categoryId);
-        $choiceFiltersCategory = ChoiceFilterQuery::findChoiceFilterByCategory(category: $category, templateId: $templateIdFind)->getData();
-        $choiceFiltersTemplate = [];
-
-        if ($templateIdFind) {
-            $choiceFiltersTemplate = ChoiceFilterQuery::create()->filterByTemplateId($templateIdFind)->find()->getData();
-        }
-
-        $choiceFilters = $choiceFiltersCategory;
-
-        if (empty($choiceFilters)) {
-            $choiceFilters = $choiceFiltersTemplate;
-        }
-
-        if (empty($choiceFilters) && $templateIdFind === null) {
+        if ($choiceFilters === null) {
             return null;
         }
 
         /** @var ChoiceFilter $choiceFilter */
-        foreach ($choiceFilters as $choiceFilter) {
+        foreach ($choiceFilters['rows'] as $choiceFilter) {
             $otherType = $choiceFilter->getChoiceFilterOther()?->getType();
 
             if (\in_array($otherType, $filter->getFilterName(), true)) {
-                return $this->hydrateFilterDto(
-                    filter: $filter,
-                    values: $values,
-                    locale: $locale,
-                    choiceFilter: $choiceFilter,
-                );
+                return $this->hydrateFilterDto(filter: $filter, values: $values, locale: $locale, choiceFilter: $choiceFilter);
             }
 
-            /**
-             * @var FilterValue $value
-             */
+            if (!$filter instanceof TheliaChoiceFilterInterface) {
+                continue;
+            }
+
+            $mainType = $filter->getChoiceFilterType();
+
+            /** @var FilterValue $value */
             foreach ($values as $value) {
-                if ($filter instanceof TheliaChoiceFilterInterface) {
-                    $mainType = $filter->getChoiceFilterType();
+                if ($choiceFilter->getAttribute() instanceof $mainType && $choiceFilter->getAttribute()->getId() === $value->getMainId()) {
+                    return $this->hydrateFilterDto(filter: $filter, values: $values, locale: $locale, choiceFilter: $choiceFilter);
+                }
 
-                    if ($choiceFilter->getAttribute() instanceof $mainType && $choiceFilter->getAttribute()->getId() === $value->getMainId()) {
-                        return $this->hydrateFilterDto(
-                            filter: $filter,
-                            values: $values,
-                            locale: $locale,
-                            choiceFilter: $choiceFilter,
-                        );
-                    }
-
-                    if ($choiceFilter->getFeature() instanceof $mainType && $choiceFilter->getFeature()->getId() === $value->getMainId()) {
-                        return $this->hydrateFilterDto(
-                            filter: $filter,
-                            values: $values,
-                            locale: $locale,
-                            choiceFilter: $choiceFilter,
-                        );
-                    }
+                if ($choiceFilter->getFeature() instanceof $mainType && $choiceFilter->getFeature()->getId() === $value->getMainId()) {
+                    return $this->hydrateFilterDto(filter: $filter, values: $values, locale: $locale, choiceFilter: $choiceFilter);
                 }
             }
         }
 
-        return $this->hydrateFilterDto(
-            filter: $filter,
-            values: $values,
-            locale: $locale
-        );
+        return $this->hydrateFilterDto(filter: $filter, values: $values, locale: $locale);
     }
 
     private function hydrateFilterDto(

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/AttributeAvFilter.php
@@ -25,10 +25,14 @@ use Thelia\Model\Attribute;
 use Thelia\Model\AttributeAvQuery;
 use Thelia\Model\AttributeCombinationQuery;
 use Thelia\Model\AttributeQuery;
+use Thelia\Model\Lang;
+use Thelia\Model\Map\AttributeCombinationTableMap;
+use Thelia\Model\Map\ProductSaleElementsTableMap;
 
 class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
+    use SelectedValuesTrait;
 
     public function getResourceType(): array
     {
@@ -40,43 +44,57 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
         return ['attribute'];
     }
 
+    /**
+     * Each attribute of the selection is read in its own mode: checked values, or `min`/`max`
+     * bounds for an attribute rendered as a slider. A product matches when one of its sale
+     * elements carries one checked value of every checked attribute: "S" or "M" widens, "S" and
+     * "blue" narrows to the variants that are both.
+     */
     public function filter(ModelCriteria $query, $value, bool $isMinOrMaxFilter = false, ?int $categoryDepth = null): void
     {
-        $rawAttributes = [];
-        foreach ($value as $attributeId => $childValue) {
-            foreach ($childValue as $type => $raw) {
-                if (!$isMinOrMaxFilter) {
-                    $rawAttributes[] = $raw;
-                    continue;
-                }
-                $query = $query
-                    ->useProductSaleElementsQuery()
-                    ->useAttributeCombinationQuery();
+        ['checked' => $checked, 'bounded' => $bounded] = $this->splitSelectedValues($value);
 
-                if ($isMinOrMaxFilter) {
-                    $operator = $type === 'min' ? Criteria::GREATER_EQUAL : Criteria::LESS_EQUAL;
+        $attributeAvIds = array_values(array_unique(array_merge(...array_values($checked ?: [[]]))));
 
-                    $query = $query
-                        ->filterByAttributeId($attributeId)
-                            ->useAttributeAvQuery()
-                                ->useI18nQuery()
-                                    ->where(\sprintf('CAST(attribute_av_i18n.title AS UNSIGNED) %s ?', $operator), (int) $raw)
-                                ->endUse()
-                            ->endUse();
-                }
-                $query
-                    ->endUse()
-                    ->endUse();
-            }
-        }
-        if (!empty($rawAttributes)) {
+        if ($attributeAvIds !== []) {
+            $count = AttributeAvQuery::create()
+                ->filterById($attributeAvIds, Criteria::IN)
+                ->withColumn('COUNT(DISTINCT attribute_id)', 'distinct_attribute_count')
+                ->select(['distinct_attribute_count'])
+                ->findOne();
+
+            // One IN for every checked value, and the HAVING asks a single sale element to hold
+            // as many distinct attributes as were checked: values of one attribute count as one.
             $query
                 ->useProductSaleElementsQuery()
                     ->useAttributeCombinationQuery()
-                        ->filterByAttributeAvId($rawAttributes, Criteria::IN)
+                        ->filterByAttributeAvId($attributeAvIds, Criteria::IN)
                     ->endUse()
                 ->endUse()
-            ;
+                ->groupBy(ProductSaleElementsTableMap::COL_ID)
+                ->having('COUNT(DISTINCT '.AttributeCombinationTableMap::COL_ATTRIBUTE_ID.') = ?', $count);
+        }
+
+        foreach ($bounded as $attributeId => $bounds) {
+            $alias = 'bounded_attribute_'.preg_replace('/\D/', '', (string) $attributeId);
+
+            $combinationQuery = $query
+                ->useProductSaleElementsQuery($alias.'_pse')
+                ->useAttributeCombinationQuery($alias)
+                ->filterByAttributeId((int) $attributeId)
+                ->useAttributeAvQuery($alias.'_av')
+                ->useI18nQuery(Lang::getDefaultLanguage()->getLocale(), $alias.'_av_i18n');
+
+            foreach ($bounds as $type => $limit) {
+                $operator = $type === 'min' ? Criteria::GREATER_EQUAL : Criteria::LESS_EQUAL;
+                $combinationQuery->where(\sprintf('CAST(%s_av_i18n.title AS UNSIGNED) %s ?', $alias, $operator), (int) $limit);
+            }
+
+            $combinationQuery
+                ->endUse()
+                ->endUse()
+                ->endUse()
+                ->endUse();
         }
     }
 
@@ -105,8 +123,9 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
     }
 
     /**
-     * The attribute values a product set offers are a DISTINCT over the combinations
-     * of its sale elements: one query instead of one per sale element.
+     * The attribute values a product set offers, each with the number of products having a
+     * sale element that carries it, are a GROUP BY over the combinations of its sale elements:
+     * one query instead of one per sale element.
      */
     public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
     {
@@ -118,8 +137,10 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
             ->useProductSaleElementsQuery()
                 ->filterByProductId($resourceIds, Criteria::IN)
             ->endUse()
-            ->select(['AttributeId', 'AttributeAvId'])
-            ->distinct()
+            ->withColumn('COUNT(DISTINCT '.ProductSaleElementsTableMap::COL_PRODUCT_ID.')', 'ProductCount')
+            ->select(['AttributeId', 'AttributeAvId', 'ProductCount'])
+            ->groupBy('AttributeId')
+            ->addGroupByColumn(AttributeCombinationTableMap::COL_ATTRIBUTE_AV_ID)
             ->find()
             ->getData();
 
@@ -129,12 +150,14 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
 
         $attributes = AttributeQuery::create()
             ->filterById(array_column($pairs, 'AttributeId'), Criteria::IN)
+            ->joinWithI18n($locale)
             ->orderByPosition()
             ->find()
             ->toKeyIndex();
 
         $attributeAvs = AttributeAvQuery::create()
             ->filterById(array_column($pairs, 'AttributeAvId'), Criteria::IN)
+            ->joinWithI18n($locale)
             ->orderByPosition()
             ->find()
             ->toKeyIndex();
@@ -165,7 +188,8 @@ class AttributeAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInte
                     ->setMainTitle($this->localizedTitle($attribute, $locale))
                     ->setMainId((int) $pair['AttributeId'])
                     ->setId((int) $pair['AttributeAvId'])
-                    ->setTitle($this->localizedTitle($attributeAv, $locale));
+                    ->setTitle($this->localizedTitle($attributeAv, $locale))
+                    ->setCount((int) $pair['ProductCount']);
         }
 
         return $values;

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/BrandFilter.php
@@ -27,6 +27,7 @@ use Thelia\Model\ProductQuery;
 class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
+    use SelectedValuesTrait;
 
     public function getResourceType(): array
     {
@@ -51,29 +52,6 @@ class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterf
         $query->filterByBrandId($brandIds, Criteria::IN);
     }
 
-    /**
-     * The selection arrives as `tfilters[brand][brand][] = id`, one or two levels deep
-     * depending on the client. Keeps the identifiers, whatever the nesting, without duplicates.
-     *
-     * @return list<int|string>
-     */
-    private function flattenSelectedValues(mixed $value): array
-    {
-        $brandIds = [];
-
-        foreach ((array) $value as $childValue) {
-            foreach ((array) $childValue as $brandId) {
-                if (\is_array($brandId) || $brandId === null || $brandId === '') {
-                    continue;
-                }
-
-                $brandIds[] = $brandId;
-            }
-        }
-
-        return array_values(array_unique($brandIds));
-    }
-
     public function getValue(ActiveRecordInterface $activeRecord, string $locale, $valueSearched = null, ?int $depth = 1): ?array
     {
         $brand = $activeRecord->getBrand();
@@ -90,8 +68,8 @@ class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterf
     }
 
     /**
-     * The brands of a product set are one DISTINCT away; reading them product by
-     * product only to deduplicate them afterwards is what made this expensive.
+     * The brands of a product set, each with the number of products carrying it, are one
+     * GROUP BY away; reading them product by product is what made this expensive.
      */
     public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
     {
@@ -99,25 +77,35 @@ class BrandFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterf
             return [];
         }
 
-        $brandIds = ProductQuery::create()
+        $rows = ProductQuery::create()
             ->filterById($resourceIds, Criteria::IN)
             ->filterByBrandId(null, Criteria::ISNOTNULL)
-            ->select('BrandId')
-            ->distinct()
+            ->withColumn('COUNT(*)', 'ProductCount')
+            ->select(['BrandId', 'ProductCount'])
+            ->groupBy('BrandId')
             ->find()
             ->getData();
 
-        if ($brandIds === []) {
+        if ($rows === []) {
             return [];
         }
 
+        $counts = array_column($rows, 'ProductCount', 'BrandId');
+
+        $brands = BrandQuery::create()
+            ->filterById(array_keys($counts), Criteria::IN)
+            ->joinWithI18n($locale)
+            ->orderByPosition()
+            ->find();
+
         $values = [];
 
-        foreach (BrandQuery::create()->filterById($brandIds, Criteria::IN)->orderByPosition()->find() as $brand) {
+        foreach ($brands as $brand) {
             $values[] =
                 (new FilterValue())
                     ->setId($brand->getId())
-                    ->setTitle($this->localizedTitle($brand, $locale));
+                    ->setTitle($this->localizedTitle($brand, $locale))
+                    ->setCount((int) $counts[$brand->getId()]);
         }
 
         return $values;

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaAggregatedFilterInterface;
@@ -21,6 +22,7 @@ use Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters\Interface\TheliaFilter
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
 use Thelia\Api\Resource\FilterValue;
 use Thelia\Model\CategoryQuery;
+use Thelia\Model\ProductCategoryQuery;
 
 class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterface
 {
@@ -80,7 +82,32 @@ class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInt
             return [];
         }
 
-        return $this->browsedCategories($locale, $valueSearched, $depth);
+        $values = $this->browsedCategories($locale, $valueSearched, $depth);
+
+        if ($values === []) {
+            return [];
+        }
+
+        // One GROUP BY gives how many products of the set sit directly in each browsed
+        // sub-category; a sub-category none of them belongs to is still listed, at zero.
+        $counts = array_column(
+            ProductCategoryQuery::create()
+                ->filterByProductId($resourceIds, Criteria::IN)
+                ->filterByCategoryId(array_map(static fn (FilterValue $value): int => $value->getId(), $values), Criteria::IN)
+                ->withColumn('COUNT(DISTINCT product_id)', 'ProductCount')
+                ->select(['CategoryId', 'ProductCount'])
+                ->groupBy('CategoryId')
+                ->find()
+                ->getData(),
+            'ProductCount',
+            'CategoryId',
+        );
+
+        foreach ($values as $value) {
+            $value->setCount((int) ($counts[$value->getId()] ?? 0));
+        }
+
+        return $values;
     }
 
     private function browsedCategories(string $locale, $valueSearched, ?int $depth): array
@@ -96,7 +123,7 @@ class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInt
         $value = [];
 
         foreach ($valueSearched as $categoryId) {
-            $mainCategory = CategoryQuery::create()->findOneById($categoryId);
+            $mainCategory = CategoryQuery::create()->joinWithI18n($locale)->findOneById($categoryId);
 
             if (!$mainCategory) {
                 continue;

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/FeatureAvFilter.php
@@ -25,11 +25,13 @@ use Thelia\Model\Feature;
 use Thelia\Model\FeatureAvQuery;
 use Thelia\Model\FeatureProductQuery;
 use Thelia\Model\FeatureQuery;
+use Thelia\Model\Lang;
 use Thelia\Model\Map\FeatureProductTableMap;
 
 class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
+    use SelectedValuesTrait;
 
     public function getResourceType(): array
     {
@@ -41,15 +43,18 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
         return ['feature'];
     }
 
+    /**
+     * Each feature of the selection is read in its own mode: checked values, or `min`/`max`
+     * bounds for a feature rendered as a slider. Checked values widen the match inside a feature
+     * and narrow it across features; a bound narrows on its own feature only.
+     */
     public function filter(ModelCriteria $query, $value, bool $isMinOrMaxFilter = false, ?int $categoryDepth = null): void
     {
-        if (!$isMinOrMaxFilter) {
-            $featureAvIds = $this->flattenSelectedValues($value);
+        ['checked' => $checked, 'bounded' => $bounded] = $this->splitSelectedValues($value);
 
-            if ($featureAvIds === []) {
-                return;
-            }
+        $featureAvIds = array_values(array_unique(array_merge(...array_values($checked ?: [[]]))));
 
+        if ($featureAvIds !== []) {
             // Every identifier selected across every feature goes into a single IN, and the
             // HAVING then asks a product to carry as many distinct features as were selected.
             // Two values of the same feature widen the match (they count as one feature), values
@@ -67,23 +72,28 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
                 ->endUse()
                 ->groupBy(FeatureProductTableMap::COL_PRODUCT_ID)
                 ->having('COUNT(DISTINCT '.FeatureProductTableMap::COL_FEATURE_ID.') = ?', $count);
-
-            return;
         }
-        foreach ($value as $featureId => $childValue) {
-            foreach ($childValue as $type => $limit) {
-                $operator = $type === 'min' ? Criteria::GREATER_EQUAL : Criteria::LESS_EQUAL;
 
-                $query
-                    ->useFeatureProductQuery()
-                    ->filterByFeatureId($featureId)
-                    ->useFeatureAvQuery()
-                    ->useI18nQuery()
-                    ->where(\sprintf('CAST(feature_av_i18n.title AS UNSIGNED) %s ?', $operator), (int) $limit)
-                    ->endUse()
-                    ->endUse()
-                    ->endUse();
+        foreach ($bounded as $featureId => $bounds) {
+            // A distinct alias per bounded feature: two sliders must each read their own join,
+            // not share the one the checked values use.
+            $alias = 'bounded_feature_'.preg_replace('/\D/', '', (string) $featureId);
+
+            $featureProductQuery = $query
+                ->useFeatureProductQuery($alias)
+                ->filterByFeatureId((int) $featureId)
+                ->useFeatureAvQuery($alias.'_av')
+                ->useI18nQuery(Lang::getDefaultLanguage()->getLocale(), $alias.'_av_i18n');
+
+            foreach ($bounds as $type => $limit) {
+                $operator = $type === 'min' ? Criteria::GREATER_EQUAL : Criteria::LESS_EQUAL;
+                $featureProductQuery->where(\sprintf('CAST(%s_av_i18n.title AS UNSIGNED) %s ?', $alias, $operator), (int) $limit);
             }
+
+            $featureProductQuery
+                ->endUse()
+                ->endUse()
+                ->endUse();
         }
     }
 
@@ -93,23 +103,6 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
      *
      * @return array<int, int|string>
      */
-    private function flattenSelectedValues(mixed $value): array
-    {
-        $featureAvIds = [];
-
-        foreach ((array) $value as $childValue) {
-            foreach ((array) $childValue as $featureAvId) {
-                if (\is_array($featureAvId) || $featureAvId === null || $featureAvId === '') {
-                    continue;
-                }
-
-                $featureAvIds[] = $featureAvId;
-            }
-        }
-
-        return array_values(array_unique($featureAvIds));
-    }
-
     public function getValue(ActiveRecordInterface $activeRecord, string $locale, $valueSearched = null, ?int $depth = 1): ?array
     {
         if (empty($activeRecord->getFeatureProductsJoinFeatureAv())) {
@@ -135,9 +128,9 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
     }
 
     /**
-     * One query for the distinct (feature, value) pairs the set holds, then the
-     * features and values themselves — bounded by the shop's taxonomy, not by the
-     * number of products.
+     * One query for the distinct (feature, value) pairs the set holds with the number of
+     * products carrying each, then the features and values themselves with their translations
+     * — bounded by the shop's taxonomy, not by the number of products.
      */
     public function getAggregatedValues(array $resourceIds, string $locale, $valueSearched = null, ?int $depth = 1): array
     {
@@ -148,8 +141,10 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
         $pairs = FeatureProductQuery::create()
             ->filterByProductId($resourceIds, Criteria::IN)
             ->filterByFeatureAvId(null, Criteria::ISNOTNULL)
-            ->select(['FeatureId', 'FeatureAvId'])
-            ->distinct()
+            ->withColumn('COUNT(DISTINCT '.FeatureProductTableMap::COL_PRODUCT_ID.')', 'ProductCount')
+            ->select(['FeatureId', 'FeatureAvId', 'ProductCount'])
+            ->groupBy('FeatureId')
+            ->addGroupByColumn(FeatureProductTableMap::COL_FEATURE_AV_ID)
             ->find()
             ->getData();
 
@@ -159,12 +154,14 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
 
         $features = FeatureQuery::create()
             ->filterById(array_column($pairs, 'FeatureId'), Criteria::IN)
+            ->joinWithI18n($locale)
             ->orderByPosition()
             ->find()
             ->toKeyIndex();
 
         $featureAvs = FeatureAvQuery::create()
             ->filterById(array_column($pairs, 'FeatureAvId'), Criteria::IN)
+            ->joinWithI18n($locale)
             ->orderByPosition()
             ->find()
             ->toKeyIndex();
@@ -195,7 +192,8 @@ class FeatureAvFilter implements TheliaFilterInterface, TheliaChoiceFilterInterf
                     ->setMainTitle($this->localizedTitle($feature, $locale))
                     ->setMainId((int) $pair['FeatureId'])
                     ->setId((int) $pair['FeatureAvId'])
-                    ->setTitle($this->localizedTitle($featureAv, $locale));
+                    ->setTitle($this->localizedTitle($featureAv, $locale))
+                    ->setCount((int) $pair['ProductCount']);
         }
 
         return $values;

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/SelectedValuesTrait.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/SelectedValuesTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\Filters;
+
+/**
+ * Reads what a `tfilters` query string selected. The selection is nested one or two levels
+ * deep depending on the client (`tfilters[brand][brand][]=1` or `tfilters[feature][7][]=12`),
+ * and a bounded group carries `min`/`max` keys instead of identifiers.
+ */
+trait SelectedValuesTrait
+{
+    /**
+     * Every identifier checked, whatever the group, without duplicates.
+     *
+     * @return list<int|string>
+     */
+    private function flattenSelectedValues(mixed $value): array
+    {
+        $ids = [];
+
+        foreach ((array) $value as $childValue) {
+            foreach ((array) $childValue as $id) {
+                if (\is_array($id) || $id === null || $id === '') {
+                    continue;
+                }
+
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * The groups of the selection split by mode: `checked` holds the identifiers checked per
+     * group, `bounded` holds the `min`/`max` bounds per group. A group is a feature or an
+     * attribute id; a group that carries both a bound and identifiers is read as bounded.
+     *
+     * @return array{checked: array<int|string, list<int|string>>, bounded: array<int|string, array{min?: mixed, max?: mixed}>}
+     */
+    private function splitSelectedValues(mixed $value): array
+    {
+        $checked = [];
+        $bounded = [];
+
+        foreach ((array) $value as $group => $childValue) {
+            $childValue = (array) $childValue;
+
+            if (\array_key_exists('min', $childValue) || \array_key_exists('max', $childValue)) {
+                $bounds = array_filter(
+                    ['min' => $childValue['min'] ?? null, 'max' => $childValue['max'] ?? null],
+                    static fn (mixed $bound): bool => $bound !== null && $bound !== '' && !\is_array($bound),
+                );
+
+                if ($bounds !== []) {
+                    $bounded[$group] = $bounds;
+                }
+
+                continue;
+            }
+
+            $ids = $this->flattenSelectedValues([$childValue]);
+
+            if ($ids !== []) {
+                $checked[$group] = $ids;
+            }
+        }
+
+        return ['checked' => $checked, 'bounded' => $bounded];
+    }
+}

--- a/core/lib/Thelia/Api/Resource/FilterValue.php
+++ b/core/lib/Thelia/Api/Resource/FilterValue.php
@@ -33,6 +33,25 @@ class FilterValue
     #[Groups([Filter::GROUP_FRONT_READ])]
     private ?int $depth = null;
 
+    /**
+     * How many resources of the browsed set would remain if this value alone were checked
+     * within its filter, null when the filter does not count.
+     */
+    #[Groups([Filter::GROUP_FRONT_READ])]
+    private ?int $count = null;
+
+    public function getCount(): ?int
+    {
+        return $this->count;
+    }
+
+    public function setCount(?int $count): self
+    {
+        $this->count = $count;
+
+        return $this;
+    }
+
     public function getDepth(): ?int
     {
         return $this->depth;

--- a/tests/Integration/Api/FacetSelectionTest.php
+++ b/tests/Integration/Api/FacetSelectionTest.php
@@ -144,6 +144,34 @@ final class FacetSelectionTest extends IntegrationTestCase
         );
     }
 
+    public function testASetOfIdsGetsItsFacetsWithoutAnyCategory(): void
+    {
+        // What a search page does: the engine ranked ACME-BLUE-S and BOLT-RED-S, no category.
+        $facets = $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    'id' => [$this->productIds['ACME-BLUE-S'], $this->productIds['BOLT-RED-S']],
+                    'tfilters' => ['brand' => ['brand' => [$this->ids['acme']]]],
+                    'locale' => 'en_US',
+                ],
+            ],
+            'products',
+        );
+
+        self::assertSame(['Acme' => 1, 'Bolt' => 1], $this->counts($facets, 'brand'));
+        self::assertSame(['Blue' => 1], $this->counts($facets, 'feature', $this->ids['colour']));
+        self::assertSame([], $this->counts($facets, 'category'));
+    }
+
+    public function testNothingIsOfferedOutsideACategoryWithoutASetOfIds(): void
+    {
+        self::assertSame([], $this->filterService->getFilters(
+            ['path_info' => '/api/front/products', 'filters' => ['tfilters' => [], 'locale' => 'en_US']],
+            'products',
+        ));
+    }
+
     /**
      * @return array<Filter>
      */

--- a/tests/Integration/Api/FacetSelectionTest.php
+++ b/tests/Integration/Api/FacetSelectionTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Api\Resource\Filter;
+use Thelia\Api\Resource\FilterValue;
+use Thelia\Model\AttributeCombination;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\Template;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The facet column of a listing: every value tells how many products it would keep, and a
+ * value that is checked keeps its siblings on offer. Checking "Acme" must not make the other
+ * brands vanish, and must not hide the "Acme" count either.
+ *
+ * Catalogue: brands Acme and Bolt; feature Colour (Blue, Red); attribute Size (S, M).
+ *
+ *   ACME-BLUE-S   Acme, Blue, one sale element S + Slim
+ *   ACME-RED-M    Acme, Red,  one sale element M
+ *   BOLT-BLUE-SM  Bolt, Blue, one sale element S and another M + Slim
+ *   BOLT-RED-S    Bolt, Red,  one sale element S
+ */
+final class FacetSelectionTest extends IntegrationTestCase
+{
+    private FilterService $filterService;
+
+    private int $categoryId = 0;
+
+    /** @var array<string, int> */
+    private array $ids = [];
+
+    /** @var array<string, int> product reference => id, in creation order */
+    private array $productIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filterService = static::getContainer()->get(FilterService::class);
+        $this->createCatalogue();
+    }
+
+    public function testEveryValueCountsTheProductsItWouldKeep(): void
+    {
+        $facets = $this->facets([]);
+
+        self::assertSame(['Acme' => 2, 'Bolt' => 2], $this->counts($facets, 'brand'));
+        self::assertSame(['Blue' => 2, 'Red' => 2], $this->counts($facets, 'feature', $this->ids['colour']));
+        self::assertSame(['S' => 3, 'M' => 2], $this->counts($facets, 'attribute', $this->ids['size']));
+    }
+
+    public function testACheckedBrandKeepsTheOtherBrandsOnOfferAndNarrowsTheRest(): void
+    {
+        $facets = $this->facets(['brand' => ['brand' => [$this->ids['acme']]]]);
+
+        // The brand facet is read from the set relaxed of the brand selection: both brands, full counts.
+        self::assertSame(['Acme' => 2, 'Bolt' => 2], $this->counts($facets, 'brand'));
+        // Every other facet follows the two Acme products.
+        self::assertSame(['Blue' => 1, 'Red' => 1], $this->counts($facets, 'feature', $this->ids['colour']));
+        self::assertSame(['S' => 1, 'M' => 1], $this->counts($facets, 'attribute', $this->ids['size']));
+    }
+
+    public function testACheckedFeatureValueKeepsItsSiblingsAndNarrowsTheOtherFilters(): void
+    {
+        $facets = $this->facets(['feature' => [$this->ids['colour'] => [$this->ids['blue']]]]);
+
+        self::assertSame(['Blue' => 2, 'Red' => 2], $this->counts($facets, 'feature', $this->ids['colour']));
+        self::assertSame(['Acme' => 1, 'Bolt' => 1], $this->counts($facets, 'brand'));
+        // Blue products: ACME-BLUE-S (S) and BOLT-BLUE-SM (S and M).
+        self::assertSame(['S' => 2, 'M' => 1], $this->counts($facets, 'attribute', $this->ids['size']));
+    }
+
+    public function testASelectionThatMatchesNothingStillOffersTheCheckedFilterToUndo(): void
+    {
+        // Bolt + Red + M matches nothing: BOLT-RED-S only comes in S.
+        $facets = $this->facets([
+            'brand' => ['brand' => [$this->ids['bolt']]],
+            'feature' => [$this->ids['colour'] => [$this->ids['red']]],
+            'attribute' => [$this->ids['size'] => [$this->ids['m']]],
+        ]);
+
+        // Relaxed of the brand: Red + M products = ACME-RED-M, whose brand is Acme.
+        self::assertSame(['Acme' => 1], $this->counts($facets, 'brand'));
+        // Relaxed of the colour: Bolt + M = BOLT-BLUE-SM, which is Blue.
+        self::assertSame(['Blue' => 1], $this->counts($facets, 'feature', $this->ids['colour']));
+        // Relaxed of the size: Bolt + Red = BOLT-RED-S, which is S.
+        self::assertSame(['S' => 1], $this->counts($facets, 'attribute', $this->ids['size']));
+    }
+
+    public function testTwoValuesOfOneAttributeWidenAndTwoAttributesNarrowOnASingleSaleElement(): void
+    {
+        self::assertSame(
+            ['ACME-BLUE-S', 'ACME-RED-M', 'BOLT-BLUE-SM', 'BOLT-RED-S'],
+            $this->matching(['attribute' => [$this->ids['size'] => [$this->ids['s'], $this->ids['m']]]]),
+        );
+        self::assertSame(
+            ['ACME-RED-M', 'BOLT-BLUE-SM'],
+            $this->matching(['attribute' => [$this->ids['size'] => [$this->ids['m']]]]),
+        );
+        // S and Slim must sit on the same sale element: BOLT-BLUE-SM has S on one and Slim on
+        // the other, so it is not a match.
+        self::assertSame(
+            ['ACME-BLUE-S'],
+            $this->matching(['attribute' => [
+                $this->ids['size'] => [$this->ids['s']],
+                $this->ids['fit'] => [$this->ids['slim']],
+            ]]),
+        );
+    }
+
+    public function testACheckedFeatureAndABoundedOneAreReadEachInItsOwnMode(): void
+    {
+        // Colour checked to Blue, Weight (numeric titles 100 / 300) bounded to at least 200.
+        self::assertSame(
+            ['BOLT-BLUE-SM'],
+            $this->matching([
+                'feature' => [
+                    $this->ids['colour'] => [$this->ids['blue']],
+                    $this->ids['weight'] => ['min' => 200],
+                ],
+            ]),
+        );
+        self::assertSame(
+            ['ACME-BLUE-S', 'ACME-RED-M'],
+            $this->matching(['feature' => [$this->ids['weight'] => ['max' => 150]]]),
+        );
+    }
+
+    /**
+     * @return array<Filter>
+     */
+    private function facets(array $tfilters): array
+    {
+        return $this->filterService->getFilters(
+            [
+                'path_info' => '/api/front/products',
+                'filters' => [
+                    'tfilters' => ['category' => [['eq' => $this->categoryId]]] + $tfilters,
+                    'locale' => 'en_US',
+                ],
+            ],
+            'products',
+        );
+    }
+
+    /**
+     * @param array<Filter> $facets
+     *
+     * @return array<string, int> value title => count, in the order the facet offers them
+     */
+    private function counts(array $facets, string $type, ?int $mainId = null): array
+    {
+        foreach ($facets as $facet) {
+            if ($facet->getType() !== $type || ($mainId !== null && $facet->getId() !== $mainId)) {
+                continue;
+            }
+
+            $counts = [];
+
+            /** @var FilterValue $value */
+            foreach ($facet->getValues() as $value) {
+                $counts[$value->getTitle()] = $value->getCount();
+            }
+
+            return $counts;
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<string> the references of the matching products, in creation order
+     */
+    private function matching(array $tfilters): array
+    {
+        $query = ProductQuery::create()->filterById(array_values($this->productIds), Criteria::IN);
+        $filtered = $this->filterService->filterWithTFilter(tfilters: $tfilters, resource: 'products', query: $query);
+
+        $matched = [];
+
+        foreach ($filtered->find($this->getPropelConnection()) as $product) {
+            $matched[] = (int) $product->getId();
+        }
+
+        return array_keys(array_filter(
+            $this->productIds,
+            static fn (int $id): bool => \in_array($id, $matched, true),
+        ));
+    }
+
+    private function createCatalogue(): void
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $template = new Template();
+        $template->setLocale('en_US');
+        $template->setName('Faceted template');
+        $template->save($connection);
+
+        $category = $factory->category();
+        $category->setDefaultTemplateId($template->getId());
+        $category->save($connection);
+        $this->categoryId = (int) $category->getId();
+
+        $acme = $factory->brand(['title' => 'Acme']);
+        $bolt = $factory->brand(['title' => 'Bolt']);
+        $colour = $factory->feature(['title' => 'Colour']);
+        $blue = $factory->featureAv($colour, ['title' => 'Blue']);
+        $red = $factory->featureAv($colour, ['title' => 'Red']);
+        $weight = $factory->feature(['title' => 'Weight']);
+        $light = $factory->featureAv($weight, ['title' => '100']);
+        $heavy = $factory->featureAv($weight, ['title' => '300']);
+        $size = $factory->attribute(['title' => 'Size']);
+        $small = $factory->attributeAv($size, ['title' => 'S']);
+        $medium = $factory->attributeAv($size, ['title' => 'M']);
+        $fit = $factory->attribute(['title' => 'Fit']);
+        $slim = $factory->attributeAv($fit, ['title' => 'Slim']);
+
+        $this->ids = [
+            'acme' => (int) $acme->getId(), 'bolt' => (int) $bolt->getId(),
+            'colour' => (int) $colour->getId(), 'blue' => (int) $blue->getId(), 'red' => (int) $red->getId(),
+            'weight' => (int) $weight->getId(),
+            'size' => (int) $size->getId(), 's' => (int) $small->getId(), 'm' => (int) $medium->getId(),
+            'fit' => (int) $fit->getId(), 'slim' => (int) $slim->getId(),
+        ];
+
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $catalogue = [
+            'ACME-BLUE-S' => [$acme, $blue, $light, [[[$size, $small], [$fit, $slim]]]],
+            'ACME-RED-M' => [$acme, $red, $light, [[[$size, $medium]]]],
+            'BOLT-BLUE-SM' => [$bolt, $blue, $heavy, [[[$size, $small]], [[$size, $medium], [$fit, $slim]]]],
+            'BOLT-RED-S' => [$bolt, $red, $heavy, [[[$size, $small]]]],
+        ];
+
+        foreach ($catalogue as $reference => [$brand, $colourValue, $weightValue, $saleElements]) {
+            $product = $factory->product($category, $taxRule, $currency, ['ref' => $reference]);
+            $product->setBrandId($brand->getId());
+            $product->save($connection);
+            $this->productIds[$reference] = (int) $product->getId();
+
+            foreach ([[$colour, $colourValue], [$weight, $weightValue]] as [$feature, $featureAv]) {
+                $featureProduct = new FeatureProduct();
+                $featureProduct->setProductId($product->getId());
+                $featureProduct->setFeatureId($feature->getId());
+                $featureProduct->setFeatureAvId($featureAv->getId());
+                $featureProduct->save($connection);
+            }
+
+            foreach ($saleElements as $index => $combinations) {
+                $saleElement = $index === 0 ? $product->getDefaultSaleElements() : $this->extraSaleElement($product, $reference.'-'.$index);
+
+                foreach ($combinations as [$attribute, $attributeAv]) {
+                    $combination = new AttributeCombination();
+                    $combination->setProductSaleElementsId($saleElement->getId());
+                    $combination->setAttributeId($attribute->getId());
+                    $combination->setAttributeAvId($attributeAv->getId());
+                    $combination->save($connection);
+                }
+            }
+        }
+    }
+
+    private function extraSaleElement(Product $product, string $reference): ProductSaleElements
+    {
+        $saleElement = new ProductSaleElements();
+        $saleElement->setProductId($product->getId());
+        $saleElement->setRef($reference);
+        $saleElement->setQuantity(1);
+        $saleElement->setIsDefault(false);
+        $saleElement->save($this->getPropelConnection());
+
+        return $saleElement;
+    }
+}


### PR DESCRIPTION
## What the facet column of a listing was missing

Three things a shopper takes for granted on a filter column, and two defects on the way.

### 1. Every value tells how many products it keeps

`FilterValue` gains a `count` (front read group). It is computed inside the aggregation queries
that already existed, one `GROUP BY` per filter: products per brand, `COUNT(DISTINCT product_id)`
per (feature, value) and per (attribute, value), products per browsed sub-category. No extra
query for the counts.

### 2. A checked value keeps its siblings on offer

Until now the facets were read from the set narrowed by *every* filter, the checked one included:
checking "Acme" left "Acme" as the only brand on offer, and a shopper could never widen to a
second brand from the column. `FilterService::getFilters()` now reads the facet of a selected
filter from the set relaxed of that filter only — per feature and per attribute for the choice
filters, as a whole for the brand — while the other facets follow the fully narrowed set. The
category filter is the browsing scope and is never relaxed. A selection that matches nothing
still offers the checked values, so the shopper can undo it.

Cost: one identifier query and one aggregation per *selected* group; nothing changes for a page
without selection.

### 3. Each feature and attribute is read in its own mode

`FilterService::isMinOrMaxFilter()` decided the bound mode for the whole batch as soon as one
feature carried a `min`/`max`: a slider and a checkbox feature in the same request were both read
as bounds (noted as a limitation in #3810). `SelectedValuesTrait::splitSelectedValues()` now splits
the selection per group, checked values on one side, bounds on the other. Bounded groups each get
their own join alias, so two sliders no longer share one.

### Defects fixed on the way

- **`AttributeAvFilter`** put every checked value of every attribute into one `IN` without a
  `HAVING`: "S" + "blue" matched S *or* blue. It now mirrors `FeatureAvFilter`, at the sale
  element level: a product matches when one of its sale elements holds one checked value of
  every checked attribute (`GROUP BY product_sale_elements.id HAVING COUNT(DISTINCT attribute_id) = n`).
- **`choice_filter` rows were re-read for every facet** of the page (category lookup +
  `findChoiceFilterByCategory` + template rows, per DTO). Read once per request.
- **Titles were lazy-loaded one query per record** (`setLocale()->getTitle()`): the taxonomy
  queries now `joinWithI18n($locale)`.
- The bounded branch called `useI18nQuery()` with its default locale (`en_US`): it now reads the
  shop's default language.

### Measured

`TFiltersQueryCountTest` (category with one feature and one attribute, no selection): **23 → 14
queries**, still flat between 2 and 8 products.

### Tests

`tests/Integration/Api/FacetSelectionTest.php`, catalogue of 4 products × 2 brands × 2 features
× 2 attributes, 6 cases: counts, relaxed brand, relaxed feature value, contradictory selection,
OR/AND on attributes at sale-element level, checked + bounded features in one request. Five fail
on `main`.

### Not in this PR

`PriceFilter` stays as it is (`// implements TheliaFilterInterface`, not registered): a price
facet has to answer the taxed, promo-aware, currency-converted price the listing shows, which the
current class does not; it deserves its own change.

### Checks

`composer cs-diff` 0 · `composer phpstan` 0 · `test:integration` 694 OK · `test:api` 235 OK (one
pre-existing skip).
