### PR TITLE
fix: answer a write with the translation it saved, not the one it replaced

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -39,6 +39,13 @@ use Thelia\Model\Lang;
 
 readonly class ApiResourcePropelTransformerService
 {
+    /**
+     * Context flag telling the transformer that the model instance it reads
+     * carries i18n columns joined before a write, so they hold the values that
+     * write replaced. Set it on a write response, never on a read.
+     */
+    public const STALE_I18N_VIRTUAL_COLUMNS = 'thelia_stale_i18n_virtual_columns';
+
     public function __construct(
         private array $apiResourceAddons,
         private ValidatorInterface $validator,
@@ -676,6 +683,8 @@ readonly class ApiResourcePropelTransformerService
         array $context,
         Collection $langs,
     ): void {
+        $staleVirtualColumns = (bool) ($context[self::STALE_I18N_VIRTUAL_COLUMNS] ?? false);
+
         foreach ($langs as $lang) {
             $i18nResource = new ($resourceClass::getI18nResourceClass());
 
@@ -698,7 +707,7 @@ readonly class ApiResourcePropelTransformerService
 
                 $virtualColumn = ltrim(strtolower($parentReflector?->getShortName().'_'.$reflector->getShortName()).'_lang_'.$lang->getLocale().'_'.$i18nFieldName, '_');
 
-                if ($baseModel->hasVirtualColumn($virtualColumn)) {
+                if (!$staleVirtualColumns && $baseModel->hasVirtualColumn($virtualColumn)) {
                     // The query left-joined every active language, so an empty column
                     // is an answer: that language has no translation. Reading it as
                     // "not loaded yet" sent one query per row and per language after a

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelPersistProcessor.php
@@ -92,7 +92,13 @@ readonly class PropelPersistProcessor implements ProcessorInterface
             $data = $this->apiResourcePropelTransformerService->modelToResource(
                 resourceClass: $data::class,
                 propelModel: $propelModel,
-                context: $postOperation->getNormalizationContext(),
+                // The model instance is the one the provider read before the write,
+                // so its joined i18n columns still hold the replaced values. Only
+                // the translation getters know what was just saved.
+                context: [
+                    ...($postOperation->getNormalizationContext() ?? []),
+                    ApiResourcePropelTransformerService::STALE_I18N_VIRTUAL_COLUMNS => true,
+                ],
                 withAddon: false,
             );
 

--- a/tests/Api/Admin/CategoryApiTest.php
+++ b/tests/Api/Admin/CategoryApiTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace Thelia\Tests\Api\Admin;
 
 use Thelia\Model\CategoryQuery;
+use Thelia\Model\Map\CategoryI18nTableMap;
+use Thelia\Model\Map\CategoryTableMap;
 use Thelia\Test\ApiTestCase;
 
 final class CategoryApiTest extends ApiTestCase
@@ -71,6 +73,38 @@ final class CategoryApiTest extends ApiTestCase
 
         self::assertJsonResponseSuccessful($response);
         self::assertSame(0, (int) CategoryQuery::create()->findPk($category->getId())->getVisible());
+    }
+
+    public function testPatchCategoryAnswersWithTheSavedTranslation(): void
+    {
+        $token = $this->authenticateAsAdmin();
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $category->setLocale('en_US')->setTitle('Title before the patch');
+        $category->setLocale('fr_FR')->setTitle('Titre Français');
+        $category->save();
+
+        $response = $this->jsonRequest('PATCH', '/api/admin/categories/'.$category->getId(), [
+            'i18ns' => [
+                'en_US' => [
+                    'title' => 'Title after the patch',
+                ],
+            ],
+        ], $token, 'merge-patch+json');
+
+        self::assertJsonResponseSuccessful($response);
+
+        $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('Title after the patch', $data['i18ns']['en_US']['title']);
+        self::assertSame('Titre Français', $data['i18ns']['fr_FR']['title']);
+
+        CategoryTableMap::clearInstancePool();
+        CategoryI18nTableMap::clearInstancePool();
+
+        self::assertSame(
+            'Title after the patch',
+            CategoryQuery::create()->findPk($category->getId())->setLocale('en_US')->getTitle(),
+        );
     }
 
     public function testDeleteCategoryRemovesResource(): void


### PR DESCRIPTION
Fixes #3820

## What happened

A `PATCH` on a translatable field saved the new value but answered with the one it replaced.

```
PATCH /api/admin/categories/12
{"i18ns":{"en_US":{"title":"Title after the patch"}}}
```

came back with `Title before the patch`, while the row already held the new one.

**The write was never at fault.** The database, a later `GET` and the back office all showed the new value. Only the response body was behind, which is why it could go unnoticed for a while: a client that trusts the answer to its own write ends up displaying stale content until it reloads.

## Why

The item provider reads the model with every active language left-joined, so `category_i18n.title` sits in a virtual column of that instance. Propel's instance pool then hands the *same* object to the write, which sets the new title and saves it — the virtual column filled by the earlier query is never refreshed and keeps the old string.

Building the response, `ApiResourcePropelTransformerService::manageTranslatableResource()` prefers that column over the translation getter. On a read that preference is right and cheap: the join answered for every language, so an empty column means "no translation", and falling back to the getter costs a query per row and per language. On the instance a write has just changed, the column is simply out of date.

## The fix

The write response now tells the transformer that the joined i18n columns belong to the query that ran *before* the write, so it reads the translation getters instead — the only source that knows what was just saved.

Reads are untouched: the eager-loaded columns are still preferred everywhere else, so the N+1 work done in #3812 / #3813 / #3814 stands. The extra queries are paid once, on the response to a single write.

## Test

`CategoryApiTest::testPatchCategoryAnswersWithTheSavedTranslation` patches one locale of a two-locale category and asserts the response carries the new title, that the untouched locale is still there, and that the row matches once the instance pool is cleared.

Red before the change:

```
Failed asserting that two strings are identical.
-'Title after the patch'
+'Title before the patch'
```

Green after.

`composer cs-diff`, `composer phpstan` and the `unit` / `api` / `http-flexy` / `http-backoffice` suites pass.
