### PR TITLE
fix: build Thelia forms from the injected form factory builder

### DIFF
--- a/core/lib/Thelia/Config/Resources/services/core/forms.php
+++ b/core/lib/Thelia/Config/Resources/services/core/forms.php
@@ -31,11 +31,17 @@ return static function (ContainerConfigurator $container): void {
 
     $services->alias('thelia.forms.validator_builder', ValidatorBuilder::class);
 
-    $services->set(FormFactoryBuilderInterface::class, FormFactoryBuilder::class);
+    // RegisterFormExtensionPass feeds this builder with every service tagged
+    // thelia.forms.extension, thelia.form.type or thelia.form.type_extension, and
+    // BaseForm builds each form from a copy of it. The constructor flag forces the
+    // core extension in first, exactly like Forms::createFormFactoryBuilder() does.
+    $services->set(FormFactoryBuilderInterface::class, FormFactoryBuilder::class)
+        ->args([true]);
 
     $services->alias('thelia.form_factory_builder', FormFactoryBuilderInterface::class);
 
-    $services->set(HttpFoundationExtension::class);
+    $services->set(HttpFoundationExtension::class)
+        ->tag('thelia.forms.extension');
 
     $services->alias('thelia.forms.extension.http_foundation_extension', HttpFoundationExtension::class);
 

--- a/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterFormExtensionPass.php
+++ b/core/lib/Thelia/Core/DependencyInjection/Compiler/RegisterFormExtensionPass.php
@@ -30,11 +30,13 @@ class RegisterFormExtensionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('thelia.form_factory_builder')) {
+        // thelia.form_factory_builder is an alias, which hasDefinition() answers no to:
+        // findDefinition() is the one that follows the alias to the real definition.
+        if (!$container->has('thelia.form_factory_builder')) {
             return;
         }
 
-        $formFactoryBuilderDefinition = $container->getDefinition('thelia.form_factory_builder');
+        $formFactoryBuilderDefinition = $container->findDefinition('thelia.form_factory_builder');
 
         /*
          * Add form extensions

--- a/core/lib/Thelia/Form/BaseForm.php
+++ b/core/lib/Thelia/Form/BaseForm.php
@@ -17,13 +17,11 @@ namespace Thelia\Form;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
-use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryBuilderInterface;
 use Symfony\Component\Form\FormInterface as SymfonyFormInterface;
-use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
@@ -77,7 +75,11 @@ abstract class BaseForm implements FormInterface
 
         $this->dispatcher = $eventDispatcher;
         $this->translator = $translator;
-        $this->formFactoryBuilder = $formFactoryBuilder;
+        // The injected builder is the shared service carrying the extensions, the types
+        // and the type extensions registered by the modules. Each form works on its own
+        // copy, so the CSRF and validator extensions added below for this form only never
+        // pile up on the instance the next form will be built from.
+        $this->formFactoryBuilder = clone $formFactoryBuilder;
         $this->validatorBuilder = $validationBuilder;
 
         $this->initFormWithRequest($type, $data, $options);
@@ -146,9 +148,6 @@ abstract class BaseForm implements FormInterface
     protected function initFormWithRequest($type, $data, $options): void
     {
         $this->validatorBuilder = Validation::createValidatorBuilder();
-
-        $this->formFactoryBuilder = Forms::createFormFactoryBuilder()
-            ->addExtension(new HttpFoundationExtension());
 
         $this->translator = Translator::getInstance();
 

--- a/tests/Integration/Form/BaseFormExtensionTest.php
+++ b/tests/Integration/Form/BaseFormExtensionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Form;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
+use Symfony\Component\Form\FormFactoryBuilder;
+use Symfony\Component\Form\FormFactoryBuilderInterface;
+use Symfony\Component\Form\FormInterface as SymfonyFormInterface;
+use Symfony\Component\Form\FormTypeExtensionInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Validation;
+use Thelia\Form\CouponCode;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The form factory builder handed to BaseForm carries what modules register
+ * through the thelia.forms.extension, thelia.form.type and
+ * thelia.form.type_extension tags. A form built without it silently ignores
+ * every one of them.
+ */
+final class BaseFormExtensionTest extends IntegrationTestCase
+{
+    public function testATypeExtensionAddedToTheInjectedBuilderReachesTheForm(): void
+    {
+        $builder = (new FormFactoryBuilder(true))
+            ->addTypeExtension($this->probeTypeExtension('from-type-extension-tag'));
+
+        $view = $this->buildCouponCodeFormWith($builder)->createView();
+
+        self::assertSame('from-type-extension-tag', $view->vars['probe_marker'] ?? null);
+    }
+
+    public function testAFormExtensionAddedToTheInjectedBuilderReachesTheForm(): void
+    {
+        $builder = (new FormFactoryBuilder(true))
+            ->addExtension(new PreloadedExtension(
+                [],
+                [FormType::class => [$this->probeTypeExtension('from-form-extension-tag')]],
+            ));
+
+        $view = $this->buildCouponCodeFormWith($builder)->createView();
+
+        self::assertSame('from-form-extension-tag', $view->vars['probe_marker'] ?? null);
+    }
+
+    public function testTheContainerBuilderKnowsTheCoreTypesAndTheHttpFoundationRequestHandler(): void
+    {
+        /** @var FormFactoryBuilderInterface $builder */
+        $builder = $this->getService('thelia.form_factory_builder');
+
+        $form = $builder->getFormFactory()
+            ->createNamedBuilder('probe', FormType::class)
+            ->add('code', TextType::class)
+            ->getForm();
+
+        self::assertTrue($form->has('code'));
+        self::assertInstanceOf(HttpFoundationRequestHandler::class, $form->getConfig()->getRequestHandler());
+    }
+
+    private function buildCouponCodeFormWith(FormFactoryBuilderInterface $builder): SymfonyFormInterface
+    {
+        /** @var RequestStack $requestStack */
+        $requestStack = $this->getService('request_stack');
+
+        $form = new CouponCode();
+        $form->init(
+            $requestStack->getMainRequest(),
+            $this->getService('event_dispatcher'),
+            $this->getService('thelia.translator'),
+            $builder,
+            Validation::createValidatorBuilder(),
+            $this->getService('security.csrf.token_storage'),
+        );
+
+        return $form->getForm();
+    }
+
+    private function probeTypeExtension(string $marker): FormTypeExtensionInterface
+    {
+        return new class($marker) extends AbstractTypeExtension {
+            public function __construct(private readonly string $marker)
+            {
+            }
+
+            public static function getExtendedTypes(): iterable
+            {
+                return [FormType::class];
+            }
+
+            public function finishView(FormView $view, SymfonyFormInterface $form, array $options): void
+            {
+                $view->vars['probe_marker'] = $this->marker;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #3826.

`RegisterFormExtensionPass` collects the services tagged `thelia.forms.extension`, `thelia.form.type` and `thelia.form.type_extension` so that a module can extend every Thelia form at once. None of it reached a form. Three things stood in the way, and each one was enough on its own:

- `BaseForm::init()` stored the injected builder, then `initFormWithRequest()` replaced it with a bare `Forms::createFormFactoryBuilder()`. Every form was built from that fresh builder.
- The pass gave up before doing anything: `thelia.form_factory_builder` is an alias, and `hasDefinition()` answers no to an alias. It never added a single method call.
- The `FormFactoryBuilder` service was built without the core extension and without the HttpFoundation extension, both of which the discarded builder used to bring along.

`BaseForm` now builds each form from a copy of the injected builder — a copy, because the CSRF and validator extensions it adds belong to that one form and must not pile up on the shared service. The pass uses `findDefinition()`, which follows the alias. The service forces the core extension in first, exactly like `Forms::createFormFactoryBuilder()` does, and `HttpFoundationExtension` is now tagged so the pass wires it in.

Nothing is tagged in the core, the shipped modules or the themes today, so a form built by a stock install ends up with the same extensions in the same order as before. The CSRF behaviour of #3825 is untouched: the token manager still arrives through `init()` and `BaseFormCsrfTokenTest` is unaffected by this change.

`tests/Integration/Form/BaseFormExtensionTest` covers the three of them: a type extension and a form extension added to the injected builder both reach the built form, and the container's builder answers with the core types and the HttpFoundation request handler. The three assertions fail on `main`.

`composer cs-diff` and `composer phpstan` are clean. The `unit`, `integration`, `api`, `http-flexy` and `http-backoffice` suites pass, except `BaseFormCsrfTokenTest::testTheDefaultTokenIsBoundToTheSessionAndRoundTrips`, which is already red on `main` (run 33069882090) since flexy 1.0.1 became the pinned theme: the theme lists `thelia_coupon_code` among `framework.csrf_protection.stateless_token_ids`, and the test reads that form's token expecting a session one. It is unrelated to this pull request.
