### PR TITLE
test: check the default csrf token on a form no theme declares stateless

### DIFF
--- a/tests/Integration/Form/BaseFormCsrfTokenTest.php
+++ b/tests/Integration/Form/BaseFormCsrfTokenTest.php
@@ -17,7 +17,7 @@ namespace Thelia\Tests\Integration\Form;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\Form\TheliaFormFactory;
 use Thelia\Core\HttpFoundation\Request;
-use Thelia\Form\CouponCode;
+use Thelia\Form\EmptyForm;
 use Thelia\Test\IntegrationTestCase;
 
 final class BaseFormCsrfTokenTest extends IntegrationTestCase
@@ -93,7 +93,7 @@ final class BaseFormCsrfTokenTest extends IntegrationTestCase
         /** @var TheliaFormFactory $factory */
         $factory = $this->getService(TheliaFormFactory::class);
 
-        return $factory->createForm(CouponCode::getName(), options: $options)->getForm();
+        return $factory->createForm(EmptyForm::getName(), options: $options)->getForm();
     }
 
     private function tokenValueOf(\Symfony\Component\Form\FormInterface $form): string
@@ -114,7 +114,7 @@ final class BaseFormCsrfTokenTest extends IntegrationTestCase
 
     private function submit(\Symfony\Component\Form\FormInterface $form, string $token): \Symfony\Component\Form\FormInterface
     {
-        $form->submit(['coupon-code' => 'ANY', '_token' => $token]);
+        $form->submit(['_token' => $token]);
 
         return $form;
     }


### PR DESCRIPTION
The default-token case of BaseFormCsrfTokenTest was built on CouponCode. Since flexy 1.0.1 declares thelia_coupon_code in stateless_token_ids (and the core now requires the stable theme), the rendered token is the constant stateless marker and the assertion fails: main is red since cc09ed865 (run 33069882090).

The stateless behaviour on a listed id is deliberate, so the test is what must move: the default-token case now runs on EmptyForm, whose id no theme declares stateless. The three stateless cases already pin their own csrf_token_id and are unchanged.