### PR TITLE
fix(api): aggregate the resource addons in front of the serializer metadata cache

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Loader/ClassMetaDataFactory.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Loader/ClassMetaDataFactory.php
@@ -21,9 +21,22 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 
-#[AsDecorator(decorates: 'api_platform.serializer.mapping.class_metadata_factory')]
+/**
+ * Which resources a module extends is known at runtime, from the modules that are
+ * active, so the addon attributes cannot be part of what a cache warmer writes to
+ * disk. The decoration priority puts this factory in front of
+ * `api_platform.serializer.mapping.cache_class_metadata_factory` (-2): behind it,
+ * a warmed metadata cache answers before the addons are aggregated and the
+ * serializer drops them from the payload for lack of a group.
+ */
+#[AsDecorator(decorates: 'api_platform.serializer.mapping.class_metadata_factory', priority: -3)]
 class ClassMetaDataFactory implements ClassMetadataFactoryInterface
 {
+    /**
+     * @var array<string, ClassMetadataInterface>
+     */
+    private array $aggregatedMetadata = [];
+
     public function __construct(
         #[AutowireDecorated]
         private ClassMetadataFactoryInterface $inner,
@@ -33,11 +46,17 @@ class ClassMetaDataFactory implements ClassMetadataFactoryInterface
 
     public function getMetadataFor($value): ClassMetadataInterface
     {
-        $metadata = $this->inner->getMetadataFor(\is_object($value) ? $this->getObjectClass($value) : $this->getRealClassName($value));
+        $className = \is_object($value) ? $this->getObjectClass($value) : $this->getRealClassName($value);
+
+        if (isset($this->aggregatedMetadata[$className])) {
+            return $this->aggregatedMetadata[$className];
+        }
+
+        $metadata = $this->inner->getMetadataFor($className);
         $resourceAddons = $this->apiResourcePropelTransformerService->getResourceAddonDefinitions($metadata->getName());
 
         if ([] === $resourceAddons) {
-            return $metadata;
+            return $this->aggregatedMetadata[$className] = $metadata;
         }
 
         foreach ($resourceAddons as $addonShortName => $addonClass) {
@@ -54,7 +73,7 @@ class ClassMetaDataFactory implements ClassMetadataFactoryInterface
             $metadata->addAttributeMetadata($addonAttributeMetadata);
         }
 
-        return $metadata;
+        return $this->aggregatedMetadata[$className] = $metadata;
     }
 
     public function hasMetadataFor(mixed $value): bool

--- a/tests/Integration/Api/ResourceAddonMetadataTest.php
+++ b/tests/Integration/Api/ResourceAddonMetadataTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Thelia\Api\Bridge\Propel\Loader\ClassMetaDataFactory;
+use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
+use Thelia\Api\Resource\Product as ProductResource;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Which resources a module extends is known from the modules that are active, so
+ * the addon attributes are aggregated into the parent metadata at runtime. A cache
+ * warmer writes what the loaders alone produce: the addon is there as a bare
+ * property name, without the groups that put it in a payload. Behind the
+ * serializer metadata cache, that warmed entry answered first, and a shop deployed
+ * the documented way — clear the cache, then warm it — served its API without the
+ * addons a shop serving from a lazily built cache returns.
+ */
+final class ResourceAddonMetadataTest extends IntegrationTestCase
+{
+    /**
+     * Nothing may cache the parent metadata in front of the aggregation, whatever
+     * the state of that cache: this is the guard the payload assertion below cannot
+     * make on its own, since it only reproduces on an already warmed cache.
+     */
+    public function testTheAddonAggregationAnswersInFrontOfTheMetadataCache(): void
+    {
+        self::assertInstanceOf(
+            ClassMetaDataFactory::class,
+            $this->getService(ClassMetadataFactoryInterface::class),
+            'The addon aggregation must decorate the serializer metadata cache, not sit behind it.',
+        );
+    }
+
+    public function testAnAddonAttributeCarriesTheGroupsOfTheAddon(): void
+    {
+        $addons = $this->getService(ApiResourcePropelTransformerService::class)
+            ->getResourceAddonDefinitions(ProductResource::class);
+
+        if ([] === $addons) {
+            self::markTestSkipped('No active module extends the product resource here.');
+        }
+
+        $attributes = $this->getService(ClassMetadataFactoryInterface::class)
+            ->getMetadataFor(ProductResource::class)
+            ->getAttributesMetadata();
+
+        foreach (array_keys($addons) as $addonShortName) {
+            self::assertArrayHasKey($addonShortName, $attributes);
+            self::assertNotSame(
+                [],
+                $attributes[$addonShortName]->getGroups(),
+                'An addon attribute without groups is dropped from every grouped payload.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
`GET /api/front/products/{id}` answered without its `ProductLibraryImagesAddon` key on a cache built by `cache:warmup`, and with it on a cache built lazily by the first request. A production shop is deployed the documented way — remove `var/cache/prod`, then warm it — so every standard deploy served the API without the attributes modules add to native resources.

## What happens

`ClassMetaDataFactory` aggregates the addon attributes into the parent resource metadata, and gives each one the groups of the addon's own properties. It decorated `api_platform.serializer.mapping.class_metadata_factory` at the default priority, which put it *behind* `api_platform.serializer.mapping.cache_class_metadata_factory` (priority -2, registered outside debug mode only — hence a dev shop and a prod shop answering differently).

`SerializerCacheWarmer` writes `serialization.php` from the mapping loaders alone. API Platform's `PropertyMetadataLoader` does list the addon there, but as a bare property name, with no groups:

```
warmed   ProductLibraryImagesAddon => []
lazy     ProductLibraryImagesAddon => [admin:product:read:single|front:product:read:single]
```

On a warmed cache the outer cache answered first, the aggregation never ran, and the serializer dropped an attribute that belongs to no group.

Which resources a module extends is known from the modules that are active, so this can never be part of what a warmer writes to disk: the aggregation has to answer in front of the cache, not behind it.

## Fix

Decoration priority -3, so `ClassMetaDataFactory` wraps the metadata cache instead of sitting behind it, plus a per-class memo so the aggregation still costs one pass per class and per request.

## Test

`tests/Integration/Api/ResourceAddonMetadataTest` asserts the aggregation answers in front of every metadata cache, and that an addon attribute carries the groups of its addon. Both are red on a warmed cache without the fix — which is the state `composer test` runs in, since `test:prepare` warms the test cache.

Fixes #3816
