### PR TITLE
fix(api): price front sale elements in the currency being browsed

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Event/ModelToResourceEvent.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Event/ModelToResourceEvent.php
@@ -28,7 +28,17 @@ class ModelToResourceEvent extends Event
     public function __construct(
         private ActiveRecordInterface $model,
         private ?ActiveRecordInterface $parentModel = null,
+        private array $context = [],
     ) {
+    }
+
+    /**
+     * The serialization context the resource is being built for. A listener
+     * reads its groups to tell an admin read from a front one.
+     */
+    public function getContext(): array
+    {
+        return $this->context;
     }
 
     public function getResource(): PropelResourceInterface

--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -79,7 +79,7 @@ readonly class ApiResourcePropelTransformerService
 
         $baseModel ??= $propelModel;
 
-        $modelToResourceEvent = new ModelToResourceEvent($baseModel, $parentModel);
+        $modelToResourceEvent = new ModelToResourceEvent($baseModel, $parentModel, $context);
         $this->eventDispatcher->dispatch($modelToResourceEvent, ModelToResourceEvent::BEFORE_TRANSFORM);
         $baseModel = $modelToResourceEvent->getModel();
 

--- a/core/lib/Thelia/Api/EventListener/ProductPriceCurrencyListener.php
+++ b/core/lib/Thelia/Api/EventListener/ProductPriceCurrencyListener.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Api\Bridge\Propel\Event\ModelToResourceEvent;
+use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
+use Thelia\Api\Resource\Currency as CurrencyResource;
+use Thelia\Api\Resource\ProductPrice as ProductPriceResource;
+use Thelia\Api\Resource\ProductSaleElements as ProductSaleElementsResource;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Model\Currency;
+use Thelia\Model\CurrencyQuery;
+
+/**
+ * Prices a sale element in the currency the shop is being browsed in.
+ *
+ * product_price holds one row per currency, and a front read returned them
+ * all, in whatever order the database answered: a consumer reading the first
+ * one priced the catalogue in a currency nobody asked for. The product loop
+ * never had that problem, it selects the price in SQL — the row of the
+ * requested currency, the default currency row converted at the currency rate
+ * when that row is missing or flagged from_default_currency. The same rule is
+ * applied here, to the rows the transformer has already loaded, so a front
+ * read answers a single price: the one the shop charges.
+ *
+ * Admin reads keep every row: the back office edits one price per currency.
+ */
+class ProductPriceCurrencyListener implements EventSubscriberInterface
+{
+    private ?Currency $currentCurrency = null;
+
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly ApiResourcePropelTransformerService $transformerService,
+    ) {
+    }
+
+    public function selectPriceOfCurrentCurrency(ModelToResourceEvent $modelToResourceEvent): void
+    {
+        $resource = $modelToResourceEvent->getResource();
+
+        if (!$resource instanceof ProductSaleElementsResource) {
+            return;
+        }
+
+        $prices = $resource->getProductPrices();
+        $context = $modelToResourceEvent->getContext();
+
+        if ([] === $prices || !$this->isFrontRead($context)) {
+            return;
+        }
+
+        $price = $this->priceOfCurrentCurrency($prices, $context);
+
+        if ($price instanceof ProductPriceResource) {
+            $resource->setProductPrices([$price]);
+        }
+    }
+
+    /**
+     * The currency lives in the session, which the front sets from its
+     * "currency" parameter. An api route is stateless — it never starts a
+     * session — so the same parameter is read from the request there.
+     */
+    public function currentCurrency(): Currency
+    {
+        if ($this->currentCurrency instanceof Currency) {
+            return $this->currentCurrency;
+        }
+
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+        $requestedCode = $request?->query->get('currency');
+
+        if (\is_string($requestedCode) && '' !== $requestedCode) {
+            $requestedCurrency = CurrencyQuery::create()
+                ->filterByVisible(true)
+                ->findOneByCode($requestedCode);
+
+            if ($requestedCurrency instanceof Currency) {
+                return $this->currentCurrency = $requestedCurrency;
+            }
+        }
+
+        $session = $request?->hasSession() ? $request->getSession() : null;
+
+        if ($session instanceof Session) {
+            return $this->currentCurrency = $session->getCurrency();
+        }
+
+        return $this->currentCurrency = Currency::getDefaultCurrency();
+    }
+
+    /**
+     * The currency is resolved once per request: the listener runs for every
+     * sale element of a collection, and reading it again there would buy a
+     * query per row.
+     */
+    public function forgetCurrentCurrency(): void
+    {
+        $this->currentCurrency = null;
+    }
+
+    public function onKernelRequest(RequestEvent $requestEvent): void
+    {
+        if ($requestEvent->isMainRequest()) {
+            $this->forgetCurrentCurrency();
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ModelToResourceEvent::AFTER_TRANSFORM => [
+                ['selectPriceOfCurrentCurrency', 0],
+            ],
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 4096],
+            ],
+            ConsoleEvents::COMMAND => [
+                ['forgetCurrentCurrency', 4096],
+            ],
+        ];
+    }
+
+    /**
+     * A front read is one no admin group takes part in. Group names carry the
+     * side they belong to, "front:product:read" against "admin:product:read",
+     * so a module resource embedding sale elements is covered too.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function isFrontRead(array $context): bool
+    {
+        $groups = $context['groups'] ?? [];
+
+        if (!\is_array($groups)) {
+            $groups = [$groups];
+        }
+
+        $isFrontRead = false;
+
+        foreach ($groups as $group) {
+            if (!\is_string($group)) {
+                continue;
+            }
+
+            if (str_starts_with($group, 'admin:')) {
+                return false;
+            }
+
+            $isFrontRead = $isFrontRead || str_starts_with($group, 'front:');
+        }
+
+        return $isFrontRead;
+    }
+
+    /**
+     * @param array<ProductPriceResource> $prices
+     * @param array<string, mixed>        $context
+     */
+    private function priceOfCurrentCurrency(array $prices, array $context): ?ProductPriceResource
+    {
+        $currency = $this->currentCurrency();
+        $defaultCurrency = Currency::getDefaultCurrency();
+
+        $ownPrice = null;
+        $defaultCurrencyPrice = null;
+
+        foreach ($prices as $price) {
+            if (!$price instanceof ProductPriceResource) {
+                continue;
+            }
+
+            $priceCurrencyId = $price->getCurrency()->getId();
+
+            if ($priceCurrencyId === $currency->getId()) {
+                $ownPrice = $price;
+            }
+
+            if ($priceCurrencyId === $defaultCurrency->getId()) {
+                $defaultCurrencyPrice = $price;
+            }
+        }
+
+        // A price of its own is what the shop charges, unless it is flagged as
+        // derived from the default currency one — the back office then stores
+        // a zero and expects the conversion to be made at read time.
+        if ($ownPrice instanceof ProductPriceResource && true !== $ownPrice->getFromDefaultCurrency()) {
+            return $ownPrice;
+        }
+
+        if (!$defaultCurrencyPrice instanceof ProductPriceResource) {
+            return $ownPrice;
+        }
+
+        $rate = $currency->getRate() / ($defaultCurrency->getRate() ?: 1.0);
+
+        // Cloning keeps everything the row of the default currency carries and
+        // only re-quotes it: the sale element it belongs to, its dates, the
+        // addons a module attached to it.
+        $price = $ownPrice ?? clone $defaultCurrencyPrice;
+        $price
+            ->setPrice($defaultCurrencyPrice->getPrice() * $rate)
+            ->setPromoPrice($defaultCurrencyPrice->getPromoPrice() * $rate);
+
+        if (!$ownPrice instanceof ProductPriceResource) {
+            $price->setCurrency($this->currencyResource($currency, $context));
+        }
+
+        return $price;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function currencyResource(Currency $currency, array $context): CurrencyResource
+    {
+        /** @var CurrencyResource $currencyResource */
+        $currencyResource = $this->transformerService->modelToResource(
+            resourceClass: CurrencyResource::class,
+            propelModel: $currency,
+            context: $context,
+        );
+
+        return $currencyResource;
+    }
+}

--- a/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
@@ -20,14 +20,15 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Attribute\AttributeAvProductEvent;
 use Thelia\Core\Event\ProductSaleElement\PseByProductEvent;
 use Thelia\Core\HttpFoundation\Request;
+use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 use Thelia\Model\AttributeAvQuery;
 use Thelia\Model\AttributeQuery;
 use Thelia\Model\ConfigQuery;
+use Thelia\Model\Currency;
 use Thelia\Model\Lang;
-use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductSaleElementsQuery;
 
 class ProductSaleElementsAccessService
@@ -35,7 +36,7 @@ class ProductSaleElementsAccessService
     protected ?Request $request;
 
     public function __construct(
-        RequestStack $requestStack,
+        private readonly RequestStack $requestStack,
         private readonly TaxEngine $taxEngine,
         private readonly SecurityContext $securityContext,
         private readonly EventDispatcherInterface $eventDispatcher,
@@ -54,6 +55,7 @@ class ProductSaleElementsAccessService
 
         $discount = 0;
         $taxCountry = $this->taxEngine->getDeliveryCountry();
+        $currency = $this->currentCurrency();
 
         if ($this->securityContext->hasCustomerUser()) {
             $discount = $this->securityContext->getCustomerUser()->getDiscount();
@@ -61,12 +63,15 @@ class ProductSaleElementsAccessService
 
         foreach (ProductSaleElementsQuery::create()->filterByVisible(true)->orderByPosition()->findByProductId($productId) as $pse) {
             $attributes = [];
-            $price = ProductPriceQuery::create()->filterByProductSaleElements($pse)->findOne();
 
-            $basePrice = $price->getPrice() * (1 - ($discount / 100));
-            $promoPrice = $price->getPromoPrice() * (1 - ($discount / 100));
-            $pse->setVirtualColumn('price_PRICE', (float) $basePrice);
-            $pse->setVirtualColumn('price_PROMO_PRICE', (float) $promoPrice);
+            // Reading the first price row priced the sale element in whichever
+            // currency the database answered first. The model knows the rule:
+            // the row of the currency being browsed, the default currency one
+            // converted at its rate when there is none.
+            $prices = $pse->getPricesByCurrency($currency, (float) $discount);
+
+            $pse->setVirtualColumn('price_PRICE', $prices->getPrice());
+            $pse->setVirtualColumn('price_PROMO_PRICE', $prices->getPromoPrice());
 
             foreach ($pse->getAttributeCombinations() as $attribute) {
                 $attributes[$attribute->getAttributeId()] = $attribute->getAttributeAvId();
@@ -152,6 +157,21 @@ class ProductSaleElementsAccessService
         }
 
         return $title ?? '';
+    }
+
+    /**
+     * The currency being browsed, which a command line has none of.
+     *
+     * The request is read from the stack rather than from the one the
+     * constructor captured: this service is built before the request it is
+     * asked about exists, and holds a null one ever after.
+     */
+    private function currentCurrency(): Currency
+    {
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+        $session = $request?->hasSession() ? $request->getSession() : null;
+
+        return $session instanceof Session ? $session->getCurrency() : Currency::getDefaultCurrency();
     }
 
     private function fallbackLocale(string $currentLocale): ?string

--- a/tests/Api/Front/ProductPriceCurrencyApiTest.php
+++ b/tests/Api/Front/ProductPriceCurrencyApiTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Currency;
+use Thelia\Model\Product;
+use Thelia\Model\ProductPrice;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A sale element holds one price row per currency. A front read must answer
+ * the one the shop charges in the currency being browsed, converted from the
+ * default currency when it has no price of its own.
+ */
+final class ProductPriceCurrencyApiTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private const CURRENCY_CODE = 'TCU';
+
+    public function testTheFrontReadConvertsThePriceOfTheDefaultCurrency(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $this->currency();
+
+        $prices = $this->pricesOfTheFrontRead($product);
+
+        self::assertCount(1, $prices, 'A front read answers the price of one currency, not every row.');
+        self::assertSame(20.0, (float) $prices[0]['price'], 'A currency rated 2 doubles the price of the default currency.');
+        self::assertSame(self::CURRENCY_CODE, $prices[0]['currency']['code'] ?? null);
+    }
+
+    public function testThePriceSetForTheCurrencyIsAnsweredAsIs(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $currency = $this->currency();
+        $this->priceRow($product, $currency, price: 9.99, promoPrice: 7.99, fromDefaultCurrency: false);
+
+        $prices = $this->pricesOfTheFrontRead($product);
+
+        self::assertCount(1, $prices);
+        self::assertSame(9.99, (float) $prices[0]['price'], 'A price of its own is what the shop charges.');
+        self::assertSame(7.99, (float) $prices[0]['promoPrice']);
+    }
+
+    public function testAPriceFlaggedAsDerivedIsConverted(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $currency = $this->currency();
+        // What the back office stores for "use the default currency price".
+        $this->priceRow($product, $currency, price: 0.0, promoPrice: 0.0, fromDefaultCurrency: true);
+
+        $prices = $this->pricesOfTheFrontRead($product);
+
+        self::assertCount(1, $prices);
+        self::assertSame(20.0, (float) $prices[0]['price'], 'A derived row is converted, not answered as the zero it stores.');
+        self::assertSame(self::CURRENCY_CODE, $prices[0]['currency']['code'] ?? null);
+    }
+
+    public function testTheAdminReadKeepsEveryCurrency(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $currency = $this->currency();
+        $this->priceRow($product, $currency, price: 9.99, promoPrice: 7.99, fromDefaultCurrency: false);
+
+        $response = $this->jsonRequest(
+            'GET',
+            '/api/admin/product_sale_elements/'.$product->getDefaultSaleElements()->getId().'?currency='.self::CURRENCY_CODE,
+            token: $this->authenticateAsAdmin(),
+        );
+
+        self::assertJsonResponseSuccessful($response);
+        $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        self::assertCount(
+            2,
+            $payload['productPrices'] ?? [],
+            'The back office edits one price per currency: it must be answered all of them.',
+        );
+    }
+
+    public function testTheCollectionResolvesThePricesWithoutAQueryPerSaleElement(): void
+    {
+        $this->currency();
+        $products = [];
+
+        for ($index = 0; $index < 3; ++$index) {
+            $products[] = $this->product(basePrice: 10.0);
+        }
+
+        $statements = $this->recordSqlQueries(function (): void {
+            $response = $this->jsonRequest('GET', '/api/front/products?currency='.self::CURRENCY_CODE);
+            self::assertJsonResponseSuccessful($response);
+        });
+
+        self::assertLessThanOrEqual(
+            \count($products),
+            self::countSqlQueriesSelectingFrom($statements, 'product_price'),
+            'Resolving the currency of a price must not read the rows a second time.',
+        );
+        self::assertLessThanOrEqual(
+            2,
+            self::countSqlQueriesSelectingFrom($statements, 'currency'),
+            'The currency being browsed is read once for the whole request, not once per sale element.',
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function pricesOfTheFrontRead(Product $product): array
+    {
+        $response = $this->jsonRequest(
+            'GET',
+            '/api/front/products/'.$product->getId().'?currency='.self::CURRENCY_CODE,
+        );
+
+        self::assertJsonResponseSuccessful($response);
+        $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        return $payload['productSaleElements'][0]['productPrices'] ?? [];
+    }
+
+    private function product(float $basePrice): Product
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->product(
+            $factory->category(),
+            $factory->taxRule(),
+            Currency::getDefaultCurrency(),
+            ['basePrice' => $basePrice],
+        );
+    }
+
+    /**
+     * Rated twice the default currency, whatever rate that one is given: the
+     * suite shares the default currency and does not always leave it at 1.
+     */
+    private function currency(): Currency
+    {
+        return $this->createFixtureFactory()->currency([
+            'code' => self::CURRENCY_CODE,
+            'symbol' => 'T',
+            'rate' => 2.0 * Currency::getDefaultCurrency()->getRate(),
+            'visible' => 1,
+        ]);
+    }
+
+    private function priceRow(
+        Product $product,
+        Currency $currency,
+        float $price,
+        float $promoPrice,
+        bool $fromDefaultCurrency,
+    ): ProductPrice {
+        $productPrice = new ProductPrice();
+        $productPrice
+            ->setProductSaleElementsId($product->getDefaultSaleElements()->getId())
+            ->setCurrencyId($currency->getId())
+            ->setPrice((string) $price)
+            ->setPromoPrice((string) $promoPrice)
+            ->setFromDefaultCurrency($fromDefaultCurrency ? 1 : 0)
+            ->save($this->getPropelConnection());
+
+        return $productPrice;
+    }
+}

--- a/tests/Integration/Api/PsePriceCurrencyTest.php
+++ b/tests/Integration/Api/PsePriceCurrencyTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Api\Service\DataAccess\ProductSaleElementsAccessService;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Model\Currency;
+use Thelia\Model\Product;
+use Thelia\Model\ProductPrice;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * psesByProduct() feeds the variant selector of a product page with its prices.
+ * It read the first price row of the sale element, whatever currency that row
+ * held, so a shop browsed in a secondary currency quoted its variants in the
+ * default one.
+ */
+final class PsePriceCurrencyTest extends IntegrationTestCase
+{
+    private const CURRENCY_CODE = 'TCU';
+
+    private ProductSaleElementsAccessService $pseAccess;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pseAccess = static::getContainer()->get(ProductSaleElementsAccessService::class);
+    }
+
+    public function testThePriceOfTheDefaultCurrencyIsConvertedToTheOneBeingBrowsed(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $this->browseIn($this->currency());
+
+        $saleElements = $this->saleElementsOf($product);
+
+        self::assertCount(1, $saleElements);
+        self::assertSame(20.0, (float) $saleElements[0]['untaxedPrice']);
+    }
+
+    public function testThePriceSetForTheCurrencyIsAnsweredAsIs(): void
+    {
+        $product = $this->product(basePrice: 10.0);
+        $currency = $this->currency();
+        $this->browseIn($currency);
+
+        $productPrice = new ProductPrice();
+        $productPrice
+            ->setProductSaleElementsId($product->getDefaultSaleElements()->getId())
+            ->setCurrencyId($currency->getId())
+            ->setPrice('9.99')
+            ->setPromoPrice('7.99')
+            ->setFromDefaultCurrency(0)
+            ->save($this->getPropelConnection());
+
+        $saleElements = $this->saleElementsOf($product);
+
+        self::assertCount(1, $saleElements);
+        self::assertSame(9.99, (float) $saleElements[0]['untaxedPrice']);
+        self::assertSame(7.99, (float) $saleElements[0]['promoUntaxedPrice']);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function saleElementsOf(Product $product): array
+    {
+        return json_decode(
+            (string) $this->pseAccess->psesByProduct($product->getId()),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+    }
+
+    private function product(float $basePrice): Product
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->product(
+            $factory->category(),
+            $factory->taxRule(),
+            Currency::getDefaultCurrency(),
+            ['basePrice' => $basePrice],
+        );
+    }
+
+    /**
+     * Rated twice the default currency, whatever rate that one is given: the
+     * suite shares the default currency and does not always leave it at 1.
+     */
+    private function currency(): Currency
+    {
+        return $this->createFixtureFactory()->currency([
+            'code' => self::CURRENCY_CODE,
+            'symbol' => 'T',
+            'rate' => 2.0 * Currency::getDefaultCurrency()->getRate(),
+            'visible' => 1,
+        ]);
+    }
+
+    private function browseIn(Currency $currency): void
+    {
+        $session = static::getContainer()->get(RequestStack::class)->getCurrentRequest()?->getSession();
+
+        self::assertInstanceOf(Session::class, $session);
+
+        $session->setCurrency($currency);
+    }
+}


### PR DESCRIPTION
`product_price` holds one row per currency. A front read returned them all, in
whatever order the database answered, with no conversion: a consumer reading the
first one priced the catalogue in a currency nobody asked for, and the Flexy
product card reads `productPrices[0]`. The product loop never had that problem,
it selects the price in SQL — the row of the requested currency, the default
currency row converted at the currency rate when that row is missing or flagged
`from_default_currency`.

The same rule now applies to the API, on the rows the transformer has already
loaded, so a front read answers a single price: the one the shop charges. The
currency is the one being browsed — the session's, or the `currency` parameter
of the request on an api route, which is stateless and has no session. It is
resolved once per request, not once per sale element. Admin reads are untouched:
the back office edits one price per currency and needs to see them all.

`psesByProduct()`, which feeds the variant selector of a product page, read the
first price row the same way. It now asks the model, whose `getPricesByCurrency()`
already states the rule. It also read the request captured in the constructor,
which is null — that service is built before the request it is asked about
exists — so the currency it resolved was always the default one.

Proof: five API tests and two integration tests, red before the fix (`10.0`
where `20.0` is charged, two price rows where one is), green after. `composer cs`,
`composer phpstan`, and the unit, api, http-flexy and http-backoffice suites are
clean; `integration` keeps its one unrelated failure
(`BaseFormCsrfTokenTest::testTheDefaultTokenIsBoundToTheSessionAndRoundTrips`),
which fails the same way on a plain checkout of `main`.

Fixes #3815
