### PR TITLE
fix: send a payment return to the checkout routes Thelia 3 declares

### DIFF
--- a/core/lib/Thelia/Module/BasePaymentModuleController.php
+++ b/core/lib/Thelia/Module/BasePaymentModuleController.php
@@ -233,13 +233,17 @@ abstract class BasePaymentModuleController extends BaseFrontController
     /**
      * Redirect the customer to the successful payment page.
      *
+     * The order is passed as a routing parameter, so a theme declaring a placeholder for it
+     * gets it in the path, and a theme declaring none — the case of the shipped ones — gets
+     * it in the query string. This is the shape AbstractPaymentModule builds too.
+     *
      * @param int $orderId the order ID
      */
     public function redirectToSuccessPage(int $orderId): void
     {
         $this->getLog()->addInfo('Redirecting customer to payment success page');
 
-        throw new RedirectException($this->retrieveUrlFromRouteId('order.placed', [], ['order_id' => $orderId], Router::ABSOLUTE_PATH));
+        throw new RedirectException($this->retrieveUrlFromRouteId('checkout_confirm', [], ['order_id' => $orderId], Router::ABSOLUTE_PATH));
     }
 
     /**
@@ -252,6 +256,6 @@ abstract class BasePaymentModuleController extends BaseFrontController
     {
         $this->getLog()->addInfo('Redirecting customer to payment failure page');
 
-        throw new RedirectException($this->retrieveUrlFromRouteId('order.failed', [], ['order_id' => $orderId, 'message' => $message], Router::ABSOLUTE_PATH));
+        throw new RedirectException($this->retrieveUrlFromRouteId('checkout_failed', [], ['order_id' => $orderId, 'message' => $message], Router::ABSOLUTE_PATH));
     }
 }

--- a/tests/Integration/Controller/Front/BasePaymentModuleControllerTest.php
+++ b/tests/Integration/Controller/Front/BasePaymentModuleControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Controller\Front;
+
+use Thelia\Core\HttpKernel\Exception\RedirectException;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Module\BasePaymentModuleController;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A payment module reaches these two redirects when the customer comes back from the
+ * gateway, which is both the least testable and the least forgiving moment of a shop.
+ * The route identifiers are plain strings resolved at that very instant, so they are
+ * pinned here against the running container.
+ */
+final class BasePaymentModuleControllerTest extends IntegrationTestCase
+{
+    public function testAConfirmedPaymentSendsTheCustomerToTheOrderConfirmationPage(): void
+    {
+        $url = $this->urlOfRedirect(static fn (PaymentControllerUnderTest $controller) => $controller->redirectToSuccessPage(42));
+
+        self::assertStringEndsWith('/checkout/confirm?order_id=42', $url);
+    }
+
+    public function testAFailedPaymentSendsTheCustomerToTheFailurePageWithTheOrderAndTheReason(): void
+    {
+        $url = $this->urlOfRedirect(
+            static fn (PaymentControllerUnderTest $controller) => $controller->redirectToFailurePage(42, 'Card declined'),
+        );
+
+        self::assertStringEndsWith('/checkout/failed?order_id=42&message=Card%20declined', $url);
+    }
+
+    public function testAFailedPaymentWithoutAReasonStillReachesTheFailurePage(): void
+    {
+        $url = $this->urlOfRedirect(static fn (PaymentControllerUnderTest $controller) => $controller->redirectToFailurePage(42, null));
+
+        self::assertStringEndsWith('/checkout/failed?order_id=42', $url);
+    }
+
+    private function urlOfRedirect(callable $redirect): string
+    {
+        try {
+            $redirect($this->controller());
+        } catch (RedirectException $redirectException) {
+            return $redirectException->getUrl();
+        }
+
+        self::fail('Expected a RedirectException to be thrown.');
+    }
+
+    private function controller(): PaymentControllerUnderTest
+    {
+        $container = static::getContainer();
+
+        $controller = new PaymentControllerUnderTest();
+        $controller->container = $container;
+        $controller->securityContext = $container->get(SecurityContext::class);
+        $controller->requestStack = $container->get('request_stack');
+        $controller->translator = $container->get('thelia.translator');
+
+        return $controller;
+    }
+}
+
+/**
+ * Stands in for the return-from-gateway controller of a payment module: it inherits the
+ * wiring under test and only names the module the log file is written for.
+ */
+final class PaymentControllerUnderTest extends BasePaymentModuleController
+{
+    protected function getModuleCode(): string
+    {
+        return 'TestPayment';
+    }
+}


### PR DESCRIPTION
`BasePaymentModuleController` still redirected to the Thelia 2 route ids `order.placed` and
`order.failed`. Neither exists in Thelia 3, so every payment module returning from its gateway
through this controller got a `RouteNotFoundException` instead of a redirect — on the success
path as well as on the failure path.

The routes are now `checkout_confirm` and `checkout_failed`, the ones the front-office theme
declares, reached through the default router the theme registers its routes in.

`order_id` (and `message` on failure) stay routing parameters rather than being appended by
hand: a theme declaring a placeholder for them gets them in the path, and a theme declaring
none — the case of the shipped ones — gets them in the query string, which is where Flexy's
`checkout_failed` action reads them. `AbstractPaymentModule::getPaymentSuccessPageUrl()` and
`getPaymentFailurePageUrl()` already build the same shape, so a module mixing both entry
points now lands on the same URLs.

The three redirects are pinned by an integration test resolving them against the running
container, next to the one covering `BaseFrontController`.

Fixes #3805.
