### PR TITLE
fix: handle the contact form submission and mail it to the store

### DIFF
--- a/core/lib/Thelia/Action/Contact.php
+++ b/core/lib/Thelia/Action/Contact.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Action;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Thelia\Core\Event\Contact\ContactEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Log\Tlog;
+use Thelia\Mailer\MailerFactory;
+use Thelia\Model\ConfigQuery;
+
+/**
+ * Sends the message a visitor wrote in the contact form to the shop.
+ *
+ * The message has no template of its own: it carries the three fields of the form and
+ * nothing else, so it is built here rather than stored in the message table, and the
+ * visitor's address is set as the reply-to so that answering it reaches them.
+ */
+class Contact extends BaseAction implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly MailerFactory $mailer,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function sendMessageToStore(ContactEvent $event): void
+    {
+        $storeEmail = ConfigQuery::getStoreEmail();
+
+        if (empty($storeEmail)) {
+            Tlog::getInstance()->addError("Can't send the contact message: the store email address is not defined.");
+
+            return;
+        }
+
+        $lines = [
+            $this->translator->trans('Sender name: %name%', ['%name%' => $event->getName()]),
+            $this->translator->trans("Sender's e-mail address: %email%", ['%email%' => $event->getEmail()]),
+            $this->translator->trans('Message content: %message%', ['%message%' => $event->getMessage()]),
+        ];
+
+        // The three lines are visitor input: escape them, or a message body carrying markup
+        // is rendered as markup in the shop manager's mail client.
+        $htmlBody = '<p>'.implode("</p>\n<p>", array_map(
+            static fn (string $line): string => nl2br(htmlspecialchars($line, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8')),
+            $lines,
+        )).'</p>';
+
+        $this->mailer->sendSimpleEmailMessage(
+            [$storeEmail => ConfigQuery::getStoreName()],
+            [$storeEmail => ConfigQuery::getStoreName()],
+            $event->getSubject(),
+            $htmlBody,
+            implode("\n\n", $lines),
+            [],
+            [],
+            [$event->getEmail() => $event->getName()],
+        );
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            TheliaEvents::CONTACT_SUBMIT => ['sendMessageToStore', 128],
+        ];
+    }
+}

--- a/core/lib/Thelia/Config/Resources/routing/routes.php
+++ b/core/lib/Thelia/Config/Resources/routing/routes.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Thelia\Controller\Api\RefreshTokenController;
+use Thelia\Controller\Front\ContactController;
 use Thelia\Controller\Front\DefaultController;
 
 return static function (RoutingConfigurator $routes): void {
@@ -31,6 +32,14 @@ return static function (RoutingConfigurator $routes): void {
 
     $routes->add('index', '/')
         ->controller([DefaultController::class, 'noAction']);
+
+    // Declared before the theme and module routes: a front-office theme serves its pages
+    // through a catch-all that matches any single segment whatever the method, so a route
+    // imported after it would never be reached. The GET of the same path stays with the
+    // theme, which owns the contact page and its markup.
+    $routes->add('contact_submit', '/contact')
+        ->controller([ContactController::class, 'send'])
+        ->methods(['POST']);
 
     $routes->import('.', 'module_attribute');
     $routes->import('.', 'template_attribute');

--- a/core/lib/Thelia/Controller/Front/ContactController.php
+++ b/core/lib/Thelia/Controller/Front/ContactController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Controller\Front;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Contact\ContactEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Form\Definition\FrontForm;
+use Thelia\Form\Exception\FormValidationException;
+
+/**
+ * Receives the contact form a front-office theme renders on its contact page.
+ *
+ * The theme owns the page and the two views; the core owns the form, the event and the
+ * route that carries the submission, so that a theme gets a working contact page from
+ * its markup alone. The message itself is sent by a listener of CONTACT_SUBMIT.
+ */
+class ContactController extends BaseFrontController
+{
+    /**
+     * The view a theme is expected to name its "message sent" page after. A theme that
+     * would rather show another page sets the form's success_url, which wins over it.
+     */
+    public const SUCCESS_VIEW = 'contact-success';
+
+    public function send(EventDispatcherInterface $eventDispatcher): Response
+    {
+        $contactForm = $this->createForm(FrontForm::CONTACT);
+
+        try {
+            $form = $this->validateForm($contactForm, 'POST');
+
+            $eventDispatcher->dispatch(new ContactEvent($form), TheliaEvents::CONTACT_SUBMIT);
+
+            return $this->generateRedirect($contactForm->getSuccessUrl('/'.self::SUCCESS_VIEW));
+        } catch (FormValidationException $exception) {
+            $this->setupFormErrorContext(
+                'contact message submission',
+                $exception->getMessage(),
+                $contactForm,
+                $exception,
+            );
+        }
+
+        if ($contactForm->hasErrorUrl()) {
+            return $this->generateRedirect($contactForm->getErrorUrl());
+        }
+
+        // Render the contact page again rather than redirect to it: the errors the parser
+        // context now carries are read from the form on this very request.
+        return $this->render('contact');
+    }
+}

--- a/tests/Http/Flexy/ContactFormSubmitTest.php
+++ b/tests/Http/Flexy/ContactFormSubmitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Thelia\Controller\Front\ContactController;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * A theme serves its pages through a catch-all that matches any single segment whatever
+ * the method, so the POST of the contact page is only handled if the core route is tried
+ * first. That ordering is what these tests pin.
+ */
+final class ContactFormSubmitTest extends WebIntegrationTestCase
+{
+    use MailerAssertionsTrait;
+
+    public function testTheContactPageIsServed(): void
+    {
+        $this->assertPageRenders('/contact');
+    }
+
+    public function testTheSuccessPageOfTheThemeIsServed(): void
+    {
+        $this->assertPageRenders('/'.ContactController::SUCCESS_VIEW);
+    }
+
+    public function testPostingTheContactPageReachesTheContactController(): void
+    {
+        $match = $this->getService(RouterInterface::class)
+            ->matchRequest(Request::create('http://localhost/contact', 'POST'));
+
+        self::assertSame(
+            [ContactController::class, 'send'],
+            $match['_controller'],
+            'The POST of the contact page must not be swallowed by the catch-all of the theme.',
+        );
+    }
+
+    public function testASubmissionTheFormRejectsIsAnsweredWithThePageAndNoMail(): void
+    {
+        $this->client->request('POST', '/contact', ['thelia_contact' => [
+            'name' => 'Jane Doe',
+            'email' => 'not-an-email',
+            'subject' => '',
+            'message' => '',
+        ]]);
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertStringContainsString(
+            'thelia_contact[message]',
+            (string) $this->client->getResponse()->getContent(),
+            'The contact page must be served again so the visitor can correct the form.',
+        );
+
+        self::assertCount(0, self::getMailerMessages());
+    }
+}

--- a/tests/Integration/Action/ContactActionTest.php
+++ b/tests/Integration/Action/ContactActionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\Form\Form;
+use Thelia\Core\Event\Contact\ContactEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Form\TheliaFormFactory;
+use Thelia\Form\Definition\FrontForm;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+final class ContactActionTest extends ActionIntegrationTestCase
+{
+    use MailerAssertionsTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // A bare install leaves the store address empty, and the listener then has no
+        // recipient to write to. The transaction of the test case rolls the value back.
+        ConfigQuery::create()
+            ->findOneByName('store_email')
+            ?->setValue('shop@example.com')
+            ->save();
+    }
+
+    public function testSubmittingTheContactFormMailsTheMessageToTheStore(): void
+    {
+        $this->dispatch(
+            new ContactEvent($this->submittedContactForm()),
+            TheliaEvents::CONTACT_SUBMIT,
+        );
+
+        self::assertCount(1, $this->mailerMessages());
+
+        $message = $this->mailerMessages()[0];
+
+        self::assertSame('A question about an order', $message->getSubject());
+        self::assertSame(
+            [ConfigQuery::getStoreEmail()],
+            array_map(static fn ($address): string => $address->getAddress(), $message->getTo()),
+        );
+
+        // Answering the shop's copy has to reach the visitor, who is not the sender.
+        self::assertSame(
+            ['jane@example.com'],
+            array_map(static fn ($address): string => $address->getAddress(), $message->getReplyTo()),
+        );
+
+        self::assertStringContainsString('jane@example.com', (string) $message->getTextBody());
+        self::assertStringContainsString('Where is my parcel?', (string) $message->getTextBody());
+        self::assertStringContainsString('Where is my parcel?', (string) $message->getHtmlBody());
+    }
+
+    public function testTheMessageIsEscapedInTheHtmlBody(): void
+    {
+        $this->dispatch(
+            new ContactEvent($this->submittedContactForm([
+                'message' => 'Hello <script>alert(1)</script>',
+            ])),
+            TheliaEvents::CONTACT_SUBMIT,
+        );
+
+        $htmlBody = (string) $this->mailerMessages()[0]->getHtmlBody();
+
+        self::assertStringNotContainsString('<script>', $htmlBody);
+        self::assertStringContainsString('&lt;script&gt;', $htmlBody);
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function submittedContactForm(array $overrides = []): Form
+    {
+        $form = $this->getService(TheliaFormFactory::class)
+            ->createForm(FrontForm::CONTACT)
+            ->getForm();
+
+        $form->submit($overrides + [
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'subject' => 'A question about an order',
+            'message' => 'Where is my parcel?',
+        ]);
+
+        return $form;
+    }
+
+    /**
+     * @return list<\Symfony\Component\Mime\Email>
+     */
+    private function mailerMessages(): array
+    {
+        return array_values(array_filter(
+            self::getMailerMessages(),
+            static fn ($message): bool => $message instanceof \Symfony\Component\Mime\Email,
+        ));
+    }
+}

--- a/tests/Integration/Controller/Front/ContactControllerTest.php
+++ b/tests/Integration/Controller/Front/ContactControllerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Controller\Front;
+
+use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Controller\Front\ContactController;
+use Thelia\Core\Form\TheliaFormFactory;
+use Thelia\Core\HttpFoundation\Request;
+use Thelia\Form\Definition\FrontForm;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The contact form is rendered by a theme and submitted to the core: this pins what the
+ * core does with that submission, from the validated form to the redirect.
+ */
+final class ContactControllerTest extends IntegrationTestCase
+{
+    use MailerAssertionsTrait;
+
+    private RequestStack $requestStack;
+
+    /** @var list<Request> */
+    private array $suspendedRequests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestStack = $this->getService(RequestStack::class);
+
+        // A bare install leaves the store address empty, and the message then has no
+        // recipient. The transaction of the test case rolls the value back.
+        ConfigQuery::create()
+            ->findOneByName('store_email')
+            ?->setValue('shop@example.com')
+            ->save();
+    }
+
+    protected function tearDown(): void
+    {
+        while (null !== $this->requestStack->getCurrentRequest()) {
+            $this->requestStack->pop();
+        }
+
+        foreach ($this->suspendedRequests as $request) {
+            $this->requestStack->push($request);
+        }
+
+        $this->suspendedRequests = [];
+
+        parent::tearDown();
+    }
+
+    public function testAValidSubmissionRedirectsToTheSuccessViewAndMailsTheStore(): void
+    {
+        $response = $this->submit();
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringEndsWith('/'.ContactController::SUCCESS_VIEW, $response->getTargetUrl());
+
+        self::assertCount(1, self::getMailerMessages());
+        self::assertSame('A question about an order', self::getMailerMessages()[0]->getSubject());
+    }
+
+    public function testAFormThatNamesItsOwnSuccessUrlIsSentThere(): void
+    {
+        $response = $this->submit(['success_url' => '/thank-you']);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringEndsWith('/thank-you', $response->getTargetUrl());
+    }
+
+    public function testAnInvalidSubmissionGoesToTheErrorUrlAndMailsNothing(): void
+    {
+        $response = $this->submit(['message' => '', 'error_url' => '/contact']);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertStringEndsWith('/contact', $response->getTargetUrl());
+
+        self::assertCount(0, self::getMailerMessages());
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function submit(array $overrides = []): Response
+    {
+        $payload = $overrides + [
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'subject' => 'A question about an order',
+            'message' => 'Where is my parcel?',
+            '_token' => $this->renderedCsrfToken(),
+        ];
+
+        $request = Request::create('http://localhost/contact', 'POST', ['thelia_contact' => $payload]);
+        $request->setSession($this->requestStack->getCurrentRequest()->getSession());
+
+        // A form reads the *main* request of the stack, so the submission has to become
+        // that request: the synthetic one the test case pushes is set aside meanwhile.
+        while (null !== $suspended = $this->requestStack->pop()) {
+            array_unshift($this->suspendedRequests, $suspended);
+        }
+
+        $this->requestStack->push($request);
+
+        return $this->getService(ContactController::class)
+            ->send($this->getService(EventDispatcherInterface::class));
+    }
+
+    /**
+     * The token the theme would have written into the page, taken from the session the
+     * submission below runs in.
+     */
+    private function renderedCsrfToken(): string
+    {
+        $form = $this->getService(TheliaFormFactory::class)
+            ->createForm(FrontForm::CONTACT)
+            ->getForm();
+
+        return (string) $form->createView()->children['_token']->vars['value'];
+    }
+}


### PR DESCRIPTION
Fixes #3837.

The contact form is rendered by the theme and its submission is now answered by the core.

### What it does

`POST /contact` is declared in the core routing, before the theme and module imports: a theme serves its pages through a catch-all matching any single segment whatever the method, so a route imported after it would never be reached. The `GET` of the same path stays with the theme, which owns the page and its markup.

The controller follows the usual chain — validate the form, dispatch the event, redirect — and the message itself is sent by a listener of `TheliaEvents::CONTACT_SUBMIT`, which had no subscriber until now:

- valid submission: the message is mailed to the store address, the visitor is redirected to the `contact-success` view, or to the `success_url` the form names;
- rejected submission: the contact page is served again with the errors, or the `error_url` the form names;
- the visitor's address is set as the reply-to, so answering the shop's copy reaches them;
- the three fields are escaped in the HTML body, so a message carrying markup is not rendered as markup in the shop manager's mail client.

The message has no template of its own — it carries the three fields of the form and nothing else — so it is built in the listener rather than stored in the `message` table, as Thelia 2 did. The wording reuses the strings the core already translates.

Rate limiting comes for free: `ContactForm` extends `FirewallForm`, which `TheliaFormValidator` already enforces.

### Tests

- `tests/Integration/Action/ContactActionTest.php` — the listener mails the message to the store, and escapes it.
- `tests/Integration/Controller/Front/ContactControllerTest.php` — the redirects of the three outcomes, and that nothing is mailed when the form is rejected.
- `tests/Http/Flexy/ContactFormSubmitTest.php` — the contact and success pages are served, and `POST /contact` reaches the controller rather than the catch-all of the theme.

Verified end to end against a running server: `GET /contact` 200, a valid POST answers `302` to `/contact-success` with the mail delivered (reply-to the visitor), an invalid POST answers 200 with the field errors and no mail.
