### PR TITLE
fix(api): skip the relation getter of a branch the transformer prunes

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -560,10 +560,20 @@ readonly class ApiResourcePropelTransformerService
                 continue;
             }
 
+            $relationAttributes = $property->getAttributes(Relation::class);
+
+            // The recursion guard prunes this branch, so nothing reads what the
+            // getter would return. Asking for it first fetched the relation rows
+            // to throw them away, once per back reference of every nested
+            // resource of a collection.
+            if ([] !== $relationAttributes && !$withRelation) {
+                continue;
+            }
+
             $value = $propelModel->{$propelGetter}();
 
-            foreach ($property->getAttributes(Relation::class) as $relationAttribute) {
-                if (!$withRelation || null === $value) {
+            foreach ($relationAttributes as $relationAttribute) {
+                if (null === $value) {
                     continue 2;
                 }
 

--- a/tests/Integration/Api/TransformerPrunedRelationQueryCountTest.php
+++ b/tests/Integration/Api/TransformerPrunedRelationQueryCountTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
+use Thelia\Api\Resource\Product as ProductResource;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The transformer walks a resource graph and prunes a branch it has already
+ * visited, or one below the maximum depth: the resource is still built, but
+ * without its relations. The Propel getter was called before the loop reached
+ * that decision, so the rows were read from the database and dropped on the
+ * next statement.
+ */
+final class TransformerPrunedRelationQueryCountTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private const RELATION_TABLES = ['product_sale_elements', 'feature_product', 'product_category'];
+
+    public function testAPrunedBranchReadsNoneOfTheRelationsItDropsAnyway(): void
+    {
+        $product = $this->productWithRelations();
+
+        $statements = $this->recordSqlQueries(function () use ($product): void {
+            $this->transform($this->freshModel($product), withRelation: false);
+        });
+
+        $reads = [];
+
+        foreach (self::RELATION_TABLES as $table) {
+            $reads[$table] = self::countSqlQueriesSelectingFrom($statements, $table);
+        }
+
+        self::assertSame(
+            array_fill_keys(self::RELATION_TABLES, 0),
+            $reads,
+            'A pruned branch returns none of these relations, so it must not read any.',
+        );
+    }
+
+    /**
+     * The same guard must not starve a branch that is walked: pruning too much
+     * would answer a product without its sale elements.
+     */
+    public function testAWalkedBranchStillReadsThem(): void
+    {
+        $product = $this->productWithRelations();
+
+        $resource = $this->transform($this->freshModel($product), withRelation: true);
+
+        self::assertNotEmpty($resource->getProductSaleElements());
+        self::assertNotEmpty($resource->getFeatureProducts());
+    }
+
+    private function transform(Product $model, bool $withRelation): ProductResource
+    {
+        /** @var ProductResource $resource */
+        $resource = $this->getService(ApiResourcePropelTransformerService::class)->modelToResource(
+            resourceClass: ProductResource::class,
+            propelModel: $model,
+            context: ['groups' => [ProductResource::GROUP_FRONT_READ, ProductResource::GROUP_FRONT_READ_SINGLE]],
+            withRelation: $withRelation,
+        );
+
+        return $resource;
+    }
+
+    /**
+     * A model carrying its relations already would measure Propel's own cache,
+     * not the transformer.
+     */
+    private function freshModel(Product $product): Product
+    {
+        $model = ProductQuery::create()->findPk($product->getId(), $this->getPropelConnection());
+
+        self::assertInstanceOf(Product::class, $model);
+
+        return $model;
+    }
+
+    private function productWithRelations(): Product
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        $feature = $factory->feature(['title' => 'Colour']);
+        $featureProduct = new FeatureProduct();
+        $featureProduct->setProductId($product->getId());
+        $featureProduct->setFeatureId($feature->getId());
+        $featureProduct->setFeatureAvId($factory->featureAv($feature, ['title' => 'Blue'])->getId());
+        $featureProduct->save($connection);
+
+        return $product;
+    }
+}


### PR DESCRIPTION
`ApiResourcePropelTransformerService::processPropertiesRessource()` called the Propel getter of every property, then decided whether the branch was walked at all. On a branch the recursion guard prunes — a resource already visited up the chain, the maximum depth reached, or the explicit `withRelation: false` of a back reference — the relation rows were read from the database and dropped on the next statement.

The getter now runs only once the branch is kept. Column properties are untouched; a walked branch reads exactly what it read before, so every payload is identical.

### Measured

`tests/Integration/Api/TransformerPrunedRelationQueryCountTest`, one product carrying sale elements, a feature and a category, transformed with `withRelation: false`:

| relation read while the branch is pruned | before | after |
|---|---|---|
| `product_sale_elements` | 1 | 0 |
| `feature_product` | 1 | 0 |
| `product_category` | 1 | 0 |

Without the change the test fails on those three counts:

```
Failed asserting that two arrays are identical.
-    'product_sale_elements' => 0,
-    'feature_product' => 0,
-    'product_category' => 0,
+    'product_sale_elements' => 1,
+    'feature_product' => 1,
+    'product_category' => 1,
```

Scope of the gain, stated plainly: the front endpoints I measured — `/api/front/products`, `/api/front/products/{id}`, `/api/front/product_images`, `/api/front/categories`, `/api/front/product_sale_elements` on a six-product fixture — run the same number of statements before and after. On those, the pruned branch is the back reference to a parent whose own walk is still in progress, so the rows it was fetching early are read a moment later anyway on the same model instance. What the change removes there is the hydration work, not a query. The query is really saved wherever nothing else reads the pruned model: the depth guard, and any caller of `modelToResource()` asking for a resource without its relations.

### Checks

`composer cs` clean, `composer phpstan` no errors, suites `unit` 393, `integration` 705, `api` 241 (1 skip) green.

Fixes #3817
