### PR TITLE
fix: read the wanted attribute of the default country

### DIFF
--- a/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
@@ -188,12 +188,14 @@ class AttributeAccessService
         return '';
     }
 
+    /**
+     * Reads an attribute of the shop's default country: its title, its iso
+     * codes, any of its columns. The argument names that attribute, the way
+     * attributeCurrency() and attributeBrand() take one; it does not name the
+     * country, since the default one is the only country this reads.
+     */
     public function attributeCountry(string $attributeName): mixed
     {
-        if ($attributeName !== 'default') {
-            return '';
-        }
-
         return $this->dataAccessWithI18n(
             'defaultCountry',
             $attributeName,

--- a/tests/Integration/Api/AttributeAccessCountryTest.php
+++ b/tests/Integration/Api/AttributeAccessCountryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Thelia\Api\Service\DataAccess\AttributeAccessService;
+use Thelia\Model\Country;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * attributeCountry() reads the shop's default country. Its argument names the
+ * attribute wanted, the way attributeCurrency() and attributeBrand() take one,
+ * and not which country to read: there is only one country to read here.
+ */
+final class AttributeAccessCountryTest extends IntegrationTestCase
+{
+    private AttributeAccessService $attributeAccess;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->attributeAccess = static::getContainer()->get(AttributeAccessService::class);
+    }
+
+    public function testItReadsAnI18nAttributeOfTheDefaultCountry(): void
+    {
+        $defaultCountry = Country::getDefaultCountry();
+        $defaultCountry->setLocale($this->currentLocale());
+
+        self::assertSame(
+            $defaultCountry->getTitle(),
+            $this->attributeAccess->attributeCountry('title'),
+        );
+    }
+
+    public function testItReadsAColumnOfTheDefaultCountry(): void
+    {
+        self::assertSame(
+            Country::getDefaultCountry()->getIsoalpha2(),
+            $this->attributeAccess->attributeCountry('isoalpha2'),
+        );
+    }
+
+    /**
+     * An attribute the country does not carry is a caller mistake, and the
+     * service says so rather than answering an empty string that looks like a
+     * country without a name.
+     */
+    public function testItRejectsAnAttributeTheCountryDoesNotCarry(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("defaultCountry has no 'not_a_country_attribute' attribute");
+
+        $this->attributeAccess->attributeCountry('not_a_country_attribute');
+    }
+
+    private function currentLocale(): string
+    {
+        $lang = static::getContainer()->get('request_stack')->getCurrentRequest()?->getSession()?->getLang();
+
+        return $lang?->getLocale() ?? 'en_US';
+    }
+}


### PR DESCRIPTION
`AttributeAccessService::attributeCountry()` accepted a single argument value, `default`, and returned an empty string for anything else. That one accepted value could not work either: the argument was then handed on to `dataAccess()` as the *attribute* wanted, which builds a getter out of it — `getDefault()`, a method a country does not have, the column being `by_default`. So the call ended in:

```
InvalidArgumentException: defaultCountry has no 'default' attribute
```

Every path either returned `''` or threw; none returned anything about the default country.

The argument is a leftover of the Smarty grammar this was ported from, where `{country ask="default" attr="title"}` named the country in `ask` and the attribute in `attr`. The port kept one parameter, and it was the wrong one: the default country is the only country this method reads, so nothing needs to name it.

The argument now names the attribute, the way `attributeCurrency()` and `attributeBrand()` take one:

```php
$attributeAccess->attributeCountry('title');      // Country title in the current locale
$attributeAccess->attributeCountry('isoalpha2');  // FR
```

An attribute a country does not carry still throws, now naming the attribute that does not exist rather than one the caller never asked for.

### Measured

`tests/Integration/Api/AttributeAccessCountryTest`, on the default country of a stock install. Without the change, all three fail:

```
1) testItReadsAnI18nAttributeOfTheDefaultCountry
-'France metropolitan'
+''

2) testItReadsAColumnOfTheDefaultCountry
-'FR'
+''

3) testItRejectsAnAttributeTheCountryDoesNotCarry
Failed asserting that exception of type "InvalidArgumentException" is thrown.
```

No call site in the core, in the Flexy theme or in the bundled modules uses `attributeCountry()`, so nothing in the distribution changes behaviour; a theme calling it gets a working method where it had none.

### Checks

`composer cs` clean, `composer phpstan` no errors, suites `unit` 393, `integration` 706, `api` 241 (1 skip) green.

Fixes #3818
