### PR TITLE
fix(install): skip the Sass build when no active theme ships Sass sources

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -331,6 +331,14 @@ foreach ([
     'tailwind:build' => 'Building the front-office stylesheet',
     'sass:build' => 'Building the Sass stylesheets',
 ] as $command => $label) {
+    // sass:build compiles the entry files the active theme declares. When none of
+    // the selected themes ships Sass, symfonycasts/sass-bundle keeps its own
+    // default entry (assets/styles/app.scss), a file Thelia does not ship, and the
+    // build fails on a stylesheet nobody asked for.
+    if ('sass:build' === $command && !hasSassSourcesToBuild($themes)) {
+        continue;
+    }
+
     $commands[] = [
         'label' => $label,
         'input' => ['command' => $command],
@@ -425,6 +433,48 @@ function resolveJwtKeyPath(string $envName, string $defaultFileName): string
     }
 
     return str_replace('%kernel.project_dir%/', THELIA_ROOT, $path);
+}
+
+/**
+ * Whether one of the selected themes, or the project itself, ships a Sass entry file.
+ *
+ * A theme built on Sass registers its own entry file with symfonycasts/sass-bundle,
+ * but only while it is the active one: on any run where another theme is selected,
+ * the bundle falls back to its default entry and the build fails on a file that does
+ * not exist. Partials (a leading underscore) are compile-time inputs, never entries.
+ *
+ * @param array<string, string> $selectedThemes
+ */
+function hasSassSourcesToBuild(array $selectedThemes): bool
+{
+    $searchDirectories = [THELIA_ROOT.'assets'];
+
+    foreach ($selectedThemes as $type => $name) {
+        $name = trim($name);
+
+        if ('' !== $name) {
+            $searchDirectories[] = THELIA_TEMPLATE_DIR.$type.DS.$name.DS.'assets';
+        }
+    }
+
+    foreach ($searchDirectories as $directory) {
+        if (!is_dir($directory)) {
+            continue;
+        }
+
+        $finder = (new Symfony\Component\Finder\Finder())
+            ->files()
+            ->in($directory)
+            ->exclude(['vendor', 'node_modules'])
+            ->name('*.scss')
+            ->notName('_*');
+
+        if ($finder->hasResults()) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
`bin/install` runs `sass:build` unconditionally. That command belongs to a theme that compiles its stylesheet with symfonycasts/sass-bundle — today only the Twig back-office — and the bundle only receives an entry file while that theme is the active one. Selecting the Smarty back-office leaves the bundle on its own default entry, `assets/styles/app.scss`, a file Thelia does not ship, and dart-sass fails on it.

The failure only shows up from the second install on, because the first run still reads `ACTIVE_ADMIN_TEMPLATE=default-twig` from `.env` (the Twig theme's Flex recipe seeds it there). `template:set` then writes the selected theme to `.env.local`, and every later run starts with the real value — the Twig theme reports itself inactive, and the Sass step fails.

The build is now queued only when one of the themes being activated, or the project itself, ships a Sass entry file (a `.scss` that is not a partial). Nothing else changes: an install on the Twig back-office still builds its stylesheet, on both a fresh run and a re-run.

Proof, same database and same flags (`--backoffice_theme=default`), before the fix:

```
run 1:   Building the Sass stylesheets ... Thelia installed successfully.
run 2:   Building the Sass stylesheets
         Error reading assets/styles/app.scss: Cannot open file.
         [ERROR] Sass build failed
         Thelia installed with 1 error(s).
```

after:

```
run 1:   Thelia installed successfully.       (Sass step skipped)
run 2:   Thelia installed successfully.       (Sass step skipped)
```

and with `--backoffice_theme=default-twig`, both runs build `var/sass/main-*.output.css` as before.

`composer cs-diff` and `composer phpstan` are clean. `bin/install` is duplicated in `thelia/thelia-project`; the mirror PR is thelia/thelia-project#67.

Fixes #3807