### PR TITLE
fix(export): total the exported orders the way they were invoiced

### DIFF
--- a/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
@@ -17,6 +17,7 @@ namespace Thelia\Domain\DataTransfer\Export\Type;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\Propel;
 use Thelia\Domain\DataTransfer\Export\JsonFileAbstractExport;
+use Thelia\Model\ConfigQuery;
 
 /**
  * Class OrderExport.
@@ -28,6 +29,17 @@ class OrderExport extends JsonFileAbstractExport
 {
     public const FILE_NAME = 'order';
     public const USE_RANGE_DATE = true;
+
+    /**
+     * Orders placed before Thelia 2.4 were totalled without any rounding at all.
+     * ConfigQuery has no constant for it: it is not a mode a shop can be set to,
+     * only a state some rows are frozen in.
+     */
+    private const ROUNDING_MODE_LEGACY = 0;
+
+    private const UNIT_PRICE = 'IF(order_product.was_in_promo = 1, order_product.promo_price, order_product.price)';
+
+    private const UNIT_TAX = 'IF(order_product.was_in_promo, order_product_tax.promo_amount, order_product_tax.amount)';
 
     protected array $orderAndAliases = [
         'order_ref' => 'ref',
@@ -94,23 +106,8 @@ class OrderExport extends JsonFileAbstractExport
                     ROUND(`order`.postage, 2) as order_postage,
                     `order`.postage_tax as "order_postage_tax",
                     `order`.postage_tax_rule_title as "order_postage_tax_rule_title",
-                    SUM(ROUND(order_product.quantity * IF(order_product.was_in_promo = 1, order_product.promo_price, order_product.price), 2) ) as order_total_price,
-                    SUM(
-                        ROUND(
-                            order_product.quantity * (
-                                IF(order_product.was_in_promo = 1, order_product.promo_price, order_product.price)
-                                +
-                                (
-                                    SELECT
-                                        COALESCE(SUM(IF(order_product.was_in_promo, order_product_tax.promo_amount, order_product_tax.amount)), 0)
-                                    FROM
-                                        order_product_tax
-                                    WHERE
-                                        order_product_tax.order_product_id = order_product.id
-                                )
-                            ), 2
-                        )
-                    ) as order_total_taxed_price,
+                    '.$this->orderTotal(taxed: false).' as order_total_price,
+                    '.$this->orderTotal(taxed: true).' as order_total_taxed_price,
                     COALESCE(delivery_module.title, `order`.delivery_module_title) as "delivery_module_title",
                     `order`.delivery_ref as "order_delivery_ref",
                     COALESCE(payment_module.title, `order`.payment_module_title) as "payment_module_title",
@@ -163,6 +160,8 @@ class OrderExport extends JsonFileAbstractExport
 
         $stmt = $con->prepare($query);
         $stmt->bindValue('locale', $locale);
+        $stmt->bindValue('legacy_rounding_pivot', (int) ConfigQuery::read('last_legacy_rounding_order_id', 0), \PDO::PARAM_INT);
+        $stmt->bindValue('sum_of_roundings_pivot', (int) ConfigQuery::read('last_sum_of_roundings_order_id', 0), \PDO::PARAM_INT);
 
         foreach ($this->getDateRangeBounds() as $bound => $date) {
             $stmt->bindValue($bound, $date->format('Y-m-d H:i:s'));
@@ -171,6 +170,57 @@ class OrderExport extends JsonFileAbstractExport
         $stmt->execute();
 
         return $this->getDataJsonCache($stmt, 'order');
+    }
+
+    /**
+     * Totals the lines of an order the way it was invoiced.
+     *
+     * One query covers the whole order history, and the rule an order was
+     * charged with depends on when it was placed: an order frozen by the 2.4
+     * upgrade was totalled without any rounding, an order placed before a shop
+     * switched to rounding of sums keeps the historical rule, and the rest
+     * follow the shop. Thelia\Model\Order::getTotalAmount() is the reference the
+     * three branches mirror — an export that disagrees with it states an amount
+     * the customer was never charged.
+     */
+    private function orderTotal(bool $taxed): string
+    {
+        return '
+                    SUM(
+                        CASE
+                            WHEN `order`.id <= :legacy_rounding_pivot THEN '.$this->lineTotal(self::ROUNDING_MODE_LEGACY, $taxed).'
+                            WHEN `order`.id <= :sum_of_roundings_pivot THEN '.$this->lineTotal(ConfigQuery::ROUNDING_MODE_SUM_OF_ROUNDINGS, $taxed).'
+                            ELSE '.$this->lineTotal(ConfigQuery::getOrderRoundingMode(), $taxed).'
+                        END
+                    )';
+    }
+
+    /**
+     * One line total, rounded where the given mode says to round: on the unit
+     * amounts under sum of roundings, on the line total under rounding of sums,
+     * nowhere at all for an order frozen by the 2.4 upgrade.
+     */
+    private function lineTotal(int $roundingMode, bool $taxed): string
+    {
+        $roundUnitAmounts = ConfigQuery::ROUNDING_MODE_SUM_OF_ROUNDINGS === $roundingMode;
+
+        $unitAmount = $roundUnitAmounts ? 'ROUND('.self::UNIT_PRICE.', 2)' : self::UNIT_PRICE;
+
+        if ($taxed) {
+            $unitTax = $roundUnitAmounts ? 'ROUND('.self::UNIT_TAX.', 2)' : self::UNIT_TAX;
+
+            $unitAmount = '('.$unitAmount.' + (
+                                SELECT COALESCE(SUM('.$unitTax.'), 0)
+                                FROM order_product_tax
+                                WHERE order_product_tax.order_product_id = order_product.id
+                            ))';
+        }
+
+        $lineTotal = 'order_product.quantity * '.$unitAmount;
+
+        return ConfigQuery::ROUNDING_MODE_ROUNDING_OF_SUMS === $roundingMode
+            ? 'ROUND('.$lineTotal.', 2)'
+            : $lineTotal;
     }
 
     /**

--- a/tests/Integration/Domain/DataTransfer/OrderExportTest.php
+++ b/tests/Integration/Domain/DataTransfer/OrderExportTest.php
@@ -16,8 +16,11 @@ namespace Thelia\Tests\Integration\Domain\DataTransfer;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Thelia\Domain\DataTransfer\Export\Type\OrderExport;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\Order;
+use Thelia\Model\OrderProduct;
+use Thelia\Model\OrderProductTax;
 use Thelia\Test\FixtureFactory;
 use Thelia\Test\IntegrationTestCase;
 
@@ -27,6 +30,13 @@ use Thelia\Test\IntegrationTestCase;
  */
 final class OrderExportTest extends IntegrationTestCase
 {
+    /** One gram of a product priced 5.678 € the kilogram, taxed 0.312 € the kilogram. */
+    private const PRICE_PER_GRAM = '0.005678';
+
+    private const TAX_PER_GRAM = '0.000312';
+
+    private const GRAMS = 300.0;
+
     private FixtureFactory $factory;
 
     protected function setUp(): void
@@ -38,6 +48,15 @@ final class OrderExportTest extends IntegrationTestCase
         // only ExportHandler::processExport() does, and this test does not go
         // through the handler.
         (new Filesystem())->mkdir(THELIA_CACHE_DIR.'export');
+    }
+
+    protected function tearDown(): void
+    {
+        // ConfigQuery caches in a static array the transaction rollback cannot
+        // reach, so a mode written here would answer the next test.
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
     }
 
     public function testItExportsEveryOrderWhenNoRangeIsGiven(): void
@@ -110,6 +129,132 @@ final class OrderExportTest extends IntegrationTestCase
         self::assertArrayHasKey('delivery_country', $aliased);
         self::assertSame($row['delivery_country_i18n_title'], $aliased['delivery_country']);
         self::assertSame($row['invoice_country_i18n_title'], $aliased['invoice_country']);
+    }
+
+    /**
+     * A shop selling by weight stores a price per gram, and the mode the shop
+     * runs decides where the cent appears. The default rounds the unit price
+     * first: 0.005678 € the gram becomes 0.01 €, and the 300 g line is invoiced
+     * 3.00 €. An export stating 1.70 € for it states an amount nobody charged.
+     */
+    public function testTheDefaultModeExportsTheAmountTheOrderWasInvoicedWith(): void
+    {
+        $order = $this->bulkOrder();
+
+        self::assertEqualsWithDelta(3.0, $this->invoicedTotal($order), 0.0001);
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /**
+     * Rounding of sums multiplies at the stored precision and rounds the line
+     * total: 300 x 0.005678 = 1.7034 before tax, 1.797 with it.
+     */
+    public function testRoundingOfSumsExportsTheAmountTheOrderWasInvoicedWith(): void
+    {
+        $this->optIn();
+
+        $order = $this->bulkOrder();
+
+        self::assertEqualsWithDelta(1.80, $this->invoicedTotal($order), 0.0001);
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /**
+     * The pivot a shop writes when it opts in: the orders it had already
+     * invoiced keep the rule they were charged with, and so does their line in
+     * the export.
+     */
+    public function testAnOrderFrozenByThePivotIsExportedWithTheHistoricalRule(): void
+    {
+        $order = $this->bulkOrder();
+
+        ConfigQuery::write('last_sum_of_roundings_order_id', (string) $order->getId());
+        $this->optIn();
+
+        self::assertEqualsWithDelta(3.0, $this->invoicedTotal($order), 0.0001);
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /**
+     * Orders placed before Thelia 2.4 were totalled without any rounding at all,
+     * and the amount their invoice states cannot be restated afterwards.
+     */
+    public function testAnOrderFrozenByThe24UpgradeIsExportedWithoutRounding(): void
+    {
+        $this->optIn();
+
+        $order = $this->bulkOrder();
+
+        ConfigQuery::write('last_legacy_rounding_order_id', (string) $order->getId());
+
+        self::assertEqualsWithDelta(1.797, $this->invoicedTotal($order), 0.0001);
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /** The taxed total of the goods, the figure the invoice states for the lines. */
+    private function invoicedTotal(Order $order): float
+    {
+        $tax = 0.0;
+
+        return $order->getTotalAmount($tax, false, false);
+    }
+
+    private function optIn(): void
+    {
+        ConfigQuery::write('order_rounding_mode', (string) ConfigQuery::ROUNDING_MODE_ROUNDING_OF_SUMS);
+    }
+
+    /**
+     * An order of one line of goods sold by weight, the case where the two
+     * rounding modes land more than a cent apart.
+     */
+    private function bulkOrder(): Order
+    {
+        $order = $this->factory->order();
+        $order->setRef('EXP-'.uniqid());
+        $order->save($this->getPropelConnection());
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('bulk-ref')
+            ->setProductSaleElementsRef('bulk-pse-ref')
+            ->setTitle('Bulk rice')
+            ->setQuantity(self::GRAMS)
+            ->setPrice(self::PRICE_PER_GRAM)
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->save($this->getPropelConnection());
+
+        (new OrderProductTax())
+            ->setOrderProductId($orderProduct->getId())
+            ->setTitle('VAT')
+            ->setDescription('')
+            ->setAmount(self::TAX_PER_GRAM)
+            ->save($this->getPropelConnection());
+
+        return $order;
+    }
+
+    /**
+     * The export carries the goods alone: postage and discount get their own
+     * columns, so the order is read the same way.
+     */
+    private function assertExportedTotalsMatchTheInvoice(Order $order): void
+    {
+        $tax = 0.0;
+        $invoicedTaxedTotal = $order->getTotalAmount($tax, false, false);
+
+        $row = $this->exportedRow($order->getRef());
+
+        self::assertEqualsWithDelta(
+            $invoicedTaxedTotal,
+            (float) $row['order_total_taxed_price'],
+            0.0001,
+            'The exported taxed total has to be the amount the order was invoiced.',
+        );
+        self::assertEqualsWithDelta($invoicedTaxedTotal - $tax, (float) $row['order_total_price'], 0.0001);
+        self::assertEqualsWithDelta($tax, (float) $row['order_total_tax'], 0.0001);
     }
 
     private function orderCreatedAt(string $modifier): Order


### PR DESCRIPTION
`OrderExport` totalled every line as `SUM(ROUND(quantity * price, 2))`: the quantity first, the cent afterwards. That is one of the two rounding rules — the one #3801 named rounding of sums — applied to every order in the file, whatever the shop actually charged.

On a shop that keeps the default rule, a unit price is rounded to the cent *before* the quantity multiplies it. A line of 300 g of bulk rice at 0.005678 € the gram is invoiced 3.00 €, and the export stated 1.80 € for it. The export also ignored the two freezes: the pivot a shop writes when it opts in (`last_sum_of_roundings_order_id`), which keeps orders already invoiced on the historical rule, and the pre-2.4 freeze (`last_legacy_rounding_order_id`), whose orders were totalled without any rounding at all.

The two totals are now built per order, in SQL, from the same three branches `Thelia\Model\Order::getTotalAmount()` reads: legacy for an order under the 2.4 pivot, sum of roundings for an order under the opt-in pivot, and the shop's mode for the rest. Historical exports are not byte-identical any more — that is the point: they stated an amount the customer was never charged. A shop already on rounding of sums sees no figure move.

Four tests in `OrderExportTest` compare the exported totals to `Order::getTotalAmount()` on the same order, one per regime. Three of them fail on `main` (1.80 instead of 3.00 twice, 1.80 instead of 1.797 for a legacy order); the rounding-of-sums one passes both before and after, which is the agreement the export already had.

`composer test` (393 / 710 / 241+1 skip / 17 / 12), `composer cs-diff` and `composer phpstan` are clean.

Out of scope and still open, found while measuring this: the top-level `LEFT JOIN order_product_tax` (and `LEFT JOIN order_coupon`) multiply the grouped rows, so an order line carrying two taxes is counted twice — a 115 € order exports as 230 €. It deserves its own change, alongside the question of what a single `tax` column should print for a line taxed twice.

Fixes #3808
