### PR TITLE
fix(export): total an order once, whatever its number of tax and coupon rows

### DIFF
--- a/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
+++ b/core/lib/Thelia/Domain/DataTransfer/Export/Type/OrderExport.php
@@ -102,7 +102,7 @@ class OrderExport extends JsonFileAbstractExport
                     `order`.created_at as "order_created_at",
                     customer.ref as "customer_ref",
                     ROUND(`order`.discount, 2) as order_discount,
-                    order_coupon.code as order_coupon_code,
+                    '.$this->couponCodes().' as order_coupon_code,
                     ROUND(`order`.postage, 2) as order_postage,
                     `order`.postage_tax as "order_postage_tax",
                     `order`.postage_tax_rule_title as "order_postage_tax_rule_title",
@@ -136,12 +136,10 @@ class OrderExport extends JsonFileAbstractExport
                     invoice_country_i18n.title as "invoice_country_i18n_title",
                     invoice_address.phone as "invoice_address_phone",
                     currency.code as "currency_code",
-                    order_product_tax.title as "order_product_tax_title"
+                    '.$this->taxTitles().' as "order_product_tax_title"
                 FROM `order`
                 LEFT JOIN customer ON customer.id = `order`.customer_id
                 LEFT JOIN order_product ON order_product.order_id = `order`.id
-                LEFT JOIN order_product_tax ON order_product_tax.order_product_id = order_product.id
-                LEFT JOIN order_coupon ON order_coupon.order_id = `order`.id
                 LEFT JOIN `module_i18n` as delivery_module ON delivery_module.id = `order`.delivery_module_id AND delivery_module.locale = :locale
                 LEFT JOIN `module_i18n` as payment_module ON payment_module.id = `order`.payment_module_id AND payment_module.locale = :locale
                 LEFT JOIN order_status_i18n ON order_status_i18n.id = `order`.status_id AND order_status_i18n.locale = :locale
@@ -170,6 +168,44 @@ class OrderExport extends JsonFileAbstractExport
         $stmt->execute();
 
         return $this->getDataJsonCache($stmt, 'order');
+    }
+
+    /**
+     * The codes of the coupons the order carries, in the single `coupons`
+     * column the export has always had.
+     *
+     * A top-level join would repeat every line of the order once per coupon,
+     * and the totals are summed over those lines: an order paid with two
+     * coupons exported twice the amount it was invoiced. Reading the codes in
+     * a subquery keeps one row per line, and an order carrying several coupons
+     * now lists them all instead of whichever one the database happened to
+     * hand back.
+     */
+    private function couponCodes(): string
+    {
+        return "
+                    (
+                        SELECT GROUP_CONCAT(order_coupon.code ORDER BY order_coupon.id SEPARATOR ', ')
+                        FROM order_coupon
+                        WHERE order_coupon.order_id = `order`.id
+                    )";
+    }
+
+    /**
+     * The tax labels the order bears, listed the same way and for the same
+     * reason: a line taxed twice reached the totals twice. The column has
+     * carried the label rather than an amount since Thelia 2 — the amount is
+     * what `order_total_tax` states.
+     */
+    private function taxTitles(): string
+    {
+        return "
+                    (
+                        SELECT GROUP_CONCAT(DISTINCT order_product_tax.title ORDER BY order_product_tax.title SEPARATOR ', ')
+                        FROM order_product_tax
+                        INNER JOIN order_product as taxed_product ON taxed_product.id = order_product_tax.order_product_id
+                        WHERE taxed_product.order_id = `order`.id
+                    )";
     }
 
     /**

--- a/tests/Integration/Domain/DataTransfer/OrderExportTest.php
+++ b/tests/Integration/Domain/DataTransfer/OrderExportTest.php
@@ -19,6 +19,7 @@ use Thelia\Domain\DataTransfer\Export\Type\OrderExport;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\Order;
+use Thelia\Model\OrderCoupon;
 use Thelia\Model\OrderProduct;
 use Thelia\Model\OrderProductTax;
 use Thelia\Test\FixtureFactory;
@@ -191,6 +192,54 @@ final class OrderExportTest extends IntegrationTestCase
         $this->assertExportedTotalsMatchTheInvoice($order);
     }
 
+    /**
+     * A line bearing two taxes is one line on the invoice. The export joined
+     * order_product_tax at the top level, so the line reached the SUM() once
+     * per tax row and the order came out doubled.
+     */
+    public function testALineTaxedTwiceIsTotalledOnce(): void
+    {
+        $order = $this->twiceTaxedOrder();
+
+        self::assertEqualsWithDelta(115.0, $this->invoicedTotal($order), 0.0001);
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /**
+     * Same multiplication through the coupons: an order carrying two of them
+     * was totalled twice, and one carrying three of them three times.
+     */
+    public function testAnOrderCarryingSeveralCouponsIsTotalledOnce(): void
+    {
+        $order = $this->twiceTaxedOrder();
+        $this->addCoupon($order, 'SPRING');
+        $this->addCoupon($order, 'SUMMER');
+
+        $this->assertExportedTotalsMatchTheInvoice($order);
+    }
+
+    /**
+     * The column holds the tax label, as it has since Thelia 2. Picking one
+     * row out of a group left the others out of the file, and which one
+     * survived was up to the database.
+     */
+    public function testEveryTaxLabelOfTheOrderReachesTheTaxColumn(): void
+    {
+        $order = $this->twiceTaxedOrder();
+
+        self::assertSame('Eco tax, VAT', $this->exportedRow($order->getRef())['order_product_tax_title']);
+    }
+
+    /** The column is aliased `coupons`, and an order can carry several. */
+    public function testEveryCouponCodeOfTheOrderReachesTheCouponColumn(): void
+    {
+        $order = $this->twiceTaxedOrder();
+        $this->addCoupon($order, 'SPRING');
+        $this->addCoupon($order, 'SUMMER');
+
+        self::assertSame('SPRING, SUMMER', $this->exportedRow($order->getRef())['order_coupon_code']);
+    }
+
     /** The taxed total of the goods, the figure the invoice states for the lines. */
     private function invoicedTotal(Order $order): float
     {
@@ -234,6 +283,56 @@ final class OrderExportTest extends IntegrationTestCase
             ->save($this->getPropelConnection());
 
         return $order;
+    }
+
+    /** One line of 100.00 € bearing a 10.00 € VAT and a 5.00 € eco tax: 115.00 € invoiced. */
+    private function twiceTaxedOrder(): Order
+    {
+        $order = $this->factory->order();
+        $order->setRef('EXP-'.uniqid());
+        $order->save($this->getPropelConnection());
+
+        $orderProduct = new OrderProduct();
+        $orderProduct
+            ->setOrderId($order->getId())
+            ->setProductRef('taxed-ref')
+            ->setProductSaleElementsRef('taxed-pse-ref')
+            ->setTitle('Twice taxed goods')
+            ->setQuantity(1.0)
+            ->setPrice('100.000000')
+            ->setWasNew(0)
+            ->setWasInPromo(0)
+            ->save($this->getPropelConnection());
+
+        foreach (['VAT' => '10.000000', 'Eco tax' => '5.000000'] as $title => $amount) {
+            (new OrderProductTax())
+                ->setOrderProductId($orderProduct->getId())
+                ->setTitle($title)
+                ->setDescription('')
+                ->setAmount($amount)
+                ->save($this->getPropelConnection());
+        }
+
+        return $order;
+    }
+
+    private function addCoupon(Order $order, string $code): void
+    {
+        (new OrderCoupon())
+            ->setOrderId($order->getId())
+            ->setCode($code)
+            ->setType('thelia.coupon.type.remove_x_amount')
+            ->setAmount('0.000000')
+            ->setTitle($code)
+            ->setShortDescription('')
+            ->setDescription('')
+            ->setExpirationDate(new \DateTime('+1 year'))
+            ->setIsCumulative(true)
+            ->setIsRemovingPostage(false)
+            ->setIsAvailableOnSpecialOffers(false)
+            ->setSerializedConditions('')
+            ->setPerCustomerUsageCount(false)
+            ->save($this->getPropelConnection());
     }
 
     /**


### PR DESCRIPTION
The order export joined `order_product_tax` and `order_coupon` at the top level and then summed the line totals over the result. Each extra joined row repeated every line of the order before the `SUM()`, so an order was totalled once per tax row and once per coupon row.

An order invoiced 115.00 (one line of 100.00 bearing a 10.00 VAT and a 5.00 eco tax) exported at 230.00. Add two coupons to it and it exported at 460.00.

Both joins existed only to carry a label — `order_coupon.code` into the `coupons` column and `order_product_tax.title` into the `tax` column — and `GROUP BY \`order\`.id` then kept whichever row the database handed back, dropping the others. They are now read in a subquery per order, which leaves one row per line for the totals and lists every label instead of one: `SPRING, SUMMER` for the coupons, `Eco tax, VAT` for the taxes. An order with a single tax and a single coupon exports exactly the same bytes as before.

The `tax` column keeps carrying the label rather than an amount, as it has since Thelia 2; the amount is what `total_taxes` states.

The three rounding branches of #3843 are untouched, and its four tests still hold: the export of an order equals `Order::getTotalAmount()` on that same order.

Fixes #3846
