### PR TITLE
fix(install): wire the first install run on the themes it was given

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -202,8 +202,11 @@ $configMap = [
 ];
 
 foreach ($themes as $type => $name) {
-    if (isset($configMap[$type]) && '' !== trim($name)) {
-        $setup->setConfig($configMap[$type], trim($name));
+    $name = trim($name);
+
+    if (isset($configMap[$type]) && '' !== $name) {
+        $setup->setConfig($configMap[$type], $name);
+        publishConfigVariableForCurrentProcess($configMap[$type], $name);
     }
 }
 
@@ -433,6 +436,26 @@ function resolveJwtKeyPath(string $envName, string $defaultFileName): string
     }
 
     return str_replace('%kernel.project_dir%/', THELIA_ROOT, $path);
+}
+
+/**
+ * Publish a Thelia configuration variable as an environment variable of the running process.
+ *
+ * Thelia\Model\Config lets an environment variable take precedence over the stored value, and
+ * the template packages declare their own theme that way in .env. The kernel booted below would
+ * otherwise run the rest of the install — module post-activation, demo import — on the theme a
+ * recipe declares rather than the one being installed: template:set writes the choice to
+ * .env.local, a file the dotenv loader has already read by then.
+ *
+ * The variable name is the one Thelia\Model\Config::getEnvName() derives from the config name.
+ */
+function publishConfigVariableForCurrentProcess(string $configName, string $value): void
+{
+    $envName = str_replace(['.', '-'], '_', strtoupper($configName));
+
+    $_SERVER[$envName] = $value;
+    $_ENV[$envName] = $value;
+    putenv($envName.'='.$value);
 }
 
 /**


### PR DESCRIPTION
`Thelia\Model\Config` lets an environment variable take precedence over the stored value, and the template packages declare their own theme that way in `.env` (`ACTIVE_ADMIN_TEMPLATE=default-twig`, `ACTIVE_FRONT_TEMPLATE=flexy`). On the very first `bin/install` run there is no `.env.local` yet, so the whole in-process kernel — module post-activation, demo import, admin creation, asset builds — runs on the theme a recipe declares instead of the one the installer was given. `template:set` writes the choice to `.env.local`, a file the dotenv loader has already read by then, so the shop only settles on the right theme from the second run on.

`bin/install` now publishes each selected theme into `$_SERVER`/`$_ENV`/`putenv()` as soon as it writes it to the `config` table, the way the `DATABASE_*` variables already are. The variable name is derived exactly as `Thelia\Model\Config::getEnvName()` derives it, so a theme handed to the installer wins over the one a recipe declares from the first command onwards.

### Before, first run with `--backoffice_theme=default`

The `config` table holds `active-admin-template = default`, yet every kernel command reads `default-twig`:

```
[PROBE] cmd=module:post-activate-all  ConfigQuery(active-admin-template)=default-twig  ENV[ACTIVE_ADMIN_TEMPLATE]=default-twig
[PROBE] cmd=thelia:demo:import        ConfigQuery(active-admin-template)=default-twig  ENV[ACTIVE_ADMIN_TEMPLATE]=default-twig
[PROBE] cmd=admin:create              ConfigQuery(active-admin-template)=default-twig  ENV[ACTIVE_ADMIN_TEMPLATE]=default-twig
```

The second run, now reading `.env.local`, reads `default` — same flags, same database, different shop.

### After

```
[PROBE] cmd=module:post-activate-all  ConfigQuery(active-admin-template)=default  ENV[ACTIVE_ADMIN_TEMPLATE]=default
[PROBE] cmd=thelia:demo:import        ConfigQuery(active-admin-template)=default  ENV[ACTIVE_ADMIN_TEMPLATE]=default
[PROBE] cmd=admin:create              ConfigQuery(active-admin-template)=default  ENV[ACTIVE_ADMIN_TEMPLATE]=default
```

Both runs agree, for `--backoffice_theme=default` and for `--backoffice_theme=default-twig`.

### Checks

Four `--with-demo` installs on an empty database, all `Thelia installed successfully.`: `default` run 1 and 2, `default-twig` run 1 and 2. `composer cs-diff` clean, `composer phpstan` reports no error, unit (393) and integration (738) suites green.

Fixes #3847
