### PR TITLE
feat: dress the api documentation page in the Thelia colours

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -1,6 +1,4 @@
 api_platform:
-    title: Hello API Platform
-    version: 1.0.0
     formats:
         jsonld: ['application/ld+json']
     docs_formats:

--- a/core/lib/Thelia/Config/Resources/packages/api_platform.php
+++ b/core/lib/Thelia/Config/Resources/packages/api_platform.php
@@ -16,8 +16,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 return static function (ContainerConfigurator $container): void {
     $container->extension('api_platform', [
-        'title' => 'API Thelia',
-        'version' => '1.0.0',
+        'title' => 'Thelia API',
+        'version' => '3.0.0',
         'show_webby' => false,
         'serializer' => [
             'hydra_prefix' => true,

--- a/core/lib/Thelia/Config/Resources/packages/twig.php
+++ b/core/lib/Thelia/Config/Resources/packages/twig.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $swaggerUi = 'bundles'.\DIRECTORY_SEPARATOR.'ApiPlatformBundle'
+        .\DIRECTORY_SEPARATOR.'SwaggerUi'.\DIRECTORY_SEPARATOR.'index.html.twig';
+
+    // API Platform renders its documentation page from a template name it
+    // hardcodes, so dressing that page as Thelia means adding a path to the
+    // bundle's Twig namespace. Twig reads the paths declared here before the
+    // ones the bundle hierarchy builds, which would take the shop's own
+    // templates/bundles/ApiPlatformBundle override away from it: the shop
+    // wins by shipping that template, and Thelia then steps aside.
+    //
+    // The check runs when the container is built, so a shop adding the file
+    // to an already warmed cache has to clear it.
+    if (\defined('THELIA_TEMPLATE_DIR') && is_file(THELIA_TEMPLATE_DIR.$swaggerUi)) {
+        return;
+    }
+
+    $container->extension('twig', [
+        'paths' => [
+            \dirname(__DIR__, 3).\DIRECTORY_SEPARATOR.'Resources'
+                .\DIRECTORY_SEPARATOR.'views'.\DIRECTORY_SEPARATOR.'ApiPlatform' => 'ApiPlatform',
+        ],
+    ]);
+};

--- a/core/lib/Thelia/Resources/views/ApiPlatform/SwaggerUi/index.html.twig
+++ b/core/lib/Thelia/Resources/views/ApiPlatform/SwaggerUi/index.html.twig
@@ -1,0 +1,94 @@
+{# The API documentation, dressed as Thelia rather than as API Platform.
+
+   `@!ApiPlatform` is the bundle's own template, so everything this file does
+   not touch — Swagger UI, ReDoc, Scalar, the format links — keeps working as
+   the bundle ships it. #}
+{% extends '@!ApiPlatform/SwaggerUi/index.html.twig' %}
+
+{% block title %}
+    <title>{{ title|default('Thelia API') }}</title>
+{% endblock %}
+
+{% block stylesheet %}
+    {{ parent() }}
+
+    <style>
+        :root {
+            --thelia-orange: #f26041;
+            --thelia-pink: #c73459;
+            --thelia-green: #99c455;
+            --thelia-ink: #282828;
+            --thelia-ink-soft: #4f4f4f;
+            --thelia-mist: #f4f7fa;
+        }
+
+        header:before {
+            background-color: var(--thelia-ink);
+        }
+
+        header #logo {
+            right: auto;
+            left: 40px;
+            color: #fff;
+            font-size: 20px;
+            font-weight: 700;
+            letter-spacing: .02em;
+            text-decoration: none;
+        }
+
+        header #logo em {
+            color: var(--thelia-orange);
+            font-style: normal;
+        }
+
+        .swagger-ui .info .title,
+        .swagger-ui .info .title small pre {
+            color: var(--thelia-ink);
+        }
+
+        .swagger-ui .info a,
+        .swagger-ui .information-container .info a,
+        #formats .info a {
+            color: var(--thelia-pink);
+        }
+
+        .swagger-ui .btn.execute {
+            background-color: var(--thelia-orange);
+            border-color: var(--thelia-orange);
+            color: #fff;
+        }
+
+        .swagger-ui .btn.authorize {
+            color: var(--thelia-green);
+            border-color: var(--thelia-green);
+        }
+
+        .swagger-ui .btn.authorize svg {
+            fill: var(--thelia-green);
+        }
+
+        .swagger-ui .opblock.opblock-get .opblock-summary-method {
+            background-color: var(--thelia-ink-soft);
+        }
+
+        .swagger-ui .opblock.opblock-post .opblock-summary-method,
+        .swagger-ui .opblock.opblock-patch .opblock-summary-method,
+        .swagger-ui .opblock.opblock-put .opblock-summary-method {
+            background-color: var(--thelia-orange);
+        }
+
+        .swagger-ui .opblock.opblock-delete .opblock-summary-method {
+            background-color: var(--thelia-pink);
+        }
+
+        .swagger-ui .scheme-container {
+            background-color: var(--thelia-mist);
+        }
+    </style>
+{% endblock %}
+
+{% block header %}
+    <header>
+        <a id="logo" href="https://thelia.net" rel="noopener">The<em>lia</em></a>
+    </header>
+{% endblock %}


### PR DESCRIPTION
`/api/docs` announced itself as `API Thelia 1.0.0` and wore the API Platform
livery: teal bar, API Platform logo, page titled `API Platform`.

### Name and version

`title` and `version` move to `Thelia API` and `3.0.0`, in the core config
(`core/lib/Thelia/Config/Resources/packages/api_platform.php`), which is where
they take effect for every install.

The two keys the API Platform recipe writes into
`config/packages/api_platform.yaml` go away, because they never did anything:
`core/lib/Thelia/Config/Resources/services.php` imports `packages/*` again while
the container is being built, after the shop's `config/packages/*.yaml` have
been read, so the core value is the one that wins.

```
# with `title: ZZZ Probe` in config/packages/api_platform.yaml
$ bin/console debug:config api_platform title
'Thelia API'
```

That is worth knowing on its own — a shop cannot override an `api_platform` key
the core sets — but it is a separate problem from this pull request.

### The page

API Platform renders the documentation from a template name it hardcodes, so
the only way in is the `@ApiPlatform` Twig namespace. The core adds a path to
it carrying a single template, which extends the bundle's own one
(`@!ApiPlatform/…`) and changes three blocks: the page title, an inline
stylesheet in the Thelia colours, and a header that says Thelia instead of
API Platform. Swagger UI, ReDoc, Scalar, the format links and the JSON-LD and
OpenAPI representations are untouched.

Twig reads the paths declared in the configuration before the ones the bundle
hierarchy builds, which would take the standard override channel away from the
shop, so the core registers its path only when
`templates/bundles/ApiPlatformBundle/SwaggerUi/index.html.twig` does not exist.
A shop that ships that template gets it, as Symfony promises:

```
# templates/bundles/ApiPlatformBundle/SwaggerUi/index.html.twig present
$ curl -s /api/docs | grep '<title>'
<title>SHOP OVERRIDE</title>
# removed again
<title>Thelia API</title>
```

Nothing is downloaded and nothing is published to `public/`: the stylesheet is
inline and there is no logo file, so the change travels with `thelia/core` and
reaches a `composer create-project` install with no file to add to the skeleton.

### Checks

- `composer test`: 1408 tests over the five suites, green.
- `composer cs-diff`, `composer phpstan`, `bin/console lint:twig`: clean.
- Rendered `/api/docs` on a fresh install: `<title>Thelia API</title>`, the
  Thelia header, the inline stylesheet, and `"title":"Thelia API"`,
  `"version":"3.0.0"` in the OpenAPI document. `?ui=re_doc`, `Accept:
  application/ld+json` and `Accept: application/vnd.openapi+json` all answer 200.
