### PR TITLE
fix(test): resume the session the client sends back between two requests

### DIFF
--- a/core/lib/Thelia/Config/Resources/services/core/event_listeners.php
+++ b/core/lib/Thelia/Config/Resources/services/core/event_listeners.php
@@ -17,14 +17,11 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Thelia\Core\EventListener\ControllerListener;
 use Thelia\Core\EventListener\ErrorListener;
 use Thelia\Core\EventListener\ResponseListener;
-use Thelia\Core\EventListener\SessionListener;
 
 return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
 
     $services->alias('response.listener', ResponseListener::class);
-
-    $services->alias('session.listener', SessionListener::class);
 
     $services->alias('controller.listener', ControllerListener::class);
 

--- a/core/lib/Thelia/Core/HttpFoundation/Session/SessionStorageFactory.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/SessionStorageFactory.php
@@ -34,7 +34,7 @@ final readonly class SessionStorageFactory implements SessionStorageFactoryInter
         $env = \is_string($_SERVER['APP_ENV'] ?? null) ? $_SERVER['APP_ENV'] : 'prod';
 
         if ('test' === $env || headers_sent()) {
-            return new MockFileSessionStorage($this->defaultSavePath);
+            return $this->createMockStorage($request);
         }
 
         $lifetime = (int) ConfigQuery::read('session_config.lifetime', 0);
@@ -52,5 +52,26 @@ final readonly class SessionStorageFactory implements SessionStorageFactoryInter
         $handler = new NativeFileSessionHandler($customSavePath ?: $this->defaultSavePath);
 
         return new NativeSessionStorage($options, $handler);
+    }
+
+    /**
+     * The native storage reads the session cookie itself, through php. The mock one never
+     * does, so it has to be handed the id the client sends back: without it every request
+     * of a same client opens a new session, and nothing a page stores for the next request
+     * — a form token, a cart, a flash message — survives the round trip.
+     *
+     * The id names the file the storage reads, so only the character set php gives session
+     * ids is accepted.
+     */
+    private function createMockStorage(?Request $request): MockFileSessionStorage
+    {
+        $storage = new MockFileSessionStorage($this->defaultSavePath);
+        $sessionId = $request?->cookies->get($storage->getName());
+
+        if (\is_string($sessionId) && 1 === preg_match('/^[a-zA-Z0-9,-]{1,128}$/', $sessionId)) {
+            $storage->setId($sessionId);
+        }
+
+        return $storage;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -145,12 +145,6 @@ parameters:
 			path: core/lib/Thelia/Api/Resource/Product.php
 
 		-
-			message: '#^Class Thelia\\Core\\EventListener\\SessionListener not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: core/lib/Thelia/Config/Resources/services/core/event_listeners.php
-
-		-
 			message: '#^Call to method getPackage\(\) on an unknown class Thelia\\Core\\Propel\\Generator\\Builder\\Om\\Mixin\\AbstractOMBuilder\.$#'
 			identifier: class.notFound
 			count: 1

--- a/tests/Http/Flexy/SessionRoundTripTest.php
+++ b/tests/Http/Flexy/SessionRoundTripTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Thelia\Core\HttpFoundation\Session\SessionFactory;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * A visitor keeps one session across the requests he sends, and a form whose token lives
+ * in that session is therefore submittable. Everything a page hands to the visitor to send
+ * back — a CSRF token, a cart, a flash message — depends on it.
+ */
+final class SessionRoundTripTest extends WebIntegrationTestCase
+{
+    public function testTheSessionOpenedByTheFirstRequestIsResumedByTheNextOne(): void
+    {
+        $this->assertPageRenders('/contact');
+        $firstSessionId = $this->sessionIdHeldByTheClient();
+
+        $this->assertPageRenders('/contact');
+        $secondSessionId = $this->sessionIdHeldByTheClient();
+
+        self::assertNotNull($firstSessionId, 'The first request must hand a session cookie to the client.');
+        self::assertSame(
+            $firstSessionId,
+            $secondSessionId,
+            'The second request must resume the session the client was handed, not open a new one.',
+        );
+    }
+
+    public function testAFormWhoseTokenLivesInTheSessionCanBeSubmittedBack(): void
+    {
+        $this->assertPageRenders('/contact');
+
+        $form = $this->client->getCrawler()->filter('form[name="thelia_contact"]')->form([
+            'thelia_contact[name]' => 'Jane Doe',
+            'thelia_contact[email]' => 'jane.doe@example.com',
+            'thelia_contact[subject]' => 'A question',
+            'thelia_contact[message]' => 'Is anybody out there?',
+        ]);
+
+        $this->client->submit($form);
+
+        self::assertSame(
+            302,
+            $this->client->getResponse()->getStatusCode(),
+            'The submission must be accepted: a rejected token serves the page again with a 200.',
+        );
+    }
+
+    private function sessionIdHeldByTheClient(): ?string
+    {
+        $sessionName = $this->getService(SessionFactory::class)->createSession()->getName();
+
+        return $this->client->getCookieJar()->get($sessionName)?->getValue();
+    }
+}


### PR DESCRIPTION
A client of a web test kept losing its session between two requests, so no form
whose CSRF token lives in the session could be submitted back from a test.

The test environment builds a `MockFileSessionStorage`, which — unlike the native
storage php drives in dev and prod — never reads the session cookie. The factory
already received the `Request`, and ignored it. It now hands the storage the id the
request carries, so the second request of a client resumes the session the first
one opened. The id names the file the storage reads, so only the character set php
gives session ids is accepted. Nothing changes for the native storage: dev and prod
run the same code as before, byte for byte.

A second, unrelated leftover goes with it: an alias of `session.listener` to a class
removed when the session moved to a factory, and to a service id Symfony no longer
uses. Nothing referenced it, and the framework session listener it looked like it
replaced was registered all along under its own id — the listener graph of the
compiled container is identical with and without it. Its only trace was an entry
in the PHPStan baseline, now gone too.

Proved by two tests added to the `http-flexy` suite: two requests of one client
share a session id, and the contact form is accepted when the token of the page is
sent back. Both fail on `main` (a new id per request; the submission answered with
the page instead of a redirect).

A real front-office walk under a cookie jar answers exactly the same headers before
and after — `PHPSESSID` set on the first response only, same `Cache-Control`, same
other cookies.

The two skipped tests of `PasswordResetLinkFlowTest` are not affected: they skip
because the installed Flexy release has no `password_reset` route yet, and they pass
without this change once a theme that ships it is installed.

Fixes #3845
