### PR TITLE
fix(template): store the email template under the name every shop reads

### DIFF
--- a/core/lib/Thelia/Core/Hook/HookHelper.php
+++ b/core/lib/Thelia/Core/Hook/HookHelper.php
@@ -41,10 +41,10 @@ class HookHelper
     public function parseActiveTemplate(int $templateType = TemplateDefinition::FRONT_OFFICE): array
     {
         $tplVar = match ($templateType) {
-            TemplateDefinition::FRONT_OFFICE => 'active-front-template',
-            TemplateDefinition::BACK_OFFICE => 'active-admin-template',
-            TemplateDefinition::PDF => 'active-pdf-template',
-            TemplateDefinition::EMAIL => 'active-mail-template',
+            TemplateDefinition::FRONT_OFFICE => TemplateDefinition::FRONT_OFFICE_CONFIG_NAME,
+            TemplateDefinition::BACK_OFFICE => TemplateDefinition::BACK_OFFICE_CONFIG_NAME,
+            TemplateDefinition::PDF => TemplateDefinition::PDF_CONFIG_NAME,
+            TemplateDefinition::EMAIL => TemplateDefinition::EMAIL_CONFIG_NAME,
             default => throw new TheliaProcessException('Unknown template type: '.$templateType),
         };
 

--- a/core/lib/Thelia/Core/Template/TemplateDefinition.php
+++ b/core/lib/Thelia/Core/Template/TemplateDefinition.php
@@ -31,7 +31,10 @@ class TemplateDefinition
     public const FRONT_OFFICE_CONFIG_NAME = 'active-front-template';
     public const BACK_OFFICE_CONFIG_NAME = 'active-admin-template';
     public const PDF_CONFIG_NAME = 'active-pdf-template';
-    public const EMAIL_CONFIG_NAME = 'active-email-template';
+    // The email template has been stored under 'active-mail-template' since 2.0.0-beta2,
+    // and that is the name the seed writes and every reader looks up. Anything else here
+    // makes 'template:set email' write a variable no shop ever reads.
+    public const EMAIL_CONFIG_NAME = 'active-mail-template';
     public const CONFIG_NAMES = [
         self::FRONT_OFFICE_SUBDIR => self::FRONT_OFFICE_CONFIG_NAME,
         self::BACK_OFFICE_SUBDIR => self::BACK_OFFICE_CONFIG_NAME,

--- a/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
+++ b/core/lib/Thelia/Core/Template/TheliaTemplateHelper.php
@@ -40,7 +40,7 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
     public function getActiveMailTemplate(): TemplateDefinition
     {
         return new TemplateDefinition(
-            ConfigQuery::read('active-mail-template', 'default'),
+            ConfigQuery::read(TemplateDefinition::EMAIL_CONFIG_NAME, 'default'),
             TemplateDefinition::EMAIL,
         );
     }
@@ -56,16 +56,16 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
 
         switch ($templateDefinition->getType()) {
             case TemplateDefinition::FRONT_OFFICE:
-                $configTemplateName = 'active-front-template';
+                $configTemplateName = TemplateDefinition::FRONT_OFFICE_CONFIG_NAME;
                 break;
             case TemplateDefinition::BACK_OFFICE:
-                $configTemplateName = 'active-admin-template';
+                $configTemplateName = TemplateDefinition::BACK_OFFICE_CONFIG_NAME;
                 break;
             case TemplateDefinition::PDF:
-                $configTemplateName = 'active-pdf-template';
+                $configTemplateName = TemplateDefinition::PDF_CONFIG_NAME;
                 break;
             case TemplateDefinition::EMAIL:
-                $configTemplateName = 'active-mail-template';
+                $configTemplateName = TemplateDefinition::EMAIL_CONFIG_NAME;
                 break;
         }
 
@@ -78,7 +78,7 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
     public function getActivePdfTemplate(): TemplateDefinition
     {
         return new TemplateDefinition(
-            ConfigQuery::read('active-pdf-template', 'default'),
+            ConfigQuery::read(TemplateDefinition::PDF_CONFIG_NAME, 'default'),
             TemplateDefinition::PDF,
         );
     }
@@ -89,7 +89,7 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
     public function getActiveAdminTemplate(): TemplateDefinition
     {
         return new TemplateDefinition(
-            ConfigQuery::read('active-admin-template', 'default'),
+            ConfigQuery::read(TemplateDefinition::BACK_OFFICE_CONFIG_NAME, 'default'),
             TemplateDefinition::BACK_OFFICE,
         );
     }
@@ -100,7 +100,7 @@ class TheliaTemplateHelper implements TemplateHelperInterface, EventSubscriberIn
     public function getActiveFrontTemplate(): TemplateDefinition
     {
         return new TemplateDefinition(
-            ConfigQuery::read('active-front-template', 'default'),
+            ConfigQuery::read(TemplateDefinition::FRONT_OFFICE_CONFIG_NAME, 'default'),
             TemplateDefinition::FRONT_OFFICE,
         );
     }

--- a/tests/Integration/Core/Template/ActiveEmailTemplateConfigTest.php
+++ b/tests/Integration/Core/Template/ActiveEmailTemplateConfigTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Template;
+
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\Template\TemplateService;
+use Thelia\Core\Template\TheliaTemplateHelper;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The email template of a shop lives in the `active-mail-template` config row: that is
+ * what the seed creates and what every database carries since 2.0.0-beta2. The row is
+ * spelled out here on purpose — the code side is free to rename its constant, the stored
+ * name is not.
+ *
+ * `template:set email <name>` writes TemplateDefinition::CONFIG_NAMES['email'], and the
+ * mailer, the hook parser and the template path resolver read the active email template.
+ * Both ends have to land on that row, or the command changes a variable nothing looks up
+ * and the shop keeps sending the emails of the template it was told to leave.
+ */
+final class ActiveEmailTemplateConfigTest extends IntegrationTestCase
+{
+    private const STORED_CONFIG_NAME = 'active-mail-template';
+    private const ANOTHER_TEMPLATE = 'an-email-template-of-its-own';
+
+    protected function tearDown(): void
+    {
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testTheCommandWritesTheRowTheShopStoresItsEmailTemplateIn(): void
+    {
+        ConfigQuery::write(TemplateDefinition::CONFIG_NAMES[TemplateDefinition::EMAIL_SUBDIR], self::ANOTHER_TEMPLATE);
+
+        self::assertSame(self::ANOTHER_TEMPLATE, ConfigQuery::read(self::STORED_CONFIG_NAME));
+    }
+
+    public function testTheTemplateHelperReadsTheStoredEmailTemplate(): void
+    {
+        $templateHelper = $this->getService(TheliaTemplateHelper::class);
+        $activeTemplate = new TemplateDefinition(
+            ConfigQuery::read(self::STORED_CONFIG_NAME, 'default'),
+            TemplateDefinition::EMAIL,
+        );
+
+        self::assertTrue($templateHelper->isActive($activeTemplate));
+
+        ConfigQuery::write(self::STORED_CONFIG_NAME, self::ANOTHER_TEMPLATE);
+
+        self::assertFalse($templateHelper->isActive($activeTemplate));
+    }
+
+    public function testTheEmailTemplatePathFollowsTheStoredEmailTemplate(): void
+    {
+        ConfigQuery::write(self::STORED_CONFIG_NAME, self::ANOTHER_TEMPLATE);
+
+        self::assertSame(
+            THELIA_TEMPLATE_DIR.TemplateDefinition::EMAIL_SUBDIR.\DIRECTORY_SEPARATOR.self::ANOTHER_TEMPLATE,
+            TemplateService::getTemplateAbsolutePathByType(TemplateDefinition::EMAIL_SUBDIR),
+        );
+    }
+}

--- a/tests/Integration/Install/SeedSqlGeneratorTest.php
+++ b/tests/Integration/Install/SeedSqlGeneratorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Install;
 
+use Thelia\Core\Template\TemplateDefinition;
 use Thelia\Install\Generator\SeedSqlGenerator;
 use Thelia\Test\IntegrationTestCase;
 
@@ -52,6 +53,34 @@ final class SeedSqlGeneratorTest extends IntegrationTestCase
         // language without wording is the gap #3697 closed.
         self::assertSame($seededLocales, $this->getLocalesOfTheSeededMessages());
         self::assertEmpty(array_diff($seededLocales, $generator->getAvailableLocales()));
+    }
+
+    public function testTheSeedCreatesEveryActiveTemplateConfigTheCodeWrites(): void
+    {
+        $seededConfigNames = $this->getSeededConfigNames();
+
+        foreach (TemplateDefinition::CONFIG_NAMES as $templateType => $configName) {
+            self::assertContains(
+                $configName,
+                $seededConfigNames,
+                \sprintf('The %s template is stored under a config variable the seed never creates.', $templateType),
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getSeededConfigNames(): array
+    {
+        $seed = file_get_contents($this->getService(SeedSqlGenerator::class)->getOutputPath());
+
+        self::assertIsString($seed);
+        self::assertSame(1, preg_match('/INSERT INTO `config`.*?\n;/s', $seed, $block));
+
+        preg_match_all("/^\s*\(\d+, '([^']+)'/m", $block[0], $matches);
+
+        return $matches[1];
     }
 
     /**


### PR DESCRIPTION
Fixes #3854

`template:set email <name>` writes `TemplateDefinition::CONFIG_NAMES['email']`, which was `active-email-template`. Nothing sending an email ever read that variable: the mailer (`TheliaTemplateHelper::getActiveMailTemplate()`), the back-office "is this template active?" check and the hook parser all read `active-mail-template`, and `active-mail-template` is the row the seed creates — the name every database has carried since 2.0.0-beta2.

So the command created a second row next to the seeded one and the shop kept sending the emails of the template it had been told to leave. Worse, the two ends did not even disagree consistently: `TemplateService` resolves the email template path from `CONFIG_NAMES` too, so the routes of the *new* template were loaded while the mailer rendered the *old* one.

## The fix

`EMAIL_CONFIG_NAME` becomes `active-mail-template`: the stored name wins, because it is the one existing shops carry and the one the seed writes — renaming it the other way would have sent every shop back to the default email template.

The three copies of the "template type → config variable" mapping that had drifted apart (`TemplateDefinition`, `TheliaTemplateHelper`, `HookHelper`) now all go through the constants, so a future rename cannot desynchronise them again.

## Before

Fresh install, `--email_theme=default`, then `template:set email another-theme`:

```
CONFIG_NAMES[email]                   = active-email-template
db active-mail-template               = 'default'
db active-email-template              = 'another-theme'
helper->getActiveMailTemplate()->name = default            <- still the old template
TemplateService(email path)           = templates/email/another-theme
```

## After

```
CONFIG_NAMES[email]                   = active-mail-template
db active-mail-template               = 'another-theme'
db active-email-template              = <no row>
helper->getActiveMailTemplate()->name = another-theme
TemplateService(email path)           = templates/email/another-theme
```

`.env.local` now publishes `ACTIVE_MAIL_TEMPLATE` instead of the inert `ACTIVE_EMAIL_TEMPLATE`.

## Tests

`tests/Integration/Core/Template/ActiveEmailTemplateConfigTest.php` pins both ends to the stored row: what the command writes lands in `active-mail-template`, and the helper and the path resolver follow it. `SeedSqlGeneratorTest` gains the invariant that every active-template config the code writes is a row the seed creates — the check that would have caught this at birth. All four assertions fail on `main` and pass here.

`setup/insert.sql` is untouched: the seed already creates the canonical row, so `generate:sql` still produces the shipped file.

## :warning: For the 3.0.0 release

Beta installs carry a stray `active-email-template` row, and a shop that ran `template:set email` on a beta has its intended template stored there while the mailer keeps using `active-mail-template`. **`setup/update/sql/3.0.0.sql` should carry the value over and drop the stray row** — it is not added here, since no update script may target an untagged version:

```sql
UPDATE `config` `stored`
    INNER JOIN `config` `stray` ON `stray`.`name` = 'active-email-template'
    SET `stored`.`value` = `stray`.`value`
    WHERE `stored`.`name` = 'active-mail-template'
      AND `stored`.`value` = 'default'
      AND `stray`.`value` <> 'default';

DELETE FROM `config` WHERE `name` = 'active-email-template';
```

The guard keeps an email template chosen in the back-office (which always wrote the canonical row) from being overwritten by a stale beta value.
