### PR TITLE
fix(config): keep environment overrides out of the shared config cache

### DIFF
--- a/core/lib/Thelia/Core/Cache/ConfigCacheService.php
+++ b/core/lib/Thelia/Core/Cache/ConfigCacheService.php
@@ -18,6 +18,14 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Thelia\Model\ConfigQuery;
 
+/**
+ * Keeps the configuration table in a cache shared by every process of the shop.
+ *
+ * The entry holds stored values only. An environment variable overriding a
+ * configuration name belongs to the process that declares it, and is applied by
+ * {@see ConfigQuery::read()} on each read, so a process started with an override
+ * can neither publish it to the others nor read theirs.
+ */
 class ConfigCacheService
 {
     public const CACHE_KEY = 'thelia_config';

--- a/core/lib/Thelia/Model/Config.php
+++ b/core/lib/Thelia/Model/Config.php
@@ -18,15 +18,28 @@ use Thelia\Model\Base\Config as BaseConfig;
 
 class Config extends BaseConfig
 {
+    /**
+     * The environment variable a configuration name is overridden by:
+     * 'active-front-template' is overridden by ACTIVE_FRONT_TEMPLATE.
+     */
+    public static function getEnvNameFor(string $configName): string
+    {
+        return str_replace(['.', '-'], '_', strtoupper($configName));
+    }
+
     public function getEnvName()
     {
-        return str_replace(
-            ['.', '-'],
-            '_',
-            strtoupper(
-                $this->getName(),
-            ),
-        );
+        return self::getEnvNameFor((string) $this->getName());
+    }
+
+    /**
+     * The stored value, ignoring any environment override. An override belongs to
+     * the process that declares it, so this is the only value a cache shared by
+     * several processes may hold.
+     */
+    public function getStoredValue(): ?string
+    {
+        return parent::getValue();
     }
 
     public function getValue(): ?string

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -40,7 +40,18 @@ class ConfigQuery extends BaseConfigQuery
     public const ROUNDING_MODE_ROUNDING_OF_SUMS = 2;
 
     protected static $booted = false;
+
+    /**
+     * Stored values only, never the environment overrides applied on top of them:
+     * this map is handed to a cache shared by every process of the shop, so a
+     * variable set for one process must not end up being read by the next one.
+     *
+     * @var array<string, string|null>
+     */
     protected static $cache = [];
+
+    /** @var array<string, string> */
+    private static array $envNames = [];
 
     /**
      * @internal
@@ -65,18 +76,19 @@ class ConfigQuery extends BaseConfigQuery
     /**
      * @internal
      *
-     * The whole table, name => value. It is small enough to load in one go
-     * and to hand to {@see initCache()} as an authoritative snapshot: every
-     * name absent from the result has no row in the table at all.
+     * The whole table, name => stored value. It is small enough to load in one
+     * go and to hand to {@see initCache()} as an authoritative snapshot: every
+     * name absent from the result has no row in the table at all. Environment
+     * overrides are deliberately left out, {@see read()} applies them.
      *
-     * @return array<string, string>
+     * @return array<string, string|null>
      */
     public static function findAllAsMap(): array
     {
         $configs = [];
 
         foreach (self::create()->find() as $config) {
-            $configs[$config->getName()] = $config->getValue();
+            $configs[$config->getName()] = $config->getStoredValue();
         }
 
         return $configs;
@@ -90,14 +102,9 @@ class ConfigQuery extends BaseConfigQuery
     public static function read(string $search, $default = null, bool $ignoreCache = false)
     {
         if ($ignoreCache) {
-            $model = self::create()->filterByName($search)->findOneOrCreate();
-
-            // The default only applies to a variable that does not exist yet: a stored
-            // '0' or '' is a value, and the cached path returns it as such.
-            return self::$cache[$search] = $model->getValue() ?? $default;
-        }
-
-        if (!self::$booted) {
+            // findOneOrCreate() puts the name in the cache, so the lookup below finds it.
+            self::$cache[$search] = self::create()->filterByName($search)->findOneOrCreate()->getStoredValue();
+        } elseif (!self::$booted) {
             // Nothing warmed the cache yet (this can run before
             // ConfigCacheService gets a chance to, e.g. a debug logger reading
             // its own config while Propel itself is still being wired up).
@@ -112,6 +119,18 @@ class ConfigQuery extends BaseConfigQuery
             return $default;
         }
 
+        // An environment variable wins over the stored value, but only for the process
+        // that has it set. Applying it here rather than caching the result is what
+        // keeps the cached snapshot readable by a process started with another
+        // environment, and this one readable by no one else.
+        $envName = self::$envNames[$search] ??= Config::getEnvNameFor($search);
+
+        if (isset($_ENV[$envName])) {
+            return (string) $_ENV[$envName];
+        }
+
+        // The default only applies to a variable that does not exist yet: a stored
+        // '0' or '' is a value, and it is returned as such.
         return self::$cache[$search] ?? $default;
     }
 
@@ -135,7 +154,7 @@ class ConfigQuery extends BaseConfigQuery
         $config->setValue($value !== null ? (string) $value : '');
         $config->save();
 
-        self::$cache[$configName] = $config->getValue();
+        self::$cache[$configName] = $config->getStoredValue();
     }
 
     public static function getConfiguredShopUrl()

--- a/tests/Integration/Core/Cache/ConfigCacheServiceTest.php
+++ b/tests/Integration/Core/Cache/ConfigCacheServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Cache;
+
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Thelia\Core\Cache\ConfigCacheService;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The cache entry outlives the process that wrote it and is read back by every
+ * other process of the shop, whatever environment they were started with. A
+ * configuration name overridden by an environment variable must therefore never
+ * reach it: the override applies where it is declared, and nowhere else.
+ */
+final class ConfigCacheServiceTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private const CONFIG_NAME = 'test-config-cache-env-override';
+    private const ENV_NAME = 'TEST_CONFIG_CACHE_ENV_OVERRIDE';
+
+    protected function tearDown(): void
+    {
+        unset($_ENV[self::ENV_NAME]);
+        ConfigQuery::resetCache();
+
+        parent::tearDown();
+    }
+
+    public function testAProcessWithAnEnvironmentOverrideDoesNotPublishItToTheOthers(): void
+    {
+        ConfigQuery::write(self::CONFIG_NAME, 'from-database');
+
+        // A single pool object stands for the entry the processes share.
+        $sharedPool = new ArrayAdapter();
+        $configCacheService = new ConfigCacheService($sharedPool);
+
+        // First process: started with the variable set, it warms the shared entry.
+        $_ENV[self::ENV_NAME] = 'from-environment';
+        ConfigQuery::resetCache();
+        $configCacheService->initCacheConfigs();
+
+        self::assertSame(
+            'from-environment',
+            ConfigQuery::read(self::CONFIG_NAME),
+            'The process that declares the variable must read it.',
+        );
+
+        $snapshot = $sharedPool->getItem(ConfigCacheService::CACHE_KEY)->get();
+
+        self::assertSame(
+            'from-database',
+            $snapshot[self::CONFIG_NAME],
+            'The shared entry must hold the stored value, not the override.',
+        );
+
+        // Second process: same shop, same cache, no variable set.
+        unset($_ENV[self::ENV_NAME]);
+        ConfigQuery::resetCache();
+        $configCacheService->initCacheConfigs();
+
+        self::assertSame(
+            'from-database',
+            ConfigQuery::read(self::CONFIG_NAME),
+            'A process without the variable must not read the value of one that had it.',
+        );
+    }
+
+    public function testReadingAnOverriddenNameTwiceStillCostsNoQuery(): void
+    {
+        ConfigQuery::write(self::CONFIG_NAME, 'from-database');
+        ConfigQuery::resetCache();
+
+        $_ENV[self::ENV_NAME] = 'from-environment';
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            self::assertSame('from-environment', ConfigQuery::read(self::CONFIG_NAME));
+            self::assertSame('from-environment', ConfigQuery::read(self::CONFIG_NAME));
+            self::assertSame('from-environment', ConfigQuery::read(self::CONFIG_NAME));
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'Applying the override on read must not cost a query.',
+        );
+    }
+}


### PR DESCRIPTION
Fixes #3855

`ConfigCacheService` stores a snapshot of the whole `config` table in a cache pool backed by the filesystem. That snapshot was built from `Config::getValue()`, which lets an environment variable win over the stored value — so the entry held whatever `$_ENV` said in the process that happened to warm it. The entry outlives that process: every later boot, including boots of a process started with a different environment, read those values back.

Reproduced on a CLI boot, three processes sharing one cache directory, config row `wt3855-probe` = `from-db`:

```
[A] env(WT3855_PROBE)='poisoned-by-A'  | pool='poisoned-by-A' | ConfigQuery::read='poisoned-by-A'
[B] env(WT3855_PROBE)=NULL             | pool='poisoned-by-A' | ConfigQuery::read='poisoned-by-A'
[C] env(WT3855_PROBE)=NULL             | pool='poisoned-by-A' | ConfigQuery::read='poisoned-by-A'
```

The snapshot now holds stored values only, and `ConfigQuery::read()` applies the environment override on each read. An override therefore applies in the process that declares it and nowhere else:

```
[A] env(WT3855_PROBE)='poisoned-by-A'  | pool='from-db' | ConfigQuery::read='poisoned-by-A'
[B] env(WT3855_PROBE)=NULL             | pool='from-db' | ConfigQuery::read='from-db'
[C] env(WT3855_PROBE)='set-by-C'       | pool='from-db' | ConfigQuery::read='set-by-C'
[D] env(WT3855_PROBE)=NULL             | pool='from-db' | ConfigQuery::read='from-db'
```

Two alternatives were dropped: leaving the overridden names out of the snapshot makes every read of them fall back to the caller's default, and deriving the cache key from the environment keeps the overridden values on disk while multiplying the entries.

Reads still cost no query: the environment variable name is derived once per config name and kept in a per-process map, so a warm read is an `isset()` plus an array lookup. Measured on 2M warm reads, best of five rounds: 57 ns per read before, 87 ns after — no extra I/O, no extra query.

Behaviour left untouched on purpose: an environment variable still only overrides a name that has a row in the table, and `Config::getValue()` still answers with the override for the back office and the config loop.

Covered by `tests/Integration/Core/Cache/ConfigCacheServiceTest.php`, which fails on `main` on both the snapshot content and the cross-process read.
