### PR TITLE
fix(config): give the shop configuration the last word over the core defaults

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -6,7 +6,6 @@ api_platform:
         jsonopenapi: ['application/vnd.openapi+json']
         html: ['text/html']
     defaults:
-        stateless: true
         cache_headers:
             vary: ['Content-Type', 'Authorization', 'Origin']
         extra_properties:

--- a/core/lib/Thelia/Config/Resources/packages/api_platform.php
+++ b/core/lib/Thelia/Config/Resources/packages/api_platform.php
@@ -55,5 +55,5 @@ return static function (ContainerConfigurator $container): void {
                 ],
             ],
         ],
-    ]);
+    ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -49,5 +49,5 @@ return static function (ContainerConfigurator $container): void {
                 'interval' => '1 hour',
             ],
         ],
-    ]);
+    ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/packages/twig.php
+++ b/core/lib/Thelia/Config/Resources/packages/twig.php
@@ -36,5 +36,5 @@ return static function (ContainerConfigurator $container): void {
             \dirname(__DIR__, 3).\DIRECTORY_SEPARATOR.'Resources'
                 .\DIRECTORY_SEPARATOR.'views'.\DIRECTORY_SEPARATOR.'ApiPlatform' => 'ApiPlatform',
         ],
-    ]);
+    ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -27,7 +27,10 @@ use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
 return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
-    // Import service configurations
+    // Import service configurations. Everything the core declares for another
+    // bundle is prepended, here and in packages/*.php: the kernel loads this file
+    // a second time from buildContainer(), after the shop's own config/packages,
+    // and a default must never win over the file the shop wrote.
     $configurator->import('packages/*');
     $configurator->import('parameters/*');
     $configurator->import('services/*');
@@ -123,7 +126,7 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
             'mailer' => [
                 'dsn' => addslashes($dsn),
             ],
-        ]);
+        ], prepend: true);
     }
 
     if ($propelAvailable) {
@@ -158,7 +161,7 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
             }
         }
 
-        $configurator->extension('api_platform', ['mapping' => ['paths' => $apiResourcePaths]]);
+        $configurator->extension('api_platform', ['mapping' => ['paths' => $apiResourcePaths]], prepend: true);
     }
 
     $serviceConfigurator->get(ConfigCacheService::class)

--- a/tests/Unit/Core/Config/CoreConfigurationDefaultsTest.php
+++ b/tests/Unit/Core/Config/CoreConfigurationDefaultsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Config;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * The kernel loads the core configuration files twice, the second time from
+ * buildContainer(), after the shop's own config/packages/*.yaml. Whatever that
+ * order, what the shop declares has to win: the core only ships defaults.
+ */
+final class CoreConfigurationDefaultsTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: array<string, mixed>, 3: string, 4: mixed}>
+     */
+    public static function coreConfigurationFileProvider(): iterable
+    {
+        yield 'api_platform title' => [
+            'packages/api_platform.php',
+            'api_platform',
+            ['title' => 'Shop API'],
+            'title',
+            'Shop API',
+        ];
+
+        yield 'api_platform stateless default' => [
+            'packages/api_platform.php',
+            'api_platform',
+            ['defaults' => ['stateless' => true]],
+            'defaults',
+            ['pagination_client_items_per_page' => true, 'stateless' => true],
+        ];
+
+        yield 'framework session save path' => [
+            'packages/framework.php',
+            'framework',
+            ['session' => ['save_path' => '/srv/sessions']],
+            'session',
+            ['save_path' => '/srv/sessions'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $shopConfiguration
+     */
+    #[DataProvider('coreConfigurationFileProvider')]
+    public function testTheShopConfigurationWinsOverTheCoreDefaults(
+        string $file,
+        string $alias,
+        array $shopConfiguration,
+        string $key,
+        mixed $expected,
+    ): void {
+        $container = new ContainerBuilder();
+        $container->registerExtension($this->createExtension($alias));
+
+        // The shop's config/packages/*.yaml is loaded before the core re-imports
+        // its own files, which is the order that used to hide it.
+        $container->loadFromExtension($alias, $shopConfiguration);
+
+        $directory = \dirname(__DIR__, 4).'/core/lib/Thelia/Config/Resources';
+        (new PhpFileLoader($container, new FileLocator($directory)))->load($file);
+
+        $merged = array_replace_recursive(...$container->getExtensionConfig($alias));
+
+        self::assertSame($expected, $merged[$key]);
+    }
+
+    private function createExtension(string $alias): Extension
+    {
+        return new class($alias) extends Extension {
+            public function __construct(private readonly string $alias)
+            {
+            }
+
+            public function getAlias(): string
+            {
+                return $this->alias;
+            }
+
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #3857.

## The problem

The kernel loads the core configuration twice: once from `configureContainer()`, before the shop's `config/packages/*.yaml`, and once more from `buildContainer()` through `loadService()`, which re-imports `Config/Resources/packages/*` **after** them. Symfony merges extension configuration in load order, so the second pass put every scalar the core sets back on top: a shop writing

```yaml
# config/packages/thelia_api.yaml
api_platform:
    title: 'Shop API'
    version: '9.9.9'
```

still got `Thelia API` / `3.0.0` out of `debug:config api_platform title`.

## The fix

Everything the core declares for another bundle is now prepended: the three files in `Config/Resources/packages/` and the two `extension()` calls `services.php` computes at build time (the mailer DSN, the API resource paths). Prepending states what that configuration is — a set of defaults — and it holds whatever the loading order becomes later, instead of depending on which pass runs last.

The same shop file now answers `Shop API` / `9.9.9`, and with no shop file the documentation page still reads `Thelia API` / `3.0.0`.

`config/packages/api_platform.yaml` loses `defaults.stateless: true`. The flag was removed on purpose in 2024 and the API Platform 4.3 recipe wrote it back during the upgrade, where it stayed dead because the core answered `false` over it. Left in place, it would flip the front API to stateless and take the cart session away from it — this is the one key whose effective value the reordering would have changed.

## Proof

Fresh install (empty directory, empty database, `--with-demo`), `debug:config` dumped for the 22 configurable bundles before and after, compared key by key: **0 differing values**. `/`, `/admin/login` and `/api/docs` answer 200, and the documentation page keeps the title and the colours #3853 gave it.

Three unit tests cover the contract; all three fail on `main`.

`composer test` — unit 396, integration 742, api 242 (1 skip), http-flexy 25 (2 skips), http-backoffice 12 (2 pre-existing deprecations). `composer cs-diff` and `composer phpstan` clean.

## Left alone

`Config/Resources/parameters/monolog.php` still wins over the shop, so the same hole remains for logging. It cannot be closed by reordering: the recipe's `config/packages/monolog.yaml` declares `main` as a `stream` handler while the core declares it as `fingers_crossed`, and letting the shop win makes the merged configuration invalid (`excluded_http_codes` on a handler that is not fingers-crossed). Moving Thelia's logging setup into the shipped `monolog.yaml` is the way out, and it changes what every shop logs — worth its own issue rather than a rider on this one.
