### PR TITLE
ci: run the test suite on PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.3', '8.4' ]
+        php: [ '8.3', '8.4', '8.5' ]
     # A leaked DB transaction once kept a DDL test waiting on a metadata lock
     # until the 6-hour runner limit. A green run takes ~15 minutes; anything
     # beyond this is a hang, fail fast.

--- a/core/lib/Thelia/Core/Event/ActionEvent.php
+++ b/core/lib/Thelia/Core/Event/ActionEvent.php
@@ -65,7 +65,6 @@ abstract class ActionEvent extends Event
     {
         $reflection = new \ReflectionClass(Event::class);
         $property = $reflection->getProperty('propagationStopped');
-        $property->setAccessible(true);
         $property->setValue($this, false);
     }
 

--- a/core/lib/Thelia/Tools/FileDownload/FileDownloader.php
+++ b/core/lib/Thelia/Tools/FileDownload/FileDownloader.php
@@ -67,8 +67,6 @@ class FileDownloader implements FileDownloaderInterface
 
         $httpCode = curl_getinfo($con, \CURLINFO_HTTP_CODE);
 
-        curl_close($con);
-
         if (false === $response || 0 !== $errno
             || ('200' !== $httpCode && '204' !== $httpCode)
         ) {

--- a/tests/Support/Trait/CreatesTestFiles.php
+++ b/tests/Support/Trait/CreatesTestFiles.php
@@ -33,7 +33,6 @@ trait CreatesTestFiles
         $tmpFile = tempnam(sys_get_temp_dir(), $prefix);
         $img = imagecreatetruecolor(1, 1);
         imagepng($img, $tmpFile);
-        imagedestroy($img);
 
         return $tmpFile;
     }


### PR DESCRIPTION
A fresh install on PHP 8.5.7 (Symfony 7.4.17, API Platform 4.3) runs the five suites green: 1423 tests, same 3 skips as on 8.3, php-cs-fixer and PHPStan clean.

The only code PHP 8.5 flags in this repository is three calls that have been no-ops since 8.0/8.1 — setAccessible(), curl_close() and imagedestroy() — removed in the first commit.

The remaining 8.5 deprecations come from the Propel fork (ModelJoin, SchemaReader, the generated model casts) and are tracked separately.