### PR TITLE
chore: give the config and setup packages a description and license

### DIFF
--- a/local/config/composer.json
+++ b/local/config/composer.json
@@ -1,5 +1,7 @@
 {
     "name": "thelia/config",
+    "description": "Application configuration installed by the Thelia installer.",
+    "license": "GPL-3.0-or-later",
     "type": "thelia-local",
     "require": {
         "thelia/installer": "~1.1"

--- a/setup/composer.json
+++ b/setup/composer.json
@@ -1,5 +1,7 @@
 {
     "name": "thelia/setup",
+    "description": "Database schema and seed data installed by the Thelia installer.",
+    "license": "GPL-3.0-or-later",
     "type": "thelia-local",
     "require": {
         "thelia/installer": "~1.1"


### PR DESCRIPTION
The thelia/config and thelia/setup packages ship without a description or a license, so `composer validate` refuses to publish them ("description is required") — a blocker for tagging them stable in the 3.0.0 train. This adds a one-line description and the GPL-3.0-or-later license (matching the core) to both source composer.json files. Metadata only; extraction to the downstream thelia/config and thelia/setup repos follows.