### PR TITLE
fix(install): align the supported PHP range across the check and composer.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ To create a shop, use the project skeleton instead: [thelia/thelia-project](http
 
 Thelia is an open source framework for building online stores and managing web content. Version 3 runs on:
 
-- PHP 8.3
+- PHP 8.3, 8.4 or 8.5
 - Symfony 7.4 LTS
 - API Platform 4.3 (standalone)
 - Propel ORM
@@ -25,10 +25,15 @@ Thelia is open source software. See the [LICENSE](LICENSE) file for details.
 
 ## Requirements
 
-- PHP 8.3 with these extensions: pdo_mysql, openssl, intl, gd, curl, dom, mbstring, zip
-- MariaDB 10.11 or MySQL 8
-- Composer 2.7+
-- Nginx or Apache, with the document root set to `public/`
+| Requirement | Supported |
+| --- | --- |
+| PHP | 8.3, 8.4 or 8.5 (8.3 recommended) |
+| Database | MariaDB 10.11 or later (recommended), or MySQL 8.x |
+| PHP extensions | pdo_mysql, openssl, intl, gd, curl, dom, mbstring, zip |
+| Composer | 2.7 or later |
+| Web server | Nginx or Apache, document root set to `public/` |
+
+How long each release series receives security fixes is listed in [SECURITY.md](SECURITY.md).
 
 ## Setting up a development environment
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": ">= 8.3",
+        "php": ">=8.3 <9.0",
         "thelia/core": "^3.0.0-beta1",
         "thelia/backoffice-default-template": "^1.0.0-beta1",
         "thelia/backoffice-default-twig-template": "^1.0",

--- a/core/composer.json
+++ b/core/composer.json
@@ -9,7 +9,7 @@
         "wiki": "http://doc.thelia.net"
     },
     "require": {
-        "php": ">= 8.3",
+        "php": ">=8.3 <9.0",
 
         "ext-curl": "*",
         "ext-intl": "*",

--- a/core/lib/Thelia/Core/Install/CheckPermission.php
+++ b/core/lib/Thelia/Core/Install/CheckPermission.php
@@ -46,9 +46,14 @@ class CheckPermission extends BaseInstall
         'upload_max_filesize' => 2097152,
     ];
 
-    protected $phpExpectedVerions = [
-        'min' => '8.2',
-        'max' => '8.3',
+    /**
+     * Supported PHP range: minimum inclusive, maximum exclusive.
+     * Thelia 3 runs on any PHP 8.3+ up to (but not including) the next major.
+     * The next major (9.0) must be validated by a Thelia release before it is allowed.
+     */
+    protected array $phpExpectedVersions = [
+        'min' => '8.3',
+        'max' => '9.0',
     ];
     protected $extensions = [
         'curl',
@@ -122,9 +127,7 @@ class CheckPermission extends BaseInstall
      */
     public function exec(): bool
     {
-        $currentVersion = substr(\PHP_VERSION, 0, strrpos(\PHP_VERSION, '.'));
-
-        if (!version_compare($currentVersion, $this->phpExpectedVerions['min'], '>=') && version_compare($currentVersion, $this->phpExpectedVerions['max'], '<=')) {
+        if (!$this->isPhpVersionSupported(\PHP_VERSION)) {
             $this->isValid = false;
             $this->validationMessages['php_version']['text'] = $this->getI18nPhpVersionText(\PHP_VERSION, false);
             $this->validationMessages['php_version']['status'] = false;
@@ -163,6 +166,18 @@ class CheckPermission extends BaseInstall
         }
 
         return $this->isValid;
+    }
+
+    /**
+     * Tell whether the given PHP version falls in the supported range
+     * (minimum inclusive, maximum exclusive). Expects a full "x.y.z" version.
+     */
+    public function isPhpVersionSupported(string $phpVersion): bool
+    {
+        $version = substr($phpVersion, 0, (int) strrpos($phpVersion, '.'));
+
+        return version_compare($version, $this->phpExpectedVersions['min'], '>=')
+            && version_compare($version, $this->phpExpectedVersions['max'], '<');
     }
 
     /**
@@ -215,7 +230,7 @@ class CheckPermission extends BaseInstall
     protected function getI18nConfigText(string $key, string $expectedValue, string $currentValue, bool $isValid): string
     {
         $sentence = $isValid ? 'The PHP "%key%" configuration value (currently %currentValue%) is correct (%expectedValue% required).'
-            : 'The PHP "%key%" configuration value (currently %currentValue%) is below minimal requirements to run Thelia2 (%expectedValue% required).';
+            : 'The PHP "%key%" configuration value (currently %currentValue%) is below minimal requirements to run Thelia (%expectedValue% required).';
 
         return $this->formatString(
             $sentence,
@@ -245,14 +260,14 @@ class CheckPermission extends BaseInstall
      */
     protected function getI18nPhpVersionText(string $currentValue, bool $isValid): string
     {
-        $sentence = $isValid ? 'PHP version %currentValue% matches the version required (>= %minExpectedValue% <= %maxExpectedValue%).'
-            : 'The installer detected PHP version %currentValue%, but Thelia 2 requires PHP between %minExpectedValue% and %maxExpectedValue%.';
+        $sentence = $isValid ? 'PHP version %currentValue% matches the version required (>= %minExpectedValue% and < %maxExpectedValue%).'
+            : 'The installer detected PHP version %currentValue%, but Thelia 3 requires PHP >= %minExpectedValue% and < %maxExpectedValue%.';
 
         return $this->formatString(
             $sentence,
             [
-                '%minExpectedValue%' => $this->phpExpectedVerions['min'],
-                '%maxExpectedValue%' => $this->phpExpectedVerions['max'],
+                '%minExpectedValue%' => $this->phpExpectedVersions['min'],
+                '%maxExpectedValue%' => $this->phpExpectedVersions['max'],
                 '%currentValue%' => $currentValue,
             ],
         );
@@ -263,7 +278,7 @@ class CheckPermission extends BaseInstall
      */
     protected function getI18nPhpVersionHint(): string
     {
-        return $this->formatString('You should change the installed PHP version to continue Thelia 2 installation.', []);
+        return $this->formatString('You should change the installed PHP version to continue Thelia 3 installation.', []);
     }
 
     /**

--- a/tests/Unit/Install/CheckPermissionPhpVersionTest.php
+++ b/tests/Unit/Install/CheckPermissionPhpVersionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Install;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Thelia\Core\Install\CheckPermission;
+
+/**
+ * Guards the supported PHP range gate: minimum inclusive (8.3), maximum
+ * exclusive (9.0). The previous condition only ever rejected versions that
+ * were both below the minimum and below the maximum, so every version at or
+ * above the minimum passed, including untested future majors.
+ */
+final class CheckPermissionPhpVersionTest extends TestCase
+{
+    public static function phpVersions(): array
+    {
+        return [
+            'below the minimum is rejected' => ['8.2.30', false],
+            'the minimum is accepted' => ['8.3.0', true],
+            'a patch of the minimum is accepted' => ['8.3.20', true],
+            'a tested minor is accepted' => ['8.4.10', true],
+            'the highest tested minor is accepted' => ['8.5.0', true],
+            'the next major is rejected' => ['9.0.0', false],
+        ];
+    }
+
+    #[DataProvider('phpVersions')]
+    public function testPhpVersionGate(string $phpVersion, bool $expectedSupported): void
+    {
+        // Bypass the constructor: it runs the full permission check (filesystem,
+        // extensions) which is irrelevant to the version range under test.
+        $check = (new \ReflectionClass(CheckPermission::class))->newInstanceWithoutConstructor();
+
+        self::assertSame($expectedSupported, $check->isPhpVersionSupported($phpVersion));
+    }
+}


### PR DESCRIPTION
## Problem

The supported PHP version was declared inconsistently across the project. In `CheckPermission`, the install check had a dead maximum bound: the condition `!(v >= min) && (v <= max)` only flagged a version that was both below the minimum and below the maximum, so every version at or above the minimum passed, including untested future majors. The bounds themselves were stale (8.2 to 8.3), the property name held a typo (`phpExpectedVerions`), some messages still said "Thelia 2", and `composer.json` set `">= 8.3"` with no upper bound.

## Policy

Thelia 3 runs on PHP 8.3, 8.4 and 8.5 (all three covered by the CI matrix), with 8.3 recommended. The supported range is any PHP 8.3+ within the 8.x series. The next major (9.0) must be validated by a Thelia release before it is allowed, so the range is capped exclusively at 9.0. This keeps future 8.x minor releases working without a code change while stopping an untested major from being installed silently.

## Changes

- `CheckPermission`: gate on a real range (`>= 8.3` and `< 9.0`) via a small testable `isPhpVersionSupported()` method, fix the `phpExpectedVersions` typo, and correct the "Thelia 2" wording in the installer messages.
- `composer.json` and `core/composer.json`: `">=8.3 <9.0"`.
- `Readme.md`: one support table (PHP, database, extensions, Composer, web server) plus a pointer to SECURITY.md for how long each series is supported.
- New unit test `CheckPermissionPhpVersionTest` covering 8.2 (rejected), 8.3/8.4/8.5 (accepted) and 9.0 (rejected). It fails on the old dead-bound logic and passes on the fix.

## Baselines

`composer test` (5 suites) green, `composer cs-diff` 0, `composer phpstan` 0.