### PR TITLE
fix(security): harden the remember-me cookie with httponly, secure and samesite

### DIFF
--- a/core/lib/Thelia/Core/Security/Token/CookieTokenProvider.php
+++ b/core/lib/Thelia/Core/Security/Token/CookieTokenProvider.php
@@ -27,17 +27,36 @@ class CookieTokenProvider
         }
     }
 
-    public function createCookie(UserInterface $user, $cookieName, $cookieExpires): void
+    public function createCookie(UserInterface $user, $cookieName, $cookieExpires, ?bool $secure = null): void
     {
         $tokenProvider = new TokenProvider();
 
         $key = $tokenProvider->encodeKey($user);
 
-        setcookie($cookieName, $key, ['expires' => time() + $cookieExpires, 'path' => '/']);
+        setcookie($cookieName, $key, $this->buildCookieOptions(time() + $cookieExpires, $secure));
     }
 
-    public function clearCookie($cookieName): void
+    public function clearCookie($cookieName, ?bool $secure = null): void
     {
-        setcookie($cookieName, '', ['expires' => time() - 3600, 'path' => '/']);
+        setcookie($cookieName, '', $this->buildCookieOptions(time() - 3600, $secure));
+    }
+
+    /**
+     * Build the options for the remember-me cookie. It holds a long-lived
+     * authentication token, so it is hardened against theft: httponly keeps it
+     * out of reach of JavaScript (XSS), samesite mitigates CSRF, and secure
+     * keeps it off cleartext HTTP. When the caller does not tell us whether the
+     * connection is secure, it is deduced from the current request so a plain
+     * HTTP local setup does not silently drop the cookie.
+     */
+    protected function buildCookieOptions(int $expires, ?bool $secure): array
+    {
+        return [
+            'expires' => $expires,
+            'path' => '/',
+            'httponly' => true,
+            'samesite' => 'Lax',
+            'secure' => $secure ?? Request::createFromGlobals()->isSecure(),
+        ];
     }
 }

--- a/tests/Unit/Security/CookieTokenProviderTest.php
+++ b/tests/Unit/Security/CookieTokenProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Security;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Core\Security\Token\CookieTokenProvider;
+
+final class CookieTokenProviderTest extends TestCase
+{
+    public function testTheRememberMeCookieIsHardenedAgainstTheftAndForgery(): void
+    {
+        $options = $this->buildOptions(time() + 2592000, false);
+
+        self::assertTrue($options['httponly'], 'the remember-me cookie must stay out of JavaScript reach');
+        self::assertSame('Lax', $options['samesite']);
+        self::assertSame('/', $options['path']);
+    }
+
+    public function testTheSecureFlagFollowsTheGivenConnection(): void
+    {
+        self::assertTrue($this->buildOptions(time(), true)['secure']);
+        self::assertFalse($this->buildOptions(time(), false)['secure']);
+    }
+
+    public function testTheSecureFlagIsDeducedFromTheRequestWhenNotGiven(): void
+    {
+        // There is no HTTPS server context in CLI, so the cookie must not
+        // require TLS: a plain HTTP setup would otherwise silently drop it.
+        self::assertFalse($this->buildOptions(time(), null)['secure']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildOptions(int $expires, ?bool $secure): array
+    {
+        $provider = new class extends CookieTokenProvider {
+            public function expose(int $expires, ?bool $secure): array
+            {
+                return $this->buildCookieOptions($expires, $secure);
+            }
+        };
+
+        return $provider->expose($expires, $secure);
+    }
+}


### PR DESCRIPTION
The remember-me authentication cookie (admin `armcn` and customer `crmcn`, a ~30-day token) was written with only `expires` and `path`. Without `httponly` it is readable from JavaScript, so any XSS can steal a long-lived session; without `secure` it travels in cleartext over HTTP; and it had no `samesite` protection.

`CookieTokenProvider` now sets `httponly`, `samesite=Lax` and `secure` on both create and clear. `secure` is deduced from the current request (HTTPS) instead of being hard-coded, so a plain-HTTP local setup does not silently drop the cookie.

Covered by `CookieTokenProviderTest`. Verified over HTTPS: `Set-Cookie: armcn=...; secure; HttpOnly; SameSite=Lax`.