### PR TITLE
fix(install): refuse to update a Thelia 2 database in place

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ Thelia 3 installs the Twig back office (`default-twig`) by default. The Smarty b
 ddev exec bin/console template:set backOffice default-twig   # or: default
 ```
 
-If you maintain a module, the migration guide is in `BREAKING_CHANGES.md` inside the default-twig template.
+If you maintain a module, the migration guide is at <https://doc.thelia.net/docs/upgrading/migrate>.
 
 ## Tests and quality
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,68 +1,53 @@
-# How to update your Thelia ?
+# Updating Thelia
 
-If you have already installed Thelia but a new version is available, you can update easily.
+This guide covers updating an existing Thelia 3 site to a newer Thelia 3 release.
 
-Before proceeding to the update, it's strongly recommended to backup your website (files and database).
-You can backup your database with tools such as [phpmyadmin](http://www.phpmyadmin.net)
- or [mysqldump](dev.mysql.com/doc/refman/5.6/en/mysqldump.html).
+**Coming from Thelia 2?** Thelia 3 cannot update a Thelia 2 database in place. The
+updater refuses any database below `3.0.0`, and moving a 2.x shop to 3.0 is a guided
+migration, not an in-place update. Follow <https://doc.thelia.net/docs/upgrading/migrate>.
 
-## 1. Update files
+## Before you start
 
-- Download the latest version of Thelia : <http://thelia.net/download/thelia.zip>
-- Extract the zip in a temporary directory  
-- Then you should replace (not only copy) all the files from the new Thelia version :
-   - all files from root directory
-   - bin (*optional*)
-   - core (**mandatory**)
-   - setup (**mandatory**)
-- Then, you have to merge (copy in your existent directories) these other directories. Normally, 
-    you haven't modify files inside these directories (just created new ones - like your frontOffice template). 
-    But If you have modified files, you should proceed carefully and try to report all your changes.      
-   - local/config
-   - local/modules
-   - templates
-   - web
+Back up your files and your database. `mysqldump` is enough for the database:
 
+```bash
+mysqldump -u <user> -p <database> > backup.sql
+```
 
-## 2. Update database
+## 1. Update the code
 
-Then you have 2 different ways to proceed. In each method, a backup of your database can be automatically 
-performed if you want to. If an error is encountered, then your database will be restored.   
-But if your database is quite large, it's better to make a backup manually. 
+Thelia 3 is a Composer package, so you update the code with Composer. From the root
+of your project:
 
-### 2.1. use the update script
+```bash
+composer update thelia/thelia --with-all-dependencies
+```
 
-In a command shell, go to the root directory of your installation, run and follow instructions : 
+Check the release notes for the version you move to: a module or a template you depend
+on may need its own bump in `composer.json`.
+
+## 2. Update the database
+
+Run the update script from the root of your project:
 
 ```bash
 php setup/update.php
 ```
 
-### 2.2. use the update wizard
+It reports the version it starts from and the one it moves to, then applies each
+database migration in order. It offers to back the database up first; on a large
+database, take the manual backup above instead. If a migration fails, the script stops
+and offers to restore that backup.
 
-An update wizard is available in the ```web/install``` directory. It's the same directory used by the install wizard.
+## 3. Rebuild the cache
 
-**You have to protect the web folder if your site is public (htaccess,  List of allowed IP, ...).**
-
-The update wizard in accessible with your favorite browser :
+Do not run `cache:clear` in production: it empties the cache without rebuilding it, and
+the first request then compiles it under load. Remove the compiled cache and the Propel
+runtime, then warm the cache back up:
 
 ```bash
-http://yourdomain.tld/[/subdomain_if_needed]/install
+rm -rf var/cache/prod var/propel/prod
+php Thelia cache:warmup --env=prod
 ```
 
-Note:
- 
-- the wizard is available only if your Thelia is not already in the latest version.
-- at the end of the process, the install directory will be removed.
-
-
-## 3. Clear cache
-
-Once the update is done successfully, you have to clear all caches :  
-
-- clear all caches in all environment :
-    - ```php Thelia thelia:cache:clear```
-    - ```php Thelia thelia:cache:clear --env=prod```
-    
-If the command fails, you can do it manually. Just delete the content of 
-the ```cache``` and ```web/cache``` directories. 
+In development, `var/cache/dev` and `var/propel/dev` are the ones to remove.

--- a/core/lib/Thelia/Core/Install/Update.php
+++ b/core/lib/Thelia/Core/Install/Update.php
@@ -42,6 +42,13 @@ class Update
     public const PHP_DIR = 'update/php/';
     public const INSTRUCTION_DIR = 'update/instruction/';
 
+    /**
+     * The oldest database version an in-place update can start from. Thelia 3
+     * ships no update script between 2.5.5 and 3.0.0-alpha1, so any database
+     * below this belongs to Thelia 2 and needs the guided migration instead.
+     */
+    public const MIN_UPDATABLE_VERSION = '3.0.0-alpha1';
+
     protected array $version;
     protected ?Tlog $logger;
 
@@ -145,6 +152,16 @@ class Update
     }
 
     /**
+     * Whether an in-place update can start from this database version. Thelia 3
+     * only continues an update already on the 3.x line: any version below
+     * 3.0.0-alpha1 belongs to Thelia 2 and needs the guided migration instead.
+     */
+    public static function isVersionUpdatable(string $currentVersion): bool
+    {
+        return version_compare($currentVersion, self::MIN_UPDATABLE_VERSION, '>=');
+    }
+
+    /**
      * Find the position of the current version in the update script list.
      *
      * Some releases ship without an update script, so the current version is not always part of
@@ -187,6 +204,16 @@ class Update
             $this->log('debug', 'You already have the latest version. No update available');
 
             throw new UpToDateException('You already have the latest version. No update available');
+        }
+
+        // A Thelia 3 codebase only continues an update already on the 3.x line.
+        // Its update scripts jump straight from 2.5.5 to 3.0.0-alpha1, so a Thelia
+        // 2.6 database would be mistaken for 2.5.5 and have the 3.0 migrations
+        // replayed over a schema they were never written for. Refuse before writing
+        // anything: moving from Thelia 2 is a guided migration, not an in-place
+        // update (see UPDATE.md).
+        if (!self::isVersionUpdatable((string) $currentVersion)) {
+            throw new UpdateException(\sprintf('This database is on Thelia %s. Thelia 3 cannot update a Thelia 2 database in place; follow the migration guide at https://doc.thelia.net/docs/upgrading/migrate before updating.', $currentVersion));
         }
 
         $index = $this->getStartIndex((string) $currentVersion);

--- a/tests/Integration/Install/UpdateMinimumVersionGuardTest.php
+++ b/tests/Integration/Install/UpdateMinimumVersionGuardTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Install;
+
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Propel;
+use Thelia\Core\Install\Exception\UpdateException;
+use Thelia\Core\Install\Update;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The updater must refuse a Thelia 2 database instead of quietly wrecking it. Its
+ * scripts jump from 2.5.5 to 3.0.0-alpha1, so a 2.6 database would be taken for
+ * 2.5.5 and have the 3.0 migrations replayed over a schema they never matched, while
+ * the version marker was rewritten to 3.0. The guard stops that before the first
+ * script runs, and leaves the marker untouched so nothing is half-migrated.
+ */
+final class UpdateMinimumVersionGuardTest extends IntegrationTestCase
+{
+    protected bool $useTransaction = false;
+
+    private string $initialVersion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initialVersion = $this->readVersionMarker();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->writeVersionMarker($this->initialVersion);
+
+        parent::tearDown();
+    }
+
+    public function testAThelia2DatabaseIsRefusedAndLeftUntouched(): void
+    {
+        $this->writeVersionMarker('2.6.2');
+
+        try {
+            (new Update(false))->process();
+            self::fail('An update from a Thelia 2 database must be refused.');
+        } catch (UpdateException $exception) {
+            self::assertStringContainsString('cannot update a Thelia 2 database in place', $exception->getMessage());
+        }
+
+        // The guard runs before any script, so the marker is exactly what it was:
+        // the database was not moved a single version forward.
+        self::assertSame('2.6.2', $this->readVersionMarker());
+    }
+
+    private function readVersionMarker(): string
+    {
+        return (string) $this->connection()
+            ->query("SELECT `value` FROM `config` WHERE `name` = 'thelia_version'")
+            ->fetchColumn();
+    }
+
+    private function writeVersionMarker(string $version): void
+    {
+        $statement = $this->connection()->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'thelia_version'");
+        $statement->execute([$version]);
+    }
+
+    private function connection(): ConnectionInterface
+    {
+        return Propel::getConnection(ProductTableMap::DATABASE_NAME);
+    }
+}

--- a/tests/Unit/Install/UpdateMinimumVersionTest.php
+++ b/tests/Unit/Install/UpdateMinimumVersionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Install;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Thelia\Core\Install\Update;
+
+/**
+ * Thelia 3 ships no update script between 2.5.5 and 3.0.0-alpha1, so its updater
+ * cannot bridge a Thelia 2 database: treated as 2.5.5, a 2.6 schema would have the
+ * 3.0 migrations replayed over it. `Update::isVersionUpdatable()` is the guard that
+ * tells a Thelia 2 database apart from one already on the 3.x line.
+ */
+final class UpdateMinimumVersionTest extends TestCase
+{
+    #[DataProvider('versionProvider')]
+    public function testOnlyThelia3DatabasesCanBeUpdatedInPlace(string $currentVersion, bool $updatable): void
+    {
+        self::assertSame($updatable, Update::isVersionUpdatable($currentVersion));
+    }
+
+    public static function versionProvider(): iterable
+    {
+        // Thelia 2 databases: refused.
+        yield 'the 2.6 line the jump skips' => ['2.6.2', false];
+        yield 'the last 2.5 the scripts stop at' => ['2.5.5', false];
+        yield 'an early 2.x' => ['2.0.0', false];
+        yield 'an empty marker is not a 3.x version' => ['', false];
+
+        // Thelia 3 databases: accepted.
+        yield 'the first 3.0 script, the boundary itself' => ['3.0.0-alpha1', true];
+        yield 'a 3.0 beta' => ['3.0.0-beta5', true];
+        yield 'the stable 3.0.0' => ['3.0.0', true];
+        yield 'a later 3.x' => ['3.1.0', true];
+    }
+}


### PR DESCRIPTION
## Why

The updater has no minimum-version guard. `getStartIndex()` resumes an unknown database version from the closest known one below it, and the update scripts jump straight from `2.5.5.sql` to `3.0.0-alpha1.sql` (there is no `2.6.x`). So a **Thelia 2.6 database is treated as 2.5.5**: the updater replays the 3.0 migrations over a 2.6 schema they were never written for, silently, and writes `thelia_version = 3.0.0`.

`UPDATE.md` was still Thelia 2.0 content (`thelia.zip`, the `web/install` wizard, `local/config`, `php Thelia thelia:cache:clear`), with no mention of Composer, 3.0 or 2.6.

## What

- **Minimum-version guard.** `Update::process()` now refuses any database below `3.0.0-alpha1` before running a single script, with a clear message and a non-zero exit. Moving from Thelia 2 is a guided migration, not an in-place update. The legitimate beta to 3.0 path is unaffected.
- **Tests.** A unit test for the version predicate (`isVersionUpdatable`) and an integration test proving `process()` refuses a `2.6.2` database and leaves the version marker untouched.
- **`UPDATE.md` rewritten** for Thelia 3: back up, `composer update`, `php setup/update.php`, then a prod cache rebuild (`rm -rf var/cache/prod var/propel/prod` + `cache:warmup`, never `cache:clear`). Points a 2.x shop to the migration guide.
- **Dead link fixed** in `Readme.md` (the module migration guide now points to the online guide instead of a `BREAKING_CHANGES.md` that no longer exists).

## Proof

Refusal, on a database marked `2.6.2`:

```
You are going to update Thelia from version 2.6.2 to version 3.0.0-beta5.
Sorry, an unexpected error has occured : This database is on Thelia 2.6.2. Thelia 3
cannot update a Thelia 2 database in place; follow the migration guide at
https://doc.thelia.net/docs/upgrading/migrate before updating.
EXIT_CODE=7
```

The version marker stays `2.6.2` (nothing was written). A `3.0.0-beta4` database still updates cleanly to `3.0.0-beta5`.

Baselines green: `composer test` (5 suites), `composer cs-diff` (0), `composer phpstan` (0).