### PR TITLE
ci: lint yaml and twig, and stop injecting the request at boot in the delivery/payment providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,16 +41,6 @@ jobs:
           composer install --no-progress --prefer-dist --optimize-autoloader
           composer update --no-interaction --prefer-dist
 
-      - name: Lint the YAML config and the Twig themes
-        # The kernel boots without a database here (Propel-backed sections degrade
-        # gracefully), so these run before the database is prepared. The back-office
-        # default-twig theme is left out on purpose: its `safe_hook` Twig function is
-        # unknown to the bare console environment, so a plain lint reports false
-        # errors on it; that theme is covered by the phpstan-botwig job instead.
-        run: |
-          php bin/console lint:yaml config/
-          php bin/console lint:twig templates/frontOffice templates/email templates/pdf core/lib/Thelia/Resources/views
-
       - name: Prepare the test database credentials
         # bin/test-prepare (run by `composer test`) reads these to create the test
         # database, build the Propel models and generate the JWT keys.
@@ -67,6 +57,18 @@ jobs:
         run: |
           php bin/test-prepare
           php bin/console importmap:install --env=test
+
+      - name: Lint the YAML config and the Twig themes
+        # Runs in the test environment: booting the kernel needs the generated Propel
+        # model classes, which bin/test-prepare builds (rerun here, it is idempotent,
+        # in case the best-effort step above did not reach it). The back-office
+        # default-twig theme is left out on purpose: its `safe_hook` Twig function is
+        # unknown to the bare console environment, so a plain lint reports false errors
+        # on it; that theme is covered by the phpstan-botwig job instead.
+        run: |
+          php bin/test-prepare
+          php bin/console lint:yaml config/ --env=test
+          php bin/console lint:twig templates/frontOffice templates/email templates/pdf core/lib/Thelia/Resources/views --env=test
 
       - name: Run CI (cs-diff, phpstan, the five PHPUnit suites)
         run: composer ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,16 @@ jobs:
           composer install --no-progress --prefer-dist --optimize-autoloader
           composer update --no-interaction --prefer-dist
 
+      - name: Lint the YAML config and the Twig themes
+        # The kernel boots without a database here (Propel-backed sections degrade
+        # gracefully), so these run before the database is prepared. The back-office
+        # default-twig theme is left out on purpose: its `safe_hook` Twig function is
+        # unknown to the bare console environment, so a plain lint reports false
+        # errors on it; that theme is covered by the phpstan-botwig job instead.
+        run: |
+          php bin/console lint:yaml config/
+          php bin/console lint:twig templates/frontOffice templates/email templates/pdf core/lib/Thelia/Resources/views
+
       - name: Prepare the test database credentials
         # bin/test-prepare (run by `composer test`) reads these to create the test
         # database, build the Propel models and generate the JWT keys.

--- a/core/lib/Thelia/Api/State/Provider/DeliveryModuleProvider.php
+++ b/core/lib/Thelia/Api/State/Provider/DeliveryModuleProvider.php
@@ -17,6 +17,7 @@ namespace Thelia\Api\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
@@ -31,7 +32,7 @@ use Thelia\Model\StateQuery;
 readonly class DeliveryModuleProvider implements ProviderInterface
 {
     public function __construct(
-        private Request $request,
+        private RequestStack $requestStack,
         private Session $session,
         private SecurityContext $securityContext,
         private AddressService $addressService,
@@ -56,7 +57,10 @@ readonly class DeliveryModuleProvider implements ProviderInterface
             return [];
         }
 
-        $deliveryAddress = $this->addressService->getDeliveryAddress($this->request, $this->securityContext);
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+        $deliveryAddress = $request instanceof Request
+            ? $this->addressService->getDeliveryAddress($request, $this->securityContext)
+            : null;
         $country = $deliveryAddress instanceof Address
             ? $deliveryAddress->getCountry()
             : CountryQuery::create()->filterByByDefault(1)->findOne();

--- a/core/lib/Thelia/Api/State/Provider/DeliveryPickupLocationProvider.php
+++ b/core/lib/Thelia/Api/State/Provider/DeliveryPickupLocationProvider.php
@@ -17,9 +17,9 @@ namespace Thelia\Api\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\Event\Delivery\PickupLocationEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\HttpFoundation\Request;
 use Thelia\Model\CountryQuery;
 use Thelia\Model\StateQuery;
 
@@ -27,7 +27,7 @@ readonly class DeliveryPickupLocationProvider implements ProviderInterface
 {
     public function __construct(
         private EventDispatcherInterface $dispatcher,
-        private Request $request,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -69,6 +69,8 @@ readonly class DeliveryPickupLocationProvider implements ProviderInterface
 
     private function requestParam(string $key): mixed
     {
-        return $this->request->query->get($key) ?? $this->request->request->get($key);
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+
+        return $request?->query->get($key) ?? $request?->request->get($key);
     }
 }

--- a/core/lib/Thelia/Domain/Module/Payment/PaymentModuleService.php
+++ b/core/lib/Thelia/Domain/Module/Payment/PaymentModuleService.php
@@ -16,13 +16,13 @@ namespace Thelia\Domain\Module\Payment;
 
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Api\Bridge\Propel\Event\PaymentModuleOptionEvent;
 use Thelia\Api\Resource\ModuleI18n;
 use Thelia\Api\Resource\PaymentModule;
 use Thelia\Core\Event\Payment\IsValidPaymentEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\HttpFoundation\Request;
 use Thelia\Model\Cart;
 use Thelia\Model\Lang;
 use Thelia\Model\Module;
@@ -32,7 +32,7 @@ use Thelia\Module\BaseModule;
 readonly class PaymentModuleService
 {
     public function __construct(
-        private Request $request,
+        private RequestStack $requestStack,
         private EventDispatcherInterface $dispatcher,
         private ContainerInterface $container,
     ) {
@@ -40,7 +40,10 @@ readonly class PaymentModuleService
 
     public function getPaymentModules($moduleId = null): array
     {
-        $request = $this->request;
+        $request = $this->requestStack->getCurrentRequest() ?? $this->requestStack->getMainRequest();
+        if (null === $request) {
+            return [];
+        }
         $dispatcher = $this->dispatcher;
         $cart = $request->getSession()->getSessionCart($dispatcher);
         $lang = $request->getSession()->getLang();


### PR DESCRIPTION
Two related quality steps toward a green `lint:container`.

**Providers read the request lazily.** `DeliveryModuleProvider`, `DeliveryPickupLocationProvider` and `PaymentModuleService` took a `Request` as a constructor argument. The container binds `Request` to `request_stack.getMainRequest()`, which is `null` at boot, so `lint:container` flagged them as invalid definitions. They now take `RequestStack` and read the current request when they run.

**CI now lints the YAML config and the Twig themes** (`lint:yaml config/` and `lint:twig` over the front, email and PDF themes plus the core views). These boot without a database, so they run before the DB is prepared.

Note on `lint:container`: it is still red for reasons outside this PR's reach. Many core `Core/Event/*` and `Tools/*` classes are swept up as autowired services by the broad `Thelia\` PSR-4 registration and inherit the same nullable-`Request` binding, and a legacy Smarty module ships plugin service definitions that lint rejects. Making it green needs a dedicated pass (narrowing what the container registers as a service), so it is not wired into CI yet. The back-office default-twig theme is likewise left out of `lint:twig`: its `safe_hook` function is unknown to the bare console Twig environment and would report false errors; that theme is covered by the phpstan-botwig job.