### PR TITLE
fix: widen the category filter when several sub-categories are checked

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/Filters/CategoryFilter.php
@@ -27,6 +27,7 @@ use Thelia\Model\ProductCategoryQuery;
 class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInterface
 {
     use LocalizedTitleTrait;
+    use SelectedValuesTrait;
 
     public const CATEGORY_DEPTH_NAME = 'category_depth';
 
@@ -36,25 +37,24 @@ class CategoryFilter implements TheliaFilterInterface, TheliaAggregatedFilterInt
 
     public function filter(ModelCriteria $query, $value, bool $isMinOrMaxFilter = false, ?int $categoryDepth = null): void
     {
-        foreach ($value as $id => $childValue) {
-            foreach ($childValue as $type => $categoryId) {
-                if (!\is_array($categoryId)) {
-                    $categoryId = [$categoryId];
+        $categoryIds = $this->flattenSelectedValues($value);
+
+        if ($categoryIds === []) {
+            return;
+        }
+
+        if ($categoryDepth) {
+            foreach ($this->filterService->getCategoriesRecursively($categoryIds, $categoryDepth) as $categories) {
+                foreach ($categories as $category) {
+                    $categoryIds[] = $category->getId();
                 }
-
-                if ($categoryDepth) {
-                    $categories = $this->filterService->getCategoriesRecursively($categoryId, $categoryDepth);
-
-                    foreach ($categories as $categoryList) {
-                        foreach ($categoryList as $category) {
-                            $categoryId[] = $category->getId();
-                        }
-                    }
-                }
-
-                $query->useProductCategoryQuery()->filterByCategoryId($categoryId)->endUse();
             }
         }
+
+        // A product is filed in a category, so two checked sub-categories can only be asked for
+        // as one IN: one condition per category would AND them on the same join, and a shopper
+        // checking a second aisle would get an empty list instead of more products.
+        $query->useProductCategoryQuery()->filterByCategoryId(array_unique($categoryIds), Criteria::IN)->endUse();
     }
 
     public function getResourceType(): array

--- a/tests/Integration/Api/CategoryFilterSelectionTest.php
+++ b/tests/Integration/Api/CategoryFilterSelectionTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\FilterService;
+use Thelia\Model\ProductQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * A product is filed in a category, so two sub-categories checked in the filter column ask for
+ * either of them. A shopper who checks a second aisle expects more products, never an empty list.
+ *
+ * With a depth, a checked category browses its own branch: checking an aisle that holds only
+ * shelves shows the products of those shelves. A hidden category stops the walk.
+ *
+ * Catalogue:
+ *
+ *   department            —
+ *     fruits             FRUIT
+ *       citrus           CITRUS
+ *     vegetables         VEGETABLE
+ *     archived (hidden)  ARCHIVED
+ *   other department     OTHER
+ */
+final class CategoryFilterSelectionTest extends IntegrationTestCase
+{
+    private const FRUIT = 'CATEGORY-FRUIT';
+    private const CITRUS = 'CATEGORY-CITRUS';
+    private const VEGETABLE = 'CATEGORY-VEGETABLE';
+    private const ARCHIVED = 'CATEGORY-ARCHIVED';
+    private const OTHER = 'CATEGORY-OTHER';
+
+    private FilterService $filterService;
+
+    /** @var array<string, int> */
+    private array $categoryIds = [];
+
+    /** @var array<string, int> product reference => id, in creation order */
+    private array $productIds = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filterService = static::getContainer()->get(FilterService::class);
+        $this->createCatalogue();
+    }
+
+    public function testOneCheckedSubCategoryKeepsItsProducts(): void
+    {
+        self::assertSame(
+            [self::FRUIT],
+            $this->matchingReferences([$this->categoryIds['fruits']]),
+        );
+    }
+
+    public function testTwoCheckedSubCategoriesWidenTheSelection(): void
+    {
+        self::assertSame(
+            [self::FRUIT, self::VEGETABLE],
+            $this->matchingReferences([$this->categoryIds['fruits'], $this->categoryIds['vegetables']]),
+        );
+    }
+
+    public function testACheckedSubCategoryRepeatedByTheQueryStringCountsOnce(): void
+    {
+        self::assertSame(
+            [self::FRUIT],
+            $this->matchingReferences([$this->categoryIds['fruits'], (string) $this->categoryIds['fruits']]),
+        );
+    }
+
+    public function testACheckedCategoryBrowsesItsOwnBranchWithADepth(): void
+    {
+        self::assertSame(
+            [self::FRUIT, self::CITRUS],
+            $this->matchingReferences([$this->categoryIds['fruits']], categoryDepth: 5),
+        );
+    }
+
+    public function testTheBrowsedCategoryWithADepthKeepsItsWholeVisibleBranch(): void
+    {
+        self::assertSame(
+            [self::FRUIT, self::CITRUS, self::VEGETABLE],
+            $this->matchingReferences([$this->categoryIds['department']], categoryDepth: 5),
+        );
+    }
+
+    public function testTheBrowsedCategoryWithoutADepthKeepsOnlyWhatItHoldsItself(): void
+    {
+        self::assertSame(
+            [],
+            $this->matchingReferences([$this->categoryIds['department']]),
+        );
+    }
+
+    /**
+     * @param list<int|string> $selection the checked category ids, as the query string carries them
+     *
+     * @return list<string> the references of the matching products, in creation order
+     */
+    private function matchingReferences(array $selection, ?int $categoryDepth = null): array
+    {
+        // Restricted to the products this test created: the filter is what is under test,
+        // not whatever else the database holds.
+        $query = ProductQuery::create()->filterById(array_values($this->productIds), Criteria::IN);
+
+        $filtered = $this->filterService->filterWithTFilter(
+            tfilters: ['category' => [$this->categoryIds['department'] => $selection]],
+            resource: 'products',
+            query: $query,
+            categoryDepth: $categoryDepth,
+        );
+
+        $matched = [];
+
+        foreach ($filtered->find($this->getPropelConnection()) as $product) {
+            $matched[] = (int) $product->getId();
+        }
+
+        return array_keys(array_filter(
+            $this->productIds,
+            static fn (int $id): bool => \in_array($id, $matched, true),
+        ));
+    }
+
+    private function createCatalogue(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $categories = ['department' => $factory->category()];
+        $departmentId = (int) $categories['department']->getId();
+
+        $categories['fruits'] = $factory->category(['parent' => $departmentId]);
+        $categories['vegetables'] = $factory->category(['parent' => $departmentId]);
+        $categories['archived'] = $factory->category(['parent' => $departmentId, 'visible' => 0]);
+        $categories['citrus'] = $factory->category(['parent' => (int) $categories['fruits']->getId()]);
+        $categories['other'] = $factory->category();
+
+        foreach ($categories as $name => $category) {
+            $this->categoryIds[$name] = (int) $category->getId();
+        }
+
+        $catalogue = [
+            self::FRUIT => 'fruits',
+            self::CITRUS => 'citrus',
+            self::VEGETABLE => 'vegetables',
+            self::ARCHIVED => 'archived',
+            self::OTHER => 'other',
+        ];
+
+        foreach ($catalogue as $reference => $name) {
+            $product = $factory->product($categories[$name], $taxRule, $currency, ['ref' => $reference]);
+            $this->productIds[$reference] = (int) $product->getId();
+        }
+    }
+}


### PR DESCRIPTION
## The bug

A product is filed in a category, so two sub-categories checked in the filter column ask for either of them. `CategoryFilter::filter()` added one `filterByCategoryId()` per checked value, and Propel reuses the same `product_category` join for all of them: the conditions AND, and a shopper checking a second aisle got an empty list instead of more products.

Reproduced on a category page listing a whole branch:

```
GET /api/front/products?tfilters[category][1][]=111&category_depth=5&visible=true   → 25 products
GET /api/front/products?tfilters[category][1][]=121&category_depth=5&visible=true   → 37 products
GET /api/front/products?tfilters[category][1][]=111&tfilters[category][1][]=121&…   → 0 products
```

The same defect was fixed for the brand filter in #3829 and for the features and attributes in #3830; the category filter was left behind.

## The fix

The selection is read with `SelectedValuesTrait::flattenSelectedValues()` — the trait those filters already use — and asked for as a single `IN`. A depth still walks the branch of every checked category, and a hidden category still stops the walk.

## Tests

`tests/Integration/Api/CategoryFilterSelectionTest.php`, on a three-level tree with one hidden aisle:

- one checked sub-category keeps its products;
- two checked sub-categories widen the selection (**red before this change: empty list**);
- an id repeated by the query string counts once;
- a checked category browses its own branch when a depth is given;
- the browsed category with a depth keeps its whole visible branch, and without one keeps only what it holds itself.

`composer test` suites unit (413), integration (761) and api (265) pass, `composer cs` fixes nothing, `composer phpstan` reports no error.

## Still open

The facet counts of this filter remain those of the products filed **directly** in each sub-category, while checking one now browses its whole branch: an aisle holding only shelves is offered at zero and then answers with a full page. That is `CategoryFilter::getAggregatedValues()`, which would need the filtering depth to count the way the filter selects — a separate change.