### PR TITLE
fix(i18n): export translation catalogues with var_export

### DIFF
--- a/core/lib/Thelia/Action/Translation.php
+++ b/core/lib/Thelia/Action/Translation.php
@@ -215,33 +215,34 @@ class Translation extends BaseAction implements EventSubscriberInterface
             }
         }
 
-        if ($fp = @fopen($file, 'w')) {
-            fwrite($fp, '<'."?php\n\n");
-            fwrite($fp, "return array(\n");
+        $texts = $event->getTranslatableStrings();
+        $translations = $event->getTranslatedStrings();
 
-            $texts = $event->getTranslatableStrings();
-            $translations = $event->getTranslatedStrings();
+        // Sort keys alphabetically while keeping index
+        asort($texts);
 
-            // Sort keys alphabetically while keeping index
-            asort($texts);
+        $catalogue = [];
 
-            foreach ($texts as $key => $text) {
-                // Write only defined (not empty) translations
-                if (!empty($translations[$key])) {
-                    $text = str_replace("'", "\\'", $text);
-
-                    $translation = str_replace("'", "\\'", $translations[$key]);
-
-                    fwrite($fp, \sprintf("    '%s' => '%s',\n", $text, $translation));
-                }
+        foreach ($texts as $key => $text) {
+            // Write only defined (not empty) translations
+            if (!empty($translations[$key])) {
+                $catalogue[$text] = $translations[$key];
             }
+        }
 
-            fwrite($fp, ");\n");
-
-            @fclose($fp);
-        } else {
+        if (false === @file_put_contents($file, self::exportCatalogue($catalogue))) {
             throw new \RuntimeException(Translator::getInstance()->trans('Failed to open translation file %file. Please be sure that this file is writable by your Web server', ['%file' => $file]));
         }
+    }
+
+    /**
+     * The catalogue is written as PHP source and read back with require, so every key and
+     * value goes through var_export: it is the only quoting the PHP parser cannot be talked
+     * out of, whatever the text holds.
+     */
+    private static function exportCatalogue(array $catalogue): string
+    {
+        return '<'."?php\n\nreturn ".var_export($catalogue, true).";\n";
     }
 
     public function writeFallbackFile(TranslationEvent $event, $eventName, EventDispatcherInterface $dispatcher): void
@@ -272,58 +273,43 @@ class Translation extends BaseAction implements EventSubscriberInterface
             }
         }
 
-        if ($fp = @fopen($file, 'w')) {
-            $texts = $event->getTranslatableStrings();
-            $customs = $event->getCustomFallbackStrings();
-            $globals = $event->getGlobalFallbackStrings();
+        $texts = $event->getTranslatableStrings();
+        $customs = $event->getCustomFallbackStrings();
+        $globals = $event->getGlobalFallbackStrings();
 
-            // just reset current translations for this domain to remove strings that do not exist anymore
-            $translations[$event->getDomain()] = [];
+        // just reset current translations for this domain to remove strings that do not exist anymore
+        $translations[$event->getDomain()] = [];
 
-            foreach ($texts as $key => $text) {
-                if (!empty($customs[$key])) {
-                    $translations[$event->getDomain()][$text] = $customs[$key];
-                }
-
-                if (!empty($globals[$key])) {
-                    $translations[$text] = $globals[$key];
-                } else {
-                    unset($translations[$text]);
-                }
+        foreach ($texts as $key => $text) {
+            if (!empty($customs[$key])) {
+                $translations[$event->getDomain()][$text] = $customs[$key];
             }
 
-            fwrite($fp, '<'."?php\n\n");
-            fwrite($fp, "return [\n");
+            if (!empty($globals[$key])) {
+                $translations[$text] = $globals[$key];
+            } else {
+                unset($translations[$text]);
+            }
+        }
 
-            // Sort keys alphabetically while keeping index
-            ksort($translations);
+        // Write only defined (not empty) translations, keys sorted alphabetically
+        $catalogue = [];
+        ksort($translations);
 
-            foreach ($translations as $key => $text) {
-                // Write only defined (not empty) translations
-                if (!empty($translations[$key])) {
-                    if (\is_array($translations[$key])) {
-                        $key = str_replace("'", "\\'", $key);
-                        fwrite($fp, \sprintf("    '%s' => [\n", $key));
-                        ksort($translations[$key]);
-
-                        foreach ($translations[$key] as $subKey => $subText) {
-                            $subKey = str_replace("'", "\\'", $subKey);
-                            $translation = str_replace("'", "\\'", $subText);
-                            fwrite($fp, \sprintf("        '%s' => '%s',\n", $subKey, $translation));
-                        }
-
-                        fwrite($fp, "    ],\n");
-                    } else {
-                        $key = str_replace("'", "\\'", $key);
-                        $translation = str_replace("'", "\\'", $text);
-                        fwrite($fp, \sprintf("    '%s' => '%s',\n", $key, $translation));
-                    }
-                }
+        foreach ($translations as $key => $text) {
+            if (empty($text)) {
+                continue;
             }
 
-            fwrite($fp, "];\n");
+            if (\is_array($text)) {
+                ksort($text);
+            }
 
-            @fclose($fp);
+            $catalogue[$key] = $text;
+        }
+
+        if (false === @file_put_contents($file, self::exportCatalogue($catalogue))) {
+            throw new \RuntimeException(Translator::getInstance()->trans('Failed to open translation file %file. Please be sure that this file is writable by your Web server', ['%file' => $file]));
         }
     }
 

--- a/core/lib/Thelia/Command/I18nPruneOverridesCommand.php
+++ b/core/lib/Thelia/Command/I18nPruneOverridesCommand.php
@@ -222,41 +222,21 @@ class I18nPruneOverridesCommand extends ContainerAwareCommand
      */
     private function writeOverrideFile(string $file, array $translations): void
     {
-        $fp = fopen($file, 'w');
-
-        if (false === $fp) {
-            throw new \RuntimeException(\sprintf('Failed to open translation file %s for writing.', $file));
-        }
-
-        fwrite($fp, '<'."?php\n\n");
-        fwrite($fp, "return [\n");
-
         ksort($translations);
 
-        foreach ($translations as $key => $value) {
+        foreach ($translations as &$value) {
             if (\is_array($value)) {
-                $escapedKey = str_replace("'", "\\'", (string) $key);
-                fwrite($fp, \sprintf("    '%s' => [\n", $escapedKey));
                 ksort($value);
-
-                foreach ($value as $subKey => $subText) {
-                    $escapedSubKey = str_replace("'", "\\'", (string) $subKey);
-                    $translation = str_replace("'", "\\'", (string) $subText);
-                    fwrite($fp, \sprintf("        '%s' => '%s',\n", $escapedSubKey, $translation));
-                }
-
-                fwrite($fp, "    ],\n");
-
-                continue;
             }
-
-            $escapedKey = str_replace("'", "\\'", (string) $key);
-            $translation = str_replace("'", "\\'", (string) $value);
-            fwrite($fp, \sprintf("    '%s' => '%s',\n", $escapedKey, $translation));
         }
+        unset($value);
 
-        fwrite($fp, "];\n");
+        // Written as PHP source and read back with require: var_export is the only quoting
+        // the parser cannot be talked out of, whatever the text holds.
+        $source = '<'."?php\n\nreturn ".var_export($translations, true).";\n";
 
-        fclose($fp);
+        if (false === @file_put_contents($file, $source)) {
+            throw new \RuntimeException(\sprintf('Failed to open translation file %s for writing.', $file));
+        }
     }
 }

--- a/tests/Integration/Action/TranslationActionTest.php
+++ b/tests/Integration/Action/TranslationActionTest.php
@@ -132,6 +132,58 @@ final class TranslationActionTest extends ActionIntegrationTestCase
         self::assertFileDoesNotExist($filePath);
     }
 
+    public function testWriteTranslationFileKeepsTextsThatEndWithABackslash(): void
+    {
+        $filePath = $this->tmpDir.'/translations.php';
+
+        $texts = ['key1' => "Path 'C:\\'", 'key2' => 'Plain'];
+        $translated = ['key1' => 'Chemin C:\\', 'key2' => "L'ordinaire \\"];
+
+        $event = TranslationEvent::createWriteFileEvent($filePath, $texts, $translated, true);
+        $event->setLocale('fr_FR');
+        $event->setDomain('core');
+        $event->setCustomFallbackStrings([]);
+        $event->setGlobalFallbackStrings([]);
+        $event->setDeveloperMode(true);
+
+        $this->dispatch($event, TheliaEvents::TRANSLATION_WRITE_FILE);
+
+        // The file is PHP source read back with require: whatever the texts hold, it must
+        // come back as the very same array.
+        self::assertSame(
+            ["Path 'C:\\'" => 'Chemin C:\\', 'Plain' => "L'ordinaire \\"],
+            require $filePath,
+        );
+    }
+
+    public function testWriteFallbackFileKeepsTextsThatEndWithABackslash(): void
+    {
+        $filePath = THELIA_LOCAL_DIR.'I18n'.DS.'zz_ZZ.php';
+        @unlink($filePath);
+
+        try {
+            $event = TranslationEvent::createWriteFileEvent(
+                $this->tmpDir.'/unused.php',
+                ['key1' => 'Path'],
+                [],
+                true,
+            );
+            $event->setLocale('zz_ZZ');
+            $event->setDomain('core');
+            $event->setCustomFallbackStrings(['key1' => 'Chemin C:\\']);
+            $event->setGlobalFallbackStrings(['key1' => "L'ordinaire \\"]);
+
+            $this->dispatch($event, TheliaEvents::TRANSLATION_WRITE_FILE);
+
+            self::assertSame(
+                ['Path' => "L'ordinaire \\", 'core' => ['Path' => 'Chemin C:\\']],
+                require $filePath,
+            );
+        } finally {
+            @unlink($filePath);
+        }
+    }
+
     public function testGetTranslatableStringsReturnsEmptyForNonExistentDirectory(): void
     {
         $event = TranslationEvent::createGetStringsEvent(


### PR DESCRIPTION
The translation writers (versioned file, local override file, `i18n:prune-overrides`) built the PHP catalogue by hand, quoting apostrophes only. A text that ends with a backslash, or that mixes backslashes and quotes, produced a file `require` could not parse, and the whole locale stopped loading.

The three writers now serialise the catalogue with `var_export`, which handles every character the parser cares about. The output format is otherwise unchanged (`'key' => 'value',` lines, sorted keys).

Two integration tests write such texts through the event and read the file back.