### PR TITLE
fix(api): accept only active locales in the locale filter parameter

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/AbstractFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/AbstractFilter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Api\Bridge\Propel\Filter;
 
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Operation;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Psr\Log\LoggerInterface;
@@ -172,6 +173,14 @@ abstract class AbstractFilter implements FilterInterface
         array $context,
     ) {
         $locale = $context['filters']['locale'] ?? Lang::getDefaultLanguage()->getLocale();
+
+        // The locale names the i18n join alias, so only a locale the eager loading
+        // extension actually joined (an active language) can be filtered or sorted on.
+        $activeLocales = array_map(static fn (Lang $lang): string => $lang->getLocale(), Lang::getActiveLangs()->getData());
+
+        if (!\is_string($locale) || !\in_array($locale, $activeLocales, true)) {
+            throw new InvalidArgumentException(\sprintf('Unknown locale "%s" for filtering "%s". Active locales: %s', \is_scalar($locale) ? (string) $locale : \gettype($locale), $property, implode(', ', $activeLocales)));
+        }
 
         return str_replace('_', '', $query->getTableMap()->getName()).'_lang_'.$locale.'.'.$property;
     }

--- a/tests/Api/Front/FrontCatalogApiTest.php
+++ b/tests/Api/Front/FrontCatalogApiTest.php
@@ -40,6 +40,21 @@ final class FrontCatalogApiTest extends ApiTestCase
         self::assertArrayHasKey('productSaleElements', $data);
     }
 
+    public function testFilteringOnATranslatedFieldAcceptsActiveLocalesOnly(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $factory->product($factory->category(), $factory->taxRule(), $factory->currency(), ['title' => 'Locale probe']);
+
+        $response = $this->jsonRequest('GET', '/api/front/products?title=Locale+probe&locale=en_US');
+        self::assertJsonResponseSuccessful($response);
+
+        // The locale names a join alias: anything but an active locale is refused up front.
+        foreach (['zz_ZZ', "en_US'", 'en_US OR 1=1'] as $locale) {
+            $response = $this->jsonRequest('GET', '/api/front/products?title=Locale+probe&locale='.rawurlencode($locale));
+            self::assertSame(400, $response->getStatusCode(), \sprintf('locale "%s" should be refused', $locale));
+        }
+    }
+
     public function testGetCategoryByIdReturnsResource(): void
     {
         $factory = $this->createFixtureFactory();


### PR DESCRIPTION
Filtering or sorting a translated field takes an optional `locale` query parameter, which names the i18n join alias the eager loading extension built for each active language. Any other value (a typo, an inactive language, an arbitrary string) reached the SQL as-is and ended in a 500.

The filter now checks the locale against the active languages and answers 400 with the list of accepted values.

Covered by an API test on `/api/front/products`.