### PR TITLE
fix(session): renew the session id when a customer or an admin authenticates

### DIFF
--- a/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
@@ -144,6 +144,10 @@ class Session extends BaseSession
 
     public function setCustomerUser(?UserInterface $user): static
     {
+        if (null !== $user) {
+            $this->renewIdOnAuthentication($this->getCustomerUser(), $user);
+        }
+
         $this->set('thelia.customer_user', $user);
 
         return $this;
@@ -161,9 +165,29 @@ class Session extends BaseSession
 
     public function setAdminUser(UserInterface $user): static
     {
+        $this->renewIdOnAuthentication($this->getAdminUser(), $user);
         $this->set('thelia.admin_user', $user);
 
         return $this;
+    }
+
+    /**
+     * A session that authenticates someone new gets a new id: the id the browser carried
+     * before the login was chosen before anyone was trusted, and may not have been chosen
+     * by this browser at all. Refreshing the same user in place (revalidation on every
+     * admin request) keeps the id, so parallel requests of that user stay on one session.
+     */
+    private function renewIdOnAuthentication(mixed $previous, UserInterface $user): void
+    {
+        if ($previous instanceof UserInterface && $previous->getId() === $user->getId()) {
+            return;
+        }
+
+        if (!$this->isStarted()) {
+            $this->start();
+        }
+
+        $this->migrate();
     }
 
     public function getAdminUser(): mixed

--- a/core/lib/Thelia/Core/HttpFoundation/Session/SessionStorageFactory.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/SessionStorageFactory.php
@@ -40,7 +40,9 @@ final readonly class SessionStorageFactory implements SessionStorageFactoryInter
         $lifetime = (int) ConfigQuery::read('session_config.lifetime', 0);
         $customSavePath = ConfigQuery::read('session_config.save_path', $this->defaultSavePath);
 
-        $options = [];
+        // Only ids php handed out are honoured: an id the browser made up (or was handed by
+        // someone else) starts a fresh session instead of being adopted.
+        $options = ['use_strict_mode' => true];
 
         if ($lifetime > 0) {
             $options['gc_maxlifetime'] = $lifetime;

--- a/tests/Integration/Core/HttpFoundation/Session/SessionTest.php
+++ b/tests/Integration/Core/HttpFoundation/Session/SessionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\HttpFoundation\Session;
+
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Test\IntegrationTestCase;
+
+final class SessionTest extends IntegrationTestCase
+{
+    public function testAuthenticatingACustomerRenewsTheSessionId(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+        $session->set('cart.id', 42);
+        $anonymousId = $session->getId();
+
+        $session->setCustomerUser($customer);
+
+        self::assertNotSame($anonymousId, $session->getId(), 'the id the browser carried before login must not survive it');
+        self::assertSame(42, $session->get('cart.id'), 'the session data follows the new id');
+
+        $loggedInId = $session->getId();
+        $session->setCustomerUser($customer);
+
+        self::assertSame($loggedInId, $session->getId(), 'refreshing the same user keeps the id');
+    }
+
+    public function testAuthenticatingAnAdminRenewsTheSessionId(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $admin = $factory->admin();
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->start();
+        $anonymousId = $session->getId();
+
+        $session->setAdminUser($admin);
+
+        self::assertNotSame($anonymousId, $session->getId());
+
+        $loggedInId = $session->getId();
+        $session->setAdminUser($admin);
+
+        self::assertSame($loggedInId, $session->getId(), 'revalidating the same admin keeps the id');
+    }
+}


### PR DESCRIPTION
The session kept the same id across a login: the id a browser carried as an anonymous visitor stayed valid once a customer or an administrator was authenticated on it. The session id is now renewed at authentication, on every login path (front form, back-office form, remember-me restoration), while the session data is kept. Refreshing the same user in place, as the admin revalidation does on every request, leaves the id untouched so parallel requests stay on one session.

The native session storage also runs with `use_strict_mode`, so an id php did not hand out starts a fresh session instead of being adopted.

Covered by two integration tests on the session class.