### PR TITLE
fix(auth): retire the remember-me token on logout and on password change

### DIFF
--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -288,6 +288,14 @@ class Customer extends BaseAction implements EventSubscriberInterface
      */
     public function logout(/* @noinspection PhpUnusedParameterInspection */ ActionEvent $event): void
     {
+        // The remember-me cookie is checked against the token stored on the account: the
+        // account forgets it here, so a copy of the cookie kept elsewhere stops working.
+        $customer = $this->securityContext->getCustomerUser();
+
+        if ($customer instanceof CustomerModel) {
+            $customer->setRememberMeToken(null)->save();
+        }
+
         $this->securityContext->clearCustomerUser();
     }
 

--- a/core/lib/Thelia/Controller/Admin/SessionController.php
+++ b/core/lib/Thelia/Controller/Admin/SessionController.php
@@ -225,6 +225,15 @@ class SessionController extends BaseAdminController
     {
         $eventDispatcher->dispatch(new DefaultActionEvent(), TheliaEvents::ADMIN_LOGOUT);
 
+        // The remember-me cookie is checked against the token stored on the account: the
+        // browser drops its copy below, the account forgets the token here, so a copy kept
+        // elsewhere stops working too.
+        $admin = $this->getSecurityContext()->getAdminUser();
+
+        if ($admin instanceof Admin) {
+            $admin->setRememberMeToken(null)->save();
+        }
+
         $this->getSecurityContext()->clearAdminUser();
 
         // Clear the remember me cookie, if any

--- a/core/lib/Thelia/Model/Admin.php
+++ b/core/lib/Thelia/Model/Admin.php
@@ -51,6 +51,9 @@ class Admin extends BaseAdmin implements UserInterface, SecurityUserInterface, P
         if (null !== $password && '' !== trim($password)) {
             $this->setAlgo('PASSWORD_BCRYPT');
 
+            // A new password retires every remember-me cookie issued under the old one.
+            $this->setRememberMeToken(null);
+
             return parent::setPassword(password_hash($password, \PASSWORD_BCRYPT));
         }
 

--- a/core/lib/Thelia/Model/Customer.php
+++ b/core/lib/Thelia/Model/Customer.php
@@ -263,6 +263,9 @@ class Customer extends BaseCustomer implements UserInterface, SecurityUserInterf
         if (null !== $password && '' !== trim($password)) {
             $this->setAlgo('PASSWORD_BCRYPT');
 
+            // A new password retires every remember-me cookie issued under the old one.
+            $this->setRememberMeToken(null);
+
             parent::setPassword(password_hash($password, \PASSWORD_BCRYPT));
         }
 

--- a/tests/Integration/Action/AdministratorActionTest.php
+++ b/tests/Integration/Action/AdministratorActionTest.php
@@ -85,6 +85,18 @@ final class AdministratorActionTest extends ActionIntegrationTestCase
         self::assertNull($reloaded->getPasswordRenewToken());
     }
 
+    public function testUpdatePasswordRetiresTheRememberMeToken(): void
+    {
+        $admin = $this->factory->admin(['login' => 'admin-remember-me-test']);
+        $admin->setRememberMeToken('issued-under-the-old-password')->save();
+
+        $event = new AdministratorUpdatePasswordEvent($admin);
+        $event->setPassword('newPassword!');
+        $this->dispatch($event, TheliaEvents::ADMINISTRATOR_UPDATEPASSWORD);
+
+        self::assertNull(AdminQuery::create()->findPk($admin->getId())->getRememberMeToken());
+    }
+
     public function testDeleteRemovesAdmin(): void
     {
         $admin = $this->factory->admin(['login' => 'admin-delete-test']);

--- a/tests/Integration/Action/CustomerActionTest.php
+++ b/tests/Integration/Action/CustomerActionTest.php
@@ -17,15 +17,19 @@ namespace Thelia\Tests\Integration\Action;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\Event\Customer\CustomerCreateOrUpdateEvent;
 use Thelia\Core\Event\Customer\CustomerCreateOrUpdateMinimalEvent;
+use Thelia\Core\Event\DefaultActionEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
 use Thelia\Test\FixtureFactory;
 use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsCustomer;
 
 final class CustomerActionTest extends IntegrationTestCase
 {
+    use LogsInAsCustomer;
+
     private EventDispatcherInterface $dispatcher;
     private FixtureFactory $factory;
 
@@ -190,5 +194,26 @@ final class CustomerActionTest extends IntegrationTestCase
             ->findOne();
 
         self::assertNull($result, 'Transaction rollback should have removed the customer from the previous test');
+    }
+
+    public function testLogoutRetiresTheRememberMeToken(): void
+    {
+        $customer = $this->factory->customer($this->factory->customerTitle());
+        $customer->setRememberMeToken('issued-at-login')->save();
+        $this->loginAsCustomerInSession($customer);
+
+        $this->dispatcher->dispatch(new DefaultActionEvent(), TheliaEvents::CUSTOMER_LOGOUT);
+
+        self::assertNull(CustomerQuery::create()->findPk($customer->getId())->getRememberMeToken());
+    }
+
+    public function testANewPasswordRetiresTheRememberMeToken(): void
+    {
+        $customer = $this->factory->customer($this->factory->customerTitle());
+        $customer->setRememberMeToken('issued-under-the-old-password')->save();
+
+        $customer->setPassword('brand-new-password')->save();
+
+        self::assertNull(CustomerQuery::create()->findPk($customer->getId())->getRememberMeToken());
     }
 }


### PR DESCRIPTION
The remember-me cookie is checked against a token stored on the account. Logging out only dropped the browser's copy of the cookie and a password change left the token in place, so a cookie kept elsewhere kept authenticating its owner.

The account now forgets the token when its owner logs out (customer and administrator) and whenever a new password is set, on every path that sets one.

Covered by three integration tests.