### PR TITLE
fix(checkout): judge the chosen delivery and payment modules the way the offer did

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -640,6 +640,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
             TheliaEvents::MODULE_DELIVERY_GET_POSTAGE
         );
 
+        // A module that does not serve this cart quotes nothing, which is not the
+        // same as quoting a free delivery.
+        if (!$deliveryPostageEvent->isValidModule()) {
+            throw new DeliveryException(\sprintf('Delivery module %s is not available for this cart', $deliveryModule->getCode()));
+        }
+
         $postage = $deliveryPostageEvent->getPostage();
 
         if (!$postage instanceof OrderPostage) {

--- a/core/lib/Thelia/Core/Event/Delivery/DeliveryPostageEvent.php
+++ b/core/lib/Thelia/Core/Event/Delivery/DeliveryPostageEvent.php
@@ -34,8 +34,8 @@ class DeliveryPostageEvent extends ActionEvent
 {
     protected bool $validModule = false;
     protected ?OrderPostage $postage = null;
-    protected ?\DateTime $deliveryDate;
-    protected ?DeliveryMode $deliveryMode;
+    protected ?\DateTime $deliveryDate = null;
+    protected ?DeliveryMode $deliveryMode = null;
     protected array $additionalData = [];
 
     public function __construct(

--- a/core/lib/Thelia/Domain/Cart/Service/CartGuard.php
+++ b/core/lib/Thelia/Domain/Cart/Service/CartGuard.php
@@ -15,18 +15,33 @@ declare(strict_types=1);
 namespace Thelia\Domain\Cart\Service;
 
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Payment\IsValidPaymentEvent;
+use Thelia\Core\Event\TheliaEvents;
 use Thelia\Domain\Checkout\Exception\EmptyCartException;
 use Thelia\Domain\Checkout\Exception\IncompleteInvoiceAddressException;
 use Thelia\Domain\Checkout\Exception\InvalidDeliveryException;
 use Thelia\Domain\Checkout\Exception\InvalidPaymentException;
 use Thelia\Domain\Checkout\Exception\MissingAddressException;
 use Thelia\Domain\Legal\CompanyIdentifierRules;
+use Thelia\Domain\Shipping\Service\DeliveryModuleEligibilityChecker;
+use Thelia\Domain\Shipping\Service\DeliveryPostageQuerier;
 use Thelia\Model\Cart;
 use Thelia\Model\CartAddressQuery;
+use Thelia\Model\Module;
 use Thelia\Model\ModuleQuery;
 
 class CartGuard
 {
+    public function __construct(
+        private readonly DeliveryModuleEligibilityChecker $deliveryModuleEligibilityChecker,
+        private readonly DeliveryPostageQuerier $deliveryPostageQuerier,
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly ContainerInterface $container,
+    ) {
+    }
+
     /**
      * @throws EmptyCartException
      * @throws PropelException
@@ -107,9 +122,33 @@ class CartGuard
             throw new InvalidDeliveryException('Delivery module is required');
         }
 
-        $module = ModuleQuery::create()->findPk($cart?->getDeliveryModuleId());
+        $module = ModuleQuery::create()->findPk($cart->getDeliveryModuleId());
         if (!$module) {
             throw new InvalidDeliveryException('Delivery module not found');
+        }
+
+        // The module the cart names was chosen by the customer: it has to be one the shop
+        // would have offered for this cart and this address, judged the same way the
+        // offer was built, or the order would ship under terms nobody quoted.
+        if (!$module->isDeliveryModule() || !$this->isActive($module)) {
+            throw new InvalidDeliveryException('Delivery module is not available');
+        }
+
+        $address = CartAddressQuery::create()->findPk($cart->getAddressDeliveryId());
+        $country = $address?->getCountry();
+
+        if (null === $address || null === $country) {
+            throw new MissingAddressException('Delivery address has no country');
+        }
+
+        if (!$this->deliveryModuleEligibilityChecker->isEligible($module, $cart, $country, $address->getState())) {
+            throw new InvalidDeliveryException('Delivery module does not deliver to this address');
+        }
+
+        $quote = $this->deliveryPostageQuerier->query($module, $cart, $address->getAddress(), $country, $address->getState());
+
+        if (!$quote['valid']) {
+            throw new InvalidDeliveryException('Delivery module does not accept this cart');
         }
     }
 
@@ -126,5 +165,22 @@ class CartGuard
         if (!$module) {
             throw new InvalidPaymentException('Payment module not found');
         }
+
+        if (!$module->isPayementModule() || !$this->isActive($module)) {
+            throw new InvalidPaymentException('Payment module is not available');
+        }
+
+        // Same judge as the payment options offered at checkout.
+        $isValidPaymentEvent = new IsValidPaymentEvent($module->getPaymentModuleInstance($this->container), $cart);
+        $this->dispatcher->dispatch($isValidPaymentEvent, TheliaEvents::MODULE_PAYMENT_IS_VALID);
+
+        if (!$isValidPaymentEvent->isValidModule()) {
+            throw new InvalidPaymentException('Payment module does not accept this cart');
+        }
+    }
+
+    private function isActive(Module $module): bool
+    {
+        return 1 === (int) $module->getActivate();
     }
 }

--- a/tests/Integration/Domain/Cart/CartGuardTest.php
+++ b/tests/Integration/Domain/Cart/CartGuardTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Cart;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Delivery\DeliveryPostageEvent;
+use Thelia\Core\Event\Payment\IsValidPaymentEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Cart\Service\CartGuard;
+use Thelia\Domain\Checkout\Exception\InvalidDeliveryException;
+use Thelia\Domain\Checkout\Exception\InvalidPaymentException;
+use Thelia\Model\Area;
+use Thelia\Model\AreaDeliveryModule;
+use Thelia\Model\Cart;
+use Thelia\Model\Country;
+use Thelia\Model\CountryArea;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Model\OrderPostage;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The cart names the delivery and payment modules the customer picked. Before an
+ * order is placed, the guard has to judge them the way the checkout offer did:
+ * an installed row is not enough.
+ */
+final class CartGuardTest extends IntegrationTestCase
+{
+    private FixtureFactory $factory;
+    private CartGuard $guard;
+
+    /** @var list<array{0: string, 1: callable}> */
+    private array $registeredListeners = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = $this->createFixtureFactory();
+        $this->guard = $this->getService(CartGuard::class);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->registeredListeners as [$eventName, $listener]) {
+            $this->dispatcher()->removeListener($eventName, $listener);
+        }
+        $this->registeredListeners = [];
+
+        parent::tearDown();
+    }
+
+    public function testAnInactiveDeliveryModuleIsRefused(): void
+    {
+        $module = $this->deliveryModule();
+        $module->setActivate(0)->save();
+        $cart = $this->cartShippedWith($module, $this->factory->country());
+
+        $this->expectException(InvalidDeliveryException::class);
+        $this->guard->checkValidDelivery($cart);
+    }
+
+    public function testADeliveryModuleThatDoesNotServeTheCountryIsRefused(): void
+    {
+        $module = $this->deliveryModule();
+        $cart = $this->cartShippedWith($module, $this->factory->country(['isoalpha2' => 'ZZ', 'isoalpha3' => 'ZZZ', 'isocode' => '999']));
+
+        $this->expectException(InvalidDeliveryException::class);
+        $this->guard->checkValidDelivery($cart);
+    }
+
+    public function testADeliveryModuleThatDeclinesTheCartIsRefused(): void
+    {
+        $module = $this->deliveryModule();
+        $country = $this->factory->country();
+        $this->serveCountryWith($module, $country);
+        $this->answerDeliveryQuoteWith(valid: false);
+        $cart = $this->cartShippedWith($module, $country);
+
+        $this->expectException(InvalidDeliveryException::class);
+        $this->guard->checkValidDelivery($cart);
+    }
+
+    public function testADeliveryModuleThatServesAndQuotesTheCartIsAccepted(): void
+    {
+        $module = $this->deliveryModule();
+        $country = $this->factory->country();
+        $this->serveCountryWith($module, $country);
+        $this->answerDeliveryQuoteWith(valid: true);
+        $cart = $this->cartShippedWith($module, $country);
+
+        $this->guard->checkValidDelivery($cart);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAnInactivePaymentModuleIsRefused(): void
+    {
+        $module = $this->paymentModule();
+        $module->setActivate(0)->save();
+        $cart = $this->factory->cart();
+        $cart->setPaymentModuleId($module->getId())->save();
+
+        $this->expectException(InvalidPaymentException::class);
+        $this->guard->checkValidPayment($cart);
+    }
+
+    public function testAPaymentModuleThatDeclinesTheCartIsRefused(): void
+    {
+        $module = $this->paymentModule();
+        $this->answerPaymentValidityWith(false);
+        $cart = $this->factory->cart();
+        $cart->setPaymentModuleId($module->getId())->save();
+
+        $this->expectException(InvalidPaymentException::class);
+        $this->guard->checkValidPayment($cart);
+    }
+
+    public function testAPaymentModuleThatAcceptsTheCartIsAccepted(): void
+    {
+        $module = $this->paymentModule();
+        $this->answerPaymentValidityWith(true);
+        $cart = $this->factory->cart();
+        $cart->setPaymentModuleId($module->getId())->save();
+
+        $this->guard->checkValidPayment($cart);
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function deliveryModule(): Module
+    {
+        return ModuleQuery::create()->filterByType(2)->filterByActivate(1)->findOne()
+            ?? throw new \RuntimeException('No delivery module installed — run bin/test-prepare.');
+    }
+
+    private function paymentModule(): Module
+    {
+        return ModuleQuery::create()->filterByType(3)->filterByActivate(1)->findOne()
+            ?? throw new \RuntimeException('No payment module installed — run bin/test-prepare.');
+    }
+
+    private function cartShippedWith(Module $module, Country $country): Cart
+    {
+        $address = $this->factory->cartAddress(null, $country);
+        $cart = $this->factory->cart();
+        $cart->setAddressDeliveryId($address->getId())->setDeliveryModuleId($module->getId())->save();
+        $product = $this->factory->product($this->factory->category(), $this->factory->taxRule(), $this->factory->currency());
+        $this->factory->cartItem($cart, $product);
+
+        return $cart;
+    }
+
+    private function serveCountryWith(Module $module, Country $country): void
+    {
+        $area = (new Area())->setName('Guard test area');
+        $area->save();
+        (new CountryArea())->setAreaId($area->getId())->setCountryId($country->getId())->save();
+        (new AreaDeliveryModule())->setAreaId($area->getId())->setDeliveryModuleId($module->getId())->save();
+    }
+
+    private function answerDeliveryQuoteWith(bool $valid): void
+    {
+        $this->listen(TheliaEvents::MODULE_DELIVERY_GET_POSTAGE, static function (DeliveryPostageEvent $event) use ($valid): void {
+            $event->setValidModule($valid);
+            if ($valid) {
+                $event->setPostage(new OrderPostage(5.0, 1.0, 'VAT'));
+            }
+            $event->stopPropagation();
+        });
+    }
+
+    private function answerPaymentValidityWith(bool $valid): void
+    {
+        $this->listen(TheliaEvents::MODULE_PAYMENT_IS_VALID, static function (IsValidPaymentEvent $event) use ($valid): void {
+            $event->setValidModule($valid);
+            $event->stopPropagation();
+        });
+    }
+
+    private function listen(string $eventName, callable $listener): void
+    {
+        $this->dispatcher()->addListener($eventName, $listener, 512);
+        $this->registeredListeners[] = [$eventName, $listener];
+    }
+
+    private function dispatcher(): EventDispatcherInterface
+    {
+        return $this->getService(EventDispatcherInterface::class);
+    }
+}


### PR DESCRIPTION
Before an order is placed, the cart guard only checked that the delivery and payment modules named on the cart existed. A module that was inactive, that did not serve the delivery country, or that declined the cart went through; and when a delivery module declined the cart, the postage quote came back as a free delivery instead of an error.

- `CartGuard` now requires an active module of the right type, a delivery area covering the address, and a positive answer from the same quote (`MODULE_DELIVERY_GET_POSTAGE`) and validity (`MODULE_PAYMENT_IS_VALID`) events the checkout offer is built from.
- `Cart::getPostageByDeliveryModuleId` throws when the module declares itself unavailable, so an invalid module never quotes 0.
- `DeliveryPostageEvent` gives its optional `deliveryDate` and `deliveryMode` a default: a module listener that stops the propagation left them uninitialised, which broke `DeliveryPostageQuerier`.

Seven integration tests cover the guard.