### PR TITLE
fix(cart): take the product from the sale element and refuse non-positive quantities

### DIFF
--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -241,8 +241,22 @@ class Cart extends BaseAction implements EventSubscriberInterface
             $discount = (float) $customer->getDiscount();
         }
 
-        $productSaleElementsId = $event->getProductSaleElementsId();
-        $productId = $event->getProductId();
+        if (null === $quantity || $quantity <= 0) {
+            throw new \InvalidArgumentException('The quantity to add to the cart must be positive');
+        }
+
+        $productSaleElements = ProductSaleElementsQuery::create()->findPk($event->getProductSaleElementsId());
+
+        if (null === $productSaleElements) {
+            $event->setCartItem(null);
+
+            return;
+        }
+
+        // The line describes one sale element; the product it belongs to follows from it,
+        // whatever the request said, so the line, its price and its tax rule agree.
+        $productId = $productSaleElements->getProductId();
+        $event->setProductId($productId);
 
         // Search for an identical item in the cart
         $findItemEvent = clone $event;
@@ -253,16 +267,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
         if ($cartItem instanceof CartItem && $append) {
             $cartItem->addQuantity($quantity)->save();
         } else {
-            $productSaleElements = ProductSaleElementsQuery::create()->findPk($productSaleElementsId);
+            $productPrices = $productSaleElements->getPricesByCurrency(
+                $currency ?? CurrencyModel::getDefaultCurrency(),
+                $discount,
+            );
 
-            if (null !== $productSaleElements) {
-                $productPrices = $productSaleElements->getPricesByCurrency(
-                    $currency ?? CurrencyModel::getDefaultCurrency(),
-                    $discount,
-                );
-
-                $cartItem = $this->doAddItem($dispatcher, $cart, $productId, $productSaleElements, $quantity, $productPrices);
-            }
+            $cartItem = $this->doAddItem($dispatcher, $cart, $productId, $productSaleElements, $quantity, $productPrices);
         }
 
         $event->setCartItem($cartItem);

--- a/core/lib/Thelia/Model/CartItem.php
+++ b/core/lib/Thelia/Model/CartItem.php
@@ -124,6 +124,10 @@ class CartItem extends BaseCartItem
      */
     public function addQuantity($value)
     {
+        if ($value <= 0) {
+            return $this;
+        }
+
         $currentQuantity = $this->getQuantity();
         $newQuantity = $currentQuantity + $value;
 

--- a/tests/Integration/Action/CartActionTest.php
+++ b/tests/Integration/Action/CartActionTest.php
@@ -72,6 +72,42 @@ final class CartActionTest extends ActionIntegrationTestCase
         self::assertSame(1, CartItemQuery::create()->filterByCartId($cart->getId())->count());
     }
 
+    public function testAddItemTakesTheProductFromTheSaleElement(): void
+    {
+        $cart = $this->newEmptyCart();
+        $category = $this->factory->category();
+        $taxRule = $this->factory->taxRule();
+        $currency = $this->factory->currency();
+        $product = $this->factory->product($category, $taxRule, $currency, ['baseQuantity' => 100]);
+        $otherProduct = $this->factory->product($category, $taxRule, $currency, ['baseQuantity' => 100]);
+
+        // The request names another product than the one the sale element belongs to.
+        $event = $this->dispatchAddItem($cart, $otherProduct->getId(), $this->defaultPseFor($product->getId())->getId(), 1);
+
+        self::assertSame($product->getId(), $event->getCartItem()->getProductId());
+    }
+
+    public function testAddItemRefusesANonPositiveQuantity(): void
+    {
+        $cart = $this->newEmptyCart();
+        $product = $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+            ['baseQuantity' => 100],
+        );
+        $pse = $this->defaultPseFor($product->getId());
+        $this->dispatchAddItem($cart, $product->getId(), $pse->getId(), 2);
+
+        try {
+            $this->dispatchAddItem($cart, $product->getId(), $pse->getId(), -5);
+            self::fail('A negative quantity must be refused');
+        } catch (\InvalidArgumentException) {
+        }
+
+        self::assertSame(2.0, (float) CartItemQuery::create()->filterByCartId($cart->getId())->findOne()->getQuantity());
+    }
+
     public function testAddItemTwiceIncrementsExistingLine(): void
     {
         $cart = $this->newEmptyCart();


### PR DESCRIPTION
Adding a line to the cart took the product id and the sale element id as two independent values from the request, and accepted any quantity. A line could therefore point at a product other than the one its sale element (and price, and tax rule) belongs to, and a negative quantity lowered an existing line, or created one below zero.

The product now follows from the sale element, and a quantity that is not strictly positive is refused, both by the add-item action and by `CartItem::addQuantity`.

Two integration tests cover the action.