### PR TITLE
feat(http): send default content-type, framing and referrer headers on every response

### DIFF
--- a/core/lib/Thelia/Core/EventListener/ResponseHeadersListener.php
+++ b/core/lib/Thelia/Core/EventListener/ResponseHeadersListener.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Response headers every page and API answer carries unless something set them first:
+ * the browser must not sniff a content type, must not frame the site from another
+ * origin, and must not send the full URL as a referrer to other sites.
+ */
+final class ResponseHeadersListener
+{
+    public const DEFAULT_HEADERS = [
+        'X-Content-Type-Options' => 'nosniff',
+        'X-Frame-Options' => 'SAMEORIGIN',
+        'Referrer-Policy' => 'strict-origin-when-cross-origin',
+    ];
+
+    #[AsEventListener(event: KernelEvents::RESPONSE, priority: -1024)]
+    public function addDefaultHeaders(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $headers = $event->getResponse()->headers;
+
+        foreach (self::DEFAULT_HEADERS as $name => $value) {
+            if (!$headers->has($name)) {
+                $headers->set($name, $value);
+            }
+        }
+    }
+}

--- a/tests/Http/Flexy/FrontPagesSmokeTest.php
+++ b/tests/Http/Flexy/FrontPagesSmokeTest.php
@@ -32,6 +32,15 @@ final class FrontPagesSmokeTest extends WebIntegrationTestCase
         $this->assertPageRenders('/');
     }
 
+    public function testEveryPageCarriesTheDefaultResponseHeaders(): void
+    {
+        $this->client->request('GET', '/');
+
+        self::assertResponseHeaderSame('X-Content-Type-Options', 'nosniff');
+        self::assertResponseHeaderSame('X-Frame-Options', 'SAMEORIGIN');
+        self::assertResponseHeaderSame('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+
     public function testAccountRedirectsWhenNotLoggedIn(): void
     {
         $this->client->request('GET', '/account');

--- a/tests/Integration/Core/EventListener/ResponseHeadersListenerTest.php
+++ b/tests/Integration/Core/EventListener/ResponseHeadersListenerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Thelia\Core\EventListener\ResponseHeadersListener;
+use Thelia\Core\HttpFoundation\Request as TheliaRequest;
+use Thelia\Test\IntegrationTestCase;
+
+final class ResponseHeadersListenerTest extends IntegrationTestCase
+{
+    public function testAMainResponseCarriesTheDefaultHeaders(): void
+    {
+        $response = new Response();
+
+        (new ResponseHeadersListener())->addDefaultHeaders($this->responseEvent($response, HttpKernelInterface::MAIN_REQUEST));
+
+        foreach (ResponseHeadersListener::DEFAULT_HEADERS as $name => $value) {
+            self::assertSame($value, $response->headers->get($name), $name);
+        }
+    }
+
+    public function testAHeaderAlreadySetIsLeftAlone(): void
+    {
+        $response = new Response();
+        $response->headers->set('X-Frame-Options', 'DENY');
+
+        (new ResponseHeadersListener())->addDefaultHeaders($this->responseEvent($response, HttpKernelInterface::MAIN_REQUEST));
+
+        self::assertSame('DENY', $response->headers->get('X-Frame-Options'));
+        self::assertSame('nosniff', $response->headers->get('X-Content-Type-Options'));
+    }
+
+    public function testASubRequestIsLeftAlone(): void
+    {
+        $response = new Response();
+
+        (new ResponseHeadersListener())->addDefaultHeaders($this->responseEvent($response, HttpKernelInterface::SUB_REQUEST));
+
+        self::assertFalse($response->headers->has('X-Frame-Options'));
+    }
+
+    private function responseEvent(Response $response, int $requestType): ResponseEvent
+    {
+        return new ResponseEvent(self::$kernel, TheliaRequest::create('/'), $requestType, $response);
+    }
+}


### PR DESCRIPTION
Every main response now carries three headers unless something set them first:

- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: strict-origin-when-cross-origin`

They are the browser defaults most sites expect and were missing on the front, the back-office and the API alike. A listener late in the response chain adds them; a theme or a module that sets its own value keeps it, and sub-requests are left alone.

Covered by an integration test on the listener and an HTTP test on the front home page.