### PR TITLE
fix(payment): carry the gateway transaction reference as a string

### DIFF
--- a/core/lib/Thelia/Module/BasePaymentModuleController.php
+++ b/core/lib/Thelia/Module/BasePaymentModuleController.php
@@ -125,12 +125,12 @@ abstract class BasePaymentModuleController extends BaseFrontController
     /**
      * Save the transaction/payment ref in the order.
      *
-     * @param int $orderId        the order ID
-     * @param int $transactionRef the transaction reference
+     * Gateways issue alphanumeric references ("PSP-4F2A-7C10"), and the column they are
+     * stored in is a 100-character string: the reference is carried as the string it is.
      *
      * @throws \Exception
      */
-    public function saveTransactionRef(EventDispatcherInterface $eventDispatcher, int $orderId, int $transactionRef): void
+    public function saveTransactionRef(EventDispatcherInterface $eventDispatcher, int $orderId, string $transactionRef): void
     {
         if (!($order = $this->getOrder($orderId)) instanceof Order) {
             return;

--- a/tests/Integration/Controller/Front/BasePaymentModuleControllerTest.php
+++ b/tests/Integration/Controller/Front/BasePaymentModuleControllerTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Controller\Front;
 
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Security\SecurityContext;
+use Thelia\Model\OrderQuery;
 use Thelia\Module\BasePaymentModuleController;
 use Thelia\Test\IntegrationTestCase;
 
@@ -48,6 +50,27 @@ final class BasePaymentModuleControllerTest extends IntegrationTestCase
         $url = $this->urlOfRedirect(static fn (PaymentControllerUnderTest $controller) => $controller->redirectToFailurePage(42, null));
 
         self::assertStringEndsWith('/checkout/failed?order_id=42', $url);
+    }
+
+    /**
+     * Payment gateways name their transactions with references such as "PSP-4F2A-7C10":
+     * the column they are stored in is a 100-character string, so the reference the
+     * module hands over must reach it as it was issued.
+     */
+    public function testTheTransactionReferenceOfTheGatewayIsSavedOnTheOrder(): void
+    {
+        $order = $this->createFixtureFactory()->order();
+
+        $this->controller()->saveTransactionRef(
+            $this->getService(EventDispatcherInterface::class),
+            (int) $order->getId(),
+            'PSP-4F2A-7C10',
+        );
+
+        self::assertSame(
+            'PSP-4F2A-7C10',
+            OrderQuery::create()->findPk($order->getId())->getTransactionRef(),
+        );
     }
 
     private function urlOfRedirect(callable $redirect): string


### PR DESCRIPTION
## Summary

- `BasePaymentModuleController::saveTransactionRef()` typed the reference as `int`, so a payment module handing over an alphanumeric reference (`PSP-4F2A-7C10`) hit a `TypeError` before the order was touched.
- `order.transaction_ref` is a `VARCHAR(100)` and `OrderEvent::setTransactionRef()` already takes a `?string`, so an `int` could not reach the order either: the reference is now carried as the string it is.

## Test plan

- [ ] `composer test:integration -- --filter BasePaymentModuleControllerTest` — the new case saves `PSP-4F2A-7C10` and reads it back from the order.