### PR TITLE
test(flexy): pin the 404 of a quote the shop has no document for

### DIFF
--- a/tests/Http/Flexy/AccountQuotationPdfTest.php
+++ b/tests/Http/Flexy/AccountQuotationPdfTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Model\Customer;
+use Thelia\Model\Order;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+use Thelia\Tests\Support\Flexy\CustomerSessionInjector;
+
+/**
+ * The order page of the Flexy theme offers a quote for an order whose status says
+ * "quotation", and the route behind that link renders a `quotation` document of the
+ * active PDF template. The default PDF template ships an invoice and a delivery slip
+ * only, so on a shop that has not added one the route has nothing to render — and a
+ * customer walking to that url must be told the page is not there, not handed a
+ * server error.
+ *
+ * The route belongs to the theme, which ships as its own package on its own release
+ * cycle: a theme older than the guard is reported as skipped rather than failed.
+ */
+final class AccountQuotationPdfTest extends WebIntegrationTestCase
+{
+    private const QUOTATION_ROUTE = 'account_order_pdf_quotation';
+
+    private const GUARDED_CONTROLLER = 'FlexyBundle\Controller\AccountOrderController';
+
+    private ?CustomerSessionInjector $injector = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (null === $this->getService(RouterInterface::class)->getRouteCollection()->get(self::QUOTATION_ROUTE)) {
+            self::markTestSkipped('The installed front-office theme has no quotation PDF route.');
+        }
+
+        if (!method_exists(self::GUARDED_CONTROLLER, 'pdfDocumentExists')) {
+            self::markTestSkipped('The installed front-office theme predates the quotation document guard.');
+        }
+
+        $this->injector = new CustomerSessionInjector();
+        $this->getService(EventDispatcherInterface::class)->addSubscriber($this->injector);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->injector?->clear();
+
+        parent::tearDown();
+    }
+
+    public function testAQuoteTheActivePdfTemplateHasNoDocumentForIsNotFound(): void
+    {
+        $customer = $this->customer();
+        $order = $this->factory()->order($customer);
+
+        $this->injector?->setCustomer($customer);
+        $this->client->request('GET', $this->quotationUrl($order));
+
+        self::assertSame(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    private function customer(): Customer
+    {
+        return $this->factory()->customer($this->factory()->customerTitle());
+    }
+
+    private function quotationUrl(Order $order): string
+    {
+        return $this->getService(RouterInterface::class)->generate(
+            self::QUOTATION_ROUTE,
+            ['orderId' => $order->getId()],
+        );
+    }
+
+    /**
+     * Built without createFixtureFactory(): that helper pushes a synthetic request when
+     * the stack is empty, and it would then be the "main" request of the call below —
+     * the one the session, and therefore the logged-in customer, is read from.
+     */
+    private function factory(): FixtureFactory
+    {
+        return new FixtureFactory($this->getPropelConnection());
+    }
+}


### PR DESCRIPTION
## Summary

- The Flexy order page offers a quote for an order whose status reads `quotation`, and the route behind it renders a `quotation` document of the active PDF template. `thelia/pdf-default-template` ships an invoice and a delivery slip only, so the route answered 500 to a logged-in customer.
- Covers the theme-side guard of thelia-templates/flexy#179: own order, `GET` the quotation url, 404.
- The route belongs to the theme, which releases on its own cycle, so the case is skipped on a theme older than the guard — the way `AccountQuotationPdfTest`'s neighbour `VirtualProductDownloadTest` already does for its own route.

Merging this before the theme release leaves the case skipped; it starts running as soon as an install carries the fixed theme, and the theme repo's own CI runs this suite against its pull requests.

## Test plan

- [ ] `composer test:http-flexy` — skipped against `thelia/flexy` 1.0.3, green against the fixed theme, and 500 vs 404 with the guard removed from it.