### PR TITLE
fix(security): store IPv6 addresses in the form firewall

### DIFF
--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1711,7 +1711,7 @@
   <table name="form_firewall" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
     <column name="form_name" required="true" size="255" type="VARCHAR" />
-    <column name="ip_address" required="true" size="15" type="VARCHAR" />
+    <column name="ip_address" required="true" size="45" type="VARCHAR" />
     <column defaultValue="1" name="attempts" type="TINYINT" />
     <index name="idx_form_firewall_form_name">
       <index-column name="form_name" />

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -2079,7 +2079,7 @@ CREATE TABLE `form_firewall`
 (
     `id` INTEGER NOT NULL AUTO_INCREMENT,
     `form_name` VARCHAR(255) NOT NULL,
-    `ip_address` VARCHAR(15) NOT NULL,
+    `ip_address` VARCHAR(45) NOT NULL,
     `attempts` TINYINT DEFAULT 1,
     `created_at` DATETIME,
     `updated_at` DATETIME,

--- a/setup/update/sql/3.0.1.sql
+++ b/setup/update/sql/3.0.1.sql
@@ -1,0 +1,22 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------
+-- Client address of a form firewall attempt
+--
+-- The firewall counts the attempts of a client by its IP address, and looks
+-- that client up by the same address on the next attempt. A 15-character
+-- column only holds an IPv4 address: an IPv6 client was either refused the
+-- write or had a prefix stored that no lookup matched again, so the firewall
+-- counted nothing at all for visitors reaching the shop over IPv6.
+--
+-- 45 characters is the longest address there is (an IPv4-mapped IPv6 one).
+-- Widened only where it is still too narrow, so the statement can be replayed.
+-- ---------------------------------------------------------------------
+
+SET @widen_column := (SELECT COUNT(*) = 1 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'form_firewall' AND `COLUMN_NAME` = 'ip_address' AND `CHARACTER_MAXIMUM_LENGTH` < 45);
+SET @statement := IF(@widen_column, 'ALTER TABLE `form_firewall` MODIFY `ip_address` VARCHAR(45) NOT NULL', 'DO 0');
+PREPARE widen_column_statement FROM @statement;
+EXECUTE widen_column_statement;
+DEALLOCATE PREPARE widen_column_statement;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/Integration/Install/UpdateTransactionTest.php
+++ b/tests/Integration/Install/UpdateTransactionTest.php
@@ -43,19 +43,26 @@ final class UpdateTransactionTest extends IntegrationTestCase
 
     protected bool $useTransaction = false;
 
-    private string $initialVersion;
+    /**
+     * A completed run rewrites the version marker and the four variables derived from it,
+     * and this case runs outside a transaction: every one of them has to be put back, or
+     * the next test reading the version of the install reads the one this run left behind.
+     *
+     * @var array<string, string>
+     */
+    private array $initialVersionRows = [];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->initialVersion = $this->readVersionMarker();
+        $this->initialVersionRows = $this->readVersionRows();
     }
 
     protected function tearDown(): void
     {
         $this->connection()->exec('DROP TABLE IF EXISTS `update_transaction_probe`');
-        $this->writeVersionMarker($this->initialVersion);
+        $this->writeVersionRows($this->initialVersionRows);
 
         parent::tearDown();
     }
@@ -161,6 +168,33 @@ final class UpdateTransactionTest extends IntegrationTestCase
     {
         $statement = $this->connection()->prepare("UPDATE `config` SET `value` = ? WHERE `name` = 'thelia_version'");
         $statement->execute([$version]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function readVersionRows(): array
+    {
+        $rows = [];
+        $statement = $this->connection()->query("SELECT `name`, `value` FROM `config` WHERE `name` LIKE 'thelia\\_%version'");
+
+        while (($row = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            $rows[(string) $row['name']] = (string) $row['value'];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, string> $rows
+     */
+    private function writeVersionRows(array $rows): void
+    {
+        $statement = $this->connection()->prepare('UPDATE `config` SET `value` = ? WHERE `name` = ?');
+
+        foreach ($rows as $name => $value) {
+            $statement->execute([$value, $name]);
+        }
     }
 
     private function connection(): ConnectionInterface

--- a/tests/Integration/Model/FormFirewallIpAddressTest.php
+++ b/tests/Integration/Model/FormFirewallIpAddressTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Thelia\Form\ContactForm;
+use Thelia\Model\FormFirewall;
+use Thelia\Model\FormFirewallQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The form firewall counts the attempts of a client by its IP address, so the address
+ * it writes down has to be the address it looks that client up by on the next attempt.
+ * An IPv6 client announces up to 45 characters, and a column too narrow for them either
+ * refuses the write or keeps a prefix no lookup matches again — either way the firewall
+ * stops counting anything for every visitor reaching the shop over IPv6.
+ */
+final class FormFirewallIpAddressTest extends IntegrationTestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function clientAddressProvider(): iterable
+    {
+        yield 'IPv4' => ['203.0.113.7'];
+        yield 'IPv6' => ['2001:0db8:85a3:0000:0000:8a2e:0370:7334'];
+        yield 'IPv4-mapped IPv6, the longest address there is' => ['0000:0000:0000:0000:0000:ffff:255.255.255.255'];
+    }
+
+    #[DataProvider('clientAddressProvider')]
+    public function testAnAttemptIsFoundAgainByTheAddressItWasRecordedFor(string $clientAddress): void
+    {
+        (new FormFirewall())
+            ->setFormName(ContactForm::getName())
+            ->setIpAddress($clientAddress)
+            ->setAttempts(1)
+            ->save();
+
+        $recorded = FormFirewallQuery::create()
+            ->filterByFormName(ContactForm::getName())
+            ->filterByIpAddress($clientAddress)
+            ->findOne();
+
+        self::assertNotNull($recorded, 'The firewall must find the attempt it recorded for this client.');
+        self::assertSame($clientAddress, $recorded->getIpAddress());
+    }
+}


### PR DESCRIPTION
The `form_firewall.ip_address` column is a VARCHAR(15): an IPv6 client submitting a guarded form (contact, login, lost password) triggers a 1406 "Data too long" error under strict SQL mode, and without strict mode the truncated address never matches again, so the firewall counts nothing for IPv6 visitors.

- `ip_address` widened to VARCHAR(45) in `local/config/schema.xml` and `setup/thelia.sql`
- new `setup/update/sql/3.0.1.sql` with a guarded `MODIFY` (the 3.0.0 script is published and left untouched)
- integration test covering IPv4, IPv6 and the 45-character IPv4-mapped form
- the update-transaction test now restores every seeded version row after a completed run, which the new script exposed

Requires a `thelia/config` and a `thelia/setup` release to reach installed shops.

Test: `composer test:integration --filter FormFirewallIpAddress` (red on main with the 1406 error, green here); full `composer test`, `cs-diff` and `phpstan` green.