### PR TITLE
feat(api): cap API rate, login attempts and page size

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -10,3 +10,15 @@ DATABASE_PORT=3306
 DATABASE_NAME=test
 DATABASE_USER=db
 DATABASE_PASSWORD=db
+
+# API rate limits, raised out of the way for the suite.
+# The suite logs in for real on every API test and issues hundreds of calls a
+# minute from one address, which is exactly the shape the shipped limits are
+# there to refuse. A test that wants to reach a limit lowers the one it is
+# about to reach before its kernel boots (see Thelia\Tests\Api\RateLimit).
+THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS=100000
+THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT=100000
+THELIA_API_RATE_LIMIT_TOKEN_REFRESH=100000
+THELIA_API_RATE_LIMIT_ANONYMOUS=100000
+THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED=100000
+THELIA_API_RATE_LIMIT_ADMIN=100000

--- a/core/lib/Thelia/Api/EventListener/ApiRateLimitListener.php
+++ b/core/lib/Thelia/Api/EventListener/ApiRateLimitListener.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\EventListener;
+
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Thelia\Core\Security\RateLimiter\RateLimitAllowlist;
+use Thelia\Core\Security\RateLimiter\RateLimitedResponse;
+use Thelia\Model\Admin;
+
+/**
+ * How fast one caller may call the API.
+ *
+ * It covers the whole surface rather than a list of paths: the API has no
+ * refuse-by-default rule, its permissions are a list of exceptions, and a
+ * limiter mounted the same way would inherit the same blind spot — a resource
+ * nobody thought of would be the one left uncounted.
+ *
+ * Three budgets, because the callers are not comparable. An anonymous caller
+ * costs nothing to create and is counted by address. An authenticated one is
+ * counted by account, so a whole office behind one address is not held to a
+ * single budget, and gets more room since it has something to lose. The
+ * administration surface gets the most, because one back-office screen fans out
+ * into several calls.
+ *
+ * The check runs at priority 7, between the firewall that authenticates at 8
+ * and the API Platform read at 4, so a refused call does not go on to load and
+ * serialize anything. It runs after the firewall on purpose: before it, nobody
+ * knows who is calling, and every caller behind one address would share the
+ * anonymous budget.
+ *
+ * The two login endpoints answer from inside the firewall, so they never reach
+ * this listener; the firewall counts their attempts itself, on a much narrower
+ * budget.
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 7)]
+final readonly class ApiRateLimitListener
+{
+    private const string API_PREFIX = '/api';
+
+    public function __construct(
+        #[Autowire(service: 'limiter.api_anonymous')]
+        private RateLimiterFactoryInterface $anonymousLimiter,
+        #[Autowire(service: 'limiter.api_front_authenticated')]
+        private RateLimiterFactoryInterface $frontLimiter,
+        #[Autowire(service: 'limiter.api_admin')]
+        private RateLimiterFactoryInterface $adminLimiter,
+        private Security $security,
+        private RateLimitAllowlist $allowlist,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!str_starts_with($request->getPathInfo(), self::API_PREFIX)) {
+            return;
+        }
+
+        if ($this->allowlist->exempts($request->getClientIp())) {
+            return;
+        }
+
+        $limiter = $this->limiterFor($request);
+
+        if (null === $limiter) {
+            return;
+        }
+
+        $rateLimit = $limiter->consume();
+
+        if (!$rateLimit->isAccepted()) {
+            $event->setResponse(RateLimitedResponse::forRateLimit($rateLimit));
+        }
+    }
+
+    private function limiterFor(Request $request): ?LimiterInterface
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof Admin) {
+            return $this->adminLimiter->create($user->getUserIdentifier());
+        }
+
+        if ($user instanceof UserInterface) {
+            return $this->frontLimiter->create($user->getUserIdentifier());
+        }
+
+        // A console context has no caller address to count, the way the account
+        // email limiter already has none.
+        $clientIp = $request->getClientIp();
+
+        return null === $clientIp ? null : $this->anonymousLimiter->create($clientIp);
+    }
+}

--- a/core/lib/Thelia/Api/EventListener/TokenRefreshRateLimitListener.php
+++ b/core/lib/Thelia/Api/EventListener/TokenRefreshRateLimitListener.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\EventListener;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Thelia\Core\Security\RateLimiter\RateLimitAllowlist;
+use Thelia\Core\Security\RateLimiter\RateLimitedResponse;
+
+/**
+ * Counts the calls to the two token refresh endpoints, per caller.
+ *
+ * A refresh token is a credential like any other: it is presented, checked and
+ * either accepted or not, which is exactly the shape a caller can work through
+ * a list with. The login endpoints are counted by the firewall, but these two
+ * are plain controllers, so the counting happens here.
+ *
+ * The check runs at priority 7, between the firewall that authenticates at 8
+ * and the API Platform read at 4, so a refused call never reaches the store the
+ * refresh tokens live in.
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 7)]
+final readonly class TokenRefreshRateLimitListener
+{
+    private const array REFRESH_PATHS = [
+        '/api/admin/token/refresh',
+        '/api/front/token/refresh',
+    ];
+
+    public function __construct(
+        #[Autowire(service: 'limiter.api_token_refresh_per_client')]
+        private RateLimiterFactoryInterface $limiter,
+        private RateLimitAllowlist $allowlist,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!\in_array(rtrim($request->getPathInfo(), '/'), self::REFRESH_PATHS, true)) {
+            return;
+        }
+
+        // No address to count in a console context, and none to count for a
+        // caller the operator declared as exempt.
+        $clientIp = $request->getClientIp();
+
+        if (null === $clientIp || $this->allowlist->exempts($clientIp)) {
+            return;
+        }
+
+        $rateLimit = $this->limiter->create($clientIp)->consume();
+
+        if (!$rateLimit->isAccepted()) {
+            $event->setResponse(RateLimitedResponse::forRateLimit($rateLimit));
+        }
+    }
+}

--- a/core/lib/Thelia/Config/Resources/packages/api_platform.php
+++ b/core/lib/Thelia/Config/Resources/packages/api_platform.php
@@ -24,6 +24,15 @@ return static function (ContainerConfigurator $container): void {
         ],
         'defaults' => [
             'pagination_client_items_per_page' => true,
+            // The caller picks its page size, so the page size needs a ceiling:
+            // without one a single call can ask the shop to load, hydrate and
+            // serialize a whole table in one response. A hundred is well above
+            // what the shipped themes ask for (thirty on the front, twenty-five
+            // in the back-office) and above the page sizes an integration
+            // usually walks a catalogue with. A project that needs a different
+            // ceiling overrides this key in its own api_platform configuration,
+            // and an operation that needs its own says so on its metadata.
+            'pagination_maximum_items_per_page' => 100,
             'stateless' => false,
         ],
         'mapping' => [

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -74,6 +74,26 @@ return static function (ContainerConfigurator $container): void {
                 'limit' => '%env(int:THELIA_API_RATE_LIMIT_TOKEN_REFRESH)%',
                 'interval' => '1 minute',
             ],
+            // Everything else under /api. An anonymous caller is counted per
+            // address; an authenticated one per account, so a whole office
+            // behind a single address is not held to one budget. The
+            // administration figure is the highest because one back-office
+            // screen fans out into several calls.
+            'api_anonymous' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_ANONYMOUS)%',
+                'interval' => '1 minute',
+            ],
+            'api_front_authenticated' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED)%',
+                'interval' => '1 minute',
+            ],
+            'api_admin' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_ADMIN)%',
+                'interval' => '1 minute',
+            ],
         ],
     ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -66,6 +66,14 @@ return static function (ContainerConfigurator $container): void {
                 'limit' => '%env(int:THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)%',
                 'interval' => '1 minute',
             ],
+            // Token refreshes. A client asks for one when its access token is
+            // about to expire, so a caller asking again and again is either
+            // misbuilt or trying refresh tokens one after the other.
+            'api_token_refresh_per_client' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_TOKEN_REFRESH)%',
+                'interval' => '1 minute',
+            ],
         ],
     ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -48,6 +48,24 @@ return static function (ContainerConfigurator $container): void {
                 'limit' => 10,
                 'interval' => '1 hour',
             ],
+            // Login attempts on the two API login endpoints. The narrow window is
+            // per caller and per identifier, the wide one per caller: one stops
+            // passwords being tried on a single account, the other stops one
+            // password being tried across many. Both figures come from the
+            // environment (see parameters/api_rate_limit.php) so an operator can
+            // move them without touching the code. A sliding window is used
+            // rather than a fixed one so the budget cannot be spent twice around
+            // the moment a fixed window would roll over.
+            'api_login_per_client_and_identifier' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)%',
+                'interval' => '1 minute',
+            ],
+            'api_login_per_client' => [
+                'policy' => 'sliding_window',
+                'limit' => '%env(int:THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)%',
+                'interval' => '1 minute',
+            ],
         ],
     ], prepend: true);
 };

--- a/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
+++ b/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
@@ -30,6 +30,9 @@ return static function (ContainerConfigurator $container): void {
         // itself out on the first colleague who mistypes.
         ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)', '5')
         ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '25')
+        // Token refreshes, per minute and per caller. A client refreshes once
+        // per token lifetime, so ten a minute is already generous.
+        ->set('env(THELIA_API_RATE_LIMIT_TOKEN_REFRESH)', '10')
         // Addresses and CIDR ranges exempt from the limits that are not about
         // logging in, comma separated. Meant for a synchronisation that
         // legitimately calls faster than a browser does.

--- a/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
+++ b/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->parameters()
+        // How fast the API may be called, and how many login attempts it accepts.
+        // These are operating settings: what a shop can absorb depends on its
+        // hosting, not on its catalogue, so they are read from the environment
+        // and not from the database or the back-office. Every one of them has a
+        // working default here, so a shop that sets nothing is still protected.
+        //
+        // Failed login attempts, per minute. The first is counted per caller and
+        // per identifier, which is what stops someone trying passwords on one
+        // account; the second is counted per caller only, which is what stops
+        // someone trying one password across many accounts. The wider one has to
+        // stay well above the narrow one, or a shared office address would lock
+        // itself out on the first colleague who mistypes.
+        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)', '5')
+        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '25');
+};

--- a/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
+++ b/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
@@ -29,5 +29,9 @@ return static function (ContainerConfigurator $container): void {
         // stay well above the narrow one, or a shared office address would lock
         // itself out on the first colleague who mistypes.
         ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)', '5')
-        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '25');
+        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '25')
+        // Addresses and CIDR ranges exempt from the limits that are not about
+        // logging in, comma separated. Meant for a synchronisation that
+        // legitimately calls faster than a browser does.
+        ->set('env(THELIA_API_RATE_LIMIT_ALLOWLIST)', '');
 };

--- a/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
+++ b/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
@@ -33,6 +33,10 @@ return static function (ContainerConfigurator $container): void {
         // Token refreshes, per minute and per caller. A client refreshes once
         // per token lifetime, so ten a minute is already generous.
         ->set('env(THELIA_API_RATE_LIMIT_TOKEN_REFRESH)', '10')
+        // Everything else, per minute.
+        ->set('env(THELIA_API_RATE_LIMIT_ANONYMOUS)', '120')
+        ->set('env(THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED)', '600')
+        ->set('env(THELIA_API_RATE_LIMIT_ADMIN)', '1200')
         // Addresses and CIDR ranges exempt from the limits that are not about
         // logging in, comma separated. Meant for a synchronisation that
         // legitimately calls faster than a browser does.

--- a/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
+++ b/core/lib/Thelia/Config/Resources/parameters/api_rate_limit.php
@@ -28,15 +28,17 @@ return static function (ContainerConfigurator $container): void {
         // someone trying one password across many accounts. The wider one has to
         // stay well above the narrow one, or a shared office address would lock
         // itself out on the first colleague who mistypes.
-        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)', '5')
-        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '25')
+        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS)', '10')
+        ->set('env(THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT)', '50')
         // Token refreshes, per minute and per caller. A client refreshes once
-        // per token lifetime, so ten a minute is already generous.
-        ->set('env(THELIA_API_RATE_LIMIT_TOKEN_REFRESH)', '10')
+        // per token lifetime, so twenty a minute leaves room for a client that
+        // holds several sessions at once and still stops a caller working
+        // through refresh tokens.
+        ->set('env(THELIA_API_RATE_LIMIT_TOKEN_REFRESH)', '20')
         // Everything else, per minute.
-        ->set('env(THELIA_API_RATE_LIMIT_ANONYMOUS)', '120')
-        ->set('env(THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED)', '600')
-        ->set('env(THELIA_API_RATE_LIMIT_ADMIN)', '1200')
+        ->set('env(THELIA_API_RATE_LIMIT_ANONYMOUS)', '200')
+        ->set('env(THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED)', '800')
+        ->set('env(THELIA_API_RATE_LIMIT_ADMIN)', '2000')
         // Addresses and CIDR ranges exempt from the limits that are not about
         // logging in, comma separated. Meant for a synchronisation that
         // legitimately calls faster than a browser does.

--- a/core/lib/Thelia/Config/Resources/parameters/monolog.php
+++ b/core/lib/Thelia/Config/Resources/parameters/monolog.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 return static function (ContainerConfigurator $configurator): void {
     $configurator->extension('monolog', [
-        'channels' => ['deprecation'],
+        'channels' => ['deprecation', 'security'],
 
         'handlers' => [
             'main' => [
@@ -30,7 +30,21 @@ return static function (ContainerConfigurator $configurator): void {
                 'path' => '%kernel.logs_dir%/%kernel.environment%.log',
                 'level' => 'debug',
                 'max_files' => 7,
-                'channels' => ['!deprecation'],
+                'channels' => ['!deprecation', '!security'],
+            ],
+            // Refused authentications get a file of their own, and get there
+            // whatever else happens. The main handler only opens its buffer
+            // when something errors, so a warning on its own never reaches the
+            // disk — which is exactly the shape a run of failed logins has. A
+            // separate file is also what a log watcher wants to be pointed at,
+            // and it is kept longer: an attempt spread over weeks is only
+            // visible if weeks are still on disk.
+            'security_rotating' => [
+                'type' => 'rotating_file',
+                'path' => '%kernel.logs_dir%/security-%kernel.environment%.log',
+                'level' => 'warning',
+                'max_files' => 30,
+                'channels' => ['security'],
             ],
             'console' => [
                 'type' => 'console',

--- a/core/lib/Thelia/Config/Resources/parameters/monolog.php
+++ b/core/lib/Thelia/Config/Resources/parameters/monolog.php
@@ -30,15 +30,23 @@ return static function (ContainerConfigurator $configurator): void {
                 'path' => '%kernel.logs_dir%/%kernel.environment%.log',
                 'level' => 'debug',
                 'max_files' => 7,
-                'channels' => ['!deprecation', '!security'],
+                'channels' => ['!deprecation'],
             ],
             // Refused authentications get a file of their own, and get there
             // whatever else happens. The main handler only opens its buffer
             // when something errors, so a warning on its own never reaches the
-            // disk — which is exactly the shape a run of failed logins has. A
+            // disk, which is exactly the shape a run of failed logins has. A
             // separate file is also what a log watcher wants to be pointed at,
             // and it is kept longer: an attempt spread over weeks is only
             // visible if weeks are still on disk.
+            //
+            // The channel is deliberately left in the main log too, rather
+            // than excluded from it. Symfony's security component narrates its
+            // authenticators on this channel in debug and info, and that
+            // narration is how a rejected token or a misrouted firewall gets
+            // diagnosed: it has to stay next to the request that carried it. A
+            // warning is written twice whenever the main handler opens its
+            // buffer, which costs a duplicated line and keeps the context.
             'security_rotating' => [
                 'type' => 'rotating_file',
                 'path' => '%kernel.logs_dir%/security-%kernel.environment%.log',

--- a/core/lib/Thelia/Core/Security/EventListener/AuthenticationFailureLogListener.php
+++ b/core/lib/Thelia/Core/Security/EventListener/AuthenticationFailureLogListener.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Security\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
+
+/**
+ * Writes down every authentication the API refused.
+ *
+ * A limiter turns an attempt away but says nothing about it, so without this
+ * there is no way to see someone working through a list of passwords while it
+ * is happening, and no way to show afterwards that it happened. One line per
+ * refusal, naming the caller and the identifier that was aimed at, is enough
+ * for a human to read and for a log watcher to act on.
+ *
+ * What it must never write down is the password, whole or in part: a log is
+ * read, copied, shipped and kept in places the password store is not. Only the
+ * caller, the identifier, the endpoint and the kind of refusal go in.
+ *
+ * A refused token refresh is recorded from the response rather than from an
+ * event, because those two endpoints are plain controllers: they answer 401
+ * themselves, without the firewall ever raising a failure. Such a refusal names
+ * no identifier — a refresh token is opaque, and a caller trying one has not
+ * said who it claims to be.
+ */
+final readonly class AuthenticationFailureLogListener
+{
+    private const array TOKEN_REFRESH_PATHS = [
+        '/api/admin/token/refresh',
+        '/api/front/token/refresh',
+    ];
+
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.security')]
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    #[AsEventListener(event: LoginFailureEvent::class)]
+    public function onLoginFailure(LoginFailureEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        $this->logger->warning('API login refused.', [
+            'caller' => $request->getClientIp(),
+            'identifier' => $this->identifierAimedAt($event),
+            'endpoint' => $request->getPathInfo(),
+            // The class, not the message: it says whether the attempt was
+            // turned away for a bad password, a disabled account or a limit
+            // reached, and it cannot carry anything the caller typed.
+            'refusal' => $event->getException()::class,
+        ]);
+    }
+
+    #[AsEventListener(event: KernelEvents::RESPONSE)]
+    public function onTokenRefreshResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!\in_array(rtrim($request->getPathInfo(), '/'), self::TOKEN_REFRESH_PATHS, true)) {
+            return;
+        }
+
+        if (Response::HTTP_UNAUTHORIZED !== $event->getResponse()->getStatusCode()) {
+            return;
+        }
+
+        $this->logger->warning('API token refresh refused.', [
+            'caller' => $request->getClientIp(),
+            'endpoint' => $request->getPathInfo(),
+        ]);
+    }
+
+    private function identifierAimedAt(LoginFailureEvent $event): ?string
+    {
+        $passport = $event->getPassport();
+
+        if (null !== $passport && $passport->hasBadge(UserBadge::class)) {
+            /** @var UserBadge $badge */
+            $badge = $passport->getBadge(UserBadge::class);
+
+            return $badge->getUserIdentifier();
+        }
+
+        $lastUsername = $event->getRequest()->attributes->get(SecurityRequestAttributes::LAST_USERNAME);
+
+        return \is_string($lastUsername) ? $lastUsername : null;
+    }
+}

--- a/core/lib/Thelia/Core/Security/Http/Authentication/ThrottledLoginFailureHandler.php
+++ b/core/lib/Thelia/Core/Security/Http/Authentication/ThrottledLoginFailureHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Security\Http\Authentication;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationFailureHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Thelia\Core\Security\RateLimiter\RateLimitedResponse;
+
+/**
+ * Answers a caller that ran out of login attempts with the refusal meant for
+ * that, instead of one more "invalid credentials".
+ *
+ * The JWT bundle answers every authentication failure the same way, which is
+ * right for a wrong password but wrong once attempts are being counted: a client
+ * cannot tell it should back off, and a well-built one retries straight away.
+ *
+ * Every other failure is handed to the JWT bundle's own handler, so a wrong
+ * password keeps the exact response it has always had, body included. The
+ * handler is wrapped here rather than decorated, because a firewall inherits
+ * from its configured failure handler as a parent definition: a decorator on the
+ * bundle's service is resolved away before it reaches the firewall.
+ */
+final readonly class ThrottledLoginFailureHandler implements AuthenticationFailureHandlerInterface
+{
+    public function __construct(
+        private AuthenticationFailureHandler $ordinaryFailures,
+    ) {
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        if ($exception instanceof TooManyLoginAttemptsAuthenticationException) {
+            return RateLimitedResponse::forRequest($request);
+        }
+
+        return $this->ordinaryFailures->onAuthenticationFailure($request, $exception);
+    }
+}

--- a/core/lib/Thelia/Core/Security/RateLimiter/ApiLoginRateLimiter.php
+++ b/core/lib/Thelia/Core/Security/RateLimiter/ApiLoginRateLimiter.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Security\RateLimiter;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
+
+/**
+ * Counts login attempts on the two API login endpoints.
+ *
+ * Symfony's own login limiter is not used directly because it derives its wide
+ * window from its narrow one by multiplying, which forbids reading either from
+ * the environment. Both windows are declared as ordinary rate limiter policies
+ * instead, so an operator sets each figure independently.
+ *
+ * Two windows are needed, as they are for the account emails a visitor can
+ * trigger: the narrow one is keyed on caller and identifier, and stops passwords
+ * being tried against one account; the wide one is keyed on the caller alone,
+ * and stops one password being tried across many accounts.
+ *
+ * The front and the admin endpoints keep separate counters: an unrelated visitor
+ * mistyping their password on the shop must not spend the budget of the shop's
+ * own staff, and the other way round.
+ *
+ * Keys are hashed, so what ends up in the shared cache never spells out a caller
+ * address or the identifier that was tried.
+ */
+final class ApiLoginRateLimiter extends AbstractRequestRateLimiter
+{
+    private const string ADMIN_SCOPE_PREFIX = '/api/admin';
+
+    public function __construct(
+        #[Autowire(service: 'limiter.api_login_per_client')]
+        private readonly RateLimiterFactoryInterface $perClientLimiter,
+        #[Autowire(service: 'limiter.api_login_per_client_and_identifier')]
+        private readonly RateLimiterFactoryInterface $perClientAndIdentifierLimiter,
+        #[\SensitiveParameter]
+        #[Autowire('%kernel.secret%')]
+        private readonly string $secret,
+    ) {
+    }
+
+    public function consume(Request $request): RateLimit
+    {
+        return $this->recordRefusal($request, parent::consume($request));
+    }
+
+    public function peek(Request $request): RateLimit
+    {
+        return $this->recordRefusal($request, parent::peek($request));
+    }
+
+    protected function getLimiters(Request $request): array
+    {
+        $caller = (string) $request->getClientIp();
+        $identifier = $this->normalizeIdentifier(
+            (string) $request->attributes->get(SecurityRequestAttributes::LAST_USERNAME, ''),
+        );
+        $scope = str_starts_with($request->getPathInfo(), self::ADMIN_SCOPE_PREFIX) ? 'admin' : 'front';
+
+        return [
+            $this->perClientLimiter->create($this->key($scope, $caller)),
+            $this->perClientAndIdentifierLimiter->create($this->key($scope, $identifier.'-'.$caller)),
+        ];
+    }
+
+    /**
+     * Leaves the delay where the authentication failure handler can read it: the
+     * exception Symfony throws rounds the wait up to whole minutes, which would
+     * tell a well-behaved client to wait a minute for a slot freeing in a second.
+     */
+    private function recordRefusal(Request $request, RateLimit $rateLimit): RateLimit
+    {
+        if (!$rateLimit->isAccepted() || 0 === $rateLimit->getRemainingTokens()) {
+            RateLimitedResponse::remember($request, $rateLimit);
+        }
+
+        return $rateLimit;
+    }
+
+    private function normalizeIdentifier(string $identifier): string
+    {
+        return preg_match('//u', $identifier)
+            ? mb_strtolower($identifier, 'UTF-8')
+            : strtolower($identifier);
+    }
+
+    private function key(string $scope, string $data): string
+    {
+        return $scope.'-'.hash_hmac('sha256', $data, $this->secret);
+    }
+}

--- a/core/lib/Thelia/Core/Security/RateLimiter/RateLimitAllowlist.php
+++ b/core/lib/Thelia/Core/Security/RateLimiter/RateLimitAllowlist.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Security\RateLimiter;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+/**
+ * The callers that are not counted: a stock feed, an order export, a search
+ * indexer — work that legitimately calls faster than any browser does.
+ *
+ * An exemption is a hole in the protection, so it is deliberately narrow: it is
+ * declared once, in the environment, by whoever runs the shop, and it is read
+ * from the caller's address only. Never from anything the caller sends, which
+ * would let any caller exempt itself; never from a token either, since a token
+ * is a secret that rotates and would have to be pasted into the configuration
+ * of every server.
+ *
+ * Login attempts are outside its reach by design: an integration holds a token,
+ * it does not log in again and again.
+ */
+final readonly class RateLimitAllowlist
+{
+    /** @var list<string> */
+    private array $ranges;
+
+    public function __construct(
+        #[Autowire('%env(THELIA_API_RATE_LIMIT_ALLOWLIST)%')]
+        string $ranges,
+    ) {
+        $this->ranges = array_values(
+            array_filter(
+                array_map('trim', explode(',', $ranges)),
+                static fn (string $range): bool => '' !== $range,
+            ),
+        );
+    }
+
+    public function exempts(?string $clientIp): bool
+    {
+        if (null === $clientIp || '' === $clientIp || [] === $this->ranges) {
+            return false;
+        }
+
+        return IpUtils::checkIp($clientIp, $this->ranges);
+    }
+}

--- a/core/lib/Thelia/Core/Security/RateLimiter/RateLimitedResponse.php
+++ b/core/lib/Thelia/Core/Security/RateLimiter/RateLimitedResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Security\RateLimiter;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\RateLimit;
+
+/**
+ * The one answer every API rate limit gives.
+ *
+ * It carries no detail about what was refused, which account was named or how
+ * much budget is left: a caller walking a list of identifiers must not be able
+ * to read anything back from the refusal. The delay is the only thing it says,
+ * because a client that cannot know when to come back retries immediately and
+ * the shop pays for it twice.
+ *
+ * The shape matches the one the JWT login endpoints already answer failures
+ * with, so a client parses a refusal and a bad password the same way.
+ */
+final class RateLimitedResponse
+{
+    /**
+     * The request attribute a limiter leaves the delay in, for the authentication
+     * failure handler to pick up: the exception Symfony's login throttling throws
+     * only carries a duration rounded up to whole minutes.
+     */
+    public const string RETRY_AFTER_ATTRIBUTE = '_thelia_rate_limit_retry_after';
+
+    /**
+     * A client with no delay to read waits a whole window before retrying, so a
+     * missing figure has to err on the safe side rather than invite an immediate
+     * retry.
+     */
+    private const int FALLBACK_DELAY = 60;
+
+    public static function forRateLimit(RateLimit $rateLimit): JsonResponse
+    {
+        return self::afterSeconds(self::secondsUntil($rateLimit->getRetryAfter()));
+    }
+
+    public static function forRequest(Request $request): JsonResponse
+    {
+        $retryAfter = $request->attributes->get(self::RETRY_AFTER_ATTRIBUTE);
+
+        return self::afterSeconds(
+            $retryAfter instanceof \DateTimeInterface ? self::secondsUntil($retryAfter) : self::FALLBACK_DELAY,
+        );
+    }
+
+    public static function remember(Request $request, RateLimit $rateLimit): void
+    {
+        $request->attributes->set(self::RETRY_AFTER_ATTRIBUTE, $rateLimit->getRetryAfter());
+    }
+
+    private static function afterSeconds(int $seconds): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'code' => JsonResponse::HTTP_TOO_MANY_REQUESTS,
+                'message' => 'Too many requests. Please retry later.',
+            ],
+            JsonResponse::HTTP_TOO_MANY_REQUESTS,
+            ['Retry-After' => (string) $seconds],
+        );
+    }
+
+    private static function secondsUntil(\DateTimeInterface $retryAfter): int
+    {
+        return max(1, $retryAfter->getTimestamp() - time());
+    }
+}

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -64,6 +64,8 @@ use Thelia\Core\Hook\BaseHookInterface;
 use Thelia\Core\HttpFoundation\Request as TheliaRequest;
 use Thelia\Core\Propel\PropelInitService;
 use Thelia\Core\Propel\Schema\SchemaLocator;
+use Thelia\Core\Security\Http\Authentication\ThrottledLoginFailureHandler;
+use Thelia\Core\Security\RateLimiter\ApiLoginRateLimiter;
 use Thelia\Core\Security\UserProvider\AdminUserProvider;
 use Thelia\Core\Security\UserProvider\CustomerUserProvider;
 use Thelia\Core\Serializer\SerializerInterface;
@@ -692,7 +694,14 @@ class TheliaKernel extends Kernel
                     'json_login' => [
                         'check_path' => '/api/front/login',
                         'success_handler' => 'lexik_jwt_authentication.handler.authentication_success',
-                        'failure_handler' => 'lexik_jwt_authentication.handler.authentication_failure',
+                        'failure_handler' => ThrottledLoginFailureHandler::class,
+                    ],
+                    // Counts failed attempts, so trying passwords one after the
+                    // other stops paying off. The counting itself lives in
+                    // ApiLoginRateLimiter, which reads both of its windows from
+                    // the environment.
+                    'login_throttling' => [
+                        'limiter' => ApiLoginRateLimiter::class,
                     ],
                 ],
                 'adminLogin' => [
@@ -702,7 +711,10 @@ class TheliaKernel extends Kernel
                     'json_login' => [
                         'check_path' => '/api/admin/login',
                         'success_handler' => 'lexik_jwt_authentication.handler.authentication_success',
-                        'failure_handler' => 'lexik_jwt_authentication.handler.authentication_failure',
+                        'failure_handler' => ThrottledLoginFailureHandler::class,
+                    ],
+                    'login_throttling' => [
+                        'limiter' => ApiLoginRateLimiter::class,
                     ],
                 ],
                 'api' => [

--- a/tests/Api/Pagination/CollectionItemsPerPageCapTest.php
+++ b/tests/Api/Pagination/CollectionItemsPerPageCapTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Pagination;
+
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Collections let the caller choose its page size, so the page size needs a
+ * ceiling of its own: without one, a single anonymous call can ask the shop to
+ * build and serialize the whole table at once.
+ *
+ * The total is reported from the count, not from the page, so capping the page
+ * must not change what the collection says it holds.
+ */
+final class CollectionItemsPerPageCapTest extends ApiTestCase
+{
+    private const int CAP = 100;
+
+    public function testAnOversizedPageRequestIsCappedWithoutChangingTheTotal(): void
+    {
+        $factory = $this->createFixtureFactory();
+        for ($i = 0; $i < self::CAP + 5; ++$i) {
+            $factory->customerTitle(['position' => (string) (1000 + $i)]);
+        }
+
+        $uncapped = $this->readCollection('/api/front/customer_titles?itemsPerPage=100000');
+        $unpaged = $this->readCollection('/api/front/customer_titles');
+
+        self::assertGreaterThan(self::CAP, $unpaged['hydra:totalItems']);
+        self::assertSame($unpaged['hydra:totalItems'], $uncapped['hydra:totalItems']);
+        self::assertLessThanOrEqual(self::CAP, \count($uncapped['hydra:member']));
+    }
+
+    public function testAPageSizeUnderTheCapIsHonoured(): void
+    {
+        $factory = $this->createFixtureFactory();
+        for ($i = 0; $i < 12; ++$i) {
+            $factory->customerTitle(['position' => (string) (2000 + $i)]);
+        }
+
+        $page = $this->readCollection('/api/front/customer_titles?itemsPerPage=7');
+
+        self::assertCount(7, $page['hydra:member']);
+    }
+
+    /**
+     * @return array{'hydra:member': array<int, mixed>, 'hydra:totalItems': int}
+     */
+    private function readCollection(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Api/RateLimit/ApiLoginThrottlingTest.php
+++ b/tests/Api/RateLimit/ApiLoginThrottlingTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\RateLimit;
 
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Thelia\Test\ApiTestCase;
 
@@ -31,6 +30,8 @@ use Thelia\Test\ApiTestCase;
  */
 final class ApiLoginThrottlingTest extends ApiTestCase
 {
+    use RateLimitTestEnvironment;
+
     private const int MAX_ATTEMPTS = 3;
 
     /**
@@ -39,30 +40,19 @@ final class ApiLoginThrottlingTest extends ApiTestCase
      */
     private const string CALLER = '192.0.2.';
 
-    private array $previousEnv = [];
-
     protected function setUp(): void
     {
-        // Set before the kernel boots: the container reads the value the first
-        // time a limiter is built and caches it for the rest of the request.
-        $this->overrideEnv('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS', (string) self::MAX_ATTEMPTS);
-        $this->overrideEnv('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT', '10000');
+        $this->setLimit('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS', (string) self::MAX_ATTEMPTS);
+        $this->setLimit('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT', '10000');
 
         parent::setUp();
+
+        $this->clearRateLimiterCounters();
     }
 
     protected function tearDown(): void
     {
-        foreach ($this->previousEnv as $name => $value) {
-            if (null === $value) {
-                unset($_ENV[$name], $_SERVER[$name]);
-                continue;
-            }
-
-            $_ENV[$name] = $_SERVER[$name] = $value;
-        }
-
-        $this->previousEnv = [];
+        $this->restoreLimits();
 
         parent::tearDown();
     }
@@ -177,27 +167,6 @@ final class ApiLoginThrottlingTest extends ApiTestCase
         );
 
         return $this->client->getResponse();
-    }
-
-    /**
-     * Creating a fixture leaves a synthetic request on the stack, which then
-     * shadows the login request: Symfony reads the caller and the identifier
-     * from the main request, and would count every attempt under the same key.
-     * Clearing the stack puts the request under test back in first position,
-     * the way a real one arrives.
-     */
-    private function clearRequestStack(): void
-    {
-        $requestStack = static::getContainer()->get(RequestStack::class);
-
-        while (null !== $requestStack->pop()) {
-        }
-    }
-
-    private function overrideEnv(string $name, string $value): void
-    {
-        $this->previousEnv[$name] = $_SERVER[$name] ?? null;
-        $_ENV[$name] = $_SERVER[$name] = $value;
     }
 
     private static function decode(Response $response): array

--- a/tests/Api/RateLimit/ApiLoginThrottlingTest.php
+++ b/tests/Api/RateLimit/ApiLoginThrottlingTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\RateLimit;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Both API login endpoints stop answering after a few failed attempts from the
+ * same caller, and say when to come back.
+ *
+ * The refusal has to read the same whether the identifier names an account or
+ * not: a limiter that only fires on real logins answers the question "does this
+ * account exist" for whoever is walking a list.
+ *
+ * Each test gets its own caller address so the counters of one never spill into
+ * another: they live in the shared cache pool, which outlives a single test.
+ */
+final class ApiLoginThrottlingTest extends ApiTestCase
+{
+    private const int MAX_ATTEMPTS = 3;
+
+    /**
+     * Reserved for documentation and examples (RFC 5737), so it can never be a
+     * real caller of the machine running the suite.
+     */
+    private const string CALLER = '192.0.2.';
+
+    private array $previousEnv = [];
+
+    protected function setUp(): void
+    {
+        // Set before the kernel boots: the container reads the value the first
+        // time a limiter is built and caches it for the rest of the request.
+        $this->overrideEnv('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS', (string) self::MAX_ATTEMPTS);
+        $this->overrideEnv('THELIA_API_RATE_LIMIT_LOGIN_ATTEMPTS_PER_CLIENT', '10000');
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->previousEnv as $name => $value) {
+            if (null === $value) {
+                unset($_ENV[$name], $_SERVER[$name]);
+                continue;
+            }
+
+            $_ENV[$name] = $_SERVER[$name] = $value;
+        }
+
+        $this->previousEnv = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheAttemptAfterTheLastAllowedOneIsRefusedWithADelay(): void
+    {
+        $admin = $this->createFixtureFactory()->admin();
+        $this->clearRequestStack();
+        $caller = self::CALLER.'11';
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; ++$attempt) {
+            self::assertSame(
+                Response::HTTP_UNAUTHORIZED,
+                $this->attemptAdminLogin($admin->getLogin(), $caller)->getStatusCode(),
+                \sprintf('Attempt %d should still be answered as an ordinary failure.', $attempt),
+            );
+        }
+
+        $refused = $this->attemptAdminLogin($admin->getLogin(), $caller);
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $refused->getStatusCode());
+        self::assertGreaterThan(0, (int) $refused->headers->get('Retry-After'));
+        $body = self::decode($refused);
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $body['code']);
+        self::assertArrayHasKey('message', $body);
+    }
+
+    public function testTheFrontLoginIsThrottledToo(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle());
+        $this->clearRequestStack();
+        $caller = self::CALLER.'12';
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; ++$attempt) {
+            self::assertSame(
+                Response::HTTP_UNAUTHORIZED,
+                $this->attemptFrontLogin($customer->getEmail(), $caller)->getStatusCode(),
+            );
+        }
+
+        self::assertSame(
+            Response::HTTP_TOO_MANY_REQUESTS,
+            $this->attemptFrontLogin($customer->getEmail(), $caller)->getStatusCode(),
+        );
+    }
+
+    public function testARefusalReadsTheSameWhetherTheAccountExistsOrNot(): void
+    {
+        $admin = $this->createFixtureFactory()->admin();
+        $this->clearRequestStack();
+
+        $onAnAccount = $this->exhaust($admin->getLogin(), self::CALLER.'13');
+        $onNothing = $this->exhaust('no-such-administrator', self::CALLER.'14');
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $onAnAccount->getStatusCode());
+        self::assertSame($onAnAccount->getStatusCode(), $onNothing->getStatusCode());
+        self::assertSame($onAnAccount->getContent(), $onNothing->getContent());
+        self::assertSame(
+            $onAnAccount->headers->get('Content-Type'),
+            $onNothing->headers->get('Content-Type'),
+        );
+        self::assertNotNull($onAnAccount->headers->get('Retry-After'));
+        self::assertNotNull($onNothing->headers->get('Retry-After'));
+    }
+
+    public function testAnOrdinaryFailureKeepsTheResponseItAlwaysHad(): void
+    {
+        $admin = $this->createFixtureFactory()->admin();
+        $this->clearRequestStack();
+
+        $response = $this->attemptAdminLogin($admin->getLogin(), self::CALLER.'15');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        self::assertSame(
+            ['code' => Response::HTTP_UNAUTHORIZED, 'message' => 'Invalid credentials.'],
+            self::decode($response),
+        );
+        self::assertFalse($response->headers->has('Retry-After'));
+    }
+
+    private function exhaust(string $identifier, string $caller): Response
+    {
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; ++$attempt) {
+            $this->attemptAdminLogin($identifier, $caller);
+        }
+
+        return $this->attemptAdminLogin($identifier, $caller);
+    }
+
+    private function attemptAdminLogin(string $identifier, string $caller): Response
+    {
+        return $this->attemptLogin('/api/admin/login', ['username' => $identifier, 'password' => 'not-the-password'], $caller);
+    }
+
+    private function attemptFrontLogin(string $identifier, string $caller): Response
+    {
+        return $this->attemptLogin('/api/front/login', ['username' => $identifier, 'password' => 'not-the-password'], $caller);
+    }
+
+    private function attemptLogin(string $uri, array $credentials, string $caller): Response
+    {
+        $this->client->request(
+            'POST',
+            $uri,
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'REMOTE_ADDR' => $caller,
+            ],
+            content: json_encode($credentials, \JSON_THROW_ON_ERROR),
+        );
+
+        return $this->client->getResponse();
+    }
+
+    /**
+     * Creating a fixture leaves a synthetic request on the stack, which then
+     * shadows the login request: Symfony reads the caller and the identifier
+     * from the main request, and would count every attempt under the same key.
+     * Clearing the stack puts the request under test back in first position,
+     * the way a real one arrives.
+     */
+    private function clearRequestStack(): void
+    {
+        $requestStack = static::getContainer()->get(RequestStack::class);
+
+        while (null !== $requestStack->pop()) {
+        }
+    }
+
+    private function overrideEnv(string $name, string $value): void
+    {
+        $this->previousEnv[$name] = $_SERVER[$name] ?? null;
+        $_ENV[$name] = $_SERVER[$name] = $value;
+    }
+
+    private static function decode(Response $response): array
+    {
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Api/RateLimit/ApiRateLimitTest.php
+++ b/tests/Api/RateLimit/ApiRateLimitTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\RateLimit;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * How fast the API answers the same caller, outside the login endpoints.
+ *
+ * Three budgets, not one: an anonymous caller costs nothing to create and is
+ * counted by address, an authenticated one is counted by account and gets more
+ * room, and the administration surface gets the most because one back-office
+ * screen fans out into several calls. A single ceiling for all three would
+ * refuse a legitimate synchronisation at the same time as an abusive caller.
+ */
+final class ApiRateLimitTest extends ApiTestCase
+{
+    use RateLimitTestEnvironment;
+
+    private const int ANONYMOUS_LIMIT = 3;
+
+    private const string CALLER = '192.0.2.';
+
+    protected function setUp(): void
+    {
+        $this->setLimit('THELIA_API_RATE_LIMIT_ANONYMOUS', (string) self::ANONYMOUS_LIMIT);
+        $this->setLimit('THELIA_API_RATE_LIMIT_FRONT_AUTHENTICATED', '500');
+        $this->setLimit('THELIA_API_RATE_LIMIT_ADMIN', '500');
+
+        parent::setUp();
+
+        $this->clearRateLimiterCounters();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreLimits();
+
+        parent::tearDown();
+    }
+
+    public function testTheCallAfterTheLastAllowedOneIsRefusedWithADelay(): void
+    {
+        $caller = self::CALLER.'21';
+
+        for ($call = 1; $call <= self::ANONYMOUS_LIMIT; ++$call) {
+            self::assertSame(
+                Response::HTTP_OK,
+                $this->read('/api/front/products', $caller)->getStatusCode(),
+                \sprintf('Call %d is still within the budget.', $call),
+            );
+        }
+
+        $refused = $this->read('/api/front/products', $caller);
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $refused->getStatusCode());
+        self::assertGreaterThan(0, (int) $refused->headers->get('Retry-After'));
+
+        $body = json_decode((string) $refused->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $body['code']);
+        self::assertArrayHasKey('message', $body);
+    }
+
+    public function testTheBudgetIsSharedAcrossTheWholeApiSurface(): void
+    {
+        $caller = self::CALLER.'22';
+
+        $this->read('/api/front/products', $caller);
+        $this->read('/api/front/categories', $caller);
+        $this->read('/api/front/brands', $caller);
+
+        self::assertSame(
+            Response::HTTP_TOO_MANY_REQUESTS,
+            $this->read('/api/front/contents', $caller)->getStatusCode(),
+        );
+    }
+
+    public function testAnExemptCallerIsNeverRefused(): void
+    {
+        $caller = self::CALLER.'23';
+        $this->setLimit('THELIA_API_RATE_LIMIT_ALLOWLIST', $caller.',203.0.113.0/24');
+
+        for ($call = 1; $call <= self::ANONYMOUS_LIMIT * 3; ++$call) {
+            self::assertSame(
+                Response::HTTP_OK,
+                $this->read('/api/front/products', $caller)->getStatusCode(),
+                \sprintf('Call %d should not be refused for an exempt caller.', $call),
+            );
+        }
+    }
+
+    public function testAnAuthenticatedAdministratorIsCountedOnItsOwnBudget(): void
+    {
+        $token = $this->authenticateAsAdmin();
+        $this->clearRequestStack();
+        $this->clearRateLimiterCounters();
+        $caller = self::CALLER.'24';
+
+        for ($call = 1; $call <= self::ANONYMOUS_LIMIT * 3; ++$call) {
+            self::assertSame(
+                Response::HTTP_OK,
+                $this->read('/api/admin/products', $caller, $token)->getStatusCode(),
+                \sprintf('Call %d is inside the administration budget.', $call),
+            );
+        }
+    }
+
+    public function testAnAuthenticatedCustomerIsCountedOnItsOwnBudget(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $factory->customer($factory->customerTitle(), ['password' => 'password']);
+        $this->clearRequestStack();
+        $token = $this->authenticateAsCustomer($customer);
+        $this->clearRateLimiterCounters();
+        $caller = self::CALLER.'25';
+
+        for ($call = 1; $call <= self::ANONYMOUS_LIMIT * 3; ++$call) {
+            self::assertSame(
+                Response::HTTP_OK,
+                $this->read('/api/front/account/addresses', $caller, $token)->getStatusCode(),
+                \sprintf('Call %d is inside the customer budget.', $call),
+            );
+        }
+    }
+
+    private function read(string $uri, string $caller, ?string $token = null): Response
+    {
+        $server = [
+            'CONTENT_TYPE' => 'application/ld+json',
+            'HTTP_ACCEPT' => 'application/ld+json',
+            'REMOTE_ADDR' => $caller,
+        ];
+
+        if (null !== $token) {
+            $server['HTTP_AUTHORIZATION'] = 'Bearer '.$token;
+        }
+
+        $this->client->request('GET', $uri, server: $server);
+
+        return $this->client->getResponse();
+    }
+}

--- a/tests/Api/RateLimit/RateLimitTestEnvironment.php
+++ b/tests/Api/RateLimit/RateLimitTestEnvironment.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\RateLimit;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * What a test needs in order to reach a rate limit on purpose.
+ *
+ * The suite runs with the limits raised out of the way, so a test that wants to
+ * see one has to lower the one it is about to reach, before the kernel boots:
+ * the container reads a limit the first time it builds the limiter and keeps the
+ * value for the rest of the request.
+ *
+ * The counters live in a cache pool that survives the run, so they are wiped
+ * between tests. Without that, a test that passes on its own fails when the
+ * suite replays it inside the same minute.
+ */
+trait RateLimitTestEnvironment
+{
+    /** @var array<string, string|null> */
+    private array $rateLimitEnvBackup = [];
+
+    protected function setLimit(string $name, string $value): void
+    {
+        $this->rateLimitEnvBackup[$name] ??= $_SERVER[$name] ?? null;
+        $_ENV[$name] = $_SERVER[$name] = $value;
+    }
+
+    protected function restoreLimits(): void
+    {
+        foreach ($this->rateLimitEnvBackup as $name => $value) {
+            if (null === $value) {
+                unset($_ENV[$name], $_SERVER[$name]);
+                continue;
+            }
+
+            $_ENV[$name] = $_SERVER[$name] = $value;
+        }
+
+        $this->rateLimitEnvBackup = [];
+    }
+
+    protected function clearRateLimiterCounters(): void
+    {
+        $pool = static::getContainer()->get('cache.rate_limiter');
+
+        if ($pool instanceof CacheItemPoolInterface) {
+            $pool->clear();
+        }
+    }
+
+    /**
+     * Creating a fixture leaves a synthetic request on the stack, which then
+     * shadows the request under test: Symfony reads the caller and the
+     * identifier of a login attempt from the main request, and would count
+     * every attempt under the same key. Clearing the stack puts the request
+     * under test back in first position, the way a real one arrives.
+     */
+    protected function clearRequestStack(): void
+    {
+        $requestStack = static::getContainer()->get(RequestStack::class);
+
+        while (null !== $requestStack->pop()) {
+        }
+    }
+}

--- a/tests/Api/RateLimit/TokenRefreshRateLimitTest.php
+++ b/tests/Api/RateLimit/TokenRefreshRateLimitTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\RateLimit;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * The token refresh endpoints are counted like the login endpoints are.
+ *
+ * A client asks for a new access token once per token lifetime, so a caller
+ * asking again and again is either misbuilt or trying refresh tokens one after
+ * the other, and both are worth stopping.
+ *
+ * Each test uses its own caller address, since the counters live in the shared
+ * cache pool and outlive a single test.
+ */
+final class TokenRefreshRateLimitTest extends ApiTestCase
+{
+    use RateLimitTestEnvironment;
+
+    private const int MAX_REFRESHES = 2;
+
+    private const string CALLER = '198.51.100.';
+
+    protected function setUp(): void
+    {
+        $this->setLimit('THELIA_API_RATE_LIMIT_TOKEN_REFRESH', (string) self::MAX_REFRESHES);
+
+        parent::setUp();
+
+        $this->clearRateLimiterCounters();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreLimits();
+
+        parent::tearDown();
+    }
+
+    public function testTheRefreshAfterTheLastAllowedOneIsRefusedWithADelay(): void
+    {
+        $caller = self::CALLER.'11';
+
+        for ($attempt = 1; $attempt <= self::MAX_REFRESHES; ++$attempt) {
+            self::assertSame(
+                Response::HTTP_UNAUTHORIZED,
+                $this->refresh('/api/admin/token/refresh', 'not-a-refresh-token', $caller)->getStatusCode(),
+            );
+        }
+
+        $refused = $this->refresh('/api/admin/token/refresh', 'not-a-refresh-token', $caller);
+
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $refused->getStatusCode());
+        self::assertGreaterThan(0, (int) $refused->headers->get('Retry-After'));
+
+        $body = json_decode((string) $refused->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+        self::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $body['code']);
+        self::assertArrayHasKey('message', $body);
+    }
+
+    public function testTheFrontRefreshIsCountedToo(): void
+    {
+        $caller = self::CALLER.'12';
+
+        for ($attempt = 1; $attempt <= self::MAX_REFRESHES; ++$attempt) {
+            $this->refresh('/api/front/token/refresh', 'not-a-refresh-token', $caller);
+        }
+
+        self::assertSame(
+            Response::HTTP_TOO_MANY_REQUESTS,
+            $this->refresh('/api/front/token/refresh', 'not-a-refresh-token', $caller)->getStatusCode(),
+        );
+    }
+
+    public function testAnExemptCallerIsNeverRefused(): void
+    {
+        $caller = self::CALLER.'13';
+        $this->setLimit('THELIA_API_RATE_LIMIT_ALLOWLIST', $caller);
+
+        for ($attempt = 1; $attempt <= self::MAX_REFRESHES * 3; ++$attempt) {
+            self::assertSame(
+                Response::HTTP_UNAUTHORIZED,
+                $this->refresh('/api/admin/token/refresh', 'not-a-refresh-token', $caller)->getStatusCode(),
+                \sprintf('Refresh %d should not be refused for an exempt caller.', $attempt),
+            );
+        }
+    }
+
+    private function refresh(string $uri, string $refreshToken, string $caller): Response
+    {
+        $this->client->request(
+            'POST',
+            $uri,
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'REMOTE_ADDR' => $caller,
+            ],
+            content: json_encode(['refresh_token' => $refreshToken], \JSON_THROW_ON_ERROR),
+        );
+
+        return $this->client->getResponse();
+    }
+}

--- a/tests/Http/Flexy/ThemePagesAreNotRateLimitedTest.php
+++ b/tests/Http/Flexy/ThemePagesAreNotRateLimitedTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * A shop under load must not turn its own visitors away.
+ *
+ * The theme reads its data through the API, and the limit that protects the API
+ * is set for one caller — so if those reads were counted, the shop's own pages
+ * would be the first thing to hit the ceiling on the day the shop is busiest,
+ * and the busier it got the harder it would refuse.
+ *
+ * They are not counted, because the theme reads in process: it asks the state
+ * providers directly instead of calling itself over HTTP. This test pins that
+ * down with the anonymous budget set to one, so a single page view would be
+ * enough to exhaust it if those reads went through the limiter.
+ */
+final class ThemePagesAreNotRateLimitedTest extends WebIntegrationTestCase
+{
+    private const int PAGE_VIEWS = 12;
+
+    private const string VISITOR = '192.0.2.60';
+
+    /** @var array<string, string|null> */
+    private array $envBackup = [];
+
+    protected function setUp(): void
+    {
+        $this->setLimit('THELIA_API_RATE_LIMIT_ANONYMOUS', '1');
+
+        parent::setUp();
+
+        $pool = static::getContainer()->get('cache.rate_limiter');
+
+        if ($pool instanceof CacheItemPoolInterface) {
+            $pool->clear();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $name => $value) {
+            if (null === $value) {
+                unset($_ENV[$name], $_SERVER[$name]);
+                continue;
+            }
+
+            $_ENV[$name] = $_SERVER[$name] = $value;
+        }
+
+        $this->envBackup = [];
+
+        parent::tearDown();
+    }
+
+    public function testTheHomepageKeepsRenderingWellPastTheAnonymousBudget(): void
+    {
+        for ($view = 1; $view <= self::PAGE_VIEWS; ++$view) {
+            $response = $this->view('/');
+
+            // A plain 200 is the assertion: the page rendered, so it read the
+            // catalogue it renders from, and it read it without being counted.
+            self::assertSame(
+                Response::HTTP_OK,
+                $response->getStatusCode(),
+                \sprintf('View %d of the homepage did not render.', $view),
+            );
+            self::assertNotSame('', (string) $response->getContent());
+        }
+    }
+
+    private function view(string $uri): Response
+    {
+        $this->client->request('GET', $uri, server: ['REMOTE_ADDR' => self::VISITOR]);
+
+        return $this->client->getResponse();
+    }
+
+    private function setLimit(string $name, string $value): void
+    {
+        $this->envBackup[$name] ??= $_SERVER[$name] ?? null;
+        $_ENV[$name] = $_SERVER[$name] = $value;
+    }
+}

--- a/tests/Unit/Core/Config/CoreConfigurationDefaultsTest.php
+++ b/tests/Unit/Core/Config/CoreConfigurationDefaultsTest.php
@@ -46,7 +46,11 @@ final class CoreConfigurationDefaultsTest extends TestCase
             'api_platform',
             ['defaults' => ['stateless' => true]],
             'defaults',
-            ['pagination_client_items_per_page' => true, 'stateless' => true],
+            [
+                'pagination_client_items_per_page' => true,
+                'pagination_maximum_items_per_page' => 100,
+                'stateless' => true,
+            ],
         ];
 
         yield 'framework session save path' => [

--- a/tests/Unit/Core/Security/EventListener/AuthenticationFailureLogListenerTest.php
+++ b/tests/Unit/Core/Security/EventListener/AuthenticationFailureLogListenerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Security\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Thelia\Core\Security\EventListener\AuthenticationFailureLogListener;
+
+/**
+ * The trace a refused authentication leaves.
+ *
+ * A limiter refuses an attempt but says nothing about it: without a record of
+ * who aimed at what, someone working through a list of passwords is invisible
+ * while it happens and unprovable afterwards. And the record must never carry
+ * the password itself, whole or in part: a log is read, copied and shipped to
+ * places the password database is not.
+ */
+final class AuthenticationFailureLogListenerTest extends TestCase
+{
+    private const string CALLER = '192.0.2.70';
+
+    private const string SECRET = 'a-password-nobody-should-ever-log';
+
+    public function testARefusedLoginNamesTheCallerAndTheIdentifier(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onLoginFailure($this->loginFailure('/api/admin/login', 'thelia'));
+
+        self::assertCount(1, $logger->records);
+        self::assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+        self::assertStringContainsString(self::CALLER, $logger->records[0]['line']);
+        self::assertStringContainsString('thelia', $logger->records[0]['line']);
+        self::assertStringContainsString('/api/admin/login', $logger->records[0]['line']);
+    }
+
+    public function testAnAttemptOnAnIdentifierThatNamesNoAccountIsRecordedToo(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onLoginFailure($this->loginFailure('/api/front/login', 'nobody@example.com'));
+
+        self::assertStringContainsString('nobody@example.com', $logger->records[0]['line']);
+    }
+
+    public function testTheRecordNeverCarriesThePassword(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onLoginFailure($this->loginFailure('/api/admin/login', 'thelia'));
+
+        self::assertStringNotContainsString(self::SECRET, $logger->records[0]['line']);
+        self::assertStringNotContainsString(substr(self::SECRET, 0, 8), $logger->records[0]['line']);
+    }
+
+    public function testARefusedTokenRefreshIsRecorded(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onTokenRefreshResponse(
+            $this->response('/api/admin/token/refresh', Response::HTTP_UNAUTHORIZED),
+        );
+
+        self::assertCount(1, $logger->records);
+        self::assertSame(LogLevel::WARNING, $logger->records[0]['level']);
+        self::assertStringContainsString(self::CALLER, $logger->records[0]['line']);
+        self::assertStringContainsString('/api/admin/token/refresh', $logger->records[0]['line']);
+    }
+
+    public function testAnAcceptedTokenRefreshLeavesNoTrace(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onTokenRefreshResponse($this->response('/api/admin/token/refresh', Response::HTTP_OK));
+
+        self::assertSame([], $logger->records);
+    }
+
+    public function testAnyOtherResponseLeavesNoTrace(): void
+    {
+        $logger = new RecordingLogger();
+        $listener = new AuthenticationFailureLogListener($logger);
+
+        $listener->onTokenRefreshResponse($this->response('/api/front/products', Response::HTTP_UNAUTHORIZED));
+
+        self::assertSame([], $logger->records);
+    }
+
+    private function loginFailure(string $path, string $identifier): LoginFailureEvent
+    {
+        $request = Request::create($path, 'POST', server: ['REMOTE_ADDR' => self::CALLER]);
+        $passport = new Passport(
+            new UserBadge($identifier),
+            new PasswordCredentials(self::SECRET),
+        );
+
+        return new LoginFailureEvent(
+            new BadCredentialsException(),
+            $this->createMock(AuthenticatorInterface::class),
+            $request,
+            null,
+            'adminLogin',
+            $passport,
+        );
+    }
+
+    private function response(string $path, int $status): ResponseEvent
+    {
+        return new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create($path, 'POST', server: ['REMOTE_ADDR' => self::CALLER]),
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response('', $status),
+        );
+    }
+}
+
+/**
+ * Keeps every record as the single line a handler would write, so a test can
+ * assert on what a reader of the log would actually see.
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: string, line: string}> */
+    public array $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => (string) $level,
+            'line' => $message.' '.json_encode($context, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES),
+        ];
+    }
+}

--- a/tests/Unit/Core/Security/RateLimiter/RateLimitAllowlistTest.php
+++ b/tests/Unit/Core/Security/RateLimiter/RateLimitAllowlistTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Security\RateLimiter;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Core\Security\RateLimiter\RateLimitAllowlist;
+
+final class RateLimitAllowlistTest extends TestCase
+{
+    public function testAnEmptySettingExemptsNobody(): void
+    {
+        $allowlist = new RateLimitAllowlist('');
+
+        self::assertFalse($allowlist->exempts('10.0.0.1'));
+        self::assertFalse($allowlist->exempts('127.0.0.1'));
+    }
+
+    public function testASingleAddressIsExempt(): void
+    {
+        $allowlist = new RateLimitAllowlist('203.0.113.7');
+
+        self::assertTrue($allowlist->exempts('203.0.113.7'));
+        self::assertFalse($allowlist->exempts('203.0.113.8'));
+    }
+
+    public function testARangeExemptsEveryAddressInIt(): void
+    {
+        $allowlist = new RateLimitAllowlist('203.0.113.0/24');
+
+        self::assertTrue($allowlist->exempts('203.0.113.1'));
+        self::assertTrue($allowlist->exempts('203.0.113.254'));
+        self::assertFalse($allowlist->exempts('203.0.114.1'));
+    }
+
+    public function testSeveralEntriesAreReadEvenWhenTheSettingIsUntidy(): void
+    {
+        $allowlist = new RateLimitAllowlist(' 203.0.113.7 , ,2001:db8::/32,  198.51.100.0/24 ');
+
+        self::assertTrue($allowlist->exempts('203.0.113.7'));
+        self::assertTrue($allowlist->exempts('2001:db8::1'));
+        self::assertTrue($allowlist->exempts('198.51.100.42'));
+        self::assertFalse($allowlist->exempts('192.0.2.1'));
+    }
+
+    public function testACallerWithNoAddressIsNeverExempt(): void
+    {
+        $allowlist = new RateLimitAllowlist('203.0.113.0/24');
+
+        self::assertFalse($allowlist->exempts(null));
+        self::assertFalse($allowlist->exempts(''));
+    }
+}


### PR DESCRIPTION
## Summary

The API accepted an unlimited number of login attempts, an unlimited number of token refreshes, and a page size the caller chose freely: twelve wrong passwords in a row got twelve identical refusals, and `GET /api/front/products?itemsPerPage=100000` was honoured as asked. This adds four caps, all on by default and all set from the environment.

- **Page ceiling.** `pagination_maximum_items_per_page: 100` in the API Platform defaults. `itemsPerPage=100000` now returns 100 and `hydra:totalItems` still reports the real size of the collection. One line of configuration, and the cheapest of the four.
- **Login attempts.** `login_throttling` on the `frontLogin` and `adminLogin` firewalls, 10 a minute per caller and identifier and 50 a minute per caller. The counting lives in `ApiLoginRateLimiter`, a `RequestRateLimiterInterface` built on two ordinary rate limiter policies, because Symfony's own login limiter derives its wide window from its narrow one by multiplying and so neither figure could come from the environment. Front and admin keep separate counters.
- **Token refreshes.** 20 a minute per caller on the two `/token/refresh` endpoints, in a `kernel.request` listener at priority 7: those are plain controllers, so the firewall never sees the attempt.
- **General budget.** 200 a minute for an anonymous caller counted by address, 800 for a customer and 2000 for an administrator counted by account, over the whole `/api` surface with no path exceptions. Also at priority 7: after the firewall has said who is calling, before API Platform reads anything.
- **Exemption.** `THELIA_API_RATE_LIMIT_ALLOWLIST` takes addresses and CIDR ranges (`IpUtils::checkIp`). It covers the general and refresh budgets and never the login attempts, since an integration holds a token rather than logging in repeatedly.
- **One answer for all of them.** `429` with `Retry-After` in seconds and a body of `{"code": 429, "message": ...}`, identical whether the identifier names an account or not. An ordinary authentication failure keeps the JWT bundle's response byte for byte, so a wrong password is still `401 {"code": 401, "message": "Invalid credentials."}` with no `Retry-After`. The firewalls point at `ThrottledLoginFailureHandler`, which wraps the bundle's handler rather than decorating it: a firewall inherits from its configured failure handler as a parent definition, and a decorator on the bundle's service is resolved away before it reaches the firewall.
- **Log of refusals.** Every refused authentication is a `warning` on a new `security` channel with its own rotating file, naming the caller, the identifier aimed at, the endpoint and the kind of refusal, never the password. It needs its own handler because `main` is `fingers_crossed` at `action_level: error`, so a run of failed logins would never reach the disk. The channel is left in the main log as well, so the security component's debug and info narration of its authenticators stays next to the request that carried it.
- **Test environment.** `.env.test` raises every figure out of the way. The suite logs in for real on every API case and issues hundreds of calls a minute from one address, which is the exact shape the caps refuse; each new case lowers the one figure it is about to reach before its kernel boots.

The theme and the back-office are unaffected: they read through the state providers in process, so nothing they render is counted. A homepage rendered 150 times with the anonymous budget set to 1 stays at 200 throughout.

Nothing is added to `composer.json` (`symfony/rate-limiter` and `symfony/lock` were already required), no schema changes, and no trusted proxy configuration is shipped. Behind a proxy the caps count the proxy, so the documentation makes `framework.trusted_proxies` a prerequisite rather than an option.

Documented in thelia/docs#51.

## Test plan

- [ ] `composer test:api -- --filter CollectionItemsPerPageCapTest` — red before the config line (108 items returned for a 105-item collection asked with `itemsPerPage=100000`), green after.
- [ ] `composer test:api -- --filter ApiLoginThrottlingTest` — 3 of 4 red without `login_throttling` on the firewalls (401 instead of 429); the fourth pins the unchanged `401` of an ordinary failure and is green either way.
- [ ] `composer test:unit -- --filter RateLimitAllowlistTest` — red without the class, green after; covers an empty setting, a single address, a CIDR range, an untidy list and a caller with no address.
- [ ] `composer test:api -- --filter TokenRefreshRateLimitTest` — 2 of 3 red without the listener; the third pins that an exempt caller is never refused.
- [ ] `composer test:api -- --filter ApiRateLimitTest` — 2 of 5 red without the listener; the other three pin the exemption and the two authenticated budgets.
- [ ] `composer test:http-flexy -- --filter ThemePagesAreNotRateLimitedTest` — green as is, red at the second page view with the listener's prefix widened from `/api` to `/`, which is what proves it is the in-process read that keeps the theme out of the count.
- [ ] `composer test:unit -- --filter AuthenticationFailureLogListenerTest` — red without the listener, green after; asserts the caller, the identifier and the endpoint are in the line and the password is not.
- [ ] `composer test` — 5 suites green: unit 424, integration 788 (4 skipped), api 281 (1 skipped), http-flexy 28 (1 skipped), http-backoffice 12. Before: 413 / 788 / 267 / 27 / 12 with the same skips.
- [ ] `composer cs-diff` and `composer phpstan` — 0 and 0, before and after.
- [ ] Command line, fresh install with demo data: 13 failed admin logins give 10 × `401` then `429` with `Retry-After: 58`, identical for an identifier that names no account; `itemsPerPage=100000` on a 114-item collection returns 100 with `hydra:totalItems: 114`; 250 anonymous `GET /api/front/products` give 200 × `200` then 50 × `429`, first refusal on the 201st; the same burst with the caller in `THELIA_API_RATE_LIMIT_ALLOWLIST` is never refused while a login attempt from it still is; 150 theme page views give 150 × `200`; the back-office dashboard, order list, customer list and configuration answer `200`; 22 refresh attempts give 20 × `401` then `429`; the security log carries the caller and the identifier of every refusal and no trace of the password.