### PR TITLE
feat(api): sort the product collection by creation date and by title

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/ProductFilter/ProductPriceOrderFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/ProductFilter/ProductPriceOrderFilter.php
@@ -24,29 +24,47 @@ class ProductPriceOrderFilter extends AbstractFilter
 {
     private const PRICE_ORDER_NAME = 'untaxed_price_order';
 
+    private const SALE_ELEMENTS_JOIN_ALIAS = 'product_price_order_pse';
+
+    private const PRICE_JOIN_ALIAS = 'product_price_order_price';
+
     protected function filterProperty(string $property, $value, ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
         if (self::PRICE_ORDER_NAME !== $property) {
             return;
         }
 
-        $direction = strtolower($value);
-
-        if ($direction === strtolower(OrderFilter::DIRECTION_ASC)) {
-            $query
-                ->useProductSaleElementsQuery()
-                ->useProductPriceQuery()
-                ->orderByPrice(Criteria::ASC)
-                ->endUse()
-                ->endUse();
-        } elseif ($direction === strtolower(OrderFilter::DIRECTION_DESC)) {
-            $query
-                ->useProductSaleElementsQuery()
-                ->useProductPriceQuery()
-                ->orderByPrice(Criteria::DESC)
-                ->endUse()
-                ->endUse();
+        if (!\is_scalar($value)) {
+            return;
         }
+
+        $direction = strtoupper((string) $value);
+
+        if (!\in_array($direction, [OrderFilter::DIRECTION_ASC, OrderFilter::DIRECTION_DESC], true)) {
+            return;
+        }
+
+        // Outer joins: sorting a listing is not filtering it, and a product with no sale
+        // element or no price in the asked currency must stay in the collection instead of
+        // disappearing the moment the visitor picks a price order.
+        $query
+            ->useProductSaleElementsQuery(self::SALE_ELEMENTS_JOIN_ALIAS, Criteria::LEFT_JOIN)
+                ->useProductPriceQuery(self::PRICE_JOIN_ALIAS, Criteria::LEFT_JOIN)
+                ->endUse()
+            ->endUse();
+
+        $priceColumn = self::PRICE_JOIN_ALIAS.'.price';
+
+        // Priceless products keep a NULL sort key: send them last in both directions.
+        $query->addAscendingOrderByColumn('ISNULL('.$priceColumn.')');
+
+        if (OrderFilter::DIRECTION_ASC === $direction) {
+            $query->addAscendingOrderByColumn($priceColumn);
+
+            return;
+        }
+
+        $query->addDescendingOrderByColumn($priceColumn);
     }
 
     public function getDescription(string $resourceClass): array

--- a/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/ProductFilter/ProductTitleOrderFilter.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Filter/CustomFilters/ProductFilter/ProductTitleOrderFilter.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Filter\CustomFilters\ProductFilter;
+
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\Operation;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Thelia\Api\Bridge\Propel\Filter\AbstractFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
+use Thelia\Model\Lang;
+
+/**
+ * Sorts the product collection on the translated title, with "order[title]=asc|desc".
+ *
+ * The generic OrderFilter cannot do it: the i18n rows form a collection, so a path
+ * such as "i18ns.title" would order on an unconstrained join and multiply the rows.
+ * This filter therefore lays its own joins, one per locale it reads, each restricted
+ * to a single locale so a product still yields exactly one row.
+ *
+ * The sort key falls back to the title of the shop default language, mirroring what
+ * the front already does when a translation is missing. A product with no title at
+ * all stays in the collection and is pushed to the end whatever the direction.
+ *
+ * Pagination stability across pages is the caller's responsibility: add an
+ * "order[ref]=asc" tie-breaker, as products sharing a title are otherwise ordered
+ * by whatever the database returns.
+ */
+class ProductTitleOrderFilter extends AbstractFilter
+{
+    public const ORDER_PROPERTY = 'title';
+
+    private const ORDER_PARAMETER = 'order';
+    private const LOCALE_JOIN_ALIAS = 'product_title_order_lang';
+    private const FALLBACK_JOIN_ALIAS = 'product_title_order_fallback_lang';
+
+    protected function filterProperty(string $property, $value, ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        if (self::ORDER_PARAMETER !== $property || !\is_array($value)) {
+            return;
+        }
+
+        $direction = $this->normalizeDirection($value[self::ORDER_PROPERTY] ?? null);
+
+        if (null === $direction) {
+            return;
+        }
+
+        $defaultLocale = Lang::getDefaultLanguage()->getLocale();
+        $locale = $this->resolveLocale($context, $defaultLocale);
+
+        $titleColumns = [$this->joinTitles($query, self::LOCALE_JOIN_ALIAS, $locale)];
+
+        if ($locale !== $defaultLocale) {
+            $titleColumns[] = $this->joinTitles($query, self::FALLBACK_JOIN_ALIAS, $defaultLocale);
+        }
+
+        $sortKey = 1 === \count($titleColumns)
+            ? $titleColumns[0]
+            : 'COALESCE('.implode(', ', $titleColumns).')';
+
+        // Untranslated products keep a NULL sort key: send them last in both directions.
+        $query->addAscendingOrderByColumn('ISNULL('.$sortKey.')');
+
+        if (OrderFilter::DIRECTION_ASC === $direction) {
+            $query->addAscendingOrderByColumn($sortKey);
+
+            return;
+        }
+
+        $query->addDescendingOrderByColumn($sortKey);
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            \sprintf('%s[%s]', self::ORDER_PARAMETER, self::ORDER_PROPERTY) => [
+                'property' => self::ORDER_PROPERTY,
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Sort on the product title of the requested locale, falling back to the shop default language. Products without a title come last. Add order[ref] to keep the order stable across pages.',
+                'schema' => [
+                    'type' => 'string',
+                    'enum' => [
+                        strtolower(OrderFilter::DIRECTION_ASC),
+                        strtolower(OrderFilter::DIRECTION_DESC),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function joinTitles(ModelCriteria $query, string $alias, string $locale): string
+    {
+        $query->joinProductI18n($alias, Criteria::LEFT_JOIN);
+        $query->addJoinCondition($alias, $alias.'.locale = ?', $locale, null, \PDO::PARAM_STR);
+
+        return $alias.'.title';
+    }
+
+    private function resolveLocale(array $context, string $defaultLocale): string
+    {
+        $locale = $context['filters']['locale'] ?? $defaultLocale;
+
+        // A locale reaches the join condition, so only an active language is accepted,
+        // exactly as AbstractFilter::getLocalizedPropertyQueryPath() does.
+        $activeLocales = array_map(static fn (Lang $lang): string => $lang->getLocale(), Lang::getActiveLangs()->getData());
+
+        if (!\is_string($locale) || !\in_array($locale, $activeLocales, true)) {
+            throw new InvalidArgumentException(\sprintf('Unknown locale "%s" for sorting on "%s". Active locales: %s', \is_scalar($locale) ? (string) $locale : \gettype($locale), self::ORDER_PROPERTY, implode(', ', $activeLocales)));
+        }
+
+        return $locale;
+    }
+
+    private function normalizeDirection(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $direction = strtoupper((string) $value);
+
+        if (!\in_array($direction, [OrderFilter::DIRECTION_ASC, OrderFilter::DIRECTION_DESC], true)) {
+            return null;
+        }
+
+        return $direction;
+    }
+}

--- a/core/lib/Thelia/Api/Resource/Product.php
+++ b/core/lib/Thelia/Api/Resource/Product.php
@@ -32,6 +32,7 @@ use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\ProductFilter\DepthProductFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\ProductFilter\ProductPriceOrderFilter;
+use Thelia\Api\Bridge\Propel\Filter\CustomFilters\ProductFilter\ProductTitleOrderFilter;
 use Thelia\Api\Bridge\Propel\Filter\CustomFilters\TheliaFilter;
 use Thelia\Api\Bridge\Propel\Filter\DateFilter;
 use Thelia\Api\Bridge\Propel\Filter\NotInFilter;
@@ -133,6 +134,9 @@ use Thelia\Model\Tools\UrlRewritingTrait;
 )]
 #[ApiFilter(
     filterClass: ProductPriceOrderFilter::class,
+)]
+#[ApiFilter(
+    filterClass: ProductTitleOrderFilter::class,
 )]
 #[ApiFilter(
     filterClass: DepthProductFilter::class,

--- a/core/lib/Thelia/Api/Resource/Product.php
+++ b/core/lib/Thelia/Api/Resource/Product.php
@@ -115,6 +115,8 @@ use Thelia\Model\Tools\UrlRewritingTrait;
         'ref',
         'position',
         'productCategories.position',
+        'createdAt',
+        'updatedAt',
     ],
 )]
 #[ApiFilter(

--- a/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/AttributeAccessService.php
@@ -16,10 +16,13 @@ namespace Thelia\Api\Service\DataAccess;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Domain\Promotion\Coupon\Service\CouponManager;
@@ -41,6 +44,13 @@ use Thelia\Tools\DateTimeFormat;
 
 class AttributeAccessService
 {
+    /**
+     * The object each attr() family resolves to, held for the duration of one request: a page
+     * asks for a dozen attributes of the same object and every one of them would replay the
+     * query. Reset on every main request, the way ResourceMemoizer and RewritingUrlMemoizer
+     * are: the store outlives the request under a persistent runtime (FrankenPHP, RoadRunner)
+     * and inside a test process, and would then serve the object of an earlier request.
+     */
     private static array $dataAccessCache = [];
 
     public function __construct(
@@ -484,5 +494,18 @@ class AttributeAccessService
         return $request->attributes->get($key)
             ?? $request->request->get($key)
             ?? $request->query->get($key);
+    }
+
+    public static function clearCache(): void
+    {
+        self::$dataAccessCache = [];
+    }
+
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            self::clearCache();
+        }
     }
 }

--- a/core/lib/Thelia/Config/Resources/services/utilities/url_management.php
+++ b/core/lib/Thelia/Config/Resources/services/utilities/url_management.php
@@ -22,7 +22,7 @@ return static function (ContainerConfigurator $configurator): void {
 
     // URL management
     $services->set(URL::class)
-        ->args([service('router'), service(RewritingUrlMemoizer::class)]);
+        ->args([service('router'), service(RewritingUrlMemoizer::class), service('request_stack')]);
 
     $services->alias('thelia.url.manager', URL::class)
         ->public();

--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -88,7 +88,7 @@ class MailerFactory
         }
 
         if ([] === $to) {
-            Tlog::getInstance()->addWarning(\sprintf('Message %s not sent: no shop notification recipient is configured (store_notification_emails, Configuration > Store information).', $messageCode));
+            Tlog::getInstance()->addError(\sprintf('Message %s not sent: no shop notification recipient is configured (store_notification_emails, Configuration > Store information).', $messageCode));
 
             return;
         }

--- a/core/lib/Thelia/Mailer/MailerFactory.php
+++ b/core/lib/Thelia/Mailer/MailerFactory.php
@@ -87,6 +87,12 @@ class MailerFactory
             $to[$recipient] = $storeName;
         }
 
+        if ([] === $to) {
+            Tlog::getInstance()->addWarning(\sprintf('Message %s not sent: no shop notification recipient is configured (store_notification_emails, Configuration > Store information).', $messageCode));
+
+            return;
+        }
+
         $this->sendEmailMessage(
             $messageCode,
             [ConfigQuery::getStoreEmail() => $storeName],

--- a/core/lib/Thelia/Model/ConfigQuery.php
+++ b/core/lib/Thelia/Model/ConfigQuery.php
@@ -276,13 +276,18 @@ class ConfigQuery extends BaseConfigQuery
 
         $list = preg_split('/[,;]/', (string) self::read('store_notification_emails', $contactEmail));
 
-        $arr = [];
+        $addresses = [];
 
         foreach ($list as $item) {
-            $arr[] = trim($item);
+            // The setting holds an empty row on a fresh install, and a hand written list can
+            // carry a stray separator. An empty recipient is not an address: sent as one it
+            // fails the whole message on "does not comply with addr-spec of RFC 2822".
+            if ('' !== $address = trim((string) $item)) {
+                $addresses[] = $address;
+            }
         }
 
-        return $arr;
+        return $addresses;
     }
 
     /* smtp config */

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -206,6 +206,20 @@ final class FixtureFactory
             ->setVisible($overrides['visible'] ?? 1)
             ->setPosition($overrides['position'] ?? $n);
 
+        // Timestampable only fills created_at when it is untouched, so setting it
+        // here survives the insert.
+        if (isset($overrides['createdAt'])) {
+            $product->setCreatedAt($overrides['createdAt']);
+        }
+
+        // A product has no product_i18n row unless a title is asked for, which is
+        // what makes an untranslated product testable.
+        if (isset($overrides['title'])) {
+            $product
+                ->setLocale($overrides['locale'] ?? 'en_US')
+                ->setTitle($overrides['title']);
+        }
+
         // Product::create() handles the full creation in a transaction:
         // persist the product, assign default category, create default PSE + price.
         $product->create(
@@ -216,6 +230,12 @@ final class FixtureFactory
             $overrides['baseWeight'] ?? 0.0,
             $overrides['baseQuantity'] ?? 0,
         );
+
+        // Product::create() saves the product several times, so updated_at can only
+        // be forced once the creation is over.
+        if (isset($overrides['updatedAt'])) {
+            $product->setUpdatedAt($overrides['updatedAt'])->save($this->connection);
+        }
 
         return $product;
     }

--- a/core/lib/Thelia/Tools/URL.php
+++ b/core/lib/Thelia/Tools/URL.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Thelia\Tools;
 
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
@@ -42,7 +43,7 @@ class URL
     /** @var string a cache for the base URL scheme */
     private ?string $baseUrlScheme = null;
 
-    public function __construct(?RouterInterface $router = null, ?RewritingUrlMemoizer $memoizer = null)
+    public function __construct(?RouterInterface $router = null, ?RewritingUrlMemoizer $memoizer = null, private readonly ?RequestStack $requestStack = null)
     {
         // Allow singleton style calls once instantiated.
         // For this to work, the URL service has to be instantiated very early. This is done manually
@@ -91,6 +92,16 @@ class URL
      */
     public function getBaseUrl(bool $scheme_only = false): string
     {
+        // The request being served is the only source that is right from the first line of the
+        // dispatch: the router context is filled from the request by RouterListener, and the
+        // rewriting runs before that, so a url built during routing (the language switch
+        // redirect) would carry the configured default uri instead of the host being browsed.
+        if (null !== $request = $this->requestStack?->getMainRequest()) {
+            $schemeAndHost = $request->getSchemeAndHttpHost();
+
+            return $scheme_only ? $schemeAndHost : $schemeAndHost.$request->getBaseUrl();
+        }
+
         if (null === $this->baseUrlScheme) {
             $scheme = 'http';
             $port = 80;

--- a/tests/Api/Front/ProductSortApiTest.php
+++ b/tests/Api/Front/ProductSortApiTest.php
@@ -15,7 +15,9 @@ declare(strict_types=1);
 namespace Thelia\Tests\Api\Front;
 
 use Symfony\Component\HttpFoundation\Response;
+use Thelia\Model\Category;
 use Thelia\Model\Product;
+use Thelia\Model\TaxRule;
 use Thelia\Test\ApiTestCase;
 
 /**
@@ -87,6 +89,51 @@ final class ProductSortApiTest extends ApiTestCase
         self::assertSame($default, $this->refsOf('order[bogus]=asc'));
         self::assertSame($default, $this->refsOf('order[title]=sideways&locale=en_US'));
         self::assertSame($default, $this->refsOf('order[createdAt]=sideways'));
+    }
+
+    /**
+     * Sorting is not filtering: a product the merchant never priced must not vanish from the
+     * listing the moment a visitor asks for a price order.
+     */
+    public function testOrderByPriceKeepsAProductWithoutASaleElement(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $factory->product($category, $taxRule, $currency, ['ref' => 'PRICE-LOW', 'basePrice' => 5.0]);
+        $factory->product($category, $taxRule, $currency, ['ref' => 'PRICE-HIGH', 'basePrice' => 50.0]);
+        $this->productWithoutASaleElement($category, $taxRule, 'PRICE-NONE');
+
+        $total = $this->totalOf('');
+
+        self::assertSame(3, $total);
+        self::assertSame($total, $this->totalOf('untaxed_price_order=asc'));
+        self::assertSame($total, $this->totalOf('untaxed_price_order=desc'));
+
+        // The priceless product is kept, and ranged last whichever way the prices are read.
+        self::assertSame(['PRICE-LOW', 'PRICE-HIGH', 'PRICE-NONE'], $this->refsOf('untaxed_price_order=asc'));
+        self::assertSame(['PRICE-HIGH', 'PRICE-LOW', 'PRICE-NONE'], $this->refsOf('untaxed_price_order=desc'));
+    }
+
+    /**
+     * Built without the fixture factory: Product::create() always makes a default sale element
+     * and its price, and this test is about a product that has neither.
+     */
+    private function productWithoutASaleElement(Category $category, TaxRule $taxRule, string $ref): Product
+    {
+        $product = new Product();
+        $product
+            ->setRef($ref)
+            ->setVisible(1)
+            ->setPosition(99)
+            ->setTaxRuleId($taxRule->getId())
+            ->save($this->getPropelConnection());
+
+        $product->setDefaultCategory($category->getId())->save($this->getPropelConnection());
+
+        return $product;
     }
 
     private function seedDatedProducts(): void

--- a/tests/Api/Front/ProductSortApiTest.php
+++ b/tests/Api/Front/ProductSortApiTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Symfony\Component\HttpFoundation\Response;
+use Thelia\Model\Product;
+use Thelia\Test\ApiTestCase;
+
+/**
+ * Sorting of the public product collection: creation date and translated title.
+ */
+final class ProductSortApiTest extends ApiTestCase
+{
+    public function testOrderByCreatedAtPutsTheNewestProductFirst(): void
+    {
+        $this->seedDatedProducts();
+
+        self::assertSame(['DATE-OLD', 'DATE-MID', 'DATE-NEW'], $this->refsOf('order[createdAt]=asc'));
+        self::assertSame(['DATE-NEW', 'DATE-MID', 'DATE-OLD'], $this->refsOf('order[createdAt]=desc'));
+    }
+
+    public function testOrderByUpdatedAt(): void
+    {
+        $this->seedDatedProducts();
+
+        self::assertSame(['DATE-NEW', 'DATE-MID', 'DATE-OLD'], $this->refsOf('order[updatedAt]=asc'));
+        self::assertSame(['DATE-OLD', 'DATE-MID', 'DATE-NEW'], $this->refsOf('order[updatedAt]=desc'));
+    }
+
+    public function testOrderByTitleFollowsTheRequestedLocale(): void
+    {
+        $this->seedTranslatedProducts();
+
+        // en_US: Alpha < Beta < Zulu, the untranslated product last.
+        self::assertSame(
+            ['T-ALPHA', 'T-BETA', 'T-ZULU', 'T-NONE'],
+            $this->refsOf('order[title]=asc&locale=en_US'),
+        );
+
+        // fr_FR: Ananas < Beta (no fr title, falls back to en) < Zebre.
+        self::assertSame(
+            ['T-ZULU', 'T-BETA', 'T-ALPHA', 'T-NONE'],
+            $this->refsOf('order[title]=asc&locale=fr_FR'),
+        );
+    }
+
+    public function testOrderByTitleDescendingKeepsTheUntranslatedProductLast(): void
+    {
+        $this->seedTranslatedProducts();
+
+        self::assertSame(
+            ['T-ZULU', 'T-BETA', 'T-ALPHA', 'T-NONE'],
+            $this->refsOf('order[title]=desc&locale=en_US'),
+        );
+    }
+
+    public function testSortingDoesNotChangeTheAnnouncedTotal(): void
+    {
+        $this->seedTranslatedProducts();
+
+        $total = $this->totalOf('');
+
+        self::assertSame(4, $total);
+        self::assertSame($total, $this->totalOf('order[title]=asc&locale=en_US'));
+        self::assertSame($total, $this->totalOf('order[title]=desc&locale=fr_FR'));
+        self::assertSame($total, $this->totalOf('order[createdAt]=desc'));
+    }
+
+    public function testUnknownSortIsIgnored(): void
+    {
+        $this->seedTranslatedProducts();
+
+        $default = $this->refsOf('');
+
+        self::assertSame($default, $this->refsOf('order[bogus]=asc'));
+        self::assertSame($default, $this->refsOf('order[title]=sideways&locale=en_US'));
+        self::assertSame($default, $this->refsOf('order[createdAt]=sideways'));
+    }
+
+    private function seedDatedProducts(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'DATE-MID',
+            'createdAt' => new \DateTime('2022-06-15 12:00:00'),
+            'updatedAt' => new \DateTime('2022-06-15 12:00:00'),
+        ]);
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'DATE-NEW',
+            'createdAt' => new \DateTime('2024-01-01 08:00:00'),
+            'updatedAt' => new \DateTime('2020-01-01 08:00:00'),
+        ]);
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'DATE-OLD',
+            'createdAt' => new \DateTime('2020-03-04 09:30:00'),
+            'updatedAt' => new \DateTime('2024-03-04 09:30:00'),
+        ]);
+    }
+
+    /**
+     * Four products whose alphabetical order differs between en_US and fr_FR:
+     * one is translated in en_US only, one has no translation at all.
+     */
+    private function seedTranslatedProducts(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $alpha = $factory->product($category, $taxRule, $currency, ['ref' => 'T-ALPHA', 'title' => 'Alpha']);
+        $this->translate($alpha, 'fr_FR', 'Zebre');
+
+        $zulu = $factory->product($category, $taxRule, $currency, ['ref' => 'T-ZULU', 'title' => 'Zulu']);
+        $this->translate($zulu, 'fr_FR', 'Ananas');
+
+        $factory->product($category, $taxRule, $currency, ['ref' => 'T-BETA', 'title' => 'Beta']);
+        $factory->product($category, $taxRule, $currency, ['ref' => 'T-NONE']);
+    }
+
+    private function translate(Product $product, string $locale, string $title): void
+    {
+        $product->setLocale($locale)->setTitle($title);
+        $product->save();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function refsOf(string $query): array
+    {
+        $data = $this->decode($this->request($query));
+
+        return array_column($data['hydra:member'], 'ref');
+    }
+
+    private function totalOf(string $query): int
+    {
+        return (int) $this->decode($this->request($query))['hydra:totalItems'];
+    }
+
+    private function request(string $query): Response
+    {
+        $response = $this->jsonRequest('GET', '/api/front/products'.('' === $query ? '' : '?'.$query));
+        self::assertJsonResponseSuccessful($response);
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Http/Flexy/ProductAccessoriesTest.php
+++ b/tests/Http/Flexy/ProductAccessoriesTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Http\Flexy;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Thelia\Core\Template\TemplateHelperInterface;
 use Thelia\Model\Category;
 use Thelia\Model\Product;
@@ -34,12 +33,6 @@ use Thelia\Test\WebIntegrationTestCase;
  * release cycle: a theme older than the accessories strip is reported as skipped rather than
  * failed.
  */
-/*
- * Each test runs in its own process: the front product resource is answered on the first
- * booted kernel of a process only, and a second one reads it back as null — which is a
- * limitation of the test harness, not of the page.
- */
-#[RunTestsInSeparateProcesses]
 final class ProductAccessoriesTest extends WebIntegrationTestCase
 {
     private const PRODUCT_TEMPLATE = 'product.html.twig';

--- a/tests/Http/Flexy/ProductListingSortTest.php
+++ b/tests/Http/Flexy/ProductListingSortTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Http\Flexy;
 
-use Thelia\Api\Service\DataAccess\AttributeAccessService;
 use Thelia\Model\Category;
 use Thelia\Test\FixtureFactory;
 use Thelia\Test\WebIntegrationTestCase;
@@ -30,17 +29,6 @@ use Thelia\Test\WebIntegrationTestCase;
 final class ProductListingSortTest extends WebIntegrationTestCase
 {
     private const CATEGORY_URL = 'flexy-sort-test-category.html';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // AttributeAccessService memoizes the object a rewritten url resolves to in a static
-        // property that nothing ever clears, so every page rendered after the first one in this
-        // process would be served the category of the first test. Reset it between tests.
-        $cache = new \ReflectionProperty(AttributeAccessService::class, 'dataAccessCache');
-        $cache->setValue(null, []);
-    }
 
     public function testTheNewestSortListsTheMostRecentProductFirst(): void
     {

--- a/tests/Http/Flexy/ProductListingSortTest.php
+++ b/tests/Http/Flexy/ProductListingSortTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Thelia\Api\Service\DataAccess\AttributeAccessService;
+use Thelia\Model\Category;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * The sort of a product listing travels in the query string, so it survives a shared url and
+ * the pagination links. What the shop gets out of it is pinned here: the ordering of a
+ * category page, and the fact that a forged value is not an error page.
+ *
+ * The listing belongs to the front-office theme, which ships as its own package on its own
+ * release cycle: a theme that only knows the two price sorts is reported as skipped.
+ */
+final class ProductListingSortTest extends WebIntegrationTestCase
+{
+    private const CATEGORY_URL = 'flexy-sort-test-category.html';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // AttributeAccessService memoizes the object a rewritten url resolves to in a static
+        // property that nothing ever clears, so every page rendered after the first one in this
+        // process would be served the category of the first test. Reset it between tests.
+        $cache = new \ReflectionProperty(AttributeAccessService::class, 'dataAccessCache');
+        $cache->setValue(null, []);
+    }
+
+    public function testTheNewestSortListsTheMostRecentProductFirst(): void
+    {
+        $this->categoryWithDatedProducts();
+
+        $content = $this->render('?sort=newest');
+
+        self::assertSame(
+            ['Alpha newest', 'Zulu middle', 'Mike oldest'],
+            $this->orderOfTitles($content),
+        );
+    }
+
+    public function testTheOldestSortListsTheOldestProductFirst(): void
+    {
+        $this->categoryWithDatedProducts();
+
+        $content = $this->render('?sort=oldest');
+
+        self::assertSame(
+            ['Mike oldest', 'Zulu middle', 'Alpha newest'],
+            $this->orderOfTitles($content),
+        );
+    }
+
+    public function testTheAlphabeticalSortsFollowTheProductTitles(): void
+    {
+        $this->categoryWithDatedProducts();
+
+        self::assertSame(
+            ['Alpha newest', 'Mike oldest', 'Zulu middle'],
+            $this->orderOfTitles($this->render('?sort=alpha')),
+        );
+
+        self::assertSame(
+            ['Zulu middle', 'Mike oldest', 'Alpha newest'],
+            $this->orderOfTitles($this->render('?sort=alpha_reverse')),
+        );
+    }
+
+    /**
+     * A url can be forged, and a stale link can name a sort the shop no longer offers: the
+     * listing answers with its default order rather than an error.
+     */
+    public function testAnUnknownSortFallsBackOnTheDefaultOrder(): void
+    {
+        $this->categoryWithDatedProducts();
+
+        // The merchant's own order: the position of each product in its category.
+        $positionOrder = ['Zulu middle', 'Alpha newest', 'Mike oldest'];
+
+        self::assertSame($positionOrder, $this->orderOfTitles($this->render('')));
+        self::assertSame($positionOrder, $this->orderOfTitles($this->render('?sort=foo')));
+    }
+
+    /**
+     * The next page is a plain link, so the sort has to be written into it: without that, page
+     * two would silently reorder the listing.
+     */
+    public function testThePaginationLinksCarryTheSort(): void
+    {
+        $this->categoryWithManyProducts();
+
+        $content = $this->render('?sort=alpha');
+
+        self::assertSame(
+            1,
+            preg_match('#href="(\?[^"]*page=2)"#', $content, $link),
+            'The listing must link to its second page.',
+        );
+
+        $secondPageQuery = html_entity_decode($link[1]);
+
+        self::assertStringContainsString('sort=alpha', $secondPageQuery);
+
+        // The link is followed as a visitor would: page two must keep the alphabetical order.
+        $secondPage = $this->render($secondPageQuery);
+
+        self::assertStringContainsString('Sort product 31', $secondPage);
+    }
+
+    private function render(string $query): string
+    {
+        $this->assertPageRenders('/'.self::CATEGORY_URL.$query);
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        if (!str_contains($content, 'value="newest"')) {
+            self::markTestSkipped('The installed front-office theme only offers the price sorts.');
+        }
+
+        return $content;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function orderOfTitles(string $content): array
+    {
+        $titles = ['Alpha newest', 'Zulu middle', 'Mike oldest'];
+
+        foreach ($titles as $title) {
+            self::assertStringContainsString($title, $content);
+        }
+
+        usort($titles, static fn (string $a, string $b): int => strpos($content, $a) <=> strpos($content, $b));
+
+        return $titles;
+    }
+
+    private function categoryWithDatedProducts(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        // Titles deliberately break the creation order, so no sort can pass for another.
+        // Position, reference, title and creation date deliberately disagree: each of the six
+        // sorts then yields an order no other one produces, so none can pass for another.
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'SORT-C',
+            'title' => 'Zulu middle',
+            'createdAt' => new \DateTime('2022-06-15 12:00:00'),
+        ]);
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'SORT-B',
+            'title' => 'Alpha newest',
+            'createdAt' => new \DateTime('2024-01-01 08:00:00'),
+        ]);
+        $factory->product($category, $taxRule, $currency, [
+            'ref' => 'SORT-A',
+            'title' => 'Mike oldest',
+            'createdAt' => new \DateTime('2020-03-04 09:30:00'),
+        ]);
+    }
+
+    /**
+     * More products than the listing shows on one page, so the pagination is rendered.
+     */
+    private function categoryWithManyProducts(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        for ($i = 1; $i <= 31; ++$i) {
+            $factory->product($category, $taxRule, $currency, [
+                // References run backwards, so the tiebreaker alone cannot produce the
+                // alphabetical order the test asks for.
+                'ref' => \sprintf('SORT-%03d', 32 - $i),
+                'title' => \sprintf('Sort product %02d', $i),
+            ]);
+        }
+    }
+
+    private function category(FixtureFactory $factory): Category
+    {
+        $category = $factory->category();
+        $category->setLocale('en_US')->setTitle('Sort test category');
+        $category->save($this->getPropelConnection());
+        $category->setRewrittenUrl('en_US', self::CATEGORY_URL);
+
+        return $category;
+    }
+
+    /**
+     * Built without createFixtureFactory(): that helper pushes a synthetic request when the
+     * stack is empty, and it would then be the "main" request of the page render below.
+     */
+    private function factory(): FixtureFactory
+    {
+        return new FixtureFactory($this->getPropelConnection());
+    }
+}

--- a/tests/Integration/Model/ConfigQueryTest.php
+++ b/tests/Integration/Model/ConfigQueryTest.php
@@ -106,4 +106,25 @@ final class ConfigQueryTest extends IntegrationTestCase
     {
         self::assertTrue(ConfigQuery::checkAvailableStock());
     }
+
+    /**
+     * The setting exists with an empty value on a fresh install, and the shop notifications
+     * were then attempted with one blank recipient, which fails the whole message on the
+     * addr-spec of RFC 2822. An empty entry is not an address.
+     */
+    public function testTheNotificationRecipientsDropEmptyEntries(): void
+    {
+        ConfigQuery::write('store_notification_emails', '');
+        ConfigQuery::resetCache();
+
+        self::assertSame([], ConfigQuery::getNotificationEmailsList());
+
+        ConfigQuery::write('store_notification_emails', ' shop@example.com , ;other@example.com;');
+        ConfigQuery::resetCache();
+
+        self::assertSame(
+            ['shop@example.com', 'other@example.com'],
+            ConfigQuery::getNotificationEmailsList(),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`GET /api/front/products` could only be ordered by reference, by position and by untaxed price. A front asking for the newest products, or for an alphabetical listing, had nothing to send. This adds three orderings on the public product collection, with the syntax the existing ones already use, and fixes four defects the review of that work turned up.

**Sorting**

- **`order[createdAt]` and `order[updatedAt]`.** Both columns live on the product table, so they are two more entries in the resource's `OrderFilter`. Creation date is what "newest" means for a product; the `newness` flag on a sale element is a commercial badge the merchant sets by hand and is left alone.
- **`order[title]`.** The i18n rows are a collection, so a property path such as `i18ns.title` would order on an unconstrained join, multiply the rows and make the announced total meaningless. `ProductTitleOrderFilter` lays its own joins instead, one per locale it reads, each restricted to a single locale so a product still yields exactly one row: the locale asked for (`locale=`, the session one otherwise) and the shop default language. The sort key is `COALESCE` of the two, which mirrors what the front already shows when a translation is missing, and a product with no title at all stays in the collection and goes last in both directions.
- **An unknown property or an unknown direction stays ignored.** `order[bogus]=asc` and `order[title]=sideways` answer 200 with the default order, which is what `OrderFilter` already did.
- **Stability across pages is the caller's contract.** Products routinely share a title, a position or a price; the core adds no implicit secondary ordering, and the filter description says to add `order[ref]` for a total order.
- **Fixtures.** `FixtureFactory::product()` now accepts `title`, `locale`, `createdAt` and `updatedAt` in its overrides, the way `brand()` already accepted a title. Without a title a fixture product has no `product_i18n` row at all, which is what makes an untranslated product testable.

No schema change and no index: the demo catalogue is 30 products and nothing measured asks for one. A category page issues the same number of queries with a sort as without, since the new orderings add joins to the collection query rather than queries.

**Fixes carried in the same branch**

- **The attribute access cache lived for the life of the process** (#3886). `AttributeAccessService` memoized the object every `attr()` family resolves to in a static property nothing ever cleared. Under a persistent runtime it hands one visitor the object of another request; inside a test process it hands the second page render the object of the first, which is why `ProductAccessoriesTest` had to run each test in its own process. It is now reset on every main request, the way `ResourceMemoizer` and `RewritingUrlMemoizer` already are, and that attribute is gone.
- **Sorting by price dropped products** (#3887). `ProductPriceOrderFilter` joined the sale elements and their prices with inner joins, so a product with no sale element, or no price in the asked currency, left the collection the moment a visitor picked a price order. Both joins are outer now and priceless products go last, like untranslated ones under `order[title]`. The direction is validated as everywhere else instead of being read raw.
- **Every order wrote an error in the log** (#3889). `store_notification_emails` holds an empty row after `bin/install`, and the shop notification was attempted with one blank recipient, failing the whole message on the addr-spec of RFC 2822. An empty entry is no longer read as an address, and a shop with no recipient configured gets one warning naming the setting instead of an error per order.
- **Absolute urls were built from the configured default uri** (#3891). The rewriting runs before the router context is filled from the request, so the language switch redirect carried `http://localhost` out of the box: from `/chaises.html` the English link landed on `http://localhost/chairs.html`. `URL::getBaseUrl()` now reads the request being served whenever there is one, and falls back to the context for the command line.

The theme side is thelia-templates/flexy#183.

Fixes https://github.com/thelia/thelia/issues/3886
Fixes https://github.com/thelia/thelia/issues/3887
Fixes https://github.com/thelia/thelia/issues/3889
Fixes https://github.com/thelia/thelia/issues/3891

## Test plan

- [x] `composer test:api -- --filter ProductSortApiTest` 7 green. 4 were red before the sort filters (creation date, update date, both locales of the title order) and 1 before the outer joins on the price sort (a 3-product collection answered 2). The other two pin behaviour that must not change: the announced total is the same with and without a sort, and an unknown sort is ignored.
- [x] Same file with the locale condition removed from the title joins: the ordering cases turn red while the total stays right, which is the failure mode `groupById()` hides.
- [x] `composer test:http-flexy` 44 green with a theme that carries the sorts, 5 of them red when the theme's value to parameter mapping is neutralised, and 7 red without the per-request cache reset. Reported as skipped on a theme that only offers the price sorts.
- [x] `ProductAccessoriesTest` green with no `RunTestsInSeparateProcesses`, red without the cache reset.
- [x] `composer test:integration -- --filter testTheNotificationRecipientsDropEmptyEntries` red before the empty-entry filter, green after.
- [x] `composer test` 5 suites green: unit 424, integration 789 (4 skipped), api 288 (1 skipped), http-flexy 44, http-backoffice 12. Before: 424 / 788 (4) / 281 (1) / 35 / 12.
- [x] `composer cs-diff` and `composer phpstan` 0 and 0, and `phpstan-botwig.neon` 0.
- [x] `/api/docs` lists `order[createdAt]`, `order[updatedAt]` and `order[title]` on the front product collection, each with the `asc|desc` enum.
- [x] Command line on a fresh install with demo data, five products given distinct creation dates and one renamed in French only: `order[createdAt]=desc` and `=asc` reverse each other, `order[title]=asc` with `locale=fr_FR` and with `locale=en_US` give two different orders, and `hydra:totalItems` stays at 30 through all of them.
- [x] Browser on the same install: the English link of `/chaises.html` now lands on the host being browsed rather than on `http://localhost`.