### PR TITLE
feat(cache): choose the application cache backend with an environment variable

### DIFF
--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -20,6 +20,17 @@ return static function (ContainerConfigurator $container): void {
             'save_path' => '%kernel.project_dir%/var/sessions/%kernel.environment%',
         ],
         'cache' => [
+            // The hosting decides where the application cache is stored, with
+            // THELIA_CACHE_DSN. Empty, it stays on the local file system.
+            'app' => 'thelia.cache.adapter',
+            // Namespace every pool key with the install path and the
+            // environment, so a shared cache server can serve several shops,
+            // and dev and prod of one shop, without any of them reading the
+            // keys of another. THELIA_CACHE_PREFIX_SEED overrides it when the
+            // same shop is deployed under different paths. Symfony inlines the
+            // seed when the container is compiled, so a change takes effect on
+            // the next cache clear, and no cast may be applied here.
+            'prefix_seed' => '%env(THELIA_CACHE_PREFIX_SEED)%',
             'pools' => [
                 // Dedicated pool for the in-process data access layer
                 // (DataAccessService::resources). Disabled by default; enable

--- a/core/lib/Thelia/Config/Resources/packages/framework.php
+++ b/core/lib/Thelia/Config/Resources/packages/framework.php
@@ -39,6 +39,13 @@ return static function (ContainerConfigurator $container): void {
                 'thelia.cache.data_access' => [
                     'adapter' => 'cache.app',
                 ],
+                // API refresh tokens. Kept apart because it is the only pool
+                // whose eviction is visible to a user: losing an item here
+                // signs an API client out. Nothing empties it on a deployment
+                // or on a cache clear; each item carries its own lifetime.
+                'thelia.cache.security' => [
+                    'adapter' => 'cache.app',
+                ],
             ],
         ],
         'rate_limiter' => [

--- a/core/lib/Thelia/Config/Resources/parameters/application_cache.php
+++ b/core/lib/Thelia/Config/Resources/parameters/application_cache.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
+    // Symfony inlines the cache key seed when the container is compiled and
+    // escapes what it inlines, so a default written as "%kernel.project_dir%"
+    // would reach every installation as that literal text and put them all in
+    // the same keyspace. The default is therefore built here, from values the
+    // kernel has already resolved.
+    $installation = $container->getParameter('kernel.project_dir').'/'.$container->getParameter('kernel.environment');
+
+    $configurator->parameters()
+        // Where the application cache pools are stored. Empty keeps them on the
+        // local file system; a data source name moves them to a shared server:
+        //   THELIA_CACHE_DSN=redis://localhost:6379
+        ->set('env(THELIA_CACHE_DSN)', '')
+        // Two installations sharing one cache server must not share a key, and
+        // neither must the development and the production of one shop. The seed
+        // defaults to the install path plus the environment; set the variable to
+        // something the shop owns when several machines serve the same shop from
+        // different paths, so that they do share their cache. It is read when the
+        // container is compiled, so a change takes a cache clear.
+        ->set('env(THELIA_CACHE_PREFIX_SEED)', $installation)
+        // Outside var/cache/<env> on purpose: emptying the shop cache, from the
+        // back office or with cache:clear, must not take the API refresh tokens
+        // with it. Pools are emptied one by one with cache:pool:clear.
+        ->set('thelia.cache.directory', '%kernel.project_dir%/var/pools/%kernel.environment%');
+};

--- a/core/lib/Thelia/Config/Resources/services/core/cache.php
+++ b/core/lib/Thelia/Config/Resources/services/core/cache.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Thelia\Core\Cache\ApplicationCacheAdapter;
 use Thelia\Core\Cache\CacheAdapterFactory;
 
 return static function (ContainerConfigurator $container): void {
@@ -24,8 +25,10 @@ return static function (ContainerConfigurator $container): void {
     // Backend of every application cache pool, cache.app included. Which one it
     // is depends on THELIA_CACHE_DSN and on nothing else, so a shop moves from
     // the local disk to a shared cache server without a line of code changing.
-    // The first two arguments belong to Symfony: it replaces them per pool.
-    $services->set('thelia.cache.adapter', AdapterInterface::class)
+    // The first two arguments belong to Symfony: it replaces them per pool, and
+    // it reads the class below to decide whether a pool can be pruned, so every
+    // backend answers under the same one.
+    $services->set('thelia.cache.adapter', ApplicationCacheAdapter::class)
         ->abstract()
         ->factory([CacheAdapterFactory::class, 'create'])
         ->args([

--- a/core/lib/Thelia/Config/Resources/services/core/cache.php
+++ b/core/lib/Thelia/Config/Resources/services/core/cache.php
@@ -16,10 +16,31 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Thelia\Core\Cache\CacheAdapterFactory;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
+    // Backend of every application cache pool, cache.app included. Which one it
+    // is depends on THELIA_CACHE_DSN and on nothing else, so a shop moves from
+    // the local disk to a shared cache server without a line of code changing.
+    // The first two arguments belong to Symfony: it replaces them per pool.
+    $services->set('thelia.cache.adapter', AdapterInterface::class)
+        ->abstract()
+        ->factory([CacheAdapterFactory::class, 'create'])
+        ->args([
+            '', // namespace
+            0, // default lifetime
+            '%env(THELIA_CACHE_DSN)%',
+            '%thelia.cache.directory%',
+            service('cache.default_marshaller')->ignoreOnInvalid(),
+        ])
+        ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+        ->tag('cache.pool', ['clearer' => 'cache.default_clearer', 'reset' => 'reset'])
+        ->tag('monolog.logger', ['channel' => 'cache']);
+
+    // Configuration and feed cache, deliberately tied to the container cache
+    // directory: it is meant to go away with cache:clear.
     $services->set(AdapterInterface::class, FilesystemAdapter::class)
         ->public()
         ->args([

--- a/core/lib/Thelia/Config/Resources/services/core/security.php
+++ b/core/lib/Thelia/Config/Resources/services/core/security.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Thelia\Controller\Api\RefreshTokenController;
 use Thelia\Core\Security\RefreshToken\AuthenticationSuccessSubscriber;
 use Thelia\Core\Security\RefreshToken\RefreshTokenService;
@@ -30,12 +29,6 @@ return static function (ContainerConfigurator $container): void {
 
     $container->parameters()
         ->set('thelia.security.jwt_refresh_token_ttl', (int) ($_ENV['JWT_REFRESH_TOKEN_TTL'] ?? 2_592_000));
-
-    $services->set(RefreshTokenService::class)
-        ->args([
-            service(AdapterInterface::class),
-            param('thelia.security.jwt_refresh_token_ttl'),
-        ]);
 
     $services->set(AuthenticationSuccessSubscriber::class)
         ->args([service(RefreshTokenService::class)])

--- a/core/lib/Thelia/Config/Resources/services/core/security.php
+++ b/core/lib/Thelia/Config/Resources/services/core/security.php
@@ -28,7 +28,11 @@ return static function (ContainerConfigurator $container): void {
         ->public();
 
     $container->parameters()
-        ->set('thelia.security.jwt_refresh_token_ttl', (int) ($_ENV['JWT_REFRESH_TOKEN_TTL'] ?? 2_592_000));
+        // How long a refresh token stays valid, in seconds. Read when the token
+        // is issued, not when the container is compiled, so a hosting that
+        // lowers it in .env.local does not have to clear the cache for it.
+        ->set('env(JWT_REFRESH_TOKEN_TTL)', '2592000')
+        ->set('thelia.security.jwt_refresh_token_ttl', '%env(int:JWT_REFRESH_TOKEN_TTL)%');
 
     $services->set(AuthenticationSuccessSubscriber::class)
         ->args([service(RefreshTokenService::class)])

--- a/core/lib/Thelia/Config/Resources/services/providers/logger.php
+++ b/core/lib/Thelia/Config/Resources/services/providers/logger.php
@@ -14,15 +14,11 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Thelia\Log\Tlog;
-
 return static function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
-    $parameters = $configurator->parameters();
 
-    // Logger
+    // Logger. The class is a parameter so a project can substitute its own;
+    // it is declared once, in parameters/thelia_core.php.
     $services->set('thelia.logger', '%thelia.logger.class%')
         ->factory([param('thelia.logger.class'), 'getInstance']);
-
-    $parameters->set('thelia.logger.class', Tlog::class);
 };

--- a/core/lib/Thelia/Config/Resources/services/providers/logger.php
+++ b/core/lib/Thelia/Config/Resources/services/providers/logger.php
@@ -25,5 +25,4 @@ return static function (ContainerConfigurator $configurator): void {
         ->factory([param('thelia.logger.class'), 'getInstance']);
 
     $parameters->set('thelia.logger.class', Tlog::class);
-    $parameters->set('thelia.cache.namespace', 'thelia_cache');
 };

--- a/core/lib/Thelia/Core/Cache/ApplicationCacheAdapter.php
+++ b/core/lib/Thelia/Core/Cache/ApplicationCacheAdapter.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\ResettableInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\NamespacedPoolInterface;
+
+/**
+ * The application cache pools, whatever backend they turned out to use.
+ *
+ * Which backend that is depends on THELIA_CACHE_DSN and is only known once the
+ * pool is built, while Symfony decides at compile time, from the class of the
+ * adapter, whether a pool can be pruned. A single class answering for every
+ * backend is what keeps `cache:pool:prune` reaching the pools: without it the
+ * command silently prunes nothing and expired entries no one reads again stay
+ * on the disk until the pool is emptied whole.
+ *
+ * Pruning is the only capability that actually varies, and a cache server
+ * expires its own keys: there is nothing left to prune and nothing failed, so
+ * `prune()` reports success. Reporting failure would make `cache:pool:prune`
+ * answer "could not be pruned" on every pool of a shop running on Redis, and
+ * exit non zero in the middle of a deployment script.
+ */
+final class ApplicationCacheAdapter implements AdapterInterface, CacheInterface, LoggerAwareInterface, NamespacedPoolInterface, PruneableInterface, ResettableInterface
+{
+    public function __construct(
+        private AdapterInterface&CacheInterface $inner,
+    ) {
+    }
+
+    /**
+     * The backend in use, for the tests and for diagnostics.
+     */
+    public function inner(): AdapterInterface&CacheInterface
+    {
+        return $this->inner;
+    }
+
+    public function getItem(mixed $key): CacheItem
+    {
+        return $this->inner->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->inner->getItems($keys);
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return $this->inner->hasItem($key);
+    }
+
+    public function clear(string $prefix = ''): bool
+    {
+        return $this->inner->clear($prefix);
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return $this->inner->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->inner->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->inner->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->inner->saveDeferred($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->inner->commit();
+    }
+
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+    {
+        return $this->inner->get($key, $callback, $beta, $metadata);
+    }
+
+    public function delete(string $key): bool
+    {
+        return $this->inner->delete($key);
+    }
+
+    public function prune(): bool
+    {
+        return !$this->inner instanceof PruneableInterface || $this->inner->prune();
+    }
+
+    public function reset(): void
+    {
+        if ($this->inner instanceof ResettableInterface) {
+            $this->inner->reset();
+        }
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        if ($this->inner instanceof LoggerAwareInterface) {
+            $this->inner->setLogger($logger);
+        }
+    }
+
+    public function withSubNamespace(string $namespace): static
+    {
+        if (!$this->inner instanceof NamespacedPoolInterface) {
+            throw new \BadMethodCallException(\sprintf('Cannot call "%s::withSubNamespace()": the backend "%s" does not implement "%s".', self::class, get_debug_type($this->inner), NamespacedPoolInterface::class));
+        }
+
+        $clone = clone $this;
+        $clone->inner = $this->inner->withSubNamespace($namespace);
+
+        return $clone;
+    }
+}

--- a/core/lib/Thelia/Core/Cache/CacheAdapterFactory.php
+++ b/core/lib/Thelia/Core/Cache/CacheAdapterFactory.php
@@ -20,6 +20,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * Builds the backend every application cache pool is stored in.
@@ -33,6 +34,10 @@ use Symfony\Component\Cache\Marshaller\MarshallerInterface;
  * falling back to the disk: a shop that believes its cache is shared while each
  * front end keeps its own would serve inconsistent pages and sign API clients
  * out at random.
+ *
+ * Every backend is returned wrapped in {@see ApplicationCacheAdapter}, so the
+ * pools have one class whatever the data source name says. Symfony reads that
+ * class when it compiles the container, well before the variable is looked at.
  */
 final class CacheAdapterFactory
 {
@@ -53,15 +58,15 @@ final class CacheAdapterFactory
         #[\SensitiveParameter] string $dsn,
         string $directory,
         ?MarshallerInterface $marshaller = null,
-    ): AdapterInterface {
+    ): ApplicationCacheAdapter {
         $dsn = trim($dsn);
 
         if ('' === $dsn) {
-            return new FilesystemAdapter($namespace, $defaultLifetime, $directory, $marshaller);
+            return new ApplicationCacheAdapter(new FilesystemAdapter($namespace, $defaultLifetime, $directory, $marshaller));
         }
 
         try {
-            return self::remote($dsn, $namespace, $defaultLifetime, $marshaller);
+            return new ApplicationCacheAdapter(self::remote($dsn, $namespace, $defaultLifetime, $marshaller));
         } catch (\Throwable $failure) {
             throw new \InvalidArgumentException(\sprintf('%s is set to "%s", which cannot be used as a cache backend: %s', self::DSN_VARIABLE, self::withoutPassword($dsn), $failure->getMessage()), 0, $failure);
         }
@@ -72,7 +77,7 @@ final class CacheAdapterFactory
         string $namespace,
         int $defaultLifetime,
         ?MarshallerInterface $marshaller,
-    ): AdapterInterface {
+    ): AdapterInterface&CacheInterface {
         $scheme = strstr($dsn, ':', true);
 
         if (!\in_array($scheme, self::REMOTE_SCHEMES, true)) {

--- a/core/lib/Thelia/Core/Cache/CacheAdapterFactory.php
+++ b/core/lib/Thelia/Core/Cache/CacheAdapterFactory.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\Cache;
+
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * Builds the backend every application cache pool is stored in.
+ *
+ * The choice belongs to the hosting, not to the shop: THELIA_CACHE_DSN empty
+ * keeps the cache on the local file system, so an installation that configures
+ * nothing depends on nothing. Filled, every pool moves to that server, which is
+ * what a shop spread over several front ends needs.
+ *
+ * A data source name that cannot be honoured stops the request instead of
+ * falling back to the disk: a shop that believes its cache is shared while each
+ * front end keeps its own would serve inconsistent pages and sign API clients
+ * out at random.
+ */
+final class CacheAdapterFactory
+{
+    /**
+     * Named in the error messages so an operator knows what to fix.
+     */
+    public const DSN_VARIABLE = 'THELIA_CACHE_DSN';
+
+    private const REMOTE_SCHEMES = ['redis', 'rediss', 'valkey', 'valkeys', 'memcached'];
+
+    /**
+     * The first two arguments are replaced by Symfony for each pool built on
+     * this adapter, so their order is part of the contract with CachePoolPass.
+     */
+    public static function create(
+        string $namespace,
+        int $defaultLifetime,
+        #[\SensitiveParameter] string $dsn,
+        string $directory,
+        ?MarshallerInterface $marshaller = null,
+    ): AdapterInterface {
+        $dsn = trim($dsn);
+
+        if ('' === $dsn) {
+            return new FilesystemAdapter($namespace, $defaultLifetime, $directory, $marshaller);
+        }
+
+        try {
+            return self::remote($dsn, $namespace, $defaultLifetime, $marshaller);
+        } catch (\Throwable $failure) {
+            throw new \InvalidArgumentException(\sprintf('%s is set to "%s", which cannot be used as a cache backend: %s', self::DSN_VARIABLE, self::withoutPassword($dsn), $failure->getMessage()), 0, $failure);
+        }
+    }
+
+    private static function remote(
+        #[\SensitiveParameter] string $dsn,
+        string $namespace,
+        int $defaultLifetime,
+        ?MarshallerInterface $marshaller,
+    ): AdapterInterface {
+        $scheme = strstr($dsn, ':', true);
+
+        if (!\in_array($scheme, self::REMOTE_SCHEMES, true)) {
+            throw new \InvalidArgumentException(\sprintf('the scheme is not one of %s://', implode('://, ', self::REMOTE_SCHEMES)));
+        }
+
+        $connection = AbstractAdapter::createConnection($dsn);
+
+        if ($connection instanceof \Memcached) {
+            return new MemcachedAdapter($connection, $namespace, $defaultLifetime, $marshaller);
+        }
+
+        return new RedisAdapter($connection, $namespace, $defaultLifetime, $marshaller);
+    }
+
+    private static function withoutPassword(#[\SensitiveParameter] string $dsn): string
+    {
+        return preg_replace('#^([a-z][a-z0-9+.-]*://[^:@/]*):[^@]*@#i', '$1:***@', $dsn) ?? $dsn;
+    }
+}

--- a/core/lib/Thelia/Core/Security/RefreshToken/RefreshTokenService.php
+++ b/core/lib/Thelia/Core/Security/RefreshToken/RefreshTokenService.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Core\Security\RefreshToken;
 
-use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -25,9 +25,10 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * deletes the item before returning, so the same refresh token cannot
  * be replayed: callers MUST issue a fresh one in the same flow.
  *
- * Storage uses the shared `thelia.cache` adapter — pair it with a
- * persistent backend (Redis, filesystem) in production. Cache eviction
- * forces re-login.
+ * Storage is the `thelia.cache.security` pool, which nothing empties on a
+ * deployment or on a cache clear, so releasing a new version does not sign the
+ * API clients out. Eviction still forces a re-login: a cache server configured
+ * to drop the oldest keys under memory pressure will disconnect clients.
  */
 final readonly class RefreshTokenService
 {
@@ -38,7 +39,8 @@ final readonly class RefreshTokenService
     private const TOKEN_BYTES = 64;
 
     public function __construct(
-        private AdapterInterface $cache,
+        #[Autowire(service: 'thelia.cache.security')]
+        private CacheItemPoolInterface $cache,
         #[Autowire(param: 'thelia.security.jwt_refresh_token_ttl')]
         private int $ttl,
     ) {

--- a/tests/Integration/Core/Cache/ApplicationCachePoolsTest.php
+++ b/tests/Integration/Core/Cache/ApplicationCachePoolsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Cache;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Event\Cache\CacheEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\RefreshToken\RefreshTokenService;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The application cache is split per use, and each part is emptied on its own.
+ * The one holding API refresh tokens is the only one whose eviction is visible
+ * to a user: emptying the shop cache, from the back office or from the command
+ * line, must not log the API clients out.
+ */
+final class ApplicationCachePoolsTest extends IntegrationTestCase
+{
+    private const PROBE_KEY = 'application-cache-pools-probe';
+
+    protected function tearDown(): void
+    {
+        foreach (['thelia.cache.security', 'thelia.cache.data_access'] as $poolId) {
+            $this->pool($poolId)->deleteItem(self::PROBE_KEY);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testTheSecurityPoolIsNotTheDataAccessPool(): void
+    {
+        $security = $this->pool('thelia.cache.security');
+        $dataAccess = $this->pool('thelia.cache.data_access');
+
+        $this->write($security, 'kept');
+        $this->write($dataAccess, 'dropped');
+
+        $dataAccess->clear();
+
+        self::assertTrue(
+            $security->getItem(self::PROBE_KEY)->isHit(),
+            'Emptying the data access pool must leave the security pool alone.',
+        );
+        self::assertFalse($dataAccess->getItem(self::PROBE_KEY)->isHit());
+    }
+
+    public function testTheSecurityPoolSurvivesTheApplicationPoolBeingEmptied(): void
+    {
+        $security = $this->pool('thelia.cache.security');
+        $this->write($security, 'kept');
+
+        $this->pool('cache.app')->clear();
+
+        self::assertTrue($security->getItem(self::PROBE_KEY)->isHit());
+    }
+
+    public function testClearingTheShopCacheKeepsTheApiClientsSignedIn(): void
+    {
+        $refreshTokens = $this->getService(RefreshTokenService::class);
+        $token = $refreshTokens->issue('cache-pools@example.org', RefreshTokenService::SCOPE_CUSTOMER);
+
+        $throwaway = sys_get_temp_dir().'/thelia-cache-clear-probe';
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        $dispatcher->dispatch(
+            new CacheEvent($throwaway, onKernelTerminate: false, invalidatePropelSchema: false),
+            TheliaEvents::CACHE_CLEAR,
+        );
+
+        self::assertNotNull(
+            $refreshTokens->consume($token),
+            'A refresh token must outlive a cache clear, otherwise every deployment signs the API clients out.',
+        );
+    }
+
+    private function pool(string $id): CacheItemPoolInterface
+    {
+        $pool = static::getContainer()->get($id);
+        self::assertInstanceOf(CacheItemPoolInterface::class, $pool);
+
+        return $pool;
+    }
+
+    private function write(CacheItemPoolInterface $pool, string $value): void
+    {
+        $item = $pool->getItem(self::PROBE_KEY);
+        $item->set($value);
+        $pool->save($item);
+    }
+}

--- a/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
+++ b/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
@@ -43,6 +43,11 @@ final class ApplicationCacheConfigurationTest extends TestCase
         self::assertSame('/srv/shop/prod', $this->parameters()['env(THELIA_CACHE_PREFIX_SEED)']);
     }
 
+    public function testTheRefreshTokensGetTheirOwnPool(): void
+    {
+        self::assertArrayHasKey('thelia.cache.security', $this->frameworkCache()['pools']);
+    }
+
     public function testAnInstallationThatConfiguresNothingStaysOnItsOwnDisk(): void
     {
         $parameters = $this->parameters();

--- a/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
+++ b/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * Two shops on one cache server, or the development and the production of the
+ * same shop, must never read each other's keys. Symfony inlines the seed when
+ * the container is compiled, so the guarantee lives in the configuration and
+ * is checked there.
+ */
+final class ApplicationCacheConfigurationTest extends TestCase
+{
+    public function testEveryPoolIsStoredWhereTheHostingAsks(): void
+    {
+        self::assertSame('thelia.cache.adapter', $this->frameworkCache()['app']);
+    }
+
+    public function testTheKeyspaceIsSeededWithTheInstallPathAndTheEnvironment(): void
+    {
+        self::assertSame('%env(THELIA_CACHE_PREFIX_SEED)%', $this->frameworkCache()['prefix_seed']);
+
+        // Resolved here rather than left as "%kernel.project_dir%": Symfony
+        // escapes what it inlines into the seed, so a placeholder would reach
+        // every shop as the same literal text.
+        self::assertSame('/srv/shop/prod', $this->parameters()['env(THELIA_CACHE_PREFIX_SEED)']);
+    }
+
+    public function testAnInstallationThatConfiguresNothingStaysOnItsOwnDisk(): void
+    {
+        $parameters = $this->parameters();
+
+        self::assertSame('', $parameters['env(THELIA_CACHE_DSN)']);
+    }
+
+    public function testThePoolsLiveOutsideTheContainerCacheDirectory(): void
+    {
+        $directory = $this->parameters()['thelia.cache.directory'];
+
+        self::assertIsString($directory);
+        self::assertStringNotContainsString('%kernel.cache_dir%', $directory);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function frameworkCache(): array
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new class extends Extension {
+            public function getAlias(): string
+            {
+                return 'framework';
+            }
+
+            public function load(array $configs, ContainerBuilder $container): void
+            {
+            }
+        });
+
+        $this->load($container, 'packages/framework.php');
+
+        return array_replace_recursive(...$container->getExtensionConfig('framework'))['cache'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parameters(): array
+    {
+        $container = new ContainerBuilder();
+        $this->load($container, 'parameters/application_cache.php');
+
+        return $container->getParameterBag()->all();
+    }
+
+    private function load(ContainerBuilder $container, string $file): void
+    {
+        $container->setParameter('kernel.project_dir', '/srv/shop');
+        $container->setParameter('kernel.environment', 'prod');
+
+        $directory = \dirname(__DIR__, 4).'/core/lib/Thelia/Config/Resources';
+
+        (new PhpFileLoader($container, new FileLocator($directory)))->load($file);
+    }
+}

--- a/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
+++ b/tests/Unit/Core/Cache/ApplicationCacheConfigurationTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Thelia\Tests\Unit\Core\Cache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -53,6 +54,20 @@ final class ApplicationCacheConfigurationTest extends TestCase
         $parameters = $this->parameters();
 
         self::assertSame('', $parameters['env(THELIA_CACHE_DSN)']);
+    }
+
+    public function testThePoolsCanBePruned(): void
+    {
+        $container = new ContainerBuilder();
+        $this->load($container, 'services/core/cache.php');
+
+        $class = $container->getDefinition('thelia.cache.adapter')->getClass();
+
+        self::assertIsString($class);
+        self::assertTrue(
+            is_a($class, PruneableInterface::class, true),
+            'CachePoolPrunerPass reads the class of the adapter, so cache:pool:prune only reaches the application pools if it is pruneable.',
+        );
     }
 
     public function testThePoolsLiveOutsideTheContainerCacheDirectory(): void

--- a/tests/Unit/Core/Cache/CacheAdapterFactoryTest.php
+++ b/tests/Unit/Core/Cache/CacheAdapterFactoryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Thelia\Core\Cache\CacheAdapterFactory;
+
+/**
+ * The hosting provider chooses where the application cache is stored with a
+ * single environment variable. An empty one keeps the shop on the file system,
+ * so an install that sets nothing depends on nothing; a filled one has to fail
+ * loudly rather than fall back to the disk, otherwise a shop believes it runs
+ * on a shared cache when it does not.
+ */
+final class CacheAdapterFactoryTest extends TestCase
+{
+    public function testAnEmptyDataSourceNameKeepsTheCacheOnTheFileSystem(): void
+    {
+        $adapter = CacheAdapterFactory::create('probe', 0, '', sys_get_temp_dir().'/thelia-cache-factory-test');
+
+        self::assertInstanceOf(FilesystemAdapter::class, $adapter);
+    }
+
+    public function testBlankSpaceCountsAsNoDataSourceName(): void
+    {
+        $adapter = CacheAdapterFactory::create('probe', 0, '   ', sys_get_temp_dir().'/thelia-cache-factory-test');
+
+        self::assertInstanceOf(FilesystemAdapter::class, $adapter);
+    }
+
+    public function testARedisDataSourceNameMovesTheCacheToRedis(): void
+    {
+        if (!\extension_loaded('redis') && !class_exists(\Predis\Client::class)) {
+            self::markTestSkipped('Neither the redis extension nor predis/predis is available.');
+        }
+
+        $adapter = CacheAdapterFactory::create(
+            'probe',
+            0,
+            'redis://redis:6379?lazy=1',
+            sys_get_temp_dir().'/thelia-cache-factory-test',
+        );
+
+        self::assertInstanceOf(RedisAdapter::class, $adapter);
+    }
+
+    public function testAnUnsupportedSchemeNamesTheVariableAndTheDataSourceName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/THELIA_CACHE_DSN/');
+        $this->expectExceptionMessageMatches('#sqlite://var/cache.db#');
+
+        CacheAdapterFactory::create('probe', 0, 'sqlite://var/cache.db', sys_get_temp_dir());
+    }
+
+    public function testTheErrorNeverRepeatsThePassword(): void
+    {
+        try {
+            CacheAdapterFactory::create('probe', 0, 'unknown://thelia:s3cr3t@example.org:6379', sys_get_temp_dir());
+        } catch (\InvalidArgumentException $failure) {
+            self::assertStringNotContainsString('s3cr3t', $failure->getMessage());
+            self::assertStringContainsString('unknown://thelia:***@example.org:6379', $failure->getMessage());
+
+            return;
+        }
+
+        self::fail('An unsupported scheme must be rejected.');
+    }
+}

--- a/tests/Unit/Core/Cache/CacheAdapterFactoryTest.php
+++ b/tests/Unit/Core/Cache/CacheAdapterFactoryTest.php
@@ -15,8 +15,11 @@ declare(strict_types=1);
 namespace Thelia\Tests\Unit\Core\Cache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\PruneableInterface;
+use Thelia\Core\Cache\ApplicationCacheAdapter;
 use Thelia\Core\Cache\CacheAdapterFactory;
 
 /**
@@ -32,14 +35,33 @@ final class CacheAdapterFactoryTest extends TestCase
     {
         $adapter = CacheAdapterFactory::create('probe', 0, '', sys_get_temp_dir().'/thelia-cache-factory-test');
 
-        self::assertInstanceOf(FilesystemAdapter::class, $adapter);
+        self::assertInstanceOf(ApplicationCacheAdapter::class, $adapter);
+        self::assertInstanceOf(FilesystemAdapter::class, $adapter->inner());
     }
 
     public function testBlankSpaceCountsAsNoDataSourceName(): void
     {
         $adapter = CacheAdapterFactory::create('probe', 0, '   ', sys_get_temp_dir().'/thelia-cache-factory-test');
 
-        self::assertInstanceOf(FilesystemAdapter::class, $adapter);
+        self::assertInstanceOf(FilesystemAdapter::class, $adapter->inner());
+    }
+
+    public function testTheFileSystemCacheStaysPruneable(): void
+    {
+        $adapter = CacheAdapterFactory::create('probe', 0, '', sys_get_temp_dir().'/thelia-cache-factory-test');
+
+        self::assertInstanceOf(PruneableInterface::class, $adapter);
+        self::assertTrue($adapter->prune(), 'Expired entries nothing reads again are only removed by cache:pool:prune.');
+    }
+
+    public function testABackendThatExpiresItsOwnKeysReportsNothingToPrune(): void
+    {
+        // cache:pool:prune calls prune() on every pool it was handed and turns
+        // a false into "could not be pruned" plus a non zero exit code. A cache
+        // server has nothing to prune, which is not a failure.
+        $adapter = new ApplicationCacheAdapter(new ArrayAdapter());
+
+        self::assertTrue($adapter->prune());
     }
 
     public function testARedisDataSourceNameMovesTheCacheToRedis(): void
@@ -55,7 +77,7 @@ final class CacheAdapterFactoryTest extends TestCase
             sys_get_temp_dir().'/thelia-cache-factory-test',
         );
 
-        self::assertInstanceOf(RedisAdapter::class, $adapter);
+        self::assertInstanceOf(RedisAdapter::class, $adapter->inner());
     }
 
     public function testAnUnsupportedSchemeNamesTheVariableAndTheDataSourceName(): void

--- a/tests/Unit/Core/Security/RefreshTokenLifetimeConfigurationTest.php
+++ b/tests/Unit/Core/Security/RefreshTokenLifetimeConfigurationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * How long a refresh token stays valid belongs to the hosting, and the hosting
+ * expects to set it in .env.local without rebuilding the container. Read from
+ * $_ENV while the container is compiled, the value is frozen into the compiled
+ * container instead, and whoever changed it sees nothing happen.
+ */
+final class RefreshTokenLifetimeConfigurationTest extends TestCase
+{
+    public function testTheLifetimeIsReadFromTheEnvironmentAtRuntime(): void
+    {
+        $parameters = $this->parameters();
+
+        self::assertSame('%env(int:JWT_REFRESH_TOKEN_TTL)%', $parameters['thelia.security.jwt_refresh_token_ttl']);
+        self::assertSame('2592000', $parameters['env(JWT_REFRESH_TOKEN_TTL)']);
+    }
+
+    public function testTheDefaultLifetimeIsThirtyDays(): void
+    {
+        self::assertSame(30 * 24 * 3600, (int) $this->parameters()['env(JWT_REFRESH_TOKEN_TTL)']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parameters(): array
+    {
+        $container = new ContainerBuilder();
+        $directory = \dirname(__DIR__, 4).'/core/lib/Thelia/Config/Resources';
+
+        (new PhpFileLoader($container, new FileLocator($directory)))->load('services/core/security.php');
+
+        return $container->getParameterBag()->all();
+    }
+}


### PR DESCRIPTION
## Summary

A shop running on several front ends, or wanting a cache that survives deployments, had no way to move the application cache off the local disk: it meant editing `config/packages/cache.yaml` by hand, with nothing documenting it, and the `TheliaCacheRedisAdapter` module declares `<thelia>2.5.0` so it does not activate on a 3.0 core. This adds the wiring, keeps the file system as the default, and separates the one pool whose eviction is visible to a user.

**Choosing the backend**

- `THELIA_CACHE_DSN` decides where every application pool is stored. Left empty, `cache.app` stays on the file system and the behaviour is the one of 3.0.0. Filled with `redis://`, `rediss://`, `valkey://`, `valkeys://` or `memcached://`, every pool moves there. No code of the shop changes in either direction.
- The data source name is resolved when a pool is first built, not when the container is compiled: `thelia.cache.adapter` is a factory service that receives `%env(THELIA_CACHE_DSN)%`, so one compiled container serves both modes.
- That service is declared the way `cache.adapter.system` is: abstract, tagged `cache.pool`, with the namespace and the default lifetime as its first two arguments so `CachePoolPass` keeps filling them per pool.
- An unsupported scheme, a missing PHP extension or an unreachable server stops the request with a message naming the variable and the data source name without its password. There is no silent fall back to the disk: a shop believing its cache is shared while each front end keeps its own would serve inconsistent pages and drop API sessions at random. When the server answers again the shop recovers with no intervention.
- No dependency added. `symfony/cache` already ships the adapters; the `redis` or `memcached` extension, or `predis/predis`, is the hosting's to provide.

**Pools**

- New pool `thelia.cache.security` holds the API refresh tokens, and `RefreshTokenService` writes there instead of the shared `thelia.cache` adapter. `TheliaEvents::CACHE_CLEAR`, which is what the back office "flush cache" button dispatches, and `cache:clear` no longer sign the API clients out.
- Application pools are stored in `var/pools/<env>` instead of `var/cache/<env>/pools`, which is what makes the line above true on the file system too: clearing the container cache removes its whole directory. `cache.system` and everything built on it, so API Platform metadata, validation, Twig components, stays in `var/cache/<env>` and is still rebuilt on every clear.
- `thelia.cache.data_access` is untouched: still off by default, still flushed on catalog changes.
- The `thelia.cache` adapter is untouched and stays inside the container cache directory: the configuration and feed caches are meant to go away with `cache:clear`.

**Keeping installations apart**

- `framework.cache.prefix_seed` now defaults to the install path plus the environment, overridable with `THELIA_CACHE_PREFIX_SEED` when several machines serve the same shop from different paths and have to share one cache. Symfony inlines that seed when the container is compiled, and escapes what it inlines, so the default is computed in `parameters/application_cache.php` from the kernel parameters; written as `%kernel.project_dir%` it would reach every installation as that same literal text and put them all in one keyspace.

**One class for every backend**

- Symfony decides from the class of the adapter, when it compiles the container, whether a pool can be pruned, while which backend is in use is only known once the pool is built. `ApplicationCacheAdapter` answers for all of them: it implements the interfaces `cache.app` carries today and delegates to the adapter the factory built. Without it `cache:pool:prune` receives an empty list, reports `[OK] Successfully pruned` and prunes nothing, and expired entries no one reads again stay on the disk until the pool is emptied whole.
- `prune()` delegates when the backend is pruneable and reports success when it is not. A cache server expires its own keys, so there is nothing to prune and nothing failed; answering otherwise would make the command print "could not be pruned" for every pool of a shop on Redis and exit non zero in the middle of a deployment.

**Also**

- `thelia.cache.namespace` was declared twice, the second time in a logger configuration file, and `thelia.logger.class` was declared twice the same way. Both duplicates are gone; the declarations kept are the ones in `parameters/thelia_core.php`.
- `JWT_REFRESH_TOKEN_TTL` was read from `$_ENV` while the container was compiled, so the refresh token lifetime was frozen into the compiled container and lowering it in `.env.local` did nothing until the next cache clear. It is now an environment variable resolved when the token is issued, with its default declared as `env(JWT_REFRESH_TOKEN_TTL)`.

Documentation: thelia/docs#52. Skeleton: thelia/thelia-project#70.

## Test plan

- [x] `composer test:unit -- --filter 'Thelia.Tests.Unit.Core.Cache'` 13 green, and `--filter RefreshTokenLifetimeConfigurationTest` 2 green, red before the fix (the parameter held the integer read at compile time and no `env()` default was declared). Red before the code: the factory class did not exist, the seed assertions failed against the Symfony default (`_/var/www/html.App_KernelTestContainer`), and the adapter of the pool definition did not implement `PruneableInterface`.
- [x] `cache:pool:prune` lists `cache.app`, `cache.http_client.pool`, `cache.rate_limiter`, `thelia.cache.data_access` and `thelia.cache.security`, on the file system and on Redis, and exits 0 in both. On disk, three entries saved with a one second lifetime: reading one drops it (3 files, then 2), `prune()` removes the two nothing read again (2 files, then 0). On Redis the same command touches no key (33 before, 33 after).
- [x] `composer test:integration -- --filter ApplicationCachePoolsTest` 3 green. The refresh token case was red before the pool split (`Failed asserting that null is not null`): the token lived in the adapter `Action/Cache` empties.
- [x] `composer test` 5 suites green on the file system backend: unit 439, integration 792 (4 skipped), api 288 (1 skipped), http-flexy 44 (17 skipped, theme 1.0.3), http-backoffice 12. Before the branch: 424 / 789 (4) / 288 (1) / 44 (17) / 12.
- [x] `composer test` 5 suites green again with `THELIA_CACHE_DSN=redis://redis:6379`, same counts. 172 keys left in Redis afterwards, all under the single namespace of the test environment.
- [x] Refresh token lifetime read at runtime: the compiled container calls `$container->getEnv('int:JWT_REFRESH_TOKEN_TTL')` instead of carrying `2592000`. With `JWT_REFRESH_TOKEN_TTL=60` in `.env.local` and the same compiled container, the service answers `60` as an `int` and the cache item of a token issued through `POST /api/admin/login` expires 60 seconds after it was written; removing the line puts it back to `2592000` with, again, no cache clear.
- [x] `composer cs-diff` 0, `composer phpstan` 0.
- [x] Without a data source name, on an install with demo data: front and back office pages answer 200, `POST /api/admin/login` then `POST /api/admin/token/refresh` answer 200, and the refresh still answers 200 after `cache:clear`, after `thelia:cache:clear` and after the back office "flush cache" button.
- [x] What each clear reaches, counted as files under `var/pools/dev` with the catalog pool enabled: `cache:clear` leaves all 16 entries in place; `thelia:cache:clear` and the back office button take the 14 of `thelia.cache.data_access` to 0 and leave the refresh token and the rate limit counter alone.
- [x] With `THELIA_CACHE_DSN=redis://redis:6379`: same walk, keys visible with `redis-cli --scan` under the expected per pool prefixes, `cache:pool:clear thelia.cache.data_access` leaves the `jwt_refresh_*` keys in place and the refresh answers 200.
- [x] Two environments on one Redis: the same shop browsed in `dev` and in `prod` writes under two different prefixes (`ksnN1VFryY` and `lOdVhxKEzL`), and the compiled containers give every pool a different namespace per environment.
- [x] Redis stopped mid session: the front answers 500 with `THELIA_CACHE_DSN is set to "redis://redis:6379", which cannot be used as a cache backend: Redis connection failed: ...`, no white page and no fall back to the disk; Redis started again and the front answers 200 on the next request.
- [x] `cache:pool:list` shows `thelia.cache.security` next to `thelia.cache.data_access`, and `debug:container` shows `RefreshTokenService` receiving `thelia.cache.security`.
- [x] No error and no deprecation attributable to this branch in the logs of that walk.
