### PR TITLE
fix(form): point the SEO form constant at the name the registry knows

### DIFF
--- a/core/lib/Thelia/Form/Definition/AdminForm.php
+++ b/core/lib/Thelia/Form/Definition/AdminForm.php
@@ -24,7 +24,7 @@ final class AdminForm
     public const ADMIN_LOGIN = 'thelia.admin.login';
     public const ADMIN_LOST_PASSWORD = 'thelia.admin.lostpassword';
     public const ADMIN_CREATE_PASSWORD = 'thelia.admin.createpassword';
-    public const SEO = 'thelia.admin.seo';
+    public const SEO = 'thelia_seo';
     public const CUSTOMER_CREATE = 'thelia.admin.customer.create';
     public const CUSTOMER_UPDATE = 'thelia.admin.customer.update';
     public const ADDRESS_CREATE = 'thelia.admin.address.create';


### PR DESCRIPTION
`AdminForm::SEO` is `'thelia.admin.seo'`. Nothing registers a form under that name, so any page
that goes through `AbstractSeoCrudController::hydrateSeoForm()` fails with:

```
OutOfBoundsException: The form '' doesn't exist
  core/lib/Thelia/Core/Form/TheliaFormFactory.php:63
```

The form itself exists. `Thelia\Form\SeoForm::getName()` returns `thelia_seo`, and that is the
name the factory can resolve against `Thelia.parser.forms`. Of the `thelia.admin.*` aliases,
`core/lib/Thelia/Config/Resources/parameters/forms.php` keeps only login, lost password and
create password. The SEO one is not in the list.

This patch points the constant at `thelia_seo`. `AbstractSeoCrudController` is the only class in
the core that reads it.

How I ran into it: the Selection module (thelia-modules/Selection) is the only subclass of
`AbstractSeoCrudController` on my install, and both of its edition pages answer 500. With this
one line, `/admin/selection/container/update/1` goes from 500 to 200. The category and product
edition pages are unaffected, since they no longer extend that class. Tested on 3.0.0-beta5 with
PHP 8.4.

Two related things this patch leaves alone.

`TheliaFormFactory::createForm()` reports the failure as `The form '' doesn't exist` because it
interpolates `$formId`, which is `null` at that point, instead of `$name`. That is why the
exception never says which form was asked for. Happy to send that one separately.

On my install the registry holds 129 form names, and before this patch 8 of the 101 `AdminForm`
constants match one of them. Some of the other 93 still have callers in the core:
`getUpdateFormId()` in `CategoryImage`, `ProductImage`, `BrandDocument` and their siblings
returns the `*_IMAGE_MODIFICATION` and `*_DOCUMENT_MODIFICATION` names. Those forms are no longer
shipped by the core, so what they resolve to depends on the active back office template. That is
a different question from this one, where the core ships the form and then asks for it under a
name nobody registers.
