### PR TITLE
fix(model): announce a written module row again

### DIFF
--- a/core/lib/Thelia/Model/Module.php
+++ b/core/lib/Thelia/Model/Module.php
@@ -35,7 +35,10 @@ class Module extends BaseModule implements FileModelParentInterface
     {
         ModuleQuery::resetActivated();
 
-        parent::postSave();
+        // The connection has to be handed over: the generated parent only
+        // dispatches ModuleEvent::POST_SAVE when it has one, so dropping it
+        // here left every listener on a module write silently unreachable.
+        parent::postSave($con);
     }
 
     public function getTranslationDomain(): string

--- a/tests/Integration/Model/ModuleWriteEventTest.php
+++ b/tests/Integration/Model/ModuleWriteEventTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Model\Event\ModuleEvent;
+use Thelia\Model\Module;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Propel announces a written row to the event dispatcher carried by the
+ * connection. A model overriding one of those hooks has to hand the connection
+ * over, or the announcement never leaves the model.
+ */
+final class ModuleWriteEventTest extends IntegrationTestCase
+{
+    #[Test]
+    public function savingAModuleAnnouncesIt(): void
+    {
+        $module = null;
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_SAVE,
+            function () use (&$module): void {
+                $module = $this->createModule('ModuleWriteEventProbe');
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Inserting a module must dispatch ModuleEvent::POST_SAVE.');
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_SAVE,
+            static function () use ($module): void {
+                $module->setVersion('2.0.0')->save();
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Updating a module must dispatch it too.');
+    }
+
+    #[Test]
+    public function deletingAModuleAnnouncesIt(): void
+    {
+        $module = $this->createModule('ModuleDeleteEventProbe');
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_DELETE,
+            static function () use ($module): void {
+                $module->delete();
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Deleting a module must dispatch ModuleEvent::POST_DELETE.');
+    }
+
+    private function countEventsDispatchedWhile(string $eventName, callable $work): int
+    {
+        $count = 0;
+        $listener = static function () use (&$count): void {
+            ++$count;
+        };
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        $dispatcher->addListener($eventName, $listener);
+
+        try {
+            $work();
+        } finally {
+            $dispatcher->removeListener($eventName, $listener);
+        }
+
+        return $count;
+    }
+
+    private function createModule(string $code): Module
+    {
+        $module = (new Module())
+            ->setCode($code)
+            ->setVersion('1.0.0')
+            ->setType(BaseModule::CLASSIC_MODULE_TYPE)
+            ->setCategory('classic')
+            ->setActivate(0)
+            ->setFullNamespace($code.'\\'.$code);
+
+        $module->save();
+
+        return $module;
+    }
+}


### PR DESCRIPTION
## Summary

- `Thelia\Model\Module::postSave()` called `parent::postSave()` without the connection. The generated parent only dispatches `ModuleEvent::POST_SAVE` when it has one, so no listener on a module write was ever reached — neither on insert nor on update.
- `propel.post.save.module` had zero effective subscribers as a result: any module or core cache keyed on a module row could not be invalidated.
- The same shape is still present in `Content::postSave()` and `Product::postSave()`; both are left for a separate change.

## Test plan

- [x] `tests/Integration/Model/ModuleWriteEventTest.php` — red before the fix (0 events on insert), green after; covers insert, update and delete.
- [x] `composer test` green (unit 439, integration 880, api 337, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors