### PR TITLE
perf(hook): resolve the module of a hook once per process

### DIFF
--- a/core/lib/Thelia/Core/EventListener/HookModuleCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/HookModuleCacheListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Model\Event\ModuleEvent;
+
+/**
+ * Keeps the module a hook belongs to resolved once per process.
+ *
+ * The lookup {@see BaseHook::__construct()} memoizes is read on every hook
+ * class built for a page and almost never written, so a plain static is the
+ * right cache. What it must not do is answer for a module row that has since
+ * been written or deleted: installing, upgrading or removing a module all
+ * happen inside a request that has already built hooks.
+ */
+readonly class HookModuleCacheListener
+{
+    #[AsEventListener(event: ModuleEvent::POST_SAVE)]
+    #[AsEventListener(event: ModuleEvent::POST_DELETE)]
+    public function onModuleWrite(): void
+    {
+        BaseHook::resetModuleClassNameCache();
+    }
+}

--- a/core/lib/Thelia/Core/Hook/BaseHook.php
+++ b/core/lib/Thelia/Core/Hook/BaseHook.php
@@ -71,6 +71,19 @@ abstract class BaseHook implements BaseHookInterface
     public ?ParserInterface $parser = null;
     public ?AssetResolverInterface $assetsResolver = null;
 
+    /**
+     * Module class name per module code, or null when the code has no row.
+     *
+     * Every hook class of a module resolves its module in its constructor, and
+     * a back-office screen builds a dozen of them: without a memo the same row
+     * is read once per hook class. Written and dropped only here and by
+     * {@see \Thelia\Core\EventListener\HookModuleCacheListener}, which drops
+     * it as soon as a module row is written or deleted.
+     *
+     * @var array<string, class-string<BaseModule>|null>
+     */
+    private static array $moduleClassNames = [];
+
     public function __construct(
         ?EventDispatcherInterface $dispatcher = null,
         ?ParserResolver $parserResolver = null,
@@ -85,15 +98,28 @@ abstract class BaseHook implements BaseHookInterface
 
         $moduleCode = explode('\\', static::class)[0];
 
-        $moduleDatabase = ModuleQuery::create()
-            ->findOneByCode($moduleCode);
+        if (!\array_key_exists($moduleCode, self::$moduleClassNames)) {
+            $moduleDatabase = ModuleQuery::create()
+                ->findOneByCode($moduleCode);
 
-        if ($moduleDatabase instanceof Module) {
-            $moduleClass = $moduleDatabase->getFullNamespace();
+            self::$moduleClassNames[$moduleCode] = $moduleDatabase instanceof Module
+                ? $moduleDatabase->getFullNamespace()
+                : null;
+        }
+
+        if (null !== $moduleClass = self::$moduleClassNames[$moduleCode]) {
             $this->module = new $moduleClass();
         }
 
         $this->translator = Translator::getInstance();
+    }
+
+    /**
+     * @internal
+     */
+    public static function resetModuleClassNameCache(): void
+    {
+        self::$moduleClassNames = [];
     }
 
     /**

--- a/core/lib/Thelia/Model/Module.php
+++ b/core/lib/Thelia/Model/Module.php
@@ -35,7 +35,10 @@ class Module extends BaseModule implements FileModelParentInterface
     {
         ModuleQuery::resetActivated();
 
-        parent::postSave();
+        // The connection has to be handed over: the generated parent only
+        // dispatches ModuleEvent::POST_SAVE when it has one, so dropping it
+        // here left every listener on a module write silently unreachable.
+        parent::postSave($con);
     }
 
     public function getTranslationDomain(): string

--- a/tests/Integration/Core/Hook/BaseHookModuleLookupTest.php
+++ b/tests/Integration/Core/Hook/BaseHookModuleLookupTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Hook;
+
+use HookModuleProbe\Hook\FirstProbeHook;
+use HookModuleProbe\Hook\SecondProbeHook;
+use HookModuleProbe\HookModuleProbe;
+use PHPUnit\Framework\Attributes\Test;
+use Thelia\Core\Hook\BaseHook;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleQuery;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A hook resolves the module it belongs to in its constructor. A page builds
+ * one hook object per hook class, a dozen of them on a back-office screen, and
+ * they all read the same module row.
+ */
+final class BaseHookModuleLookupTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private const MODULE_CODE = 'HookModuleProbe';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once THELIA_ROOT.'tests/fixtures/hooks/HookModuleProbe/HookModuleProbe.php';
+        require_once THELIA_ROOT.'tests/fixtures/hooks/HookModuleProbe/Hook/FirstProbeHook.php';
+        require_once THELIA_ROOT.'tests/fixtures/hooks/HookModuleProbe/Hook/SecondProbeHook.php';
+
+        BaseHook::resetModuleClassNameCache();
+    }
+
+    protected function tearDown(): void
+    {
+        BaseHook::resetModuleClassNameCache();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theModuleRowIsReadOnceForEveryHookClassOfTheModule(): void
+    {
+        $this->createProbeModule();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            new FirstProbeHook();
+            new SecondProbeHook();
+            new FirstProbeHook();
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'module'),
+            'Three hooks of the same module must read its row once.',
+        );
+    }
+
+    #[Test]
+    public function everyHookStillCarriesItsOwnModuleInstance(): void
+    {
+        $this->createProbeModule();
+
+        $first = new FirstProbeHook();
+        $second = new SecondProbeHook();
+
+        self::assertInstanceOf(HookModuleProbe::class, $first->module);
+        self::assertInstanceOf(HookModuleProbe::class, $second->module);
+        self::assertNotSame($first->module, $second->module);
+    }
+
+    #[Test]
+    public function aModuleWithNoRowIsNotLookedUpAgain(): void
+    {
+        self::assertNull(ModuleQuery::create()->findOneByCode(self::MODULE_CODE));
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            new FirstProbeHook();
+            new SecondProbeHook();
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'module'),
+            'A module code with no row must not be looked up once per hook class either.',
+        );
+        self::assertNull((new FirstProbeHook())->module);
+    }
+
+    #[Test]
+    public function writingTheModuleRowIsSeenByTheNextHook(): void
+    {
+        self::assertNull((new FirstProbeHook())->module, 'Nothing is installed under that code yet.');
+
+        $this->createProbeModule();
+
+        self::assertInstanceOf(
+            HookModuleProbe::class,
+            (new FirstProbeHook())->module,
+            'Installing the module must drop the memo the hooks answered from.',
+        );
+    }
+
+    private function createProbeModule(): void
+    {
+        (new Module())
+            ->setCode(self::MODULE_CODE)
+            ->setVersion('1.0.0')
+            ->setType(BaseModule::CLASSIC_MODULE_TYPE)
+            ->setCategory('classic')
+            ->setActivate(1)
+            ->setFullNamespace(HookModuleProbe::class)
+            ->save();
+    }
+}

--- a/tests/Integration/Model/ModuleWriteEventTest.php
+++ b/tests/Integration/Model/ModuleWriteEventTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Thelia\Model\Event\ModuleEvent;
+use Thelia\Model\Module;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Propel announces a written row to the event dispatcher carried by the
+ * connection. A model overriding one of those hooks has to hand the connection
+ * over, or the announcement never leaves the model.
+ */
+final class ModuleWriteEventTest extends IntegrationTestCase
+{
+    #[Test]
+    public function savingAModuleAnnouncesIt(): void
+    {
+        $module = null;
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_SAVE,
+            function () use (&$module): void {
+                $module = $this->createModule('ModuleWriteEventProbe');
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Inserting a module must dispatch ModuleEvent::POST_SAVE.');
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_SAVE,
+            static function () use ($module): void {
+                $module->setVersion('2.0.0')->save();
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Updating a module must dispatch it too.');
+    }
+
+    #[Test]
+    public function deletingAModuleAnnouncesIt(): void
+    {
+        $module = $this->createModule('ModuleDeleteEventProbe');
+
+        $dispatched = $this->countEventsDispatchedWhile(
+            ModuleEvent::POST_DELETE,
+            static function () use ($module): void {
+                $module->delete();
+            },
+        );
+
+        self::assertSame(1, $dispatched, 'Deleting a module must dispatch ModuleEvent::POST_DELETE.');
+    }
+
+    private function countEventsDispatchedWhile(string $eventName, callable $work): int
+    {
+        $count = 0;
+        $listener = static function () use (&$count): void {
+            ++$count;
+        };
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        $dispatcher->addListener($eventName, $listener);
+
+        try {
+            $work();
+        } finally {
+            $dispatcher->removeListener($eventName, $listener);
+        }
+
+        return $count;
+    }
+
+    private function createModule(string $code): Module
+    {
+        $module = (new Module())
+            ->setCode($code)
+            ->setVersion('1.0.0')
+            ->setType(BaseModule::CLASSIC_MODULE_TYPE)
+            ->setCategory('classic')
+            ->setActivate(0)
+            ->setFullNamespace($code.'\\'.$code);
+
+        $module->save();
+
+        return $module;
+    }
+}

--- a/tests/fixtures/hooks/HookModuleProbe/Hook/FirstProbeHook.php
+++ b/tests/fixtures/hooks/HookModuleProbe/Hook/FirstProbeHook.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HookModuleProbe\Hook;
+
+use Thelia\Core\Hook\BaseHook;
+
+class FirstProbeHook extends BaseHook
+{
+}

--- a/tests/fixtures/hooks/HookModuleProbe/Hook/SecondProbeHook.php
+++ b/tests/fixtures/hooks/HookModuleProbe/Hook/SecondProbeHook.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HookModuleProbe\Hook;
+
+use Thelia\Core\Hook\BaseHook;
+
+class SecondProbeHook extends BaseHook
+{
+}

--- a/tests/fixtures/hooks/HookModuleProbe/HookModuleProbe.php
+++ b/tests/fixtures/hooks/HookModuleProbe/HookModuleProbe.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HookModuleProbe;
+
+use Thelia\Module\BaseModule;
+
+/**
+ * Stands in for the module a hook belongs to.
+ *
+ * It lives outside the Thelia namespace on purpose: a hook resolves its module
+ * from the first segment of its own class name, so only a class named after a
+ * module code exercises that path.
+ */
+class HookModuleProbe extends BaseModule
+{
+}


### PR DESCRIPTION
## Summary

- `BaseHook::__construct()` ran `ModuleQuery::findOneByCode()` for every hook class instantiated. A back-office screen builds one object per hook class, so the same module row was read once per class: 12 identical `SELECT ... FROM module WHERE code = ?` measured on a shop with 12 back-office hook classes, 6 on the demo shop of this repository.
- The module class name is now memoized per module code, the way `BaseModule::$moduleIds` already memoizes module ids. Each hook still gets its own module object.
- The memo is dropped on a module row write or delete, so installing, upgrading or removing a module inside a request is seen by the next hook built.
- Measured on the demo shop of this repository: `GET /admin` 6 → 5 lookups, `GET /admin/products` 5 → 4.

Stacked on #3899: without it the module write event never reaches the listener that drops the memo.

## Test plan

- [x] `tests/Integration/Core/Hook/BaseHookModuleLookupTest.php` — red before (3 lookups for 3 hooks, 2 for a module with no row), green after; also covers that each hook keeps its own module object and that installing the module is seen by the next hook.
- [x] `composer test` green (unit 439, integration 884, api 337, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors