### PR TITLE
perf(model): read the configuration of a module in one go

### DIFF
--- a/core/lib/Thelia/Core/EventListener/ModuleConfigCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/ModuleConfigCacheListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Core\EventListener;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Model\Event\ModuleConfigEvent;
+use Thelia\Model\Event\ModuleConfigI18nEvent;
+use Thelia\Model\ModuleConfigQuery;
+
+/**
+ * Keeps {@see ModuleConfigQuery::getConfigValue()} answering from the database
+ * of the current request.
+ *
+ * The configuration of a module is read many times per page and written from
+ * the back office, so what it is read from lives no longer than a request or a
+ * console command, and a write on a row drops it at once - including a write
+ * made straight on the model, not through setConfigValue().
+ */
+readonly class ModuleConfigCacheListener
+{
+    #[AsEventListener(event: ModuleConfigEvent::POST_SAVE)]
+    #[AsEventListener(event: ModuleConfigEvent::POST_DELETE)]
+    #[AsEventListener(event: ModuleConfigI18nEvent::POST_SAVE)]
+    #[AsEventListener(event: ModuleConfigI18nEvent::POST_DELETE)]
+    public function onModuleConfigWrite(): void
+    {
+        ModuleConfigQuery::resetConfigCache();
+    }
+
+    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            ModuleConfigQuery::resetConfigCache();
+        }
+    }
+
+    #[AsEventListener(event: ConsoleEvents::COMMAND)]
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        ModuleConfigQuery::resetConfigCache();
+    }
+}

--- a/core/lib/Thelia/Model/ModuleConfigQuery.php
+++ b/core/lib/Thelia/Model/ModuleConfigQuery.php
@@ -25,24 +25,88 @@ use Thelia\Model\Base\ModuleConfigQuery as BaseModuleConfigQuery;
  */
 class ModuleConfigQuery extends BaseModuleConfigQuery
 {
+    /**
+     * Configuration rows of a module, by name, once they have been read.
+     *
+     * A module reads its own configuration wherever it needs it, and a page
+     * ends up asking for the same handful of names again and again. The whole
+     * configuration of a module is small enough to read in one go and answer
+     * from, the way {@see ConfigQuery} answers for the configuration table.
+     *
+     * @var array<int, array<string, ModuleConfig>>
+     */
+    private static array $configsByModuleId = [];
+
+    /**
+     * Resolved values, by "module id|name|locale".
+     *
+     * @var array<string, string|null>
+     */
+    private static array $values = [];
+
+    /** The locale a row answers in when the caller names none. */
+    private static ?string $rowDefaultLocale = null;
+
     public function getConfigValue(int $moduleId, string $variableName, mixed $defaultValue = null, $valueLocale = null): ?string
     {
-        $value = null;
+        $valueKey = $moduleId.'|'.$variableName.'|'.($valueLocale ?? '');
 
-        $configValue = self::create()
-            ->filterByModuleId($moduleId)
-            ->filterByName($variableName)
-            ->findOne();
-
-        if (null !== $configValue) {
-            if (null !== $valueLocale) {
-                $configValue->setLocale($valueLocale);
-            }
-
-            $value = $configValue->getValue();
+        if (!\array_key_exists($valueKey, self::$values)) {
+            self::$values[$valueKey] = self::readConfigValue($moduleId, $variableName, $valueLocale);
         }
 
-        return $value ?? (null === $defaultValue ? null : (string) $defaultValue);
+        return self::$values[$valueKey] ?? (null === $defaultValue ? null : (string) $defaultValue);
+    }
+
+    /**
+     * Drops everything read so far.
+     *
+     * @internal
+     */
+    public static function resetConfigCache(): void
+    {
+        self::$configsByModuleId = [];
+        self::$values = [];
+    }
+
+    private static function readConfigValue(int $moduleId, string $variableName, ?string $valueLocale): ?string
+    {
+        $configValue = self::configsOfModule($moduleId)[$variableName] ?? null;
+
+        if (null === $configValue) {
+            return null;
+        }
+
+        // The row object is shared by every read of the request, so the locale
+        // to answer in is set on every read and not only when the caller names
+        // one: the locale a previous reader asked for must not leak into this
+        // one.
+        $configValue->setLocale($valueLocale ?? self::rowDefaultLocale());
+
+        return $configValue->getValue();
+    }
+
+    /**
+     * @return array<string, ModuleConfig>
+     */
+    private static function configsOfModule(int $moduleId): array
+    {
+        if (\array_key_exists($moduleId, self::$configsByModuleId)) {
+            return self::$configsByModuleId[$moduleId];
+        }
+
+        $configs = [];
+
+        foreach (self::create()->filterByModuleId($moduleId)->find() as $config) {
+            $configs[$config->getName()] = $config;
+        }
+
+        return self::$configsByModuleId[$moduleId] = $configs;
+    }
+
+    private static function rowDefaultLocale(): string
+    {
+        return self::$rowDefaultLocale ??= (new ModuleConfig())->getLocale();
     }
 
     /**
@@ -85,6 +149,8 @@ class ModuleConfigQuery extends BaseModuleConfigQuery
             ->setValue($variableValue !== null ? (string) $variableValue : null)
             ->save();
 
+        self::resetConfigCache();
+
         return $this;
     }
 
@@ -105,6 +171,8 @@ class ModuleConfigQuery extends BaseModuleConfigQuery
         ) {
             $moduleConfig->delete();
         }
+
+        self::resetConfigCache();
 
         return $this;
     }

--- a/tests/Integration/Model/ModuleConfigQueryReadTest.php
+++ b/tests/Integration/Model/ModuleConfigQueryReadTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use PHPUnit\Framework\Attributes\Test;
+use Thelia\Model\Module;
+use Thelia\Model\ModuleConfigQuery;
+use Thelia\Module\BaseModule;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A module reads its configuration wherever it needs it, and a page asks for
+ * the same handful of names over and over.
+ */
+final class ModuleConfigQueryReadTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private int $moduleId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $module = (new Module())
+            ->setCode('ModuleConfigReadProbe')
+            ->setVersion('1.0.0')
+            ->setType(BaseModule::CLASSIC_MODULE_TYPE)
+            ->setCategory('classic')
+            ->setActivate(1)
+            ->setFullNamespace('ModuleConfigReadProbe\\ModuleConfigReadProbe');
+        $module->save();
+
+        $this->moduleId = $module->getId();
+
+        ModuleConfigQuery::create()->setConfigValue($this->moduleId, 'title', 'Shop title');
+        ModuleConfigQuery::create()->setConfigValue($this->moduleId, 'subtitle', 'Shop subtitle');
+
+        ModuleConfigQuery::resetConfigCache();
+    }
+
+    protected function tearDown(): void
+    {
+        ModuleConfigQuery::resetConfigCache();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theConfigurationOfAModuleIsReadInOneGo(): void
+    {
+        $moduleId = $this->moduleId;
+
+        $statements = $this->recordSqlQueries(static function () use ($moduleId): void {
+            for ($read = 0; $read < 3; ++$read) {
+                ModuleConfigQuery::create()->getConfigValue($moduleId, 'title');
+                ModuleConfigQuery::create()->getConfigValue($moduleId, 'subtitle');
+                ModuleConfigQuery::create()->getConfigValue($moduleId, 'absent');
+            }
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'module_config'),
+            'Nine reads of three names must cost one read of the module configuration.',
+        );
+    }
+
+    #[Test]
+    public function theValuesAreTheOnesStored(): void
+    {
+        self::assertSame('Shop title', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+        self::assertSame('Shop subtitle', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'subtitle'));
+        self::assertNull(ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'absent'));
+        self::assertSame('fallback', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'absent', 'fallback'));
+    }
+
+    #[Test]
+    public function eachLocaleAnswersWithItsOwnValue(): void
+    {
+        ModuleConfigQuery::create()->setConfigValue($this->moduleId, 'title', 'Titre de la boutique', 'fr_FR');
+
+        self::assertSame(
+            'Titre de la boutique',
+            ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title', null, 'fr_FR'),
+        );
+        self::assertSame(
+            'Shop title',
+            ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'),
+            'A read naming no locale must not inherit the one a previous read asked for.',
+        );
+        self::assertSame(
+            'Titre de la boutique',
+            ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title', null, 'fr_FR'),
+        );
+    }
+
+    #[Test]
+    public function writingAValueIsSeenByTheNextRead(): void
+    {
+        self::assertSame('Shop title', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+
+        ModuleConfigQuery::create()->setConfigValue($this->moduleId, 'title', 'Another title');
+
+        self::assertSame('Another title', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+    }
+
+    #[Test]
+    public function creatingAValueIsSeenByTheNextRead(): void
+    {
+        self::assertNull(ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'created_later'));
+
+        ModuleConfigQuery::create()->setConfigValue($this->moduleId, 'created_later', 'now there');
+
+        self::assertSame('now there', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'created_later'));
+    }
+
+    #[Test]
+    public function deletingAValueIsSeenByTheNextRead(): void
+    {
+        self::assertSame('Shop title', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+
+        ModuleConfigQuery::create()->deleteConfigValue($this->moduleId, 'title');
+
+        self::assertNull(ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+    }
+
+    #[Test]
+    public function aWriteStraightOnTheModelIsSeenByTheNextRead(): void
+    {
+        self::assertSame('Shop title', ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'));
+
+        $row = ModuleConfigQuery::create()
+            ->filterByModuleId($this->moduleId)
+            ->filterByName('title')
+            ->findOne();
+        $row->setValue('Written on the model')->save();
+
+        self::assertSame(
+            'Written on the model',
+            ModuleConfigQuery::create()->getConfigValue($this->moduleId, 'title'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `ModuleConfigQuery::getConfigValue()` ran one `SELECT` per read with no memo, so the same names were read again and again: 11 to 16 queries per page on a shop with a handful of configured modules, 5 on the demo shop of this repository for two distinct names.
- The whole configuration of a module is now read on the first ask and answered from, the way `ConfigQuery` already does for the `config` table.
- The locale is set on every read rather than only when the caller names one, so a read naming no locale cannot inherit the locale a previous reader asked for.
- Dropped on a write, on a delete — including a write made straight on the model rather than through `setConfigValue()` — and at the start of every request and console command, so it never outlives the database state it was read from.
- Measured on the demo shop of this repository: `GET /` 152 → 148 queries, `GET /admin` 126 → 122.

## Test plan

- [x] `tests/Integration/Model/ModuleConfigQueryReadTest.php` — red before (9 queries for 9 reads of 3 names, and a read naming no locale answering in the previous reader's locale), green after.
- [x] Covers the stored values, the per-locale values, the default value, and invalidation on create / update / delete / write on the model.
- [x] `composer test` green (unit 439, integration 885, api 337, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors