### PR TITLE
feat(customer): come back to the page a visitor was on once they have signed in

### DIFF
--- a/core/lib/Thelia/Controller/Front/BaseFrontController.php
+++ b/core/lib/Thelia/Controller/Front/BaseFrontController.php
@@ -19,6 +19,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Thelia\Controller\BaseController;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Template\ParserInterface;
+use Thelia\Domain\Customer\Service\AuthenticationReturnUrl;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\ModuleQuery;
 
@@ -40,7 +41,10 @@ class BaseFrontController extends BaseController
     public function checkAuth(): void
     {
         if (false === $this->getSecurityContext()->hasAuthenticatedCustomerUser()) {
-            throw new RedirectException($this->retrieveUrlFromRouteId('customer_login'));
+            // The guarded page travels with the redirection: signing in is a detour, and
+            // dropping the visitor on their account afterwards leaves them to find their
+            // own way back to the cart, the checkout step or the order they asked for.
+            throw new RedirectException($this->retrieveUrlFromRouteId('customer_login', [AuthenticationReturnUrl::PARAMETER => $this->getRequest()->getRequestUri()]));
         }
     }
 

--- a/core/lib/Thelia/Domain/Customer/Service/AuthenticationReturnUrl.php
+++ b/core/lib/Thelia/Domain/Customer/Service/AuthenticationReturnUrl.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Customer\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Thelia\Tools\RedirectUrl;
+
+/**
+ * Carries the page a visitor was on until they have signed in.
+ *
+ * Signing in interrupts what someone was doing — filling a cart, reading a product
+ * sheet, going through the checkout — and the account pages are rarely where they
+ * meant to go. The interrupted URL travels as the "redirect" parameter of the
+ * sign-in links, is remembered for the length of the journey (a failed attempt, the
+ * two registration steps, the activation code) and is handed back once the session
+ * holds a customer.
+ *
+ * Two things it deliberately does not do: read the Referer header, which the browser
+ * may strip or a third-party page may set, and read the previous URL the core keeps
+ * in session, which the sign-in page itself overwrites as soon as it is rendered.
+ */
+readonly class AuthenticationReturnUrl
+{
+    /**
+     * Query (or form) parameter naming the page to come back to. Anything a visitor
+     * puts in it is checked against the current host before use.
+     */
+    public const PARAMETER = 'redirect';
+
+    private const SESSION_KEY = 'thelia.authentication_return_url';
+
+    public function __construct(
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * The value a sign-in link should carry to come back to $request.
+     */
+    public function of(Request $request): string
+    {
+        return $request->getRequestUri();
+    }
+
+    /**
+     * The parameter carried by the current request, when it points inside the shop.
+     */
+    public function requested(): ?string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request instanceof Request) {
+            return null;
+        }
+
+        $url = $request->query->get(self::PARAMETER) ?? $request->request->get(self::PARAMETER);
+
+        if (!\is_string($url) || !RedirectUrl::isSafe($url, $request->getHost())) {
+            return null;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Remembers the return URL the current request carries.
+     *
+     * Called by the pages of the sign-in journey: the parameter reaches the first of
+     * them only, and the session carries it through the steps that follow. A request
+     * without the parameter leaves what is already remembered untouched, so landing on
+     * the registration form from the sign-in page does not lose the destination.
+     */
+    public function capture(): void
+    {
+        $url = $this->requested();
+
+        if (null === $url) {
+            return;
+        }
+
+        $this->session()?->set(self::SESSION_KEY, $url);
+    }
+
+    /**
+     * Where to send a visitor who just signed in, and forgets it.
+     *
+     * The parameter of the current request wins over what was remembered: it is the
+     * more recent intent, and a form that posts one says where it wants to go.
+     */
+    public function consume(string $default): string
+    {
+        $session = $this->session();
+        $remembered = $session?->get(self::SESSION_KEY);
+
+        $this->forget();
+
+        $url = $this->requested();
+
+        if (null === $url && \is_string($remembered) && $this->isSafe($remembered)) {
+            $url = $remembered;
+        }
+
+        return $url ?? $default;
+    }
+
+    /**
+     * Drops the remembered URL, for a caller that decides the destination itself.
+     */
+    public function forget(): void
+    {
+        $this->session()?->remove(self::SESSION_KEY);
+    }
+
+    private function isSafe(string $url): bool
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        return $request instanceof Request && RedirectUrl::isSafe($url, $request->getHost());
+    }
+
+    private function session(): ?SessionInterface
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request instanceof Request || !$request->hasSession()) {
+            return null;
+        }
+
+        return $request->getSession();
+    }
+}

--- a/core/lib/Thelia/Form/BaseForm.php
+++ b/core/lib/Thelia/Form/BaseForm.php
@@ -35,6 +35,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\TheliaFormEvent;
 use Thelia\Core\Translation\Translator;
 use Thelia\Model\ConfigQuery;
+use Thelia\Tools\RedirectUrl;
 use Thelia\Tools\URL;
 
 /**
@@ -212,7 +213,7 @@ abstract class BaseForm implements FormInterface
      */
     public function hasErrorUrl(): bool
     {
-        return null !== $this->form->get('error_url')->getData();
+        return $this->hasDefinedUrl('error_url');
     }
 
     /**
@@ -233,7 +234,19 @@ abstract class BaseForm implements FormInterface
      */
     public function hasSuccessUrl(): bool
     {
-        return null !== $this->form->get('success_url')->getData();
+        return $this->hasDefinedUrl('success_url');
+    }
+
+    /**
+     * A template that always renders the hidden field submits an empty string when it has
+     * no URL to give: that is no URL at all, and answering true here would send the visitor
+     * to the shop home page instead of wherever the controller would have taken them.
+     */
+    private function hasDefinedUrl(string $parameterName): bool
+    {
+        $url = $this->form->get($parameterName)->getData();
+
+        return \is_string($url) && '' !== trim($url);
     }
 
     /**
@@ -264,31 +277,11 @@ abstract class BaseForm implements FormInterface
 
     /**
      * A redirection URL is considered safe when it is a relative path, or an absolute
-     * http(s) URL whose host matches the current request host. Protocol-relative URLs,
-     * backslash tricks and non-http schemes (javascript:, data:, file:, ...) are rejected.
+     * http(s) URL whose host matches the current request host.
      */
     private function isSafeRedirectUrl(string $url): bool
     {
-        $url = trim($url);
-
-        if ('' === $url || str_starts_with($url, '//') || str_contains($url, '\\')) {
-            return false;
-        }
-
-        if (preg_match('#^https?://#i', $url)) {
-            $host = parse_url($url, \PHP_URL_HOST);
-
-            return \is_string($host) && '' !== $host
-                && isset($this->request)
-                && 0 === strcasecmp($host, $this->request->getHost());
-        }
-
-        // Reject any other scheme (javascript:, data:, file:, https:evil.com, ...).
-        if (preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url)) {
-            return false;
-        }
-
-        return true;
+        return isset($this->request) && RedirectUrl::isSafe($url, $this->request->getHost());
     }
 
     public function createView()

--- a/core/lib/Thelia/Tools/RedirectUrl.php
+++ b/core/lib/Thelia/Tools/RedirectUrl.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tools;
+
+/**
+ * Decides whether a URL a visitor handed over may be redirected to.
+ *
+ * Form fields (success_url, error_url) and query parameters that say where to go
+ * next are written by whoever sends the request, so they are checked here before
+ * a Location header is built out of them (CWE-601).
+ */
+final class RedirectUrl
+{
+    /**
+     * A redirection URL is safe when it is a relative path, or an absolute http(s)
+     * URL whose host is the one being browsed. Protocol-relative URLs, backslash
+     * tricks and non-http schemes (javascript:, data:, file:, ...) are rejected.
+     */
+    public static function isSafe(string $url, string $currentHost): bool
+    {
+        $url = trim($url);
+
+        if ('' === $url || str_starts_with($url, '//') || str_contains($url, '\\')) {
+            return false;
+        }
+
+        if (preg_match('#^https?://#i', $url)) {
+            $host = parse_url($url, \PHP_URL_HOST);
+
+            return \is_string($host) && '' !== $host && 0 === strcasecmp($host, $currentHost);
+        }
+
+        // Reject any other scheme (javascript:, data:, file:, https:evil.com, ...).
+        return 1 !== preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url);
+    }
+}

--- a/tests/Http/Flexy/GuestCheckoutTestCase.php
+++ b/tests/Http/Flexy/GuestCheckoutTestCase.php
@@ -254,14 +254,19 @@ abstract class GuestCheckoutTestCase extends WebIntegrationTestCase
         OrderTableMap::clearRelatedInstancePool();
     }
 
+    /**
+     * The query string is left out of the comparison: a redirection to the login page
+     * carries the page to come back to, and none of these assertions are about that.
+     */
     protected function assertResponseRedirectsTo(string $path): void
     {
         $response = $this->client->getResponse();
+        $location = (string) $response->headers->get('Location');
 
         self::assertTrue($response->isRedirect(), 'The request must answer with a redirect.');
         self::assertStringEndsWith(
             $path,
-            (string) $response->headers->get('Location'),
+            parse_url($location, \PHP_URL_PATH) ?: $location,
             \sprintf('The redirect must lead to "%s".', $path),
         );
     }

--- a/tests/Http/Flexy/SignInReturnUrlTest.php
+++ b/tests/Http/Flexy/SignInReturnUrlTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Thelia\Domain\Customer\Service\AuthenticationReturnUrl;
+use Thelia\Model\Customer;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * Signing in interrupts what a visitor was doing, and they are meant to come back to it.
+ *
+ * The page they were on travels as a query parameter of the sign-in links, the form posts
+ * it back, and the session remembers it for as long as the journey takes. What a visitor
+ * writes in that parameter is checked against the shop host, so it cannot be used to
+ * bounce someone off the shop (CWE-601).
+ */
+final class SignInReturnUrlTest extends WebIntegrationTestCase
+{
+    private const PASSWORD = 'a-password-of-a-real-account';
+
+    public function testTheSignInLinkOfAPageNamesThatPage(): void
+    {
+        $crawler = $this->client->request('GET', '/contact');
+
+        self::assertNotSame(
+            0,
+            $crawler->filter('a[href*="'.AuthenticationReturnUrl::PARAMETER.'=%2Fcontact"], a[href*="'.AuthenticationReturnUrl::PARAMETER.'=/contact"]')->count(),
+            'The header sign-in link must carry the page it is displayed on.',
+        );
+    }
+
+    public function testAVisitorComesBackToThePageTheySignedInFrom(): void
+    {
+        $account = $this->enabledAccount();
+
+        $this->submitLoginForm('/customer/login?'.AuthenticationReturnUrl::PARAMETER.'=/contact', $account);
+
+        self::assertStringEndsWith('/contact', $this->redirectionTarget());
+    }
+
+    public function testAReturnUrlLeavingTheShopIsIgnored(): void
+    {
+        $account = $this->enabledAccount();
+
+        $this->submitLoginForm(
+            '/customer/login?'.AuthenticationReturnUrl::PARAMETER.'='.urlencode('https://evil.example.net/pwn'),
+            $account,
+        );
+
+        self::assertStringEndsWith('/account', $this->redirectionTarget());
+    }
+
+    public function testTheDestinationSurvivesAWrongPassword(): void
+    {
+        $account = $this->enabledAccount();
+        $signInPage = '/customer/login?'.AuthenticationReturnUrl::PARAMETER.'=/contact';
+
+        $this->submitLoginForm($signInPage, $account, 'not-the-password');
+
+        // Second attempt from the bare sign-in page: the parameter is gone from the URL,
+        // and the session is what still knows where the visitor was going.
+        $this->submitLoginForm('/customer/login', $account);
+
+        self::assertStringEndsWith('/contact', $this->redirectionTarget());
+    }
+
+    public function testAGuardedPageIsNamedInTheRedirectionToTheSignInPage(): void
+    {
+        $this->client->request('GET', '/account/orders');
+
+        self::assertStringContainsString(
+            AuthenticationReturnUrl::PARAMETER.'=',
+            $this->redirectionLocation(),
+            'A page behind the login must be named in the redirection, to be given back after the sign-in.',
+        );
+    }
+
+    public function testRegisteringSignsTheNewCustomerIn(): void
+    {
+        $crawler = $this->client->request('GET', '/customer/register');
+        $form = $crawler->filter('form[name="flexybundle_form_customer_register_form"]')->form();
+
+        $form['flexybundle_form_customer_register_form[firstname]'] = 'Jane';
+        $form['flexybundle_form_customer_register_form[lastname]'] = 'Doe';
+        $form['flexybundle_form_customer_register_form[email]'] = 'signed-in-on-registration@example.com';
+        $form['flexybundle_form_customer_register_form[password]'] = self::PASSWORD;
+
+        $this->client->submit($form);
+
+        // The account pages answer 200 only to a session that holds an account: before the
+        // registration signed the new customer in, this bounced back to the login form.
+        $this->client->request('GET', '/account');
+
+        self::assertSame(
+            200,
+            $this->client->getResponse()->getStatusCode(),
+            'The first registration step must sign the new customer in, as nothing is left to check.',
+        );
+    }
+
+    private function submitLoginForm(string $signInPage, Customer $account, ?string $password = null): void
+    {
+        $crawler = $this->client->request('GET', $signInPage);
+        $form = $crawler->filter('form[name="thelia_customer_login"]')->form();
+
+        $form['thelia_customer_login[email]'] = (string) $account->getEmail();
+        $form['thelia_customer_login[password]'] = $password ?? self::PASSWORD;
+        $form['thelia_customer_login[account]'] = '1';
+
+        $this->client->submit($form);
+    }
+
+    /**
+     * The path alone: the destination is what these assertions are about, not the query
+     * string a redirection to the sign-in page carries.
+     */
+    private function redirectionTarget(): string
+    {
+        $location = $this->redirectionLocation();
+
+        return parse_url($location, \PHP_URL_PATH) ?: $location;
+    }
+
+    private function redirectionLocation(): string
+    {
+        $response = $this->client->getResponse();
+
+        self::assertTrue($response->isRedirect(), 'The request must answer with a redirect.');
+
+        return (string) $response->headers->get('Location');
+    }
+
+    private function enabledAccount(): Customer
+    {
+        $fixtures = new FixtureFactory($this->getPropelConnection());
+        $account = $fixtures->customer($fixtures->customerTitle(), ['password' => self::PASSWORD]);
+
+        // Fixtures come out disabled, and an unconfirmed account is sent to the activation
+        // page instead of signing in.
+        $account->setEnable(1)->save($this->getPropelConnection());
+
+        return $account;
+    }
+}

--- a/tests/Http/Flexy/SignInReturnUrlTest.php
+++ b/tests/Http/Flexy/SignInReturnUrlTest.php
@@ -18,6 +18,7 @@ use Thelia\Domain\Customer\Service\AuthenticationReturnUrl;
 use Thelia\Model\Customer;
 use Thelia\Test\FixtureFactory;
 use Thelia\Test\WebIntegrationTestCase;
+use Twig\Environment;
 
 /**
  * Signing in interrupts what a visitor was doing, and they are meant to come back to it.
@@ -30,6 +31,21 @@ use Thelia\Test\WebIntegrationTestCase;
 final class SignInReturnUrlTest extends WebIntegrationTestCase
 {
     private const PASSWORD = 'a-password-of-a-real-account';
+
+    /**
+     * A theme older than this feature carries none of it, and the core ships with whichever
+     * theme version it is given: reported as a skip rather than a failure. The Twig function
+     * the sign-in links call is what the templates and the controller were changed together
+     * with, so its presence answers for the whole of it.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (null === $this->getService(Environment::class)->getFunction('sign_in_path')) {
+            self::markTestSkipped('The installed front-office theme does not carry the return to the interrupted page yet.');
+        }
+    }
 
     public function testTheSignInLinkOfAPageNamesThatPage(): void
     {

--- a/tests/Integration/Controller/Front/BaseFrontControllerTest.php
+++ b/tests/Integration/Controller/Front/BaseFrontControllerTest.php
@@ -20,6 +20,7 @@ use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\HttpKernel\Exception\RedirectException;
 use Thelia\Core\Security\SecurityContext;
+use Thelia\Domain\Customer\Service\AuthenticationReturnUrl;
 use Thelia\Test\IntegrationTestCase;
 
 /**
@@ -40,6 +41,26 @@ final class BaseFrontControllerTest extends IntegrationTestCase
     public function testAnAnonymousVisitorIsSentToTheLoginPage(): void
     {
         $this->assertRedirectsTo('/customer/login', static fn (FrontControllerUnderTest $controller) => $controller->checkAuth());
+    }
+
+    /**
+     * The page that was asked for comes back once the visitor has signed in, so the
+     * redirection names it.
+     */
+    public function testTheGuardedPageTravelsWithTheRedirectionToTheLoginPage(): void
+    {
+        try {
+            $this->controller()->checkAuth();
+        } catch (RedirectException $redirect) {
+            self::assertStringContainsString(
+                AuthenticationReturnUrl::PARAMETER.'='.rawurlencode('/'),
+                $redirect->getUrl(),
+            );
+
+            return;
+        }
+
+        self::fail('Expected a RedirectException towards the login page.');
     }
 
     /**
@@ -90,7 +111,9 @@ final class BaseFrontControllerTest extends IntegrationTestCase
         try {
             $guard($this->controller());
         } catch (RedirectException $redirect) {
-            self::assertStringEndsWith($expectedPath, $redirect->getUrl());
+            // The query string a guard may append (the page to come back to, for the
+            // login) is not what these assertions are about.
+            self::assertStringEndsWith($expectedPath, parse_url($redirect->getUrl(), \PHP_URL_PATH) ?: $redirect->getUrl());
 
             return;
         }

--- a/tests/Unit/Domain/Customer/AuthenticationReturnUrlTest.php
+++ b/tests/Unit/Domain/Customer/AuthenticationReturnUrlTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Domain\Customer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Thelia\Domain\Customer\Service\AuthenticationReturnUrl;
+
+final class AuthenticationReturnUrlTest extends TestCase
+{
+    private const DEFAULT = '/account';
+
+    public function testTheLinkOfAPageComesBackToThatPage(): void
+    {
+        [$service] = $this->serviceFor('/checkout/delivery?slot=12');
+
+        self::assertSame('/checkout/delivery?slot=12', $service->of(Request::create('/checkout/delivery?slot=12')));
+    }
+
+    public function testConsumesTheParameterOfTheCurrentRequest(): void
+    {
+        [$service] = $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => '/checkout/cart']);
+
+        self::assertSame('/checkout/cart', $service->consume(self::DEFAULT));
+    }
+
+    public function testFallsBackToTheDefaultWithoutAnything(): void
+    {
+        [$service] = $this->serviceFor('/customer/login');
+
+        self::assertSame(self::DEFAULT, $service->consume(self::DEFAULT));
+    }
+
+    public function testRefusesAParameterLeavingTheShop(): void
+    {
+        [$service] = $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => 'https://evil.example.net/pwn']);
+
+        self::assertSame(self::DEFAULT, $service->consume(self::DEFAULT));
+    }
+
+    public function testCapturedUrlSurvivesTheNextRequests(): void
+    {
+        $session = $this->session();
+
+        $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => '/category/wine'], $session)[0]->capture();
+
+        // The registration form, then its second step: neither carries the parameter.
+        $this->serviceFor('/customer/register', session: $session)[0]->capture();
+        $onSecondStep = $this->serviceFor('/customer/informations', session: $session)[0];
+
+        self::assertSame('/category/wine', $onSecondStep->consume(self::DEFAULT));
+        self::assertSame(self::DEFAULT, $onSecondStep->consume(self::DEFAULT), 'consume() forgets what it hands back');
+    }
+
+    public function testTheParameterOfTheRequestWinsOverWhatWasCaptured(): void
+    {
+        $session = $this->session();
+        $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => '/category/wine'], $session)[0]->capture();
+
+        $posted = $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => '/checkout/cart'], $session)[0];
+
+        self::assertSame('/checkout/cart', $posted->consume(self::DEFAULT));
+    }
+
+    public function testForgetDropsWhatWasCaptured(): void
+    {
+        $session = $this->session();
+        $this->serviceFor('/customer/login', [AuthenticationReturnUrl::PARAMETER => '/category/wine'], $session)[0]->capture();
+
+        $service = $this->serviceFor('/customer/login', session: $session)[0];
+        $service->forget();
+
+        self::assertSame(self::DEFAULT, $service->consume(self::DEFAULT));
+    }
+
+    public function testWorksWithoutASession(): void
+    {
+        $stack = new RequestStack();
+        $stack->push(Request::create('/customer/login'));
+        $service = new AuthenticationReturnUrl($stack);
+
+        $service->capture();
+        $service->forget();
+
+        self::assertSame(self::DEFAULT, $service->consume(self::DEFAULT));
+    }
+
+    /**
+     * @return array{AuthenticationReturnUrl, Request}
+     */
+    private function serviceFor(string $uri, array $parameters = [], ?Session $session = null): array
+    {
+        $query = [] === $parameters ? '' : '?'.http_build_query($parameters);
+        $request = Request::create($uri.$query);
+        $request->setSession($session ?? $this->session());
+
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        return [new AuthenticationReturnUrl($stack), $request];
+    }
+
+    private function session(): Session
+    {
+        return new Session(new MockArraySessionStorage());
+    }
+}

--- a/tests/Unit/Tools/RedirectUrlTest.php
+++ b/tests/Unit/Tools/RedirectUrlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Tools;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Thelia\Tools\RedirectUrl;
+
+final class RedirectUrlTest extends TestCase
+{
+    #[DataProvider('safeUrls')]
+    public function testAcceptsUrlsThatStayOnTheShop(string $url): void
+    {
+        self::assertTrue(RedirectUrl::isSafe($url, 'shop.example.com'));
+    }
+
+    #[DataProvider('unsafeUrls')]
+    public function testRejectsUrlsThatLeaveTheShop(string $url): void
+    {
+        self::assertFalse(RedirectUrl::isSafe($url, 'shop.example.com'));
+    }
+
+    public static function safeUrls(): iterable
+    {
+        yield 'relative path' => ['/checkout/delivery'];
+        yield 'relative path with query' => ['/category/wine?page=2'];
+        yield 'path without leading slash' => ['account'];
+        yield 'absolute url on the same host' => ['https://shop.example.com/cart'];
+        yield 'same host, other scheme' => ['http://shop.example.com/cart'];
+        yield 'same host, different case' => ['https://SHOP.example.com/cart'];
+        yield 'surrounded by spaces' => ['  /cart  '];
+    }
+
+    public static function unsafeUrls(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'blank' => ['   '];
+        yield 'another host' => ['https://evil.example.net/pwn'];
+        yield 'protocol relative' => ['//evil.example.net/pwn'];
+        yield 'backslash trick' => ['/\\evil.example.net'];
+        yield 'javascript scheme' => ['javascript:alert(1)'];
+        yield 'data scheme' => ['data:text/html,<script>alert(1)</script>'];
+        yield 'scheme without slashes' => ['https:evil.example.net'];
+        yield 'host lookalike' => ['https://shop.example.com.evil.net/cart'];
+    }
+}


### PR DESCRIPTION
Signing in, or creating an account, always lands on `/account` today, whatever the visitor
was doing when they were asked for it: filling a cart, reading a product sheet, entering
the checkout. They then have to find their own way back. Thelia 2 did not behave that way —
its mini-login posted `{navigate to="current"}` as `success_url` — and the checkout
identification page added with the guest checkout is the only place in Flexy that says
where to go next.

## What this adds

- `Thelia\Domain\Customer\Service\AuthenticationReturnUrl`: remembers the page to come
  back to. It reads the `redirect` parameter of the request, keeps it in the session for
  the length of the sign-in journey (a wrong password, the two registration steps, the
  activation code) and hands it back once the session holds a customer. It deliberately
  ignores the `Referer` header and the previous URL the core keeps in session — the latter
  is overwritten by the sign-in page itself as soon as it is rendered, so reading it would
  send the visitor back to the form they had just filled in.
- `BaseFrontController::checkAuth()` now names the guarded page in its redirection, so a
  visitor sent to the login page from the order history or a checkout step is given that
  page back.
- `Thelia\Tools\RedirectUrl`: the same-host check that `BaseForm` had inline, so the
  service and the form share one rule. A URL that leaves the shop, a protocol-relative
  URL, a backslash trick or a `javascript:` scheme falls back to the trusted default
  (CWE-601). No behaviour change for the form fields.
- `BaseForm::hasSuccessUrl()` / `hasErrorUrl()` no longer answer `true` for an empty
  hidden field. A template that always renders `success_url` submits an empty string when
  it has no destination to give; answering `true` there sent the visitor to the shop home
  page instead of wherever the controller would have taken them.

The theme side (the sign-in links carrying the page they are on, the login form posting
the destination, and signing a new customer in at the end of the registration) is in
thelia-templates/flexy.

## Tests

- `tests/Unit/Tools/RedirectUrlTest.php`: 16 cases, safe and unsafe URLs.
- `tests/Unit/Domain/Customer/AuthenticationReturnUrlTest.php`: the parameter, the session
  hand-over across requests, the priority between the two, and no session at all.
- `tests/Http/Flexy/SignInReturnUrlTest.php`: over http — the link of a page names that
  page, signing in comes back to it, a URL leaving the shop is ignored, the destination
  survives a wrong password, a guarded page is named in the redirection, and the first
  registration step signs the new customer in.
- `tests/Integration/Controller/Front/BaseFrontControllerTest.php`: the guarded page
  travels with the redirection.

`composer ci` is green locally (cs-diff, phpstan, the five PHPUnit suites) on a DDEV
install of this branch with the Flexy theme at its own `main`.