### PR TITLE
perf(database): name the character set in the DSN

### DIFF
--- a/core/lib/Thelia/Config/DatabaseConfigurationSource.php
+++ b/core/lib/Thelia/Config/DatabaseConfigurationSource.php
@@ -27,6 +27,15 @@ use Symfony\Component\Yaml\Yaml;
  */
 class DatabaseConfigurationSource
 {
+    /**
+     * Character set of a connection that does not name one itself.
+     *
+     * "utf8" is an alias for utf8mb3 in MySQL and MariaDB: it stores three
+     * bytes per character and rejects everything outside the Basic Multilingual
+     * Plane, emoji included.
+     */
+    public const DEFAULT_CHARSET = 'utf8mb4';
+
     /** Map of [connection name => connection ParameterBag]. */
     protected array $connections;
 
@@ -48,7 +57,7 @@ class DatabaseConfigurationSource
                     'driver' => 'mysql',
                     'user' => $envParameters['thelia.database_user'],
                     'password' => $envParameters['thelia.database_password'],
-                    'dsn' => \sprintf('mysql:host=%s;dbname=%s;port=%s', $envParameters['thelia.database_host'], $envParameters['thelia.database_name'], $envParameters['thelia.database_port']),
+                    'dsn' => \sprintf('mysql:host=%s;dbname=%s;port=%s;charset=%s', $envParameters['thelia.database_host'], $envParameters['thelia.database_name'], $envParameters['thelia.database_port'], self::DEFAULT_CHARSET),
                     'classname' => ConnectionWrapper::class,
                 ],
                 $envParameters,
@@ -133,18 +142,14 @@ class DatabaseConfigurationSource
         foreach ($this->connections as $connectionName => $connectionParameterBag) {
             $propelConnections[$connectionName] = [
                 'adapter' => $connectionParameterBag->get('driver'),
-                'dsn' => $connectionParameterBag->get('dsn'),
+                // The character set travels in the DSN, where pdo_mysql applies
+                // it while the connection is being opened. Asking for it with a
+                // SET NAMES afterwards costs a round trip on every single
+                // connection, and a remote database charges for each one.
+                'dsn' => self::withCharset($connectionParameterBag->get('dsn')),
                 'user' => $connectionParameterBag->get('user'),
                 'password' => $connectionParameterBag->get('password'),
                 'classname' => $connectionParameterBag->get('classname'),
-                'settings' => [
-                    'queries' => [
-                        // "utf8" is an alias for utf8mb3 in MySQL and MariaDB: it
-                        // stores three bytes per character and rejects everything
-                        // outside the Basic Multilingual Plane, emoji included.
-                        "SET NAMES 'utf8mb4'",
-                    ],
-                ],
             ];
         }
 
@@ -166,12 +171,30 @@ class DatabaseConfigurationSource
         $theliaConnectionParameterBag = $this->connections[DatabaseConfiguration::THELIA_CONNECTION_NAME];
 
         return new \PDO(
-            $theliaConnectionParameterBag->get('dsn'),
+            self::withCharset($theliaConnectionParameterBag->get('dsn')),
             $theliaConnectionParameterBag->get('user'),
             $theliaConnectionParameterBag->get('password'),
-            [
-                \PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4'",
-            ],
         );
+    }
+
+    /**
+     * Names the character set in a MySQL DSN that does not name one already.
+     *
+     * A connection described in a database.yml carries its DSN verbatim, so a
+     * shop that has chosen a character set keeps it.
+     */
+    public static function withCharset(string $dsn): string
+    {
+        if (!str_starts_with($dsn, 'mysql:')) {
+            return $dsn;
+        }
+
+        foreach (explode(';', substr($dsn, \strlen('mysql:'))) as $parameter) {
+            if (str_starts_with(strtolower(ltrim($parameter)), 'charset=')) {
+                return $dsn;
+            }
+        }
+
+        return rtrim($dsn, ';').';charset='.self::DEFAULT_CHARSET;
     }
 }

--- a/tests/Integration/Core/Propel/ConnectionCharsetTest.php
+++ b/tests/Integration/Core/Propel/ConnectionCharsetTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Propel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Thelia\Model\Config;
+use Thelia\Model\ConfigQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The character set asked for in the DSN has to be the one the connection
+ * actually speaks: it replaces the SET NAMES that used to be run on every
+ * connection, so nothing else sets it any more.
+ */
+final class ConnectionCharsetTest extends IntegrationTestCase
+{
+    #[Test]
+    public function theConnectionSpeaksFourByteUnicode(): void
+    {
+        $variables = $this->getPropelConnection()
+            ->query("SHOW VARIABLES LIKE 'character_set_client'")
+            ->fetch(\PDO::FETCH_ASSOC);
+
+        self::assertSame('utf8mb4', $variables['Value']);
+    }
+
+    #[Test]
+    public function aFourByteCharacterSurvivesARoundTrip(): void
+    {
+        $name = 'charset_probe_'.bin2hex(random_bytes(4));
+        $value = 'Caffè 🍰 漢字';
+
+        (new Config())
+            ->setName($name)
+            ->setValue($value)
+            ->save();
+
+        ConfigQuery::resetCache();
+
+        self::assertSame(
+            $value,
+            ConfigQuery::create()->findOneByName($name)->getValue(),
+            'A character outside the Basic Multilingual Plane must not be lost.',
+        );
+    }
+}

--- a/tests/Unit/Config/DatabaseConfigurationSourceCharsetTest.php
+++ b/tests/Unit/Config/DatabaseConfigurationSourceCharsetTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Thelia\Config\DatabaseConfiguration;
+use Thelia\Config\DatabaseConfigurationSource;
+
+/**
+ * The character set of a connection belongs in its DSN: pdo_mysql applies it
+ * while the connection is being opened, where it costs nothing, instead of the
+ * round trip a SET NAMES pays on every connection.
+ */
+final class DatabaseConfigurationSourceCharsetTest extends TestCase
+{
+    #[Test]
+    public function theDsnBuiltFromTheEnvironmentNamesTheCharacterSet(): void
+    {
+        $connections = $this->sourceFromEnvironment()
+            ->getPropelConnectionsConfiguration()['propel']['database']['connections'];
+
+        self::assertSame(
+            'mysql:host=db.example.org;dbname=shop;port=3306;charset=utf8mb4',
+            $connections[DatabaseConfiguration::THELIA_CONNECTION_NAME]['dsn'],
+        );
+    }
+
+    #[Test]
+    public function noQueryIsRunToOpenAConnection(): void
+    {
+        $connection = $this->sourceFromEnvironment()
+            ->getPropelConnectionsConfiguration()['propel']['database']['connections'][DatabaseConfiguration::THELIA_CONNECTION_NAME];
+
+        self::assertArrayNotHasKey(
+            'settings',
+            $connection,
+            'A connection must not carry an initialisation query any more.',
+        );
+    }
+
+    #[Test]
+    public function aDsnNamingItsOwnCharacterSetKeepsIt(): void
+    {
+        self::assertSame(
+            'mysql:host=localhost;dbname=shop;charset=latin1',
+            DatabaseConfigurationSource::withCharset('mysql:host=localhost;dbname=shop;charset=latin1'),
+        );
+        self::assertSame(
+            'mysql:host=localhost;dbname=shop;CHARSET=Latin1',
+            DatabaseConfigurationSource::withCharset('mysql:host=localhost;dbname=shop;CHARSET=Latin1'),
+        );
+    }
+
+    #[Test]
+    public function aDsnOfAnotherDriverIsLeftAlone(): void
+    {
+        self::assertSame(
+            'pgsql:host=localhost;dbname=shop',
+            DatabaseConfigurationSource::withCharset('pgsql:host=localhost;dbname=shop'),
+        );
+    }
+
+    #[Test]
+    public function aTrailingSemicolonDoesNotProduceAnEmptyParameter(): void
+    {
+        self::assertSame(
+            'mysql:host=localhost;dbname=shop;charset=utf8mb4',
+            DatabaseConfigurationSource::withCharset('mysql:host=localhost;dbname=shop;'),
+        );
+    }
+
+    private function sourceFromEnvironment(): DatabaseConfigurationSource
+    {
+        return new DatabaseConfigurationSource([
+            'kernel.environment' => 'test',
+            'thelia.database_host' => 'db.example.org',
+            'thelia.database_name' => 'shop',
+            'thelia.database_port' => '3306',
+            'thelia.database_user' => 'shop',
+            'thelia.database_password' => 'secret',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Propel opened every connection and then ran `SET NAMES 'utf8mb4'` on it, declared as an initialisation query. That is one round trip per connection, on top of the handshake — measurable as soon as the database is not on the same host (≈1.9 ms per query on the deployment this came from).
- `pdo_mysql` applies the `charset` named in the DSN during the handshake, so the connection speaks utf8mb4 with nothing sent afterwards. Verified on MariaDB 10.11: `character_set_client`, `character_set_connection` and `character_set_results` are all `utf8mb4`, and no `SET NAMES` reaches the server (general log). The DSN `charset` parameter is handled by pdo_mysql itself, so MySQL and MariaDB behave the same.
- A DSN written in a `database.yml` that already names a character set keeps it, and a DSN of another driver is left untouched.
- One observable difference: `SET NAMES` also reset `collation_connection` to the default collation of the character set, so a hosting that configures a connection collation (a MySQL `init_connect`, for instance) had it overwritten. It is now honoured. On a server that configures none, the collation is the same as before.
- Measured on the demo shop of this repository: `GET /` 152 → 151 queries, one per connection saved.

## Test plan

- [x] `tests/Unit/Config/DatabaseConfigurationSourceCharsetTest.php` — red before, green after: the DSN carries the charset, the connection no longer carries an initialisation query, an explicit charset is kept, a non-mysql DSN is untouched.
- [x] `tests/Integration/Core/Propel/ConnectionCharsetTest.php` — the connection speaks utf8mb4 and a four-byte character survives a round trip.
- [x] Fresh install replayed on an emptied database (`bin/install --with-demo --with-admin`), front office and back office answer 200.
- [x] `composer test` green (unit 444, integration 880, api 337, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors