### PR TITLE
perf(api): batch the relations reached under a collection

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/PropelRelationPreloader.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/PropelRelationPreloader.php
@@ -18,19 +18,28 @@ use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Map\RelationMap;
 use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Propel;
+use Symfony\Component\Serializer\Annotation\Groups;
 use Thelia\Api\Bridge\Propel\Attribute\Relation;
 use Thelia\Api\Resource\PropelResourceInterface;
+use Thelia\Api\Resource\TranslatableResourceInterface;
 
 /**
- * Reads the to-many relations of a whole collection at once.
+ * Reads the relations of a whole collection at once.
  *
- * A collection cannot join them: one product with three sale elements would
- * come back as three product rows and the page count would be wrong. So the
- * query returns the parents alone, and the transformer then asks each parent
- * for its children, one query per row — the shape that makes a page cost more
- * as the catalogue grows. Propel reads the same rows for the whole collection
- * in one statement per relation, which is what this does, before the first
- * parent is transformed.
+ * {@see \Thelia\Api\Bridge\Propel\Extension\EagerLoadingExtension} joins what a
+ * query can join: the many-to-one relations of the resource being read, and its
+ * translations. It stops at the first collection, because joining one product
+ * with three sale elements would come back as three product rows and make the
+ * page count wrong. The query therefore returns the parents alone and the
+ * transformer asks each parent for its children, one query per row.
+ *
+ * Underneath that collection nothing is joined at all, so each child in turn
+ * paid a query for its own relations and one per language for their
+ * translations: a product carrying twelve characteristics spent forty-eight
+ * queries on the features and the values behind them.
+ *
+ * Propel reads the same rows for a whole collection in one statement per
+ * relation, which is what this does, before the first parent is transformed.
  */
 final readonly class PropelRelationPreloader
 {
@@ -42,25 +51,40 @@ final readonly class PropelRelationPreloader
 
     /**
      * @param class-string<PropelResourceInterface> $resourceClass
+     * @param bool                                  $joinedByTheQuery whether the query that returned these rows
+     *                                                                joined their many-to-one relations and their
+     *                                                                translations, which holds for the collection a
+     *                                                                provider hands over and never for one reached
+     *                                                                underneath it
      */
-    public function preload(ObjectCollection $models, string $resourceClass, array $context): void
-    {
-        // populateRelation() hands each child back to its parent through the
+    public function preload(
+        ObjectCollection $models,
+        string $resourceClass,
+        array $context,
+        bool $joinedByTheQuery = true,
+    ): void {
+        // populateRelation() hands each row back to its relatives through the
         // instance pool. Without it Propel refuses the call, and reading the
         // relation row by row stays the only way.
         if (!Propel::isInstancePoolingEnabled()) {
             return;
         }
 
-        $this->walk($models, $resourceClass, $context, [], 0);
+        $this->walk($models, $resourceClass, $context, [], 0, $joinedByTheQuery);
     }
 
     /**
      * @param class-string<PropelResourceInterface> $resourceClass
      * @param array<class-string, true>             $visited
      */
-    private function walk(ObjectCollection $models, string $resourceClass, array $context, array $visited, int $depth): void
-    {
+    private function walk(
+        ObjectCollection $models,
+        string $resourceClass,
+        array $context,
+        array $visited,
+        int $depth,
+        bool $joinedByTheQuery,
+    ): void {
         if ($models->isEmpty() || $depth >= $this->maxDepth || isset($visited[$resourceClass])) {
             return;
         }
@@ -77,12 +101,23 @@ final readonly class PropelRelationPreloader
         $visited[$resourceClass] = true;
         $reflector = new \ReflectionClass($resourceClass);
 
+        if (!$joinedByTheQuery) {
+            $this->preloadTranslations($models, $tableMap, $resourceClass, $reflector, $context);
+        }
+
         foreach ($reflector->getProperties() as $property) {
             $relationAttribute = $property->getAttributes(Relation::class)[0] ?? null;
 
-            // Many-to-one relations are already joined by the eager loading
-            // extension, which only leaves out the ones that would duplicate rows.
-            if (null === $relationAttribute || 'array' !== $property->getType()?->getName()) {
+            if (null === $relationAttribute) {
+                continue;
+            }
+
+            $isCollectionRelation = 'array' === $property->getType()?->getName();
+
+            // The eager loading extension already joined the many-to-one ends of
+            // the rows the query returned, leaving out only the ones that would
+            // have duplicated them.
+            if (!$isCollectionRelation && $joinedByTheQuery) {
                 continue;
             }
 
@@ -90,7 +125,20 @@ final readonly class PropelRelationPreloader
                 continue;
             }
 
-            $relationName = $this->relationNameBehind($tableMap, $this->transformerService->resolvePropelGetterName($property));
+            $targetClass = $relationAttribute->getArguments()['targetResource'] ?? null;
+
+            // A relation pointing back at a resource already walked is the way
+            // back up the branch, and those rows are in hand: reading them again
+            // would cost a query to answer with what the caller passed in.
+            if (\is_string($targetClass) && isset($visited[$targetClass])) {
+                continue;
+            }
+
+            $relationName = $this->relationNameBehind(
+                $tableMap,
+                $this->transformerService->resolvePropelGetterName($property),
+                $isCollectionRelation,
+            );
 
             if (null === $relationName) {
                 continue;
@@ -102,12 +150,64 @@ final readonly class PropelRelationPreloader
                 continue;
             }
 
-            $targetClass = $relationAttribute->getArguments()['targetResource'] ?? null;
-
             if (\is_string($targetClass) && is_subclass_of($targetClass, PropelResourceInterface::class)) {
-                $this->walk($related, $targetClass, $context, $visited, $depth + 1);
+                $this->walk($related, $targetClass, $context, $visited, $depth + 1, joinedByTheQuery: false);
             }
         }
+    }
+
+    /**
+     * A translated model answers getTranslation() out of the translations it
+     * already holds before it queries for one, so reading them for the whole
+     * collection covers every language of every row in one statement.
+     *
+     * @param class-string<PropelResourceInterface> $resourceClass
+     */
+    private function preloadTranslations(
+        ObjectCollection $models,
+        TableMap $tableMap,
+        string $resourceClass,
+        \ReflectionClass $reflector,
+        array $context,
+    ): void {
+        if (!is_subclass_of($resourceClass, TranslatableResourceInterface::class)) {
+            return;
+        }
+
+        if (!$this->returnsTranslations($reflector, $context)) {
+            return;
+        }
+
+        $relationName = $tableMap->getPhpName().'I18n';
+
+        if (!$tableMap->hasRelation($relationName)) {
+            return;
+        }
+
+        $models->populateRelation($relationName);
+    }
+
+    /**
+     * The gate {@see \Thelia\Api\Bridge\Propel\Extension\EagerLoadingExtension}
+     * applies before joining the translations of the resource it reads.
+     */
+    private function returnsTranslations(\ReflectionClass $reflector, array $context): bool
+    {
+        if (!isset($context['groups']) || !$reflector->hasProperty('i18ns')) {
+            return true;
+        }
+
+        $groupsAttribute = $reflector->getProperty('i18ns')
+            ->getAttributes(Groups::class, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? null;
+
+        if (null === $groupsAttribute) {
+            return false;
+        }
+
+        $arguments = $groupsAttribute->getArguments();
+        $groups = $arguments['groups'] ?? $arguments[0] ?? [];
+
+        return [] !== array_intersect((array) $groups, (array) $context['groups']);
     }
 
     /**
@@ -135,14 +235,18 @@ final readonly class PropelRelationPreloader
      * key, and only the one the resource reads may be populated: the getter
      * name is what tells them apart.
      */
-    private function relationNameBehind(TableMap $tableMap, string $getterName): ?string
+    private function relationNameBehind(TableMap $tableMap, string $getterName, bool $isCollectionRelation): ?string
     {
+        $wantedType = $isCollectionRelation ? RelationMap::ONE_TO_MANY : RelationMap::MANY_TO_ONE;
+
         foreach ($tableMap->getRelations() as $relation) {
-            if (RelationMap::ONE_TO_MANY !== $relation->getType()) {
+            if ($wantedType !== $relation->getType()) {
                 continue;
             }
 
-            if ('get'.$relation->getPluralName() === $getterName) {
+            $name = $isCollectionRelation ? $relation->getPluralName() : $relation->getName();
+
+            if ('get'.$name === $getterName) {
                 return $relation->getName();
             }
         }

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelItemProvider.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelItemProvider.php
@@ -21,9 +21,11 @@ use ApiPlatform\Metadata\Put;
 use ApiPlatform\State\ProviderInterface;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Thelia\Api\Bridge\Propel\Event\ItemProviderQueryEvent;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
+use Thelia\Api\Bridge\Propel\Service\PropelRelationPreloader;
 use Thelia\Api\Resource\PropelResourceInterface;
 use Thelia\Api\State\Provider\TFiltersProvider;
 use Thelia\Model\LangQuery;
@@ -32,6 +34,7 @@ readonly class PropelItemProvider implements ProviderInterface
 {
     public function __construct(
         private ApiResourcePropelTransformerService $apiResourcePropelTransformerService,
+        private PropelRelationPreloader $propelRelationPreloader,
         private EventDispatcherInterface $eventDispatcher,
         private TFiltersProvider $filtersProvider,
         private iterable $propelItemExtensions = [],
@@ -71,10 +74,19 @@ readonly class PropelItemProvider implements ProviderInterface
             $extension->applyToItem($query, $resourceClass, $operation, $context);
         }
 
-        $propelModel = $query->findOne();
+        // findOne() is limit(1) plus a formatter that keeps a single row. Keeping
+        // the collection it came in costs the same query and gives the preloader
+        // something to read the relations of the row from, in one statement each
+        // instead of one per relation of every nested row.
+        $models = $query->limit(1)->find();
+        $propelModel = $models->getFirst();
 
         if (null === $propelModel) {
             return null;
+        }
+
+        if ($models instanceof ObjectCollection) {
+            $this->propelRelationPreloader->preload($models, $resourceClass, $context);
         }
 
         $langs = null;

--- a/core/lib/Thelia/Test/Trait/ForgetsPooledModels.php
+++ b/core/lib/Thelia/Test/Trait/ForgetsPooledModels.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Test\Trait;
+
+use Propel\Runtime\Map\TableMap;
+use Propel\Runtime\Propel;
+
+/**
+ * Empties Propel's instance pools around a measured piece of work.
+ *
+ * A test builds its fixtures in the same process as the request it measures,
+ * so the rows that request reads are already in memory: a relation answered
+ * from the pool costs no query, and a count taken that way says nothing about
+ * what the same page costs to a browser, which starts with nothing pooled.
+ *
+ * Pooling itself has to stay on. It is what hands a preloaded row back to the
+ * parent that asks for it, and Propel refuses to read a relation in bulk
+ * without it.
+ */
+trait ForgetsPooledModels
+{
+    /**
+     * @return list<string> the statements the work ran
+     */
+    protected function recordSqlQueriesWithoutPooledModels(callable $work): array
+    {
+        $wasEnabled = Propel::isInstancePoolingEnabled();
+        Propel::enableInstancePooling();
+        self::forgetPooledModels();
+
+        try {
+            return $this->recordSqlQueries($work);
+        } finally {
+            self::forgetPooledModels();
+
+            if (!$wasEnabled) {
+                Propel::disableInstancePooling();
+            }
+        }
+    }
+
+    /**
+     * The pools live on the generated table map classes, as statics that
+     * outlive the kernel: the database map is rebuilt on every boot and knows
+     * nothing of them, so the loaded classes themselves are what to ask.
+     */
+    protected static function forgetPooledModels(): void
+    {
+        foreach (get_declared_classes() as $class) {
+            if (!is_subclass_of($class, TableMap::class) || !method_exists($class, 'clearInstancePool')) {
+                continue;
+            }
+
+            $class::clearInstancePool();
+        }
+    }
+}

--- a/tests/Api/Front/ProductCollectionNestedRelationPreloadTest.php
+++ b/tests/Api/Front/ProductCollectionNestedRelationPreloadTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Category;
+use Thelia\Model\Lang;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\ForgetsPooledModels;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A collection reads its to-many relations in one query each, and then each of
+ * the rows those queries returned went back to the database on its own: the
+ * category behind a product link, and one translation of it per active
+ * language. A page of products listed under five categories spent twenty-five
+ * queries reaching them.
+ */
+final class ProductCollectionNestedRelationPreloadTest extends ApiTestCase
+{
+    use ForgetsPooledModels;
+    use RecordsSqlQueries;
+
+    private const CATEGORY_COUNT = 5;
+
+    public function testTheCategoryBehindEachProductLinkIsReadOnceForThePage(): void
+    {
+        $categories = $this->catalogue();
+
+        $payload = [];
+        $statements = $this->recordSqlQueriesWithoutPooledModels(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products?itemsPerPage='.self::CATEGORY_COUNT);
+        });
+
+        $reads = [
+            'category' => self::countSqlQueriesSelectingFrom($statements, 'category'),
+            'category_i18n' => self::countSqlQueriesSelectingFrom($statements, 'category_i18n'),
+        ];
+
+        self::assertSame(
+            ['category' => 1, 'category_i18n' => 1],
+            $reads,
+            'The categories of a page and their translations are one read each, not one read per product.',
+        );
+
+        // The rows must be the same ones, only fetched together.
+        $titles = [];
+
+        foreach ($payload['hydra:member'] as $member) {
+            foreach ($member['productCategories'] as $productCategory) {
+                $titles[] = $productCategory['category']['i18ns']['en_US']['title'] ?? null;
+            }
+        }
+
+        sort($titles);
+
+        self::assertSame(
+            array_map(
+                static fn (Category $category): string => 'Category '.$category->getId().' en_US',
+                $categories,
+            ),
+            $titles,
+        );
+    }
+
+    /**
+     * @return list<Category>
+     */
+    private function catalogue(): array
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $categories = [];
+
+        for ($index = 0; $index < self::CATEGORY_COUNT; ++$index) {
+            $category = $factory->category();
+
+            foreach (Lang::getActiveLangs() as $lang) {
+                $category
+                    ->setLocale((string) $lang->getLocale())
+                    ->setTitle('Category '.$category->getId().' '.$lang->getLocale());
+            }
+
+            $category->save($connection);
+            $factory->product($category, $taxRule, $currency);
+
+            $categories[] = $category;
+        }
+
+        return $categories;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Api/Front/ProductCollectionToManyPreloadTest.php
+++ b/tests/Api/Front/ProductCollectionToManyPreloadTest.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Api\Front;
 
-use Propel\Runtime\Propel;
 use Thelia\Model\Currency;
 use Thelia\Model\Product;
 use Thelia\Model\ProductPrice;
 use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\ForgetsPooledModels;
 use Thelia\Test\Trait\RecordsSqlQueries;
 
 /**
@@ -31,6 +31,7 @@ use Thelia\Test\Trait\RecordsSqlQueries;
  */
 final class ProductCollectionToManyPreloadTest extends ApiTestCase
 {
+    use ForgetsPooledModels;
     use RecordsSqlQueries;
 
     private const PRODUCT_COUNT = 4;
@@ -40,7 +41,7 @@ final class ProductCollectionToManyPreloadTest extends ApiTestCase
         $products = $this->catalogue();
 
         $payload = [];
-        $statements = $this->withInstancePooling(function () use (&$payload): void {
+        $statements = $this->recordSqlQueriesWithoutPooledModels(function () use (&$payload): void {
             $payload = $this->readJson('/api/front/products');
         });
 
@@ -63,32 +64,6 @@ final class ProductCollectionToManyPreloadTest extends ApiTestCase
 
             foreach ($member['productSaleElements'] as $saleElement) {
                 self::assertNotEmpty($saleElement['productPrices'] ?? []);
-            }
-        }
-    }
-
-    /**
-     * Instance pooling is what hands a preloaded row back to its parent, and
-     * the test suite turns it off to keep rolled back rows out of the next
-     * test. Turn it back on around the measured request only, then empty the
-     * pools it filled.
-     *
-     * @return list<string>
-     */
-    private function withInstancePooling(callable $work): array
-    {
-        $wasEnabled = Propel::isInstancePoolingEnabled();
-        Propel::enableInstancePooling();
-
-        try {
-            return $this->recordSqlQueries($work);
-        } finally {
-            foreach (Propel::getServiceContainer()->getDatabaseMap('thelia')->getTables() as $tableMap) {
-                $tableMap->clearInstancePool();
-            }
-
-            if (!$wasEnabled) {
-                Propel::disableInstancePooling();
             }
         }
     }

--- a/tests/Api/Front/ProductFeaturePreloadTest.php
+++ b/tests/Api/Front/ProductFeaturePreloadTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Feature;
+use Thelia\Model\FeatureAv;
+use Thelia\Model\FeatureProduct;
+use Thelia\Model\Lang;
+use Thelia\Model\Product;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\ForgetsPooledModels;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A product read returns its characteristics, and each of them names a feature
+ * and a value living in their own tables. The relation holding them is a
+ * collection, so the query cannot join it without duplicating the product row,
+ * and nothing below that collection is joined either: every characteristic was
+ * asked for its feature, its value and a translation of each in every active
+ * language. A product carrying twelve characteristics spent forty-eight
+ * queries on them.
+ */
+final class ProductFeaturePreloadTest extends ApiTestCase
+{
+    use ForgetsPooledModels;
+    use RecordsSqlQueries;
+
+    private const FEATURE_COUNT = 6;
+
+    private const READ_ONCE_PER_PRODUCT = [
+        'feature',
+        'feature_i18n',
+        'feature_av',
+        'feature_av_i18n',
+    ];
+
+    public function testTheSingleReadResolvesEachFeatureTableOnceForTheWholeProduct(): void
+    {
+        $product = $this->productWithFeatures();
+
+        $payload = [];
+        $statements = $this->recordSqlQueriesWithoutPooledModels(function () use ($product, &$payload): void {
+            $payload = $this->readJson('/api/front/products/'.$product->getId());
+        });
+
+        self::assertCount(
+            self::FEATURE_COUNT,
+            $payload['featureProducts'] ?? [],
+            'The read must return every characteristic, otherwise nothing is measured.',
+        );
+
+        $reads = [];
+
+        foreach (self::READ_ONCE_PER_PRODUCT as $table) {
+            $reads[$table] = self::countSqlQueriesSelectingFrom($statements, $table);
+        }
+
+        self::assertSame(
+            array_fill_keys(self::READ_ONCE_PER_PRODUCT, 1),
+            $reads,
+            'Each table behind the characteristics is one read for the product, not one read per characteristic.',
+        );
+    }
+
+    /**
+     * The rows have to be the same ones, only fetched together.
+     */
+    public function testTheFeaturesAndTheirTranslationsAreStillReturned(): void
+    {
+        $product = $this->productWithFeatures();
+
+        $payload = [];
+        $this->recordSqlQueriesWithoutPooledModels(function () use ($product, &$payload): void {
+            $payload = $this->readJson('/api/front/products/'.$product->getId());
+        });
+
+        $titles = [];
+
+        foreach ($payload['featureProducts'] as $featureProduct) {
+            foreach ($this->activeLocales() as $locale) {
+                $titles[] = [
+                    $featureProduct['feature']['i18ns'][$locale]['title'] ?? null,
+                    $featureProduct['featureAv']['i18ns'][$locale]['title'] ?? null,
+                ];
+            }
+        }
+
+        $expected = [];
+
+        foreach (range(1, self::FEATURE_COUNT) as $index) {
+            foreach ($this->activeLocales() as $locale) {
+                $expected[] = ['Feature '.$index.' '.$locale, 'Value '.$index.' '.$locale];
+            }
+        }
+
+        self::assertSame($expected, $titles);
+    }
+
+    private function productWithFeatures(): Product
+    {
+        $connection = $this->getPropelConnection();
+        $factory = $this->createFixtureFactory();
+
+        $product = $factory->product($factory->category(), $factory->taxRule(), $factory->currency());
+
+        for ($index = 1; $index <= self::FEATURE_COUNT; ++$index) {
+            $feature = $factory->feature(['title' => 'Feature '.$index.' en_US']);
+            $featureAv = $factory->featureAv($feature, ['title' => 'Value '.$index.' en_US']);
+
+            $this->translate($feature, 'Feature '.$index);
+            $this->translate($featureAv, 'Value '.$index);
+
+            $featureProduct = new FeatureProduct();
+            $featureProduct->setProductId($product->getId());
+            $featureProduct->setFeatureId($feature->getId());
+            $featureProduct->setFeatureAvId($featureAv->getId());
+            $featureProduct->setPosition($index);
+            $featureProduct->save($connection);
+        }
+
+        return $product;
+    }
+
+    /**
+     * A translation missing in one language is read one row at a time whether
+     * the page batched the others or not, so the product under test is
+     * translated everywhere: what is measured is then the batch alone.
+     */
+    private function translate(Feature|FeatureAv $model, string $title): void
+    {
+        foreach ($this->activeLocales() as $locale) {
+            $model->setLocale($locale)->setTitle($title.' '.$locale);
+        }
+
+        $model->save($this->getPropelConnection());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function activeLocales(): array
+    {
+        return array_map(
+            static fn (Lang $lang): string => (string) $lang->getLocale(),
+            iterator_to_array(Lang::getActiveLangs()),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary

- `EagerLoadingExtension` joins the relations of the resource a query returns and stops at the first collection, since joining a to-many would duplicate the rows a page counts. Nothing under that collection was joined either, so every row read its own relations and one translation per active language.
- `PropelRelationPreloader` now also reads the many-to-one ends and the translations of the collections it walks below the first level, and skips a relation pointing back at a resource it already holds. `PropelItemProvider` keeps the collection its query already builds (`findOne()` is `limit(1)` plus a formatter that returns one row), so a single read is batched the same way.
- Measured on the test shop, four active languages, nothing pooled: `/api/front/products/{id}` on a product with six characteristics goes from 82 to 27 statements (`feature`, `feature_i18n`, `feature_av`, `feature_av_i18n`: 6/24/6/24 to 1/1/1/1); `/api/front/products` over five products in five translated categories goes from 47 to 23 (`category`, `category_i18n`: 5/20 to 1/1).

## Test plan

- [x] `tests/Api/Front/ProductFeaturePreloadTest.php` and `tests/Api/Front/ProductCollectionNestedRelationPreloadTest.php` bound the statements per table and check the payload still carries the same rows and titles. Both fail before the change.
- [x] New `Thelia\Test\Trait\ForgetsPooledModels` empties Propel's instance pools around a measured request. A test builds its fixtures in the same process as the request, so a pooled relation answers with no query and a count taken that way measures nothing. `ProductCollectionToManyPreloadTest` moves onto it: its own clearing walked the database map, which is rebuilt on every kernel boot and holds no table map by then.
- [x] `composer test` (5 suites) green, same skips as before
- [x] `composer cs-diff` clean
- [x] `composer phpstan` clean