### PR TITLE
perf(api): count a paginated collection once

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Extension/PaginationExtension.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Extension/PaginationExtension.php
@@ -29,24 +29,18 @@ class PaginationExtension implements QueryResultCollectionExtensionInterface
     {
     }
 
-    private function getPagination(ModelCriteria $query, ?Operation $operation, array $context): ?array
+    private function getPagination(?Operation $operation, array $context): ?array
     {
-        $enabled = $this->pagination->isEnabled($operation, $context);
-
-        if (!$enabled) {
+        if (!$this->pagination->isEnabled($operation, $context)) {
             return null;
         }
 
-        $context = $this->addCountToContext($query, $context);
-
+        // Pagination reads a total only to walk back from the end of a GraphQL
+        // `last` window, and that is the offset getResult() throws away below.
+        // Counting here therefore answered nothing, and ran the heaviest
+        // statement of the page a second time: the pager counts the rows itself,
+        // and that is the total the response carries.
         return $this->pagination->getPagination($operation, $context);
-    }
-
-    private function addCountToContext(ModelCriteria $query, array $context): array
-    {
-        $context['count'] = $query->count();
-
-        return $context;
     }
 
     public function supportsResult(string $resourceClass, ?Operation $operation = null, array $context = []): bool
@@ -56,7 +50,7 @@ class PaginationExtension implements QueryResultCollectionExtensionInterface
 
     public function getResult(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = [])
     {
-        if (null === $pagination = $this->getPagination($query, $operation, $context)) {
+        if (null === $pagination = $this->getPagination($operation, $context)) {
             return $query->find();
         }
 

--- a/tests/Api/Front/ProductCollectionPaginationCountTest.php
+++ b/tests/Api/Front/ProductCollectionPaginationCountTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A paginated collection needs its total once, to say how many items there
+ * are. The pagination extension took it before reading the page and threw the
+ * answer away: the offset it fed is never used, and the pager counts the rows
+ * again a moment later. The page therefore ran the heaviest statement it has
+ * twice, a COUNT over the whole filtered catalogue.
+ */
+final class ProductCollectionPaginationCountTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private const PRODUCT_COUNT = 3;
+
+    public function testAPaginatedCollectionCountsItsTotalOnce(): void
+    {
+        $this->catalogue();
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products?itemsPerPage=2');
+        });
+
+        self::assertCount(2, $payload['hydra:member'] ?? [], 'The page must be the one that was asked for.');
+        self::assertGreaterThanOrEqual(
+            self::PRODUCT_COUNT,
+            $payload['hydra:totalItems'] ?? 0,
+            'The total must still be answered.',
+        );
+
+        self::assertSame(
+            1,
+            self::countCounts($statements),
+            'The total of a page is counted once: '.implode("\n", $statements),
+        );
+    }
+
+    /**
+     * @param list<string> $statements
+     */
+    private static function countCounts(array $statements): int
+    {
+        return \count(array_filter(
+            $statements,
+            static fn (string $statement): bool => str_contains($statement, 'COUNT('),
+        ));
+    }
+
+    private function catalogue(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        for ($index = 0; $index < self::PRODUCT_COUNT; ++$index) {
+            $factory->product($category, $taxRule, $currency);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary

- `PaginationExtension` counted the collection before reading the page. The only thing that total feeds is `Pagination::getOffset()` walking back from the end of a GraphQL `last` window, and `getResult()` discards the offset it returns.
- So every paginated collection ran a COUNT over the whole filtered set twice: once for nothing, once from the pager. On a catalogue of 14,885 products that is the heaviest statement of the page.
- The total the response carries comes from `PropelModelPager`, which counts the rows on its own. Nothing else read the context key.

## Test plan

- [x] `tests/Api/Front/ProductCollectionPaginationCountTest.php` asserts one COUNT per paginated read and checks the page and `hydra:totalItems` are unchanged. It fails before the change (2 counts).
- [x] `composer test` (5 suites) green, same skips as before
- [x] `composer cs-diff` clean
- [x] `composer phpstan` clean