### PR TITLE
fix(api): do not rebuild the addons of a back-referenced parent

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -596,7 +596,12 @@ readonly class ApiResourcePropelTransformerService
                             context: $context,
                             langs: $langs,
                             withRelation: false,
-                            withAddon: $withAddon,
+                            // This is the way back up to the parent, which the
+                            // caller is already holding, addons built and all.
+                            // Building them again bought every row an addon
+                            // resolves a second time, once per child of every
+                            // resource identified by its relations.
+                            withAddon: false,
                         ),
                     );
                     continue 2;

--- a/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
+++ b/tests/Api/Front/ProductCollectionAddonQueryCountTest.php
@@ -85,6 +85,27 @@ final class ProductCollectionAddonQueryCountTest extends ApiTestCase
         );
     }
 
+    /**
+     * A resource identified by its relations builds its IRI out of them, so the
+     * transformer walks back up to the parent whatever the groups return. That
+     * parent is the product being read, already built with its addons, and
+     * building them a second time bought the addon's rows twice per product.
+     */
+    public function testTheSingleReadBuildsTheAddonOnce(): void
+    {
+        $product = $this->productWithALibraryImage();
+
+        $statements = $this->recordSqlQueries(function () use ($product): void {
+            $this->readJson('/api/front/products/'.$product->getId());
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'library_item_image'),
+            'The read returns one product, so the addon resolves its rows once.',
+        );
+    }
+
     private function productWithALibraryImage(): Product
     {
         $factory = $this->createFixtureFactory();


### PR DESCRIPTION
## Summary

- A resource identified by its relations (`#[CompositeIdentifiers]`) builds its IRI out of them, so `shouldHydrateRelation()` lets the parent through whatever the groups return and the transformer walks back up to it. That parent is the resource the caller already holds, addons built and all.
- Building them again resolved every row an addon reads a second time. A product sheet read `library_item_image` twice for one product; on a listing the audited shop paid two extra queries per product carrying an addon, 54 of them on a 30-card page.
- The branch already truncates the relations of that parent (`withRelation: false`), and nothing in the core, the Flexy theme or the bundled modules reads an addon through a back reference.

## Test plan

- [x] `ProductCollectionAddonQueryCountTest::testTheSingleReadBuildsTheAddonOnce` asserts one `library_item_image` read per product read. It fails before the change (2 reads). The two existing tests in that file, on the collection and on the single read still returning the addon, stay green.
- [x] `composer test` (5 suites) green, same skips as before
- [x] `composer cs-diff` clean
- [x] `composer phpstan` clean