### PR TITLE
perf(kernel): stop opening a second connection on every request

### DIFF
--- a/core/lib/Thelia/Core/Propel/PropelInitService.php
+++ b/core/lib/Thelia/Core/Propel/PropelInitService.php
@@ -17,6 +17,7 @@ namespace Thelia\Core\Propel;
 use Propel\Generator\Command\ConfigConvertCommand;
 use Propel\Generator\Command\ModelBuildCommand;
 use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Connection\Exception\ConnectionException;
 use Propel\Runtime\Propel;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
@@ -233,18 +234,24 @@ class PropelInitService
      */
     public function init(bool $force = false): bool
     {
-        if (!$force && !TheliaKernel::isInstalled()) {
-            return false;
-        }
-
         $this->waitForConcurrentBuild();
 
         // Fast path must not purge the cache on failure: a transient error on one worker
         // would otherwise cascade into a pool-wide outage. Let exceptions bubble.
         if (!$force && $this->isCacheComplete()) {
-            $this->loadPropelRuntime();
+            // Propel is loaded before the shop is asked whether it is
+            // installed, so the question is put to the connection the request
+            // works on anyway. The other way round it cost a second
+            // connection, its handshake and a query, on every single request.
+            if (!$this->loadPropelRuntime()) {
+                return false;
+            }
 
-            return true;
+            return TheliaKernel::isInstalled();
+        }
+
+        if (!$force && !TheliaKernel::isInstalled()) {
+            return false;
         }
 
         $lock = (new LockFactory(new FlockStore()))->createLock('propel-cache-generation');
@@ -262,9 +269,7 @@ class PropelInitService
             }
 
             if (!$force && $this->isCacheComplete()) {
-                $this->loadPropelRuntime();
-
-                return true;
+                return $this->loadPropelRuntime() && TheliaKernel::isInstalled();
             }
 
             (new Filesystem())->mkdir(\dirname($buildingFlag));
@@ -336,17 +341,28 @@ class PropelInitService
             && file_get_contents($hashFile) === file_get_contents($modelHashFile);
     }
 
-    private function loadPropelRuntime(): void
+    /**
+     * @return bool false when no database answers behind the configured
+     *              credentials, which is the shop the installer is there for
+     */
+    private function loadPropelRuntime(): bool
     {
         require_once $this->getPropelInitFile();
 
-        $theliaDatabaseConnection = Propel::getConnection('TheliaMain');
+        try {
+            $theliaDatabaseConnection = Propel::getConnection('TheliaMain');
+        } catch (ConnectionException|\PDOException) {
+            return false;
+        }
+
         $theliaDatabaseConnection->setAttribute(ConnectionWrapper::PROPEL_ATTR_CACHE_PREPARES, true);
 
         if ($this->debug) {
             Propel::getServiceContainer()->setLogger('defaultLogger', Tlog::getInstance());
             $theliaDatabaseConnection->useDebug(true);
         }
+
+        return true;
     }
 
     public function getPropelCacheDir(): string

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -54,6 +54,7 @@ use Thelia\Api\Bridge\Propel\Extension\QueryItemExtensionInterface;
 use Thelia\Api\Bridge\Propel\Filter\FilterInterface;
 use Thelia\Api\Resource\ResourceAddonInterface;
 use Thelia\Condition\Implementation\ConditionInterface;
+use Thelia\Config\DatabaseConfiguration;
 use Thelia\Controller\ControllerInterface;
 use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\Bundle\TheliaBundle;
@@ -215,9 +216,20 @@ class TheliaKernel extends Kernel
     /**
      * @throws \Throwable
      */
-    protected function initializeContainer(): void
+    /**
+     * Initializes Propel, building its cache if necessary.
+     *
+     * Idempotent: whether the request or the console gets here first, the
+     * database is configured once.
+     *
+     * @throws \Throwable
+     */
+    private function initializePropel(): void
     {
-        // initialize Propel, building its cache if necessary
+        if (isset($this->propelInitService)) {
+            return;
+        }
+
         $this->propelSchemaLocator = new SchemaLocator(
             THELIA_CONF_DIR,
             THELIA_MODULE_DIR,
@@ -237,6 +249,11 @@ class TheliaKernel extends Kernel
             $this->theliaDatabaseConnection = Propel::getConnection('TheliaMain');
             $this->checkMySQLConfigurations($this->theliaDatabaseConnection);
         }
+    }
+
+    protected function initializeContainer(): void
+    {
+        $this->initializePropel();
 
         parent::initializeContainer();
 
@@ -433,8 +450,23 @@ class TheliaKernel extends Kernel
             return false;
         }
 
+        // Once Propel is configured, the question goes to the connection the
+        // request is going to work on anyway. Asking it on a connection of its
+        // own cost a TCP handshake and a query on every single request,
+        // whatever the request did afterwards - the most expensive thing a
+        // request needing no data at all could do, on a remote database.
+        if (Propel::getServiceContainer()->hasConnectionManager(DatabaseConfiguration::THELIA_CONNECTION_NAME)) {
+            try {
+                return self::shopHasConfiguration(
+                    Propel::getConnection(DatabaseConfiguration::THELIA_CONNECTION_NAME),
+                );
+            } catch (\Throwable) {
+                return false;
+            }
+        }
+
         try {
-            $connection = new \PDO(
+            return self::shopHasConfiguration(new \PDO(
                 \sprintf('mysql:host=%s;dbname=%s;port=%s',
                     $host,
                     self::resolveEnv('DATABASE_NAME', ''),
@@ -442,18 +474,25 @@ class TheliaKernel extends Kernel
                 ),
                 self::resolveEnv('DATABASE_USER', ''),
                 self::resolveEnv('DATABASE_PASSWORD', ''),
-            );
-            $result = $connection->query('SELECT id FROM `config`');
-            $found = $result && (false !== $result->fetch(\PDO::FETCH_ASSOC));
-
-            if ($found) {
-                self::$installed = true;
-            }
-
-            return $found;
-        } catch (\Exception $e) {
+            ));
+        } catch (\Exception) {
             return false;
         }
+    }
+
+    /**
+     * @param ConnectionInterface|\PDO $connection
+     */
+    private static function shopHasConfiguration(object $connection): bool
+    {
+        $result = $connection->query('SELECT id FROM `config`');
+        $found = $result && (false !== $result->fetch(\PDO::FETCH_ASSOC));
+
+        if ($found) {
+            self::$installed = true;
+        }
+
+        return $found;
     }
 
     private function loadAutoConfigureInterfaces(ContainerBuilder $container): void
@@ -777,10 +816,6 @@ class TheliaKernel extends Kernel
      */
     private function preBoot(): ContainerInterface
     {
-        if (!self::isInstalled()) {
-            throw new \RuntimeException('Thelia is not installed');
-        }
-
         if ($this->debug) {
             $this->startTime = microtime(true);
         }
@@ -792,6 +827,20 @@ class TheliaKernel extends Kernel
         }
 
         $this->initializeBundles();
+
+        // Configuring Propel is what answers whether the shop is installed,
+        // and it answers on the connection the request works on. Asked before,
+        // the question opened a connection of its own, ran one query and
+        // closed it, on every single request - the most expensive thing a
+        // request needing no data at all could do, on a remote database. The
+        // container is still not built until the answer is yes: it needs the
+        // Propel models a shop that is not installed has not generated.
+        $this->initializePropel();
+
+        if (!self::isInstalled()) {
+            throw new \RuntimeException('Thelia is not installed');
+        }
+
         $this->initializeContainer();
 
         $container = $this->container;

--- a/tests/Integration/Core/TheliaKernelInstalledProbeTest.php
+++ b/tests/Integration/Core/TheliaKernelInstalledProbeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core;
+
+use PHPUnit\Framework\Attributes\Test;
+use Thelia\Core\TheliaKernel;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * Whether the shop is installed is asked on every request, before anything
+ * else. It has to be asked on the connection the request works on: a
+ * connection of its own costs a TCP handshake and a query, on every request,
+ * whatever the request goes on to do.
+ */
+final class TheliaKernelInstalledProbeTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->forgetTheAnswer();
+    }
+
+    #[Test]
+    public function theQuestionIsAskedOnTheConnectionOfTheRequest(): void
+    {
+        $statements = $this->recordSqlQueries(static function (): void {
+            self::assertTrue(TheliaKernel::isInstalled());
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'The question must reach the Propel connection, not one opened for it alone.',
+        );
+    }
+
+    #[Test]
+    public function theAnswerIsAskedForOnlyOnce(): void
+    {
+        TheliaKernel::isInstalled();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            TheliaKernel::isInstalled();
+            TheliaKernel::isInstalled();
+        });
+
+        self::assertSame([], $statements, 'A yes is remembered for the rest of the process.');
+    }
+
+    private function forgetTheAnswer(): void
+    {
+        $memo = new \ReflectionProperty(TheliaKernel::class, 'installed');
+        $memo->setValue(null, null);
+    }
+}

--- a/tests/Integration/Core/TheliaKernelNotInstalledTest.php
+++ b/tests/Integration/Core/TheliaKernelNotInstalledTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * A shop with no configuration in its database is not installed, and the
+ * kernel has to say so before it builds a container: the container describes
+ * services built on Propel models that a shop which has never been installed
+ * has not generated, so building it first turns a plain "not installed" into
+ * a fatal error naming an unrelated class.
+ *
+ * The kernel is booted in a subprocess: Propel keeps its configuration in
+ * process-wide state, so a kernel pointed at another database has to be a
+ * process of its own.
+ */
+final class TheliaKernelNotInstalledTest extends TestCase
+{
+    private const REFUSED = 'REFUSED: Thelia is not installed';
+
+    /**
+     * A database every MySQL and MariaDB server holds, that every account can
+     * read, and that holds no shop: it stands for a database that answers but
+     * has never been installed into, without the test needing the right to
+     * create one.
+     */
+    private const DATABASE_WITHOUT_A_SHOP = 'information_schema';
+
+    private string $environment;
+    private string $script;
+
+    protected function setUp(): void
+    {
+        $suffix = bin2hex(random_bytes(6));
+        $this->environment = 'notinstalled'.$suffix;
+        $this->script = sys_get_temp_dir().'/thelia-not-installed-'.$suffix.'.php';
+
+        (new Filesystem())->dumpFile($this->script, $this->bootScript());
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove([
+            $this->script,
+            THELIA_ROOT.'var/cache/'.$this->environment,
+            THELIA_ROOT.'var/propel/'.$this->environment,
+        ]);
+    }
+
+    #[Test]
+    public function aDatabaseThatDoesNotExistIsNotInstalled(): void
+    {
+        $output = $this->bootKernelAgainst('thelia_no_such_database_'.bin2hex(random_bytes(4)));
+
+        self::assertStringContainsString(self::REFUSED, $output);
+    }
+
+    #[Test]
+    public function aDatabaseWithNoConfigurationIsNotInstalled(): void
+    {
+        $output = $this->bootKernelAgainst(self::DATABASE_WITHOUT_A_SHOP);
+
+        self::assertStringContainsString(self::REFUSED, $output);
+    }
+
+    #[Test]
+    public function noContainerIsBuiltForAShopThatIsNotInstalled(): void
+    {
+        $this->bootKernelAgainst(self::DATABASE_WITHOUT_A_SHOP);
+
+        $cacheDirectory = THELIA_ROOT.'var/cache/'.$this->environment;
+
+        self::assertSame(
+            [],
+            glob($cacheDirectory.'/*Container*') ?: [],
+            'The container must not be built before the shop is known to be installed.',
+        );
+    }
+
+    private function bootKernelAgainst(string $databaseName): string
+    {
+        $process = new Process(
+            [\PHP_BINARY, $this->script],
+            env: ['THELIA_PROBE_DATABASE_NAME' => $databaseName],
+        );
+        $process->run();
+
+        return $process->getOutput().$process->getErrorOutput();
+    }
+
+    /**
+     * Boots the project kernel against the database named in the environment
+     * and reports what it did, so the assertions read one line of output
+     * instead of the state of a process that is already gone.
+     */
+    private function bootScript(): string
+    {
+        $script = <<<'BOOT'
+            <?php
+
+            require '%1$svendor/autoload.php';
+
+            (new Symfony\Component\Dotenv\Dotenv())->bootEnv('%1$s.env');
+
+            $database = getenv('THELIA_PROBE_DATABASE_NAME');
+            $_SERVER['DATABASE_NAME'] = $_ENV['DATABASE_NAME'] = $database;
+            putenv('DATABASE_NAME='.$database);
+
+            try {
+                (new App\Kernel('%2$s', false))->handle(
+                    Symfony\Component\HttpFoundation\Request::create('/'),
+                );
+
+                echo "BOOTED\n";
+            } catch (RuntimeException $exception) {
+                echo 'REFUSED: '.$exception->getMessage()."\n";
+            } catch (Throwable $exception) {
+                echo 'FAILED: '.$exception::class.': '.$exception->getMessage()."\n";
+            }
+            BOOT;
+
+        return \sprintf($script, THELIA_ROOT, $this->environment);
+    }
+}


### PR DESCRIPTION
## Summary

- `TheliaKernel::preBoot()` asked `isInstalled()` before Propel was configured, so the question was put to a `\PDO` of its own: a TCP handshake, one `SELECT id FROM config`, and a close, on every single request — whatever the request went on to do. Measured on the demo shop of this repository: 2 application connections per request, one of them carrying a single query.
- Propel is now configured first, and the question goes to the connection the request works on. One connection per request instead of two. On a deployment where the database is not on the same host this is the most expensive thing a request needing no data at all could do (≈6 ms for a handshake there, against ≈1.9 ms for a query).
- The container is still not built until the answer is yes. That ordering matters: the container describes services built on Propel models that a shop which has never been installed has not generated, so building it first turns a plain "not installed" into a fatal error naming an unrelated form type.
- Propel initialization is idempotent, so the request path and the console path each configure the database exactly once.
- Measured on the demo shop of this repository: `GET /` and `GET /admin` go from 2 application connections to 1, query count unchanged.

## Test plan

- [x] `tests/Integration/Core/TheliaKernelInstalledProbeTest.php` — red before (the question reached no Propel connection), green after; also covers that a yes is remembered for the process.
- [x] `tests/Integration/Core/TheliaKernelNotInstalledTest.php` — boots the kernel in a subprocess against a database that does not exist and against one that holds no shop; both refuse with "Thelia is not installed", and no container is written. All three go red if the check is moved after the container is built.
- [x] Fresh install from an empty database (`bin/install --with-demo --with-admin`): front office 200, back-office login 200.
- [x] `composer test` green (unit 439, integration 883, api 337, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors