### PR TITLE
perf(api): resolve the rewritten urls of a page in one read

### DIFF
--- a/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
@@ -756,7 +756,7 @@ readonly class ApiResourcePropelTransformerService
             }
         }
 
-        $propelModel->setLocale($this->serializedLocale($context, $langs));
+        $propelModel->setLocale($this->serializationLocale($context, $langs));
     }
 
     /**
@@ -773,7 +773,7 @@ readonly class ApiResourcePropelTransformerService
      *
      * @param Collection<int, Lang> $langs
      */
-    private function serializedLocale(array $context, Collection $langs): string
+    public function serializationLocale(array $context, Collection $langs): string
     {
         $requested = $context['filters']['locale'] ?? null;
         $default = null;

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
@@ -25,6 +25,7 @@ use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 use Thelia\Api\Bridge\Propel\Service\PropelRelationPreloader;
 use Thelia\Api\Bridge\Propel\State\Pagination\PropelPaginator;
 use Thelia\Api\Resource\PropelResourceInterface;
+use Thelia\Api\Service\API\PublicUrlPreloader;
 use Thelia\Model\Lang;
 
 readonly class PropelCollectionProvider implements ProviderInterface
@@ -32,6 +33,7 @@ readonly class PropelCollectionProvider implements ProviderInterface
     public function __construct(
         private ApiResourcePropelTransformerService $apiResourcePropelTransformerService,
         private PropelRelationPreloader $propelRelationPreloader,
+        private PublicUrlPreloader $publicUrlPreloader,
         private iterable $propelCollectionExtensions = [],
     ) {
     }
@@ -80,28 +82,28 @@ readonly class PropelCollectionProvider implements ProviderInterface
             $this->propelRelationPreloader->preload($models, $resourceClass, $context);
         }
 
-        if ($results instanceof PropelModelPager) {
-            $resources = array_map(
-                fn ($propelModel): PropelResourceInterface => $this->apiResourcePropelTransformerService->modelToResource(
-                    resourceClass: $resourceClass,
-                    propelModel: $propelModel,
-                    context: $context,
-                    langs: $langs,
-                ),
-                iterator_to_array($results->getResults())
-            );
-
-            return new PropelPaginator($results, $resources);
-        }
-
-        return array_map(
+        $resources = array_map(
             fn ($propelModel): PropelResourceInterface => $this->apiResourcePropelTransformerService->modelToResource(
                 resourceClass: $resourceClass,
                 propelModel: $propelModel,
                 context: $context,
                 langs: $langs,
             ),
-            iterator_to_array($results),
+            iterator_to_array($results instanceof PropelModelPager ? $results->getResults() : $results),
         );
+
+        // The serializer is about to ask each resource for its public url, and
+        // each of those resolves a rewritten url of its own. Filling the memo
+        // for the page is one read per view instead of one per item.
+        $this->publicUrlPreloader->preload(
+            $resources,
+            $this->apiResourcePropelTransformerService->serializationLocale($context, $langs),
+        );
+
+        if ($results instanceof PropelModelPager) {
+            return new PropelPaginator($results, $resources);
+        }
+
+        return $resources;
     }
 }

--- a/core/lib/Thelia/Api/Service/API/PublicUrlPreloader.php
+++ b/core/lib/Thelia/Api/Service/API/PublicUrlPreloader.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Service\API;
+
+use Thelia\Tools\URL;
+
+/**
+ * Fills the rewritten url memo for a whole page of resources.
+ *
+ * `publicUrl` belongs to the read groups of every resource that has one, so
+ * something calls the getter once per item, and the getter resolves a rewritten
+ * url of its own: one rewriting_url read per item of every page. The lookup is
+ * memoized per view, locale and id, so filling the memo for the page first
+ * turns that into one read per view.
+ */
+final readonly class PublicUrlPreloader
+{
+    /**
+     * @param iterable<mixed> $resources resources holding the propel model their
+     *                                   url is resolved from
+     */
+    public function preload(iterable $resources, string $locale): void
+    {
+        $viewIdsByView = [];
+
+        foreach ($resources as $resource) {
+            if (!method_exists($resource, 'getUrl') || !method_exists($resource, 'getRewrittenUrlViewName')) {
+                continue;
+            }
+
+            $view = $resource->getRewrittenUrlViewName();
+
+            if ('' === $view) {
+                continue;
+            }
+
+            $viewIdsByView[$view][] = $resource->getId();
+        }
+
+        foreach ($viewIdsByView as $view => $viewIds) {
+            URL::getInstance()->preloadRewrittenUrls($view, $locale, $viewIds);
+        }
+    }
+}

--- a/core/lib/Thelia/Api/Service/API/ResourceService.php
+++ b/core/lib/Thelia/Api/Service/API/ResourceService.php
@@ -21,7 +21,6 @@ use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Log\Tlog;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
-use Thelia\Tools\URL;
 
 readonly class ResourceService
 {
@@ -39,6 +38,7 @@ readonly class ResourceService
         private LangService $localeService,
         private ResourceMemoizer $memoizer,
         private ResourceCache $resourceCache,
+        private PublicUrlPreloader $publicUrlPreloader,
     ) {
     }
 
@@ -111,7 +111,7 @@ readonly class ResourceService
             // getPublicUrl() is itself serialized through GROUP_*_READ, so the Serializer
             // below is about to call it once per item: the batch lookup has to run before
             // that normalization, not before the addPublicUrl() call it feeds afterward.
-            $this->preloadPublicUrls($result, $currentLocale);
+            $this->publicUrlPreloader->preload($result, $currentLocale);
         }
 
         $normalizedData = $this->normalizer->normalizeData($result, $context, $format);
@@ -220,36 +220,6 @@ readonly class ResourceService
         }
 
         return $finalNormalizedData;
-    }
-
-    /**
-     * Fills the rewritten url cache for the whole collection in one query per
-     * view name, instead of one query per item once addUrlToEntry() starts
-     * calling getUrl() in a loop.
-     *
-     * @param iterable<mixed> $resources
-     */
-    private function preloadPublicUrls(iterable $resources, string $currentLocale): void
-    {
-        $viewIdsByView = [];
-
-        foreach ($resources as $resource) {
-            if (!method_exists($resource, 'getUrl') || !method_exists($resource, 'getRewrittenUrlViewName')) {
-                continue;
-            }
-
-            $view = $resource->getRewrittenUrlViewName();
-
-            if ('' === $view) {
-                continue;
-            }
-
-            $viewIdsByView[$view][] = $resource->getId();
-        }
-
-        foreach ($viewIdsByView as $view => $viewIds) {
-            URL::getInstance()->preloadRewrittenUrls($view, $currentLocale, $viewIds);
-        }
     }
 
     private function addUrlToEntry(mixed $resource, array $entry, string $currentLocale): array

--- a/tests/Api/Front/ProductCollectionPublicUrlBatchTest.php
+++ b/tests/Api/Front/ProductCollectionPublicUrlBatchTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Product;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * `publicUrl` belongs to the read groups of a product, so the serializer calls
+ * the getter once per item of a page and each call resolved a rewritten url of
+ * its own. The lookup is memoized per view, locale and id, and the theme's own
+ * data path already fills that memo for a whole page: the serializer path did
+ * not, and paid one rewriting_url read per product listed.
+ */
+final class ProductCollectionPublicUrlBatchTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private const PRODUCT_COUNT = 5;
+
+    public function testAPageResolvesItsRewrittenUrlsInOneRead(): void
+    {
+        $products = $this->catalogue();
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products?itemsPerPage='.self::PRODUCT_COUNT);
+        });
+
+        foreach ($products as $product) {
+            self::assertSame(
+                $product->getUrl('en_US'),
+                $this->member($payload, $product->getId())['publicUrl'] ?? null,
+                'Every product of the page must keep the url it had.',
+            );
+        }
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'rewriting_url'),
+            'A page resolves its rewritten urls in one read per view.',
+        );
+    }
+
+    /**
+     * @return list<Product>
+     */
+    private function catalogue(): array
+    {
+        $factory = $this->createFixtureFactory();
+        $category = $factory->category();
+        $taxRule = $factory->taxRule();
+        $currency = $factory->currency();
+
+        $products = [];
+
+        for ($index = 0; $index < self::PRODUCT_COUNT; ++$index) {
+            $products[] = $factory->product(
+                $category,
+                $taxRule,
+                $currency,
+                ['title' => 'Listed product '.$index, 'locale' => 'en_US'],
+            );
+        }
+
+        return $products;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri): array
+    {
+        $response = $this->jsonRequest('GET', $uri);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function member(array $payload, ?int $productId): array
+    {
+        foreach ($payload['hydra:member'] ?? [] as $member) {
+            if (($member['id'] ?? null) === $productId) {
+                return $member;
+            }
+        }
+
+        self::fail('The collection must return the products under test, otherwise nothing is measured.');
+    }
+}


### PR DESCRIPTION
## Summary

- `publicUrl` belongs to the read groups of every resource that has one, so the serializer calls the getter once per item of a page and each call resolved a rewritten url on its own. A page of 24 products spent 24 `rewriting_url` reads; a five-product page in the test suite spends 5.
- `ResourceService` already filled the memo for a whole page on the theme's data path, and #3897 is what made that memo reachable from the serializer. `PropelCollectionProvider` now fills it too, in one read per view.
- The batch moves into `PublicUrlPreloader`, which both paths share instead of keeping the same loop twice.

## Test plan

- [x] `tests/Api/Front/ProductCollectionPublicUrlBatchTest.php` asserts one `rewriting_url` read for a five-product page and checks every item keeps the url it had. It fails before the change (5 reads).
- [x] `composer test` (5 suites) green, same skips as before
- [x] `composer cs-diff` clean
- [x] `composer phpstan` clean
