### PR TITLE
fix(logging): let a shop configure its own monolog handlers

### DIFF
--- a/core/lib/Thelia/Core/DependencyInjection/LoggingDefaults.php
+++ b/core/lib/Thelia/Core/DependencyInjection/LoggingDefaults.php
@@ -12,13 +12,50 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+namespace Thelia\Core\DependencyInjection;
 
-return static function (ContainerConfigurator $configurator): void {
-    $configurator->extension('monolog', [
-        'channels' => ['deprecation', 'security'],
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-        'handlers' => [
+/**
+ * The logging a shop gets when it has not written its own.
+ *
+ * These are defaults, so they are prepended, and they are prepended in groups:
+ * a group holding a handler the application names is dropped whole.
+ *
+ * Merging into a handler the application named would be worse than useless,
+ * because most handler options belong to one handler type - a shop turning
+ * "main" into a plain stream would inherit `action_level` and
+ * `excluded_http_codes` from the fingers-crossed default below, and the
+ * configuration would be refused. And a group is the unit rather than a
+ * handler because a buffering handler is nothing without the handler it writes
+ * through: leaving "main_stream" behind, once a shop has written its own
+ * "main", would put a second handler on the same file.
+ */
+final class LoggingDefaults
+{
+    public static function prependTo(ContainerBuilder $container): void
+    {
+        $handlers = [];
+        $named = self::handlersOfTheApplication($container);
+
+        foreach (self::handlerGroups() as $group) {
+            if ([] === array_intersect_key($group, $named)) {
+                $handlers += $group;
+            }
+        }
+
+        $container->prependExtensionConfig('monolog', [
+            'channels' => ['deprecation', 'security'],
+            'handlers' => $handlers,
+        ]);
+    }
+
+    /**
+     * @return list<array<string, array<string, mixed>>>
+     */
+    private static function handlerGroups(): array
+    {
+        return [[
             'main' => [
                 'type' => 'fingers_crossed',
                 'action_level' => 'error',
@@ -32,6 +69,7 @@ return static function (ContainerConfigurator $configurator): void {
                 'max_files' => 7,
                 'channels' => ['!deprecation'],
             ],
+        ], [
             // Refused authentications get a file of their own, and get there
             // whatever else happens. The main handler only opens its buffer
             // when something errors, so a warning on its own never reaches the
@@ -54,11 +92,13 @@ return static function (ContainerConfigurator $configurator): void {
                 'max_files' => 30,
                 'channels' => ['security'],
             ],
+        ], [
             'console' => [
                 'type' => 'console',
                 'process_psr_3_messages' => false,
                 'channels' => ['!event', '!doctrine', '!deprecation'],
             ],
+        ], [
             'deprecations_rotating' => [
                 'type' => 'rotating_file',
                 'path' => '%kernel.logs_dir%/deprecations-%kernel.environment%.log',
@@ -66,6 +106,22 @@ return static function (ContainerConfigurator $configurator): void {
                 'max_files' => 2,
                 'channels' => ['deprecation'],
             ],
-        ],
-    ]);
-};
+        ]];
+    }
+
+    /**
+     * @return array<string, true> the handler names the application has declared
+     */
+    private static function handlersOfTheApplication(ContainerBuilder $container): array
+    {
+        $names = [];
+
+        foreach ($container->getExtensionConfig('monolog') as $configuration) {
+            foreach (array_keys($configuration['handlers'] ?? []) as $name) {
+                $names[$name] = true;
+            }
+        }
+
+        return $names;
+    }
+}

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -58,6 +58,7 @@ use Thelia\Controller\ControllerInterface;
 use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\Bundle\TheliaBundle;
 use Thelia\Core\DependencyInjection\Loader\XmlFileLoader;
+use Thelia\Core\DependencyInjection\LoggingDefaults;
 use Thelia\Core\DependencyInjection\TheliaContainer;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Hook\BaseHookInterface;
@@ -360,6 +361,10 @@ class TheliaKernel extends Kernel
         $container = parent::buildContainer();
 
         $this->loadService($container);
+
+        // Prepended once the config/packages of the shop have been read, so
+        // that what the shop wrote about logging is what the shop gets.
+        LoggingDefaults::prependTo($container);
 
         $this->loadAutoConfigureInterfaces($container);
         $this->loadUtilsXmlConfiguration($container);

--- a/tests/Integration/Core/LoggingConfigurationTest.php
+++ b/tests/Integration/Core/LoggingConfigurationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * config/packages/monolog.yaml of this repository sends the main handler
+ * through a "nested" stream of its own. That is what the shop wrote, so that
+ * is what has to happen: the rotating file the core would have written
+ * through, had the shop said nothing, must not be in the chain at all.
+ */
+final class LoggingConfigurationTest extends IntegrationTestCase
+{
+    #[Test]
+    public function theHandlerTheShopNamedIsTheOneThatWrites(): void
+    {
+        $token = 'logging-configuration-probe-'.bin2hex(random_bytes(6));
+
+        /** @var LoggerInterface $logger */
+        $logger = $this->getService('logger');
+        $logger->error($token);
+
+        self::assertStringContainsString(
+            $token,
+            $this->read($this->fileTheShopNamed()),
+            'The stream named in config/packages/monolog.yaml must be the one the main handler writes through.',
+        );
+        self::assertStringNotContainsString(
+            $token,
+            $this->read($this->fileTheCoreWouldHaveNamed()),
+            'The default the core offers a shop that writes nothing must not be added to a shop that wrote its own.',
+        );
+    }
+
+    private function fileTheShopNamed(): string
+    {
+        return THELIA_LOG_DIR.'test.log';
+    }
+
+    private function fileTheCoreWouldHaveNamed(): string
+    {
+        return THELIA_LOG_DIR.'test-'.date('Y-m-d').'.log';
+    }
+
+    private function read(string $file): string
+    {
+        return is_file($file) ? (string) file_get_contents($file) : '';
+    }
+}

--- a/tests/Unit/Core/DependencyInjection/LoggingDefaultsTest.php
+++ b/tests/Unit/Core/DependencyInjection/LoggingDefaultsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
+use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Thelia\Core\DependencyInjection\LoggingDefaults;
+
+/**
+ * What a shop writes in its config/packages about logging is what the shop
+ * gets. The core only fills in what the shop said nothing about.
+ */
+final class LoggingDefaultsTest extends TestCase
+{
+    #[Test]
+    public function aShopThatWritesNothingGetsTheLoggingOfTheCore(): void
+    {
+        $handlers = $this->handlersOf($this->container());
+
+        self::assertSame('fingers_crossed', $handlers['main']['type']);
+        self::assertSame('main_stream', $handlers['main']['handler']);
+        self::assertArrayHasKey('security_rotating', $handlers);
+        self::assertArrayHasKey('deprecations_rotating', $handlers);
+        self::assertArrayHasKey('console', $handlers);
+    }
+
+    #[Test]
+    public function aShopNamingWhereTheMainHandlerWritesIsObeyed(): void
+    {
+        $container = $this->container([
+            'handlers' => [
+                'main' => [
+                    'type' => 'fingers_crossed',
+                    'action_level' => 'error',
+                    'handler' => 'nested',
+                    'excluded_http_codes' => [404, 405],
+                ],
+                'nested' => [
+                    'type' => 'stream',
+                    'path' => 'php://stderr',
+                    'level' => 'debug',
+                ],
+            ],
+        ]);
+
+        $handlers = $this->handlersOf($container);
+
+        self::assertSame('nested', $handlers['main']['handler']);
+        self::assertSame('php://stderr', $handlers['nested']['path']);
+    }
+
+    #[Test]
+    public function aShopTurningTheMainHandlerIntoAnotherTypeGetsAValidConfiguration(): void
+    {
+        $container = $this->container([
+            'handlers' => [
+                'main' => [
+                    'type' => 'stream',
+                    'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                    'level' => 'debug',
+                ],
+            ],
+        ]);
+
+        $handlers = $this->handlersOf($container);
+
+        self::assertSame('stream', $handlers['main']['type']);
+        self::assertArrayNotHasKey(
+            'main_stream',
+            $handlers,
+            'The handler the fingers-crossed default wrote through has no reason to survive it, and would put a second handler on the same file.',
+        );
+    }
+
+    #[Test]
+    public function whatTheShopSaidNothingAboutIsStillThere(): void
+    {
+        $container = $this->container([
+            'handlers' => [
+                'main' => [
+                    'type' => 'stream',
+                    'path' => '%kernel.logs_dir%/%kernel.environment%.log',
+                ],
+            ],
+        ]);
+
+        $handlers = $this->handlersOf($container);
+
+        self::assertSame('rotating_file', $handlers['security_rotating']['type']);
+        self::assertSame('rotating_file', $handlers['deprecations_rotating']['type']);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function handlersOf(ContainerBuilder $container): array
+    {
+        LoggingDefaults::prependTo($container);
+
+        return (new Processor())->processConfiguration(
+            new Configuration(),
+            $container->getExtensionConfig('monolog'),
+        )['handlers'];
+    }
+
+    /**
+     * @param array<string, mixed> $applicationConfiguration what a config/packages/monolog.yaml holds
+     */
+    private function container(array $applicationConfiguration = []): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new MonologExtension());
+
+        if ([] !== $applicationConfiguration) {
+            $container->loadFromExtension('monolog', $applicationConfiguration);
+        }
+
+        return $container;
+    }
+}


### PR DESCRIPTION
## Summary

- The core declared its monolog handlers from `Config/Resources/parameters/monolog.php`, and appended them. That file is loaded again by `buildContainer()`, after the `config/packages` of the shop — as the comment in `Config/Resources/services.php` already says, which is why everything else the core declares for another bundle is prepended. Monolog was the one that was not, so a core default always won over the file the shop wrote.
- Observed on a shop whose `config/packages/monolog.yaml` sent the main handler through a stream of its own: `debug:config monolog` answered `handlers.main.handler: main_stream`, the core value, and the stream the shop declared stayed a top-level handler at debug level with no buffer in front of it — 1500 to 3800 DEBUG lines written to the error log on every request.
- The defaults are now prepended once the shop has been read, and group by group: a group holding a handler the shop named is dropped whole. Merging into a handler the shop named cannot work, because handler options belong to a handler type — a shop turning `main` into a plain stream inherited `action_level` and `excluded_http_codes` and the configuration was refused outright. And the group rather than the handler is the unit because a buffering handler is nothing without the handler it writes through: leaving `main_stream` behind would put a second handler on the same file.
- A shop that writes no `monolog.yaml` gets exactly the logging it got before.

Verified on `config/packages/monolog.yaml` of this repository: in prod `handlers.main.handler` is now `nested` as the file asks (it was `main_stream`), and the root `channels` list no longer carries the same names three times.

## Test plan

- [x] `tests/Unit/Core/DependencyInjection/LoggingDefaultsTest.php` — a shop that writes nothing gets the core handlers; a shop naming where the main handler writes is obeyed; a shop turning the main handler into another type gets a configuration that validates; the handlers the shop said nothing about are still there.
- [x] `tests/Integration/Core/LoggingConfigurationTest.php` — red before, green after: an error logged in the test environment lands in the stream `config/packages/monolog.yaml` names, and not in the rotating file the core would have written through.
- [x] `composer test` green (unit 443, integration 891, api 341, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors