### PR TITLE
fix(kernel): survive a module template directory that is gone

### DIFF
--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -921,7 +921,7 @@ class TheliaKernel extends Kernel
         $cacheFile = $this->getCacheDir().DS.'module_template_dirs.php';
 
         if (file_exists($cacheFile)) {
-            return require $cacheFile;
+            return self::templateDirsStillOnDisk(require $cacheFile);
         }
 
         $dirs = [];
@@ -957,5 +957,40 @@ class TheliaKernel extends Kernel
         }
 
         return $dirs;
+    }
+
+    /**
+     * Drops the directories a module has taken away since the list was written.
+     *
+     * The list is written once and read on every request afterwards, so it
+     * outlives what it describes: a template directory removed by an upgrade,
+     * or a module deleted from the disk while its row stays. A parser handed a
+     * directory that is not there refuses to load anything at all, which takes
+     * the whole back office down with a message naming a path rather than the
+     * stale list. Leaving the entry out keeps the shop standing, and the log
+     * says which module to clear the cache for.
+     *
+     * @param list<array{int, string, string, string}> $templateDirs
+     *
+     * @return list<array{int, string, string, string}>
+     */
+    private static function templateDirsStillOnDisk(array $templateDirs): array
+    {
+        $stillOnDisk = [];
+
+        foreach ($templateDirs as $templateDir) {
+            if (is_dir($templateDir[2])) {
+                $stillOnDisk[] = $templateDir;
+                continue;
+            }
+
+            Tlog::getInstance()->addWarning(\sprintf(
+                'Template directory "%s" of module %s is no longer on disk: it is left out of the parsers until the cache is cleared.',
+                $templateDir[2],
+                $templateDir[3],
+            ));
+        }
+
+        return $stillOnDisk;
     }
 }

--- a/tests/Integration/Core/ModuleTemplateDirsCacheTest.php
+++ b/tests/Integration/Core/ModuleTemplateDirsCacheTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Filesystem\Filesystem;
+use Thelia\Core\Template\TemplateDefinition;
+use Thelia\Core\TheliaKernel;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The template directories of the activated modules are listed once and read
+ * from a cache file on every request afterwards, so the list outlives what it
+ * describes. A parser handed a directory that is no longer there refuses to
+ * load anything at all, and the back office answers 500 with a message naming
+ * a path rather than the stale list.
+ */
+final class ModuleTemplateDirsCacheTest extends IntegrationTestCase
+{
+    private string $cacheFile;
+    private ?string $savedList = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacheFile = static::$kernel->getCacheDir().\DIRECTORY_SEPARATOR.'module_template_dirs.php';
+        $this->savedList = is_file($this->cacheFile) ? (string) file_get_contents($this->cacheFile) : null;
+    }
+
+    protected function tearDown(): void
+    {
+        $filesystem = new Filesystem();
+
+        null === $this->savedList
+            ? $filesystem->remove($this->cacheFile)
+            : $filesystem->dumpFile($this->cacheFile, $this->savedList);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function aDirectoryThatIsGoneIsLeftOutOfTheList(): void
+    {
+        $onDisk = [TemplateDefinition::BACK_OFFICE, 'default-twig', THELIA_ROOT.'templates', 'Probe'];
+        $gone = [TemplateDefinition::BACK_OFFICE, 'default-twig', THELIA_ROOT.'templates/gone-with-an-upgrade', 'Probe'];
+
+        $this->writeList([$onDisk, $gone]);
+
+        self::assertSame([$onDisk], $this->readList());
+    }
+
+    #[Test]
+    public function aListThatIsStillTrueIsReadAsItIs(): void
+    {
+        $list = [[TemplateDefinition::FRONT_OFFICE, 'flexy', THELIA_ROOT.'templates', 'Probe']];
+
+        $this->writeList($list);
+
+        self::assertSame($list, $this->readList());
+    }
+
+    /**
+     * @param list<array{int, string, string, string}> $templateDirs
+     */
+    private function writeList(array $templateDirs): void
+    {
+        (new Filesystem())->dumpFile(
+            $this->cacheFile,
+            '<?php return '.var_export($templateDirs, true).';',
+        );
+    }
+
+    /**
+     * @return list<array{int, string, string, string}>
+     */
+    private function readList(): array
+    {
+        return (new \ReflectionMethod(TheliaKernel::class, 'getModuleTemplateDirs'))
+            ->invoke(static::$kernel);
+    }
+}


### PR DESCRIPTION
## Summary

- `TheliaKernel::getModuleTemplateDirs()` lists the template directories of the activated modules once and reads them back from `var/cache/<env>/module_template_dirs.php` on every request, so the list outlives what it describes: a directory removed by a module upgrade, or a module taken off the disk while its row stays in `module`.
- A parser handed a directory that is not there refuses to load anything at all, so the whole back office answered 500 with a message naming a path — nothing pointing at the stale list that named it.
- Entries whose directory is gone are now left out, with a warning naming the module so an operator knows what to clear the cache for. A shop where the list is still true reads it unchanged.

Not changed: `cache:clear` does remove that file, in `dev` and in `prod` — checked on this branch by sentinel, so it needed no warmer or clearer of its own.

## Test plan

- [x] `tests/Integration/Core/ModuleTemplateDirsCacheTest.php` — red before, green after: a list naming a directory that is gone comes back without it, and a list that is still true comes back as it is.
- [x] `composer test` green (unit 439, integration 892, api 341, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors