### PR TITLE
fix(routing): put the rewriting router listener strictly first

### DIFF
--- a/core/lib/Thelia/Config/Resources/services/core/routing.php
+++ b/core/lib/Thelia/Config/Resources/services/core/routing.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Controller\Admin\BaseAdminController;
 use Thelia\Core\Routing\Loader\XmlFileLoader;
 use Thelia\Core\Routing\ModuleAttributeLoader;
@@ -77,11 +78,25 @@ return static function (ContainerConfigurator $container): void {
             service('request.context'),
         ]);
 
-    // Router listener
+    // Router listener.
+    //
+    // FrameworkBundle registers a RouterListener of its own, on the same
+    // events, and its copy answers kernel.request at the same priority 32. At
+    // equal priority the order comes down to the order the two were
+    // registered in, and whichever runs second returns at once because
+    // _controller is already set - so which of the two actually routed the
+    // request was left to chance, and only this one has the rewriting router
+    // in its chain. One point of priority puts it strictly in front.
+    //
+    // The events are declared here rather than taken from the class, so the
+    // one priority that is deliberately not the class's is visible. The test
+    // RouterListenerPriorityTest keeps the list in step with the class.
     $services->set('listener.router', RouterListener::class)
         ->args([
             service('router.chainRequest'),
             service('request_stack'),
         ])
-        ->tag('kernel.event_subscriber');
+        ->tag('kernel.event_listener', ['event' => KernelEvents::REQUEST, 'method' => 'onKernelRequest', 'priority' => 33])
+        ->tag('kernel.event_listener', ['event' => KernelEvents::FINISH_REQUEST, 'method' => 'onKernelFinishRequest', 'priority' => 0])
+        ->tag('kernel.event_listener', ['event' => KernelEvents::EXCEPTION, 'method' => 'onKernelException', 'priority' => -64]);
 };

--- a/tests/Integration/Core/Routing/RouterListenerPriorityTest.php
+++ b/tests/Integration/Core/Routing/RouterListenerPriorityTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Routing;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Cmf\Component\Routing\ChainRouter;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Two RouterListener objects answer kernel.request: the one the core
+ * registers, whose router chain holds the rewriting router, and the one
+ * FrameworkBundle registers. Whichever runs second returns at once, because
+ * _controller is already set, so the one that runs first is the one that
+ * routes - and at equal priority that was decided by the order the two were
+ * registered in.
+ */
+final class RouterListenerPriorityTest extends IntegrationTestCase
+{
+    #[Test]
+    public function theListenerHoldingTheRewritingRouterRoutesTheRequest(): void
+    {
+        $routerListeners = $this->routerListenersOnRequest();
+
+        self::assertCount(2, $routerListeners, 'This test has nothing to say if there is only one.');
+        self::assertInstanceOf(
+            ChainRouter::class,
+            $this->routerOf($routerListeners[0]),
+            'The first router listener to run must be the one whose chain holds the rewriting router.',
+        );
+    }
+
+    #[Test]
+    public function theDeclaredEventsAreTheOnesTheClassSubscribesTo(): void
+    {
+        $subscribed = $this->eventsRouterListenerSubscribesTo();
+        $declared = $this->eventsTheCoreDeclares();
+
+        self::assertSame(
+            array_keys($subscribed),
+            array_keys($declared),
+            'The core declares the events of RouterListener one by one; the class now subscribes to another set.',
+        );
+
+        foreach ($subscribed as $event => $priority) {
+            KernelEvents::REQUEST === $event
+                ? self::assertGreaterThan(
+                    $priority,
+                    $declared[$event],
+                    'The core listener must stay strictly in front of the one FrameworkBundle registers.',
+                )
+                : self::assertSame($priority, $declared[$event], \sprintf('The priority declared for %s must be the priority of the class.', $event));
+        }
+    }
+
+    /**
+     * @return list<RouterListener> in the order they run
+     */
+    private function routerListenersOnRequest(): array
+    {
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getService('event_dispatcher');
+
+        $routerListeners = [];
+
+        foreach ($dispatcher->getListeners(KernelEvents::REQUEST) as $listener) {
+            $object = \is_array($listener) ? ($listener[0] ?? null) : null;
+
+            if ($object instanceof RouterListener) {
+                $routerListeners[] = $object;
+            }
+        }
+
+        return $routerListeners;
+    }
+
+    private function routerOf(RouterListener $listener): object
+    {
+        return (new \ReflectionProperty(RouterListener::class, 'matcher'))->getValue($listener);
+    }
+
+    /**
+     * @return array<string, int> priority per event, as the class asks for it
+     */
+    private function eventsRouterListenerSubscribesTo(): array
+    {
+        $events = [];
+
+        foreach (RouterListener::getSubscribedEvents() as $event => $parameters) {
+            $priorities = \is_array($parameters[0]) ? $parameters : [$parameters];
+
+            foreach ($priorities as $priority) {
+                $events[$event] = $priority[1] ?? 0;
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * @return array<string, int> priority per event, as the core declares it
+     */
+    private function eventsTheCoreDeclares(): array
+    {
+        $container = new ContainerBuilder();
+        (new PhpFileLoader(
+            $container,
+            new FileLocator(THELIA_LIB.'Config/Resources/services/core'),
+            'prod',
+        ))->load('routing.php');
+
+        $definition = $container->getDefinition('listener.router');
+
+        self::assertSame(
+            [],
+            $definition->getTag('kernel.event_subscriber'),
+            'Declaring the events one by one and subscribing at the same time would register each of them twice.',
+        );
+
+        $events = [];
+
+        foreach ($definition->getTag('kernel.event_listener') as $tag) {
+            $events[$tag['event']] = $tag['priority'];
+        }
+
+        return $events;
+    }
+}


### PR DESCRIPTION
## Summary

- Two `RouterListener` objects answer `kernel.request` at priority 32: the one the core registers around the chain router, which is the only one that can consult `router.rewrite`, and the one FrameworkBundle registers around `router`.
- Whichever runs second returns immediately, `_controller` being set already, so the one that runs first is the one that routes. At equal priority that came down to the order the two services were registered in — nothing guaranteed the rewriting router would ever be consulted.
- The core listener now declares its three events one by one, with `kernel.request` one point in front of FrameworkBundle's and the other two at the priorities of the class.
- No measurable cost either way: this is about which listener decides, not about how long it takes.

FrameworkBundle's listener is deliberately left in place: it is the one that keeps `router.request_context` in step with the request, and `router.default` generates URLs from that context.

## Test plan

- [x] `tests/Integration/Core/Routing/RouterListenerPriorityTest.php` — the first router listener to run is the one holding the chain router (an invariant that used to hold only by luck), and the events declared in the config match what `RouterListener::getSubscribedEvents()` asks for, with `kernel.request` strictly in front. The second assertion is red before the change and green after.
- [x] `debug:event-dispatcher kernel.request` shows the core listener at 33 and FrameworkBundle's at 32.
- [x] `composer test` green (unit 439, integration 892, api 341, http-flexy 89, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors