### PR TITLE
fix(checkout): follow-ups on ordering without an account

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
         "symfony/flex": "^2.4",
         "thelia/flexy": "^1.0",
         "ext-simplexml": "*",
-        "ext-dom": "*",
-        "symfony/webpack-encore-bundle": "^2.4"
+        "ext-dom": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.*",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -20,8 +20,4 @@ return [
     BackOfficeDefaultBundle\BackOfficeDefaultBundle::class => ['all' => true],
     BackOfficeDefaultTwigBundle\BackOfficeDefaultTwigBundle::class => ['all' => true],
     FlexyBundle\FlexyBundle::class => ['all' => true],
-    Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
-    Symfonycasts\SassBundle\SymfonycastsSassBundle::class => ['all' => true],
-    TalesFromADev\Twig\Extra\Tailwind\Bridge\Symfony\Bundle\TalesFromADevTwigExtraTailwindBundle::class => ['all' => true],
-    Symfonycasts\TailwindBundle\SymfonycastsTailwindBundle::class => ['all' => true],
 ];

--- a/core/lib/Thelia/Action/Customer.php
+++ b/core/lib/Thelia/Action/Customer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Action;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -33,12 +34,14 @@ use Thelia\Domain\Cart\Service\CartRetriever;
 use Thelia\Domain\Customer\Exception\CustomerException;
 use Thelia\Domain\Customer\Exception\InvalidPasswordResetTokenException;
 use Thelia\Domain\Customer\Service\CustomerCodeManager;
+use Thelia\Domain\Customer\Service\CustomerGuestConversionService;
 use Thelia\Domain\Customer\Service\CustomerTitleService;
 use Thelia\Domain\Customer\Service\PasswordResetService;
 use Thelia\Domain\Localization\Service\LangService;
 use Thelia\Mailer\MailerFactory;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Customer as CustomerModel;
+use Thelia\Model\CustomerQuery;
 use Thelia\Model\Event\CustomerEvent;
 use Thelia\Model\LangQuery;
 
@@ -62,6 +65,7 @@ class Customer extends BaseAction implements EventSubscriberInterface
         protected CartContext $cartContext,
         protected PasswordResetService $passwordResetService,
         protected CustomerCodeManager $customerCodeManager,
+        protected CustomerGuestConversionService $customerGuestConversionService,
     ) {
     }
 
@@ -89,8 +93,28 @@ class Customer extends BaseAction implements EventSubscriberInterface
         );
     }
 
+    /**
+     * Register an account from the shop's own signup form.
+     *
+     * An address that already carries a passwordless record — someone who ordered
+     * without an account — completes that record rather than opening a second one beside
+     * it: the orders, the addresses and the history hang off it, and the promise made to
+     * a buyer who orders without an account is that signing up later brings them back to
+     * what they bought.
+     *
+     * @throws PropelException
+     */
     public function createMinimal(CustomerCreateOrUpdateMinimalEvent $event): void
     {
+        $guestRecord = $this->guestRecordOn((string) $event->getEmail());
+
+        if ($guestRecord instanceof CustomerModel) {
+            $this->completeGuestRecord($guestRecord, $event);
+            $event->setCustomer($guestRecord);
+
+            return;
+        }
+
         $customer = new CustomerModel();
 
         $customer->createOrUpdateWithoutAddress(
@@ -114,6 +138,58 @@ class Customer extends BaseAction implements EventSubscriberInterface
         );
 
         $event->setCustomer($customer);
+    }
+
+    /**
+     * The passwordless record an address already carries, if there is one to complete.
+     *
+     * An anonymized record is not one: its identifying data is gone, so there is nothing
+     * left to hand back and nothing that says the person signing up is the one it was
+     * emptied for.
+     *
+     * @throws PropelException
+     */
+    private function guestRecordOn(string $email): ?CustomerModel
+    {
+        if ('' === trim($email)) {
+            return null;
+        }
+
+        return CustomerQuery::create()
+            ->filterByEmail($email)
+            ->filterByIsGuest(1)
+            ->filterByAnonymizedAt(null, Criteria::ISNULL)
+            ->orderById(Criteria::DESC)
+            ->findOne();
+    }
+
+    /**
+     * Put the password the signup form asked for on the record the orders hang off.
+     *
+     * The same path as completing the account from an order tracking link: the record
+     * keeps `is_guest` until the activation code is answered, so what is written here
+     * opens nothing on its own. Ordering without an account is open to everyone, so an
+     * address in that record proves nothing about who typed it, and reading the mailbox
+     * is what tells the two apart.
+     *
+     * @throws PropelException
+     */
+    private function completeGuestRecord(
+        CustomerModel $guestRecord,
+        CustomerCreateOrUpdateMinimalEvent $event,
+    ): void {
+        $guestRecord
+            ->setTitleId($event->getTitle())
+            ->setFirstname($event->getFirstname())
+            ->setLastname($event->getLastname());
+
+        if (null !== $event->getLangId()) {
+            $guestRecord->setLangId($event->getLangId());
+        }
+
+        $guestRecord->save();
+
+        $this->customerGuestConversionService->convert($guestRecord, (string) $event->getPassword());
     }
 
     /**

--- a/core/lib/Thelia/Api/Resource/GuestCustomer.php
+++ b/core/lib/Thelia/Api/Resource/GuestCustomer.php
@@ -16,6 +16,7 @@ namespace Thelia\Api\Resource;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
@@ -53,11 +54,15 @@ use Thelia\Api\State\Processor\GuestCustomerRegistrationProcessor;
         // Also open, and authorized inside the processor rather than here: it accepts
         // either the guest's own token or a valid order tracking token, and a security
         // expression cannot see the second one — it arrives in the body.
+        // Accepted, not completed: the password is written but the record stays a guest
+        // until the activation code mailed to the address is answered, so a caller that
+        // read 201 would offer a sign-in that cannot work yet.
         new Post(
             uriTemplate: '/front/guest-customers/{id}/convert',
+            status: Response::HTTP_ACCEPTED,
             denormalizationContext: ['groups' => [self::GROUP_FRONT_CONVERT]],
             validationContext: ['groups' => [self::GROUP_FRONT_CONVERT]],
-            normalizationContext: ['groups' => [self::GROUP_FRONT_READ]],
+            normalizationContext: ['groups' => [self::GROUP_FRONT_READ, self::GROUP_FRONT_CONVERTED]],
             read: false,
             processor: GuestCustomerConversionProcessor::class,
         ),
@@ -68,6 +73,7 @@ final class GuestCustomer
     public const GROUP_FRONT_READ = 'front:guest_customer:read';
     public const GROUP_FRONT_WRITE = 'front:guest_customer:write';
     public const GROUP_FRONT_CONVERT = 'front:guest_customer:convert';
+    public const GROUP_FRONT_CONVERTED = 'front:guest_customer:converted';
 
     #[Groups([self::GROUP_FRONT_READ])]
     public ?int $id = null;
@@ -119,4 +125,13 @@ final class GuestCustomer
 
     #[Groups([self::GROUP_FRONT_READ])]
     public ?int $cartId = null;
+
+    /**
+     * Whether the account still has to be opened by the code mailed to its address.
+     *
+     * Only on the conversion answer, and true for as long as that is what happens: a
+     * caller reads it rather than inferring an open account from a success status.
+     */
+    #[Groups([self::GROUP_FRONT_CONVERTED])]
+    public ?bool $activationCodeRequired = null;
 }

--- a/core/lib/Thelia/Api/State/Processor/GuestCustomerConversionProcessor.php
+++ b/core/lib/Thelia/Api/State/Processor/GuestCustomerConversionProcessor.php
@@ -83,6 +83,9 @@ final readonly class GuestCustomerConversionProcessor implements ProcessorInterf
         $response->email = $converted->getEmail();
         $response->firstname = $converted->getFirstname();
         $response->lastname = $converted->getLastname();
+        // The record is still a guest: the password is written, the account is not open,
+        // and the code mailed to the address is what opens it.
+        $response->activationCodeRequired = $converted->isGuest();
 
         return $response;
     }

--- a/core/lib/Thelia/Command/CustomerAnonymizeCommand.php
+++ b/core/lib/Thelia/Command/CustomerAnonymizeCommand.php
@@ -21,10 +21,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Thelia\Core\Event\Customer\CustomerAnonymizeEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
 
 /**
- * Erases the identifying data of one customer, keeping the orders.
+ * Erases the identifying data of a customer, keeping the orders.
+ *
+ * An email address may carry more than one row: ordering without an account opens one,
+ * and registering later opens another. An erasure request is about the person behind the
+ * address, so every row it carries is erased — reading only the first would leave the
+ * other one's name, addresses and orders untouched, and say nothing about it.
  */
 class CustomerAnonymizeCommand extends ContainerAwareCommand
 {
@@ -42,19 +48,31 @@ class CustomerAnonymizeCommand extends ContainerAwareCommand
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = (string) $input->getArgument('email');
-        $customer = CustomerQuery::create()->findOneByEmail($email);
+        $customers = CustomerQuery::create()->filterByEmail($email)->orderById()->find();
 
-        if (null === $customer) {
+        if (0 === $customers->count()) {
             $output->writeln(\sprintf('<error>No customer found with email "%s".</error>', $email));
 
             return 1;
         }
 
+        $references = implode(', ', array_map(
+            static fn (Customer $customer): string => (string) $customer->getRef(),
+            iterator_to_array($customers),
+        ));
+
+        $output->writeln(\sprintf(
+            '<info>%d customer record(s) found on "%s": %s</info>',
+            $customers->count(),
+            $email,
+            $references,
+        ));
+
         if (!$input->getOption('force')) {
             $question = new ConfirmationQuestion(
                 \sprintf(
-                    'Anonymize customer %s (%s)? This cannot be undone. [y/N] ',
-                    $customer->getRef(),
+                    'Anonymize %d record(s) on %s? This cannot be undone. [y/N] ',
+                    $customers->count(),
                     $email,
                 ),
                 false,
@@ -67,14 +85,16 @@ class CustomerAnonymizeCommand extends ContainerAwareCommand
             }
         }
 
-        $this->getDispatcher()->dispatch(
-            new CustomerAnonymizeEvent($customer),
-            TheliaEvents::CUSTOMER_ANONYMIZE,
-        );
+        foreach ($customers as $customer) {
+            $this->getDispatcher()->dispatch(
+                new CustomerAnonymizeEvent($customer),
+                TheliaEvents::CUSTOMER_ANONYMIZE,
+            );
+        }
 
         $output->writeln(\sprintf(
-            '<info>Customer %s anonymized. Orders kept, account disabled.</info>',
-            $customer->getRef(),
+            '<info>%d customer record(s) anonymized. Orders kept, accounts disabled.</info>',
+            $customers->count(),
         ));
 
         return 0;

--- a/core/lib/Thelia/Command/CustomerPersonalDataExportCommand.php
+++ b/core/lib/Thelia/Command/CustomerPersonalDataExportCommand.php
@@ -17,13 +17,19 @@ namespace Thelia\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Thelia\Core\Event\Customer\CustomerPersonalDataExportEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Model\CustomerQuery;
 
 /**
- * Writes everything the shop knows about one customer as JSON.
+ * Writes everything the shop knows about an email address as JSON.
+ *
+ * An address may carry more than one row: ordering without an account opens one, and
+ * registering later opens another. The export is therefore a list, one entry per row —
+ * an export that stopped at the first would hand the buyer half of their own history
+ * without saying so.
  */
 class CustomerPersonalDataExportCommand extends ContainerAwareCommand
 {
@@ -44,19 +50,33 @@ class CustomerPersonalDataExportCommand extends ContainerAwareCommand
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = (string) $input->getArgument('email');
-        $customer = CustomerQuery::create()->findOneByEmail($email);
+        $customers = CustomerQuery::create()->filterByEmail($email)->orderById()->find();
 
-        if (null === $customer) {
+        if (0 === $customers->count()) {
             $output->writeln(\sprintf('<error>No customer found with email "%s".</error>', $email));
 
             return 1;
         }
 
-        $event = new CustomerPersonalDataExportEvent($customer);
-        $this->getDispatcher()->dispatch($event, TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT);
+        $personalData = [];
+
+        foreach ($customers as $customer) {
+            $event = new CustomerPersonalDataExportEvent($customer);
+            $this->getDispatcher()->dispatch($event, TheliaEvents::CUSTOMER_PERSONAL_DATA_EXPORT);
+
+            $personalData[] = $event->getPersonalData();
+        }
+
+        // Beside the JSON rather than in it: the export goes to the standard output when
+        // no file is asked for, and a count written there would not be JSON any more.
+        $this->countOutput($output)->writeln(\sprintf(
+            '<info>%d customer record(s) found on "%s".</info>',
+            $customers->count(),
+            $email,
+        ));
 
         $json = json_encode(
-            $event->getPersonalData(),
+            $personalData,
             \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR,
         );
 
@@ -77,5 +97,10 @@ class CustomerPersonalDataExportCommand extends ContainerAwareCommand
         $output->writeln(\sprintf('<info>Personal data of %s written to %s</info>', $email, $outputFile));
 
         return 0;
+    }
+
+    private function countOutput(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
     }
 }

--- a/core/lib/Thelia/Domain/Order/Service/GuestOrderAccessService.php
+++ b/core/lib/Thelia/Domain/Order/Service/GuestOrderAccessService.php
@@ -25,13 +25,17 @@ use Thelia\Model\OrderQuery;
  * A guest has no account to sign into, so the link is the only thing that identifies
  * the person entitled to see the order. It is signed rather than stored: it names the
  * order and the moment it stops being accepted, and it is signed together with the
- * address and the password hash of the customer behind it. Nothing is written when a
- * link is handed out, a link issued for one order cannot be replayed on another, and a
- * link stops being accepted the moment the address or the password behind it changes.
+ * address behind it and with whether that record is still a passwordless one. Nothing is
+ * written when a link is handed out, a link issued for one order cannot be replayed on
+ * another, and a link stops being accepted the moment the address changes or the account
+ * is opened.
  *
- * A guest carries an empty password hash, so converting the guest account into a real
- * one invalidates every link issued while it was a guest — which is what should happen:
- * from then on the orders are reached by signing in.
+ * Deliberately not the password hash: a buyer who chooses a password is still a guest
+ * until the activation code is answered, so signing the hash killed the link at the very
+ * moment it was the only way back to the order — the buyer could neither sign in nor
+ * reopen their link, and a code that never arrived put the order out of reach for good.
+ * What is signed is the state that actually decides, so the link dies when the account
+ * becomes usable and not before.
  */
 final readonly class GuestOrderAccessService
 {
@@ -77,7 +81,7 @@ final readonly class GuestOrderAccessService
                 $orderId,
                 $expiresAt,
                 (string) $customer?->getEmail(),
-                (string) $customer?->getPassword(),
+                true === $customer?->isGuest(),
             ),
         );
     }
@@ -88,41 +92,72 @@ final readonly class GuestOrderAccessService
      */
     public function findOrderForToken(string $token): ?Order
     {
+        [$order, $accountWasOpened] = $this->resolve($token);
+
+        return $accountWasOpened ? null : $order;
+    }
+
+    /**
+     * The order a link would still open, were the account it belongs to not open already.
+     *
+     * The one case worth telling the buyer about: their order is not gone, it is behind a
+     * sign-in. Everything else — expired, forged, naming no order — stays indistinguishable
+     * from everything else, so a token nobody was issued learns nothing from asking.
+     */
+    public function findOrderNowBehindAnAccount(string $token): ?Order
+    {
+        [$order, $accountWasOpened] = $this->resolve($token);
+
+        return $accountWasOpened ? $order : null;
+    }
+
+    /**
+     * @return array{0: ?Order, 1: bool} the order the token names, and whether it is only
+     *                                   turned away because the account has been opened
+     */
+    private function resolve(string $token): array
+    {
         $parts = explode('.', $token);
 
         if (3 !== \count($parts)) {
-            return null;
+            return [null, false];
         }
 
         [$rawOrderId, $rawExpiresAt, $signature] = $parts;
 
         if (!ctype_digit($rawOrderId) || !ctype_digit($rawExpiresAt)) {
-            return null;
+            return [null, false];
         }
 
         $orderId = (int) $rawOrderId;
         $expiresAt = (int) $rawExpiresAt;
         $order = OrderQuery::create()->findPk($orderId);
         $customer = $order?->getCustomer();
+        $email = (string) $customer?->getEmail();
 
-        // Signed even when the order is gone, and always compared, so an id that names
-        // no order and a signature that does not match take the same path and the same time.
-        $expectedSignature = $this->sign(
-            $orderId,
-            $expiresAt,
-            (string) $customer?->getEmail(),
-            (string) $customer?->getPassword(),
-        );
+        // Both variants are computed for every token, so that telling the two apart costs
+        // the same work whichever one matches — and so that an id that names no order and
+        // a signature that does not match take the same path.
+        $whileAGuest = $this->sign($orderId, $expiresAt, $email, true);
+        $onceAnAccount = $this->sign($orderId, $expiresAt, $email, false);
 
-        if (!hash_equals($expectedSignature, $signature) || !$order instanceof Order) {
-            return null;
+        $issuedByThisShop = hash_equals($whileAGuest, $signature) || hash_equals($onceAnAccount, $signature);
+
+        if (!$issuedByThisShop || !$order instanceof Order) {
+            return [null, false];
         }
 
         if ($expiresAt <= time()) {
-            return null;
+            return [null, false];
         }
 
-        return $order;
+        // The link is the way in only while there is no account to sign into. An opened
+        // account is the buyer's own order waiting behind a sign-in, not a dead link.
+        if (true !== $customer?->isGuest()) {
+            return [$order, true];
+        }
+
+        return [$order, false];
     }
 
     public function getLinkLifetimeInSeconds(): int
@@ -137,7 +172,7 @@ final readonly class GuestOrderAccessService
         return $configured > 0 ? $configured : self::DEFAULT_LINK_LIFETIME_IN_SECONDS;
     }
 
-    private function sign(int $orderId, int $expiresAt, string $email, string $passwordHash): string
+    private function sign(int $orderId, int $expiresAt, string $email, bool $recordIsStillAGuest): string
     {
         $key = hash_hmac(
             self::SIGNATURE_ALGORITHM,
@@ -148,7 +183,7 @@ final readonly class GuestOrderAccessService
 
         return hash_hmac(
             self::SIGNATURE_ALGORITHM,
-            implode("\0", [$orderId, $expiresAt, $email, $passwordHash]),
+            implode("\0", [$orderId, $expiresAt, $email, $recordIsStillAGuest ? 'guest' : 'account']),
             $key,
         );
     }

--- a/tests/Api/Front/GuestCustomerConversionApiTest.php
+++ b/tests/Api/Front/GuestCustomerConversionApiTest.php
@@ -79,6 +79,33 @@ final class GuestCustomerConversionApiTest extends ApiTestCase
         );
     }
 
+    /**
+     * A headless front that reads 201 believes the account is open, and offers a sign-in
+     * that cannot work: the record stays a guest until the activation code is answered.
+     * The status says the request was accepted and not completed, and the payload says
+     * what is still owed.
+     */
+    public function testTheAnswerSaysTheAccountIsStillWaitingForItsCode(): void
+    {
+        $this->enableGuestCheckout();
+
+        [, $guest] = $this->registerGuest();
+        $response = $this->convert($guest['id'], ['password' => 'a-chosen-password'], $guest['token']);
+
+        self::assertSame(
+            202,
+            $response->getStatusCode(),
+            'Accepted, not done: nothing can be signed into yet.',
+        );
+
+        $payload = json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+
+        self::assertTrue(
+            $payload['activationCodeRequired'] ?? false,
+            'The answer has to say what the caller is still waiting on.',
+        );
+    }
+
     private function login(string $email, string $password): \Symfony\Component\HttpFoundation\Response
     {
         $this->client->request(

--- a/tests/Api/Front/GuestOrderTrackingApiTest.php
+++ b/tests/Api/Front/GuestOrderTrackingApiTest.php
@@ -104,7 +104,13 @@ final class GuestOrderTrackingApiTest extends ApiTestCase
         self::assertSame(404, $response->getStatusCode());
     }
 
-    public function testTheLinkStopsWorkingOnceTheAccountIsCompleted(): void
+    /**
+     * Choosing a password is not the moment the account opens: the activation code sent
+     * by mail still has to be answered, and until it is, the buyer can neither sign in
+     * nor reach the order any other way. So the link outlives the password, and dies
+     * with the account it is being replaced by.
+     */
+    public function testTheLinkOutlivesThePasswordWhileTheAccountIsStillWaitingOnItsCode(): void
     {
         $factory = $this->createFixtureFactory();
         $guest = $factory->guestCustomer($factory->customerTitle());
@@ -119,12 +125,29 @@ final class GuestOrderTrackingApiTest extends ApiTestCase
             ['password' => 'a-chosen-password', 'orderToken' => $token],
         );
 
+        self::assertJsonResponseSuccessful(
+            $this->jsonRequest('GET', '/api/front/guest-orders/'.$token),
+            'A password that has not been activated yet leaves the buyer nothing else to reach the order with.',
+        );
+    }
+
+    public function testTheLinkStopsWorkingOnceTheAccountIsOpen(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $guest = $factory->guestCustomer($factory->customerTitle());
+        $order = $factory->order($guest);
+        $token = $this->trackingToken($order);
+
+        self::assertJsonResponseSuccessful($this->jsonRequest('GET', '/api/front/guest-orders/'.$token));
+
+        $guest->setPassword('a-chosen-password')->setIsGuest(0)->setEnable(1)->save();
+
         $response = $this->jsonRequest('GET', '/api/front/guest-orders/'.$token);
 
         self::assertSame(
             404,
             $response->getStatusCode(),
-            'From the moment the account has a password, its orders are reached by signing in.',
+            'From the moment the account is open, its orders are reached by signing in.',
         );
     }
 

--- a/tests/Http/BackOffice/ConfigStoreGuestCheckoutTest.php
+++ b/tests/Http/BackOffice/ConfigStoreGuestCheckoutTest.php
@@ -72,8 +72,7 @@ final class ConfigStoreGuestCheckoutTest extends WebIntegrationTestCase
     {
         $this->loginAdmin();
 
-        $this->client->request('GET', '/admin/configuration/store');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/configuration/store');
         $content = (string) $this->client->getResponse()->getContent();
 
         self::assertStringContainsString('config-store-guest-checkout-mode', $content);
@@ -95,8 +94,8 @@ final class ConfigStoreGuestCheckoutTest extends WebIntegrationTestCase
             ? GuestCheckoutMode::EnabledUnlessProductForbids
             : GuestCheckoutMode::Enabled;
 
-        $crawler = $this->client->request('GET', '/admin/configuration/store');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/configuration/store');
+        $crawler = $this->client->getCrawler();
 
         $button = $crawler->filter('[data-testid="config-store-save-stay"]');
         self::assertGreaterThan(0, $button->count(), 'The store configuration form must expose its Save button.');

--- a/tests/Http/BackOffice/CustomerGuestCheckoutTest.php
+++ b/tests/Http/BackOffice/CustomerGuestCheckoutTest.php
@@ -90,8 +90,7 @@ final class CustomerGuestCheckoutTest extends WebIntegrationTestCase
         ]);
 
         // Both rows show up and the guest one carries the badge markup.
-        $this->client->request('GET', '/admin/customers?q=badge-probe');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/customers?q=badge-probe');
         $content = (string) $this->client->getResponse()->getContent();
 
         self::assertStringContainsString('bo-customer-guest', $content, 'The guest badge markup must be present on the list.');
@@ -99,15 +98,13 @@ final class CustomerGuestCheckoutTest extends WebIntegrationTestCase
         self::assertStringContainsString('Roger', $content);
 
         // guest=with isolates the guest customer.
-        $this->client->request('GET', '/admin/customers?guest=with&q=badge-probe');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/customers?guest=with&q=badge-probe');
         $guestOnly = (string) $this->client->getResponse()->getContent();
         self::assertStringContainsString('Gustave', $guestOnly);
         self::assertStringNotContainsString('Roger', $guestOnly);
 
         // guest=without isolates the registered customer.
-        $this->client->request('GET', '/admin/customers?guest=without&q=badge-probe');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/customers?guest=without&q=badge-probe');
         $registeredOnly = (string) $this->client->getResponse()->getContent();
         self::assertStringContainsString('Roger', $registeredOnly);
         self::assertStringNotContainsString('Gustave', $registeredOnly);
@@ -125,16 +122,14 @@ final class CustomerGuestCheckoutTest extends WebIntegrationTestCase
         $guest = $factory->guestCustomer($title, ['email' => 'guest-mention-probe@test.com']);
         $registered = $factory->customer($title, ['email' => 'registered-mention-probe@test.com']);
 
-        $this->client->request('GET', '/admin/customer/update?customer_id='.$guest->getId());
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/customer/update?customer_id='.$guest->getId());
         self::assertStringContainsString(
             'customer-edit-guest-badge',
             (string) $this->client->getResponse()->getContent(),
             'A guest customer fiche must carry the guest mention.',
         );
 
-        $this->client->request('GET', '/admin/customer/update?customer_id='.$registered->getId());
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/customer/update?customer_id='.$registered->getId());
         self::assertStringNotContainsString(
             'customer-edit-guest-badge',
             (string) $this->client->getResponse()->getContent(),

--- a/tests/Http/BackOffice/ProductGuestCheckoutForbiddenTest.php
+++ b/tests/Http/BackOffice/ProductGuestCheckoutForbiddenTest.php
@@ -92,8 +92,8 @@ final class ProductGuestCheckoutForbiddenTest extends WebIntegrationTestCase
         // Pulled from the product list's create-product modal rather than the
         // edit page (see the class docblock): both forms share the same
         // csrf_token_id ('admin.product'), so the token is valid for either.
-        $crawler = $this->client->request('GET', '/admin/products');
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertPageRenders('/admin/products');
+        $crawler = $this->client->getCrawler();
         $token = $crawler->filter('[name="thelia_product_creation[_token]"]')->attr('value');
         self::assertNotNull($token, 'The product list must render a CSRF token this test can reuse.');
 

--- a/tests/Http/Flexy/GuestAccountConversionTest.php
+++ b/tests/Http/Flexy/GuestAccountConversionTest.php
@@ -52,21 +52,20 @@ final class GuestAccountConversionTest extends GuestCheckoutTestCase
         );
     }
 
-    public function testTheOfferIsNotMadeForAnOrderOfARealAccount(): void
+    /**
+     * The tracking link exists for buyers who have no account to sign into. An order
+     * that hangs off one is reached through it, and the page says so.
+     */
+    public function testAnOrderOfARealAccountIsReachedBySigningIn(): void
     {
         $this->skipUnlessTheThemeHasTheTrackingPage();
 
         $fixtures = $this->fixtures();
         $order = $fixtures->order($fixtures->customer($fixtures->customerTitle()));
 
-        $crawler = $this->client->request('GET', '/order/track/'.$this->tokenFor($order));
+        $this->client->request('GET', '/order/track/'.$this->tokenFor($order));
 
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
-        self::assertCount(
-            0,
-            $crawler->filter('a[href$="/account"]'),
-            'There is nothing to complete on an account that already has an owner.',
-        );
+        $this->assertResponseRedirectsTo('/customer/login');
     }
 
     public function testChoosingAPasswordCompletesTheAccountWithoutSigningIn(): void
@@ -142,7 +141,12 @@ final class GuestAccountConversionTest extends GuestCheckoutTestCase
         }
     }
 
-    public function testTheLinkStopsWorkingOnceTheAccountIsCompleted(): void
+    /**
+     * Choosing a password opens nothing — the record stays a guest until the code is
+     * answered — and until then the link is the only way back to the order: the buyer
+     * can neither sign in nor be sent a reset link.
+     */
+    public function testTheLinkKeepsWorkingWhileTheAccountWaitsForItsCode(): void
     {
         $this->skipUnlessTheThemeHasTheTrackingPage();
 
@@ -156,9 +160,41 @@ final class GuestAccountConversionTest extends GuestCheckoutTestCase
         $this->client->request('GET', '/order/track/'.$token);
 
         self::assertSame(
-            404,
+            200,
             $this->client->getResponse()->getStatusCode(),
-            'A link signed against the old password hash must stop being accepted.',
+            'Between choosing a password and answering the code there is no other way in.',
+        );
+    }
+
+    /**
+     * Once the account is open the order is reached by signing in — so the link says so
+     * rather than answering that the page does not exist, which is what the buyer would
+     * read as "my order is gone".
+     */
+    public function testTheLinkSendsTheBuyerToSignInOnceTheAccountIsOpen(): void
+    {
+        $this->skipUnlessTheThemeHasTheTrackingPage();
+
+        $guest = $this->guest();
+        $order = $this->guestOrder($guest);
+        $token = $this->tokenFor($order);
+
+        $this->client->submit($this->accountFormFor($order, $token));
+
+        $guest->setIsGuest(0)->setEnable(1)->save();
+
+        $this->client->restart();
+        $this->forgetHydratedModels();
+        $this->client->request('GET', '/order/track/'.$token);
+
+        $this->assertResponseRedirectsTo('/customer/login');
+
+        $crawler = $this->client->followRedirect();
+
+        self::assertStringContainsString(
+            'in your customer account',
+            $crawler->text(),
+            'The page the buyer lands on has to say why their link no longer opens the order.',
         );
     }
 

--- a/tests/Http/Flexy/GuestCheckoutAddressScopeTest.php
+++ b/tests/Http/Flexy/GuestCheckoutAddressScopeTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Thelia\Domain\Checkout\Enum\GuestCheckoutMode;
+use Thelia\Model\Address;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\Customer;
+
+/**
+ * What the delivery step lets a guest do with an address id it was not given.
+ *
+ * One customer row is shared by everyone who ever ordered on an address — ordering
+ * without an account proves nothing about owning the address, so the row is reused
+ * rather than duplicated — and the addresses of every buyer before hang off it. The
+ * rendered list is narrowed to the addresses of the identification in hand, but the
+ * live actions take an id straight from the request, so each of them is asked here for
+ * an address belonging to the buyer before.
+ *
+ * Everything below goes through the real component endpoint, with the props the page
+ * itself handed out: this is the request the page makes, with one number changed. The
+ * billing block, which only appears on the payment step, is covered by
+ * {@see \Thelia\Tests\Integration\Flexy\GuestCheckoutAddressGuardTest}.
+ */
+final class GuestCheckoutAddressScopeTest extends GuestCheckoutTestCase
+{
+    private const FIRST_BUYER_STREET = '12 rue du Premier Acheteur';
+
+    private const SECOND_BUYER_STREET = '34 rue du Second Acheteur';
+
+    private const DELIVERY_COMPONENT = 'Organisms:Delivery:Base';
+
+    public function testTheDeliveryStepRefusesToOpenTheAddressOfTheBuyerBefore(): void
+    {
+        [$firstAddress, $crawler] = $this->twoGuestsOnOneEmail();
+
+        $this->callLiveAction($crawler, self::DELIVERY_COMPONENT, 'setEditingAddress', [
+            'addressId' => $firstAddress->getId(),
+        ]);
+
+        $this->assertTheActionWasRefused();
+    }
+
+    public function testTheDeliveryStepRefusesToDeleteTheAddressOfTheBuyerBefore(): void
+    {
+        [$firstAddress, $crawler] = $this->twoGuestsOnOneEmail();
+
+        $this->callLiveAction($crawler, self::DELIVERY_COMPONENT, 'deleteAddress', [
+            'addressId' => $firstAddress->getId(),
+        ]);
+
+        $this->assertTheActionWasRefused();
+        self::assertNotNull(
+            AddressQuery::create()->findPk($firstAddress->getId()),
+            'The address of the buyer before must still be there.',
+        );
+    }
+
+    public function testTheDeliveryStepRefusesToShipToTheAddressOfTheBuyerBefore(): void
+    {
+        [$firstAddress, $crawler] = $this->twoGuestsOnOneEmail();
+
+        $this->callLiveAction($crawler, self::DELIVERY_COMPONENT, 'selectDeliveryAddress', [
+            'addressId' => $firstAddress->getId(),
+        ]);
+
+        $this->assertTheActionWasRefused();
+    }
+
+    public function testTheDeliveryStepRefusesToInvoiceTheAddressOfTheBuyerBefore(): void
+    {
+        [$firstAddress, $crawler] = $this->twoGuestsOnOneEmail();
+
+        $this->callLiveAction($crawler, self::DELIVERY_COMPONENT, 'selectInvoiceAddress', [
+            'addressId' => $firstAddress->getId(),
+        ]);
+
+        $this->assertTheActionWasRefused();
+    }
+
+    /**
+     * Two identifications on one email address, from two browsers that share nothing.
+     *
+     * @return array{0: Address, 1: Crawler} the address of the first buyer, and the
+     *                                       delivery page of the second one
+     */
+    private function twoGuestsOnOneEmail(): array
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+
+        $this->identifyAsAGuestLivingAt(self::FIRST_BUYER_STREET);
+
+        $guest = $this->guestCustomerOf(self::GUEST_EMAIL);
+
+        self::assertInstanceOf(Customer::class, $guest);
+
+        $firstAddress = AddressQuery::create()
+            ->filterByCustomerId($guest->getId())
+            ->filterByAddress1(self::FIRST_BUYER_STREET)
+            ->findOne()
+        ;
+
+        self::assertInstanceOf(Address::class, $firstAddress, 'The first buyer must have left their address behind.');
+
+        $this->client->restart();
+        $this->identifyAsAGuestLivingAt(self::SECOND_BUYER_STREET);
+
+        $crawler = $this->client->request('GET', '/checkout/delivery');
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        return [$firstAddress, $crawler];
+    }
+
+    private function identifyAsAGuestLivingAt(string $street): void
+    {
+        $this->openASessionWithACart();
+
+        $this->client->submit($this->guestFormOf($this->requestIdentificationPage(), [
+            'flexybundle_form_guest_checkout[address1]' => $street,
+        ]));
+
+        $this->assertResponseRedirectsTo('/checkout/delivery');
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    private function callLiveAction(Crawler $crawler, string $component, string $action, array $arguments): void
+    {
+        [$url, $props] = $this->liveComponentOnThePage($crawler, $component);
+
+        $this->client->request(
+            'POST',
+            \sprintf('%s/%s', rtrim($url, '/'), $action),
+            ['data' => json_encode(['args' => $arguments, 'props' => $props], \JSON_THROW_ON_ERROR)],
+        );
+    }
+
+    /**
+     * The endpoint and the signed props the page itself put on the component.
+     *
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    private function liveComponentOnThePage(Crawler $crawler, string $component): array
+    {
+        $node = $crawler->filter(\sprintf('[data-live-name-value="%s"]', $component));
+
+        self::assertGreaterThan(
+            0,
+            $node->count(),
+            \sprintf('The delivery page must carry the "%s" component for this to mean anything.', $component),
+        );
+
+        return [
+            (string) $node->attr('data-live-url-value'),
+            json_decode((string) $node->attr('data-live-props-value'), true, flags: \JSON_THROW_ON_ERROR),
+        ];
+    }
+
+    /**
+     * A refusal, whichever shape the component runtime gives it: what must never happen
+     * is the action going through and answering with a rendered component.
+     */
+    private function assertTheActionWasRefused(): void
+    {
+        self::assertGreaterThanOrEqual(
+            400,
+            $this->client->getResponse()->getStatusCode(),
+            'An address that was not typed on this identification must not be reachable.',
+        );
+    }
+}

--- a/tests/Http/Flexy/GuestCheckoutIdentificationTest.php
+++ b/tests/Http/Flexy/GuestCheckoutIdentificationTest.php
@@ -65,23 +65,56 @@ final class GuestCheckoutIdentificationTest extends GuestCheckoutTestCase
         );
     }
 
-    public function testTheIdentificationPageDoesNotOfferToOrderWithoutAnAccountWhenTheShopRequiresOne(): void
+    /**
+     * The page has nothing left to offer on a shop that requires an account: the choice
+     * it exists to present is down to one. Reachable by a bookmark or a shared link, it
+     * would otherwise stand as an orphan page of a feature the shop never turned on.
+     */
+    public function testTheIdentificationPageIsNotServedWhenTheShopRequiresAnAccount(): void
     {
         $this->skipUnlessTheThemeHasTheIdentificationPage();
         $this->setGuestCheckoutMode(GuestCheckoutMode::Disabled);
         $this->openASessionWithACart();
 
-        $crawler = $this->requestIdentificationPage();
+        $this->client->request('GET', '/checkout/identify');
 
-        self::assertCount(
-            0,
-            $crawler->filter('form[name="flexybundle_form_guest_checkout"]'),
-            'A shop that requires an account must not put the guest form on the page.',
+        $this->assertResponseRedirectsTo('/customer/login');
+    }
+
+    /**
+     * The step trail of the cart page names the step the buyer is actually taken to. It
+     * announced the delivery step while the next screen turned out to be the
+     * identification one, so the trail renamed itself between two pages.
+     */
+    public function testTheCartAnnouncesTheIdentificationStepWhenThatIsWhereItLeads(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+        $this->openASessionWithACart();
+
+        $crawler = $this->client->request('GET', '/checkout/cart');
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertStringContainsString(
+            'Identification',
+            $crawler->filter('.CheckoutSteps')->text(''),
+            'The trail must name the step the "next" button leads to.',
         );
-        self::assertGreaterThan(
-            0,
-            $crawler->filter('form[name="thelia_customer_login"]')->count(),
-            'The sign-in block stays, whatever the setting.',
+    }
+
+    public function testTheCartStillAnnouncesTheDeliveryStepOnAShopThatRequiresAnAccount(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Disabled);
+        $this->openASessionWithACart();
+
+        $crawler = $this->client->request('GET', '/checkout/cart');
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertStringNotContainsString(
+            'Identification',
+            $crawler->filter('.CheckoutSteps')->text(''),
+            'A shop with no identification step must not announce one.',
         );
     }
 
@@ -95,13 +128,11 @@ final class GuestCheckoutIdentificationTest extends GuestCheckoutTestCase
         $this->setGuestCheckoutMode(GuestCheckoutMode::EnabledUnlessProductForbids);
         $this->openASessionWithACart(guestCheckoutForbidden: true);
 
-        $crawler = $this->requestIdentificationPage();
+        $this->client->request('GET', '/checkout/identify');
 
-        self::assertCount(
-            0,
-            $crawler->filter('form[name="flexybundle_form_guest_checkout"]'),
-            'A cart holding a product that requires an account must not offer to order without one.',
-        );
+        // Nothing left to choose between: the page is not served at all, rather than
+        // served with the offer taken out of it.
+        $this->assertResponseRedirectsTo('/customer/login');
     }
 
     public function testACartWithoutSuchAProductIsStillOfferedTheGuestCheckoutInThatMode(): void
@@ -197,7 +228,7 @@ final class GuestCheckoutIdentificationTest extends GuestCheckoutTestCase
         $this->submitGuestFormWithoutTheConsentBox();
 
         self::assertSame(
-            200,
+            422,
             $this->client->getResponse()->getStatusCode(),
             'The form comes back rather than placing an order under a consent nobody gave.',
         );

--- a/tests/Http/Flexy/GuestCheckoutIdentificationTest.php
+++ b/tests/Http/Flexy/GuestCheckoutIdentificationTest.php
@@ -16,6 +16,8 @@ namespace Thelia\Tests\Http\Flexy;
 
 use Thelia\Domain\Checkout\Enum\GuestCheckoutMode;
 use Thelia\Domain\Customer\CustomerFacade;
+use Thelia\Model\AddressQuery;
+use Thelia\Model\ConfigQuery;
 use Thelia\Model\Customer;
 use Thelia\Model\CustomerQuery;
 
@@ -286,6 +288,90 @@ final class GuestCheckoutIdentificationTest extends GuestCheckoutTestCase
      * The consent box is a checkbox: unticking it takes the field out of the submission
      * altogether, which is what the browser does and what a `$form[...] = ''` would not.
      */
+    /**
+     * A professional buyer has parcels delivered in the name of their company, and a
+     * carrier reads that name off the label — the billing block asked for one and the
+     * delivery block did not.
+     */
+    public function testTheDeliveryBlockAsksForACompanyName(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+        $this->openASessionWithACart();
+
+        $crawler = $this->requestIdentificationPage();
+
+        self::assertCount(
+            1,
+            $crawler->filter('[name="flexybundle_form_guest_checkout[company]"]'),
+            'The delivery address must offer a company name, as the billing one does.',
+        );
+    }
+
+    public function testTheCompanyNameTypedOnTheDeliveryBlockIsWrittenOnTheAddress(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+        $this->openASessionWithACart();
+
+        $this->client->submit($this->guestFormOf($this->requestIdentificationPage(), [
+            'flexybundle_form_guest_checkout[company]' => 'Dupont et Fils',
+        ]));
+
+        $this->assertResponseRedirectsTo('/checkout/delivery');
+
+        $guest = $this->guestCustomerOf(self::GUEST_EMAIL);
+
+        self::assertSame(
+            'Dupont et Fils',
+            AddressQuery::create()->filterByCustomerId($guest?->getId())->findOne()?->getCompany(),
+        );
+    }
+
+    /**
+     * The box is the consent the order is placed under, so the buyer has to be able to
+     * read what they are agreeing to — and the merchant to show which text it was.
+     */
+    public function testTheConsentBoxLinksToTheDocumentTheShopDesignates(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+        $this->openASessionWithACart();
+
+        $content = $this->fixtures()->content($this->fixtures()->folder(), ['title' => 'Privacy policy']);
+        ConfigQuery::write('terms_conditions_content_id', (string) $content->getId());
+
+        $crawler = $this->requestIdentificationPage();
+
+        self::assertStringContainsString(
+            'Privacy policy',
+            $crawler->filter('form[name="flexybundle_form_guest_checkout"]')->text(''),
+            'The document the box commits the buyer to has to be reachable from the box.',
+        );
+    }
+
+    /**
+     * A box that is not compulsory must not be marked as one: the sign-in block of this
+     * page carried the asterisk the login page does not.
+     */
+    public function testTheRememberMeBoxIsNotMarkedAsCompulsory(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+        $this->openASessionWithACart();
+
+        $crawler = $this->requestIdentificationPage();
+
+        $rememberMe = $crawler->filter('input[name="thelia_customer_login[remember_me]"]')->closest('label');
+
+        self::assertNotNull($rememberMe, 'The sign-in block must offer the box.');
+        self::assertStringNotContainsString(
+            '*',
+            $rememberMe->text(''),
+            'Nothing is asked of the buyer by ticking it.',
+        );
+    }
+
     private function submitGuestFormWithoutTheConsentBox(): void
     {
         $prefix = 'flexybundle_form_guest_checkout';

--- a/tests/Http/Flexy/GuestCheckoutProductRefusalTest.php
+++ b/tests/Http/Flexy/GuestCheckoutProductRefusalTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Thelia\Domain\Checkout\Enum\GuestCheckoutMode;
+use Thelia\Model\Cart;
+use Thelia\Model\Map\CartTableMap;
+
+/**
+ * A cart holding a product the shop only sells to account holders.
+ *
+ * Two things are owed to the buyer here: being stopped where the cart stops being
+ * orderable, rather than several steps later on the last click, and being told why.
+ * A silent redirect to the sign-in page reads as the shop having changed its mind.
+ */
+final class GuestCheckoutProductRefusalTest extends GuestCheckoutTestCase
+{
+    private const REASON = 'requires an account';
+
+    public function testTheVisitorIsToldWhyTheOrderCannotBePlacedWithoutAnAccount(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::EnabledUnlessProductForbids);
+        $this->openASessionWithACart(guestCheckoutForbidden: true);
+
+        $this->client->request('GET', '/checkout/delivery');
+
+        $this->assertResponseRedirectsTo('/customer/login');
+        $this->assertTheReasonIsOnThePageTheVisitorLandsOn();
+    }
+
+    /**
+     * A shop that simply requires an account says nothing about products: the visitor is
+     * sent to the sign-in page the way they always were.
+     */
+    public function testAShopThatRequiresAnAccountSaysNothingAboutProducts(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Disabled);
+        $this->openASessionWithACart();
+
+        $this->client->request('GET', '/checkout/delivery');
+
+        $this->assertResponseRedirectsTo('/customer/login');
+
+        $landed = $this->client->followRedirect();
+
+        self::assertStringNotContainsString(self::REASON, $landed->text());
+    }
+
+    public function testTheDeliveryStepStopsAGuestWhoseCartGainedSuchAProduct(): void
+    {
+        $cart = $this->aGuestInTheCheckout();
+
+        $this->addAForbiddenProductTo($cart);
+
+        $this->client->request('GET', '/checkout/delivery');
+
+        $this->assertResponseRedirectsTo('/customer/login');
+        $this->assertTheReasonIsOnThePageTheVisitorLandsOn();
+    }
+
+    public function testThePaymentStepStopsAGuestWhoseCartGainedSuchAProduct(): void
+    {
+        $cart = $this->aGuestInTheCheckout();
+
+        $this->addAForbiddenProductTo($cart);
+
+        $this->client->request('GET', '/checkout/payment');
+
+        $this->assertResponseRedirectsTo('/customer/login');
+        $this->assertTheReasonIsOnThePageTheVisitorLandsOn();
+    }
+
+    private function aGuestInTheCheckout(): Cart
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::EnabledUnlessProductForbids);
+
+        $cart = $this->openASessionWithACart();
+
+        $this->client->submit($this->guestFormOf($this->requestIdentificationPage()));
+        $this->assertResponseRedirectsTo('/checkout/delivery');
+
+        return $cart;
+    }
+
+    private function addAForbiddenProductTo(Cart $cart): void
+    {
+        $fixtures = $this->fixtures();
+        $product = $fixtures->product(
+            $fixtures->category(),
+            $fixtures->taxRule(),
+            $fixtures->currency(),
+        );
+        $product->setGuestCheckoutForbidden(1)->save();
+
+        $fixtures->cartItem($cart, $product);
+
+        // The requests already served left the cart in the Propel instance pool with the
+        // line collection they read: without this the checkout goes on seeing the cart as
+        // it was before this product went into it.
+        CartTableMap::clearInstancePool();
+        CartTableMap::clearRelatedInstancePool();
+    }
+
+    private function assertTheReasonIsOnThePageTheVisitorLandsOn(): void
+    {
+        $landed = $this->client->followRedirect();
+
+        self::assertStringContainsString(
+            self::REASON,
+            $landed->text(),
+            'A buyer turned away has to read why, or they read it as the shop changing its mind.',
+        );
+    }
+}

--- a/tests/Http/Flexy/GuestCheckoutProductRefusalTest.php
+++ b/tests/Http/Flexy/GuestCheckoutProductRefusalTest.php
@@ -104,6 +104,7 @@ final class GuestCheckoutProductRefusalTest extends GuestCheckoutTestCase
             $fixtures->category(),
             $fixtures->taxRule(),
             $fixtures->currency(),
+            ['title' => 'A product that requires an account'],
         );
         $product->setGuestCheckoutForbidden(1)->save();
 

--- a/tests/Http/Flexy/GuestCheckoutSessionTest.php
+++ b/tests/Http/Flexy/GuestCheckoutSessionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Http\Flexy;
 
+use Thelia\Api\Security\GuestRegistrationLimiter;
 use Thelia\Domain\Checkout\Enum\GuestCheckoutMode;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\CartQuery;
@@ -188,9 +189,10 @@ final class GuestCheckoutSessionTest extends GuestCheckoutTestCase
         $crawler = $this->client->submit($this->guestFormOf($this->requestIdentificationPage()));
 
         self::assertSame(
-            200,
+            422,
             $this->client->getResponse()->getStatusCode(),
-            'The page comes back rather than sending the buyer on with an order nobody owns.',
+            'The page comes back rather than sending the buyer on with an order nobody owns, '
+            .'and it has to say so it is a refusal or the tunnel paints nothing.',
         );
         self::assertStringContainsString(
             'already has an account',
@@ -242,13 +244,46 @@ final class GuestCheckoutSessionTest extends GuestCheckoutTestCase
         ]);
 
         self::assertSame(
-            200,
+            422,
             $this->client->getResponse()->getStatusCode(),
             'The form comes back rather than writing an address nobody can deliver an invoice to.',
         );
         self::assertNull(
             $this->guestCustomerOf(self::GUEST_EMAIL),
             'Nothing may be opened on a submission the form refuses.',
+        );
+    }
+
+    /**
+     * The tunnel navigates client-side, and the client-side navigation drops a form
+     * response that answers 200 without redirecting — the buyer then clicks and nothing
+     * moves, whatever the page holds. Every refusal of this form therefore has to answer
+     * with a status that says it is one, this one included.
+     */
+    public function testTheFormSaysItIsARefusalWhenTooManyAttemptsWereMade(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+
+        $limiter = $this->getService(GuestRegistrationLimiter::class);
+
+        // Spent before the submission, the way a buyer who kept retrying would have.
+        do {
+            $budgetLeft = $limiter->allows(self::GUEST_EMAIL);
+        } while ($budgetLeft);
+
+        $this->openASessionWithACart();
+        $crawler = $this->client->submit($this->guestFormOf($this->requestIdentificationPage()));
+
+        self::assertSame(
+            422,
+            $this->client->getResponse()->getStatusCode(),
+            'A buyer who is turned away has to be told, and a 200 here is painted by nothing.',
+        );
+        self::assertStringContainsString(
+            'Too many attempts',
+            $crawler->text(),
+            'The reason has to be on the page that comes back.',
         );
     }
 

--- a/tests/Http/Flexy/GuestCheckoutSessionTest.php
+++ b/tests/Http/Flexy/GuestCheckoutSessionTest.php
@@ -287,6 +287,50 @@ final class GuestCheckoutSessionTest extends GuestCheckoutTestCase
         );
     }
 
+    /**
+     * A buyer who orders again from the same address, having typed the very same thing,
+     * must not leave a second copy of it behind: the record is shared, so the copies pile
+     * up on it, and the day they open an account they find their own address several
+     * times over.
+     */
+    public function testOrderingTwiceFromTheSameAddressDoesNotWriteItTwice(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+
+        $this->identifyAsAGuestLivingAt(self::FIRST_BUYER_STREET);
+
+        $guestId = $this->guestCustomerOf(self::GUEST_EMAIL)?->getId();
+
+        $this->client->restart();
+        $this->identifyAsAGuestLivingAt(self::FIRST_BUYER_STREET);
+
+        self::assertCount(
+            1,
+            AddressQuery::create()->filterByCustomerId($guestId)->find(),
+            'The same address typed twice is one address.',
+        );
+    }
+
+    public function testADifferentAddressOnTheSameEmailIsStillWritten(): void
+    {
+        $this->skipUnlessTheThemeHasTheIdentificationPage();
+        $this->setGuestCheckoutMode(GuestCheckoutMode::Enabled);
+
+        $this->identifyAsAGuestLivingAt(self::FIRST_BUYER_STREET);
+
+        $guestId = $this->guestCustomerOf(self::GUEST_EMAIL)?->getId();
+
+        $this->client->restart();
+        $this->identifyAsAGuestLivingAt(self::SECOND_BUYER_STREET);
+
+        self::assertCount(
+            2,
+            AddressQuery::create()->filterByCustomerId($guestId)->find(),
+            'Two different addresses are two addresses, whoever typed them.',
+        );
+    }
+
     private function identifyAsAGuestLivingAt(string $street): void
     {
         $this->openASessionWithACart();

--- a/tests/Http/Flexy/GuestCheckoutTestCase.php
+++ b/tests/Http/Flexy/GuestCheckoutTestCase.php
@@ -95,10 +95,14 @@ abstract class GuestCheckoutTestCase extends WebIntegrationTestCase
         $cart = $this->cartOpenedAfter($highestCartIdBefore);
 
         $fixtures = $this->fixtures();
+
+        // Titled on purpose: the cart page renders every line through a component whose
+        // title is a non-nullable string, so an untranslated product takes the page down.
         $product = $fixtures->product(
             $fixtures->category(),
             $fixtures->taxRule(),
             $fixtures->currency(),
+            ['title' => 'A product in the cart'],
         );
 
         if ($guestCheckoutForbidden) {

--- a/tests/Integration/Command/CustomerPersonalDataCommandsTest.php
+++ b/tests/Integration/Command/CustomerPersonalDataCommandsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The two commands a shop answers a personal-data request with, on an email address that
+ * carries more than one row.
+ *
+ * Ordering without an account opens a row of its own, and registering later opens
+ * another: the account is not the guest row, and neither is the whole of what the shop
+ * knows about that address. A command that reads one row answers half the request —
+ * silently, since it has no way of saying it stopped at the first.
+ */
+final class CustomerPersonalDataCommandsTest extends IntegrationTestCase
+{
+    private const EMAIL = 'two-rows-on-one-address@test.com';
+
+    public function testAnonymizingAnAddressReachesEveryRowItCarries(): void
+    {
+        [$account, $guest] = $this->anAddressCarryingAnAccountAndAGuestRow();
+
+        $tester = $this->runCommand('customer:anonymize', ['email' => self::EMAIL, '--force' => true]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('2', $tester->getDisplay(), 'The command has to say how many rows it found.');
+
+        self::assertTrue($this->isAnonymized($account), 'The account on that address must be anonymized.');
+        self::assertTrue($this->isAnonymized($guest), 'The guest row on that address must be too.');
+    }
+
+    public function testExportingAnAddressReadsEveryRowItCarries(): void
+    {
+        [$account, $guest] = $this->anAddressCarryingAnAccountAndAGuestRow();
+
+        $tester = $this->runCommand('customer:export-personal-data', ['email' => self::EMAIL]);
+
+        self::assertSame(0, $tester->getStatusCode());
+
+        $exported = $tester->getDisplay();
+
+        self::assertStringContainsString(
+            (string) $account->getRef(),
+            $exported,
+            'The account on that address must be in what the buyer is handed.',
+        );
+        self::assertStringContainsString(
+            (string) $guest->getRef(),
+            $exported,
+            'So must the orders they placed before opening it.',
+        );
+    }
+
+    /**
+     * @return array{0: Customer, 1: Customer}
+     */
+    private function anAddressCarryingAnAccountAndAGuestRow(): array
+    {
+        $fixtures = $this->createFixtureFactory();
+        $title = $fixtures->customerTitle();
+
+        $guest = $fixtures->guestCustomer($title, ['email' => self::EMAIL]);
+        $account = $fixtures->customer($title, ['email' => self::EMAIL]);
+
+        return [$account, $guest];
+    }
+
+    private function isAnonymized(Customer $customer): bool
+    {
+        return null !== CustomerQuery::create()->findPk($customer->getId())?->getAnonymizedAt();
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function runCommand(string $command, array $input): CommandTester
+    {
+        $tester = new CommandTester((new Application(self::$kernel))->find($command));
+        $tester->execute($input);
+
+        return $tester;
+    }
+}

--- a/tests/Integration/Domain/Customer/RegistrationOnAGuestAddressTest.php
+++ b/tests/Integration/Domain/Customer/RegistrationOnAGuestAddressTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Customer;
+
+use Thelia\Domain\Customer\DTO\CustomerRegisterDTO;
+use Thelia\Domain\Customer\Service\CustomerRegistrationService;
+use Thelia\Model\Customer;
+use Thelia\Model\CustomerQuery;
+use Thelia\Model\Order;
+use Thelia\Model\OrderQuery;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * Opening an account on the address an order was already placed under.
+ *
+ * The buyer who ordered without an account and then signs up from the shop expects to
+ * find that order waiting for them, and that is what the feature promises. Their history
+ * hangs off the row the order was placed under, so the registration completes that row
+ * instead of opening a second one beside it — two rows on one address would split the
+ * history in half and show the shop two customers with the same name.
+ */
+final class RegistrationOnAGuestAddressTest extends IntegrationTestCase
+{
+    private const EMAIL = 'ordered-then-registered@test.com';
+
+    private const PASSWORD = 'a-password-of-their-own';
+
+    public function testRegisteringOnTheAddressOfAGuestOrderCompletesThatRecord(): void
+    {
+        $guest = $this->aGuestWhoAlreadyOrdered();
+
+        $registered = $this->register();
+
+        self::assertSame(
+            $guest->getId(),
+            $registered->getId(),
+            'The registration must complete the record the orders hang off, not open another.',
+        );
+        self::assertCount(
+            1,
+            CustomerQuery::create()->filterByEmail(self::EMAIL)->find(),
+            'One address, one person, one record.',
+        );
+    }
+
+    public function testTheOrderPlacedWithoutAnAccountStaysOnTheRecord(): void
+    {
+        $guest = $this->aGuestWhoAlreadyOrdered();
+        $orderId = $this->orderOf($guest)->getId();
+
+        $registered = $this->register();
+
+        self::assertSame(
+            $registered->getId(),
+            OrderQuery::create()->findPk($orderId)?->getCustomerId(),
+            'The order the buyer placed before signing up must be in the history they sign in to.',
+        );
+    }
+
+    /**
+     * The account is not open on the strength of a signup form alone: ordering without
+     * an account is open to anyone, so the record may carry somebody else's orders, and
+     * what separates the two is reading the mailbox. The activation code decides, exactly
+     * as it does when the account is completed from the order tracking link.
+     */
+    public function testTheRecordIsOnlyOpenedOnceTheActivationCodeIsAnswered(): void
+    {
+        $this->aGuestWhoAlreadyOrdered();
+
+        $registered = $this->register();
+
+        self::assertNotSame('', $registered->getPassword(), 'The password the buyer chose must be on the record.');
+        self::assertTrue($registered->isGuest(), 'The record is opened by the activation code, not by the form.');
+        self::assertSame(0, $registered->getEnable(), 'And it stays closed until then.');
+    }
+
+    private function aGuestWhoAlreadyOrdered(): Customer
+    {
+        $fixtures = $this->createFixtureFactory();
+        $guest = $fixtures->guestCustomer($fixtures->customerTitle(), ['email' => self::EMAIL]);
+
+        $fixtures->order($guest);
+
+        return $guest;
+    }
+
+    private function orderOf(Customer $guest): Order
+    {
+        $order = OrderQuery::create()->filterByCustomerId($guest->getId())->findOne();
+
+        self::assertInstanceOf(Order::class, $order);
+
+        return $order;
+    }
+
+    private function register(): Customer
+    {
+        /** @var CustomerRegistrationService $registration */
+        $registration = $this->getService(CustomerRegistrationService::class);
+
+        return $registration->registerCustomer(new CustomerRegisterDTO(
+            firstname: 'Camille',
+            lastname: 'Durand',
+            email: self::EMAIL,
+            password: self::PASSWORD,
+        ));
+    }
+}

--- a/tests/Integration/Domain/Order/GuestOrderAccessServiceTest.php
+++ b/tests/Integration/Domain/Order/GuestOrderAccessServiceTest.php
@@ -87,12 +87,32 @@ final class GuestOrderAccessServiceTest extends IntegrationTestCase
     }
 
     /**
-     * The password hash of the customer is part of what is signed, and a guest has
-     * none. Completing the account gives it one, which retires every link handed out
-     * while there was no account to sign into — from then on the order is reached the
-     * way every other customer reaches theirs.
+     * Choosing a password opens nothing: the record stays a guest until the activation
+     * code is answered, so the buyer can neither sign in nor be sent a reset link. The
+     * link has to carry them through that gap — otherwise a code that never arrives puts
+     * the order out of reach for good.
      */
-    public function testALinkStopsWorkingOnceTheGuestCompletesTheAccount(): void
+    public function testTheLinkOutlivesThePasswordBeingChosen(): void
+    {
+        $guest = $this->guest();
+        $order = $this->factory->order($guest);
+        $token = $this->service->createToken($order);
+
+        $this->getService(CustomerGuestConversionService::class)->convert($guest, 'a-chosen-password');
+
+        self::assertInstanceOf(
+            Order::class,
+            $this->service->findOrderForToken($token),
+            'Between the password being chosen and the code being answered there is no other way in.',
+        );
+    }
+
+    /**
+     * What retires the link is the account becoming usable, which is what the activation
+     * code decides. From then on the order is reached the way every other customer
+     * reaches theirs.
+     */
+    public function testALinkStopsWorkingOnceTheAccountIsOpen(): void
     {
         $guest = $this->guest();
         $order = $this->factory->order($guest);
@@ -100,11 +120,50 @@ final class GuestOrderAccessServiceTest extends IntegrationTestCase
 
         self::assertInstanceOf(Order::class, $this->service->findOrderForToken($token));
 
-        $this->getService(CustomerGuestConversionService::class)->convert($guest, 'a-chosen-password');
+        $guest->setIsGuest(0)->setEnable(1)->save();
 
         self::assertNull(
             $this->service->findOrderForToken($token),
-            'A link issued to a guest must not survive the account it belonged to gaining a password.',
+            'A link issued to a guest must not survive the account it belonged to being opened.',
+        );
+    }
+
+    /**
+     * Told apart from a dead link, and from a dead link only: a buyer sent back to their
+     * own order has to learn that it is waiting behind a sign-in, while a token nobody
+     * was ever issued must learn nothing at all.
+     */
+    public function testALinkRetiredByAnOpenedAccountIsRecognisedAsSuch(): void
+    {
+        $guest = $this->guest();
+        $order = $this->factory->order($guest);
+        $token = $this->service->createToken($order);
+
+        $guest->setIsGuest(0)->setEnable(1)->save();
+
+        $found = $this->service->findOrderNowBehindAnAccount($token);
+
+        self::assertInstanceOf(Order::class, $found);
+        self::assertSame($order->getId(), $found->getId());
+    }
+
+    public function testAForgedOrExpiredLinkIsNeverTakenForOneRetiredByAnAccount(): void
+    {
+        $guest = $this->guest();
+        $order = $this->factory->order($guest);
+        [$orderId, $expiresAt] = explode('.', $this->service->createToken($order));
+
+        $guest->setIsGuest(0)->setEnable(1)->save();
+
+        self::assertNull(
+            $this->service->findOrderNowBehindAnAccount(
+                \sprintf('%s.%s.%s', $orderId, $expiresAt, bin2hex(random_bytes(32))),
+            ),
+            'A forged token must say nothing, whatever the state of the account it aims at.',
+        );
+        self::assertNull(
+            $this->service->findOrderNowBehindAnAccount($this->service->createToken($order, -1)),
+            'Nor must an expired one.',
         );
     }
 

--- a/tests/Integration/Flexy/GuestCheckoutAddressGuardTest.php
+++ b/tests/Integration/Flexy/GuestCheckoutAddressGuardTest.php
@@ -38,6 +38,20 @@ final class GuestCheckoutAddressGuardTest extends IntegrationTestCase
 
     private const SECOND_BUYER_STREET = '34 rue du Second Acheteur';
 
+    /**
+     * A skip rather than a failure: the core ships with whichever theme version it is
+     * given, and the scope this asks about is decided by the theme. Asking a theme that
+     * has no say in it proves nothing.
+     */
+    protected function setUp(): void
+    {
+        if (!method_exists(GuestCheckoutGate::class, 'assertVisible')) {
+            self::markTestSkipped('The installed theme does not scope the checkout addresses.');
+        }
+
+        parent::setUp();
+    }
+
     public function testTheBillingBlockRefusesToOpenTheAddressOfTheBuyerBefore(): void
     {
         [$foreignAddress] = $this->aSharedRowWithTwoBuyers();

--- a/tests/Integration/Flexy/GuestCheckoutAddressGuardTest.php
+++ b/tests/Integration/Flexy/GuestCheckoutAddressGuardTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Flexy;
+
+use FlexyBundle\Components\Forms\Address\Base as AddressForm;
+use FlexyBundle\Components\Organisms\Invoice\Base as InvoiceBlock;
+use FlexyBundle\Service\GuestCheckoutGate;
+use Thelia\Model\Address;
+use Thelia\Model\Customer;
+use Thelia\Test\IntegrationTestCase;
+
+/**
+ * The billing block and the address form, asked for an address of the buyer before.
+ *
+ * One customer row is shared by everyone who ever ordered on an email address, so the
+ * addresses of several people hang off it and belonging to the row proves nothing. What
+ * decides is the identification in hand: the addresses typed on it, and no others.
+ *
+ * The delivery step is covered over HTTP by
+ * {@see \Thelia\Tests\Http\Flexy\GuestCheckoutAddressScopeTest}; the billing block only
+ * appears on the payment step, so it is asked here directly.
+ */
+final class GuestCheckoutAddressGuardTest extends IntegrationTestCase
+{
+    private const FIRST_BUYER_STREET = '12 rue du Premier Acheteur';
+
+    private const SECOND_BUYER_STREET = '34 rue du Second Acheteur';
+
+    public function testTheBillingBlockRefusesToOpenTheAddressOfTheBuyerBefore(): void
+    {
+        [$foreignAddress] = $this->aSharedRowWithTwoBuyers();
+
+        $this->expectException(\Throwable::class);
+
+        $this->invoiceBlock()->setEditingAddress((int) $foreignAddress->getId());
+    }
+
+    public function testTheBillingBlockRefusesToInvoiceTheAddressOfTheBuyerBefore(): void
+    {
+        [$foreignAddress] = $this->aSharedRowWithTwoBuyers();
+
+        $this->expectException(\Throwable::class);
+
+        $this->invoiceBlock()->selectInvoiceAddress((int) $foreignAddress->getId());
+    }
+
+    public function testTheBillingBlockStillOpensAnAddressOfThisIdentification(): void
+    {
+        [, $ownAddress] = $this->aSharedRowWithTwoBuyers();
+
+        $block = $this->invoiceBlock();
+        $block->setEditingAddress((int) $ownAddress->getId());
+
+        self::assertSame(
+            (int) $ownAddress->getId(),
+            $block->editingAddressId,
+            'The buyer must still be able to correct what they typed a moment ago.',
+        );
+    }
+
+    /**
+     * The form is where the street, the name and the phone number would actually be
+     * read: it fills its fields from the address it is mounted on.
+     */
+    public function testTheAddressFormDoesNotFillItselfWithTheAddressOfTheBuyerBefore(): void
+    {
+        [$foreignAddress] = $this->aSharedRowWithTwoBuyers();
+
+        $form = $this->addressForm();
+        $form->addressId = (int) $foreignAddress->getId();
+
+        self::assertNotSame(
+            self::FIRST_BUYER_STREET,
+            $this->streetShownBy($form),
+            'The form must not hand back the address of whoever ordered on this email before.',
+        );
+    }
+
+    public function testTheAddressFormStillFillsItselfWithAnAddressOfThisIdentification(): void
+    {
+        [, $ownAddress] = $this->aSharedRowWithTwoBuyers();
+
+        $form = $this->addressForm();
+        $form->addressId = (int) $ownAddress->getId();
+
+        self::assertSame(
+            self::SECOND_BUYER_STREET,
+            $this->streetShownBy($form),
+            'Correcting the address just typed is the whole point of the edit form.',
+        );
+    }
+
+    private function streetShownBy(AddressForm $form): mixed
+    {
+        return $form->getFormView()->children['address1']->vars['value'] ?? null;
+    }
+
+    /**
+     * One guest row carrying the addresses of two buyers, with the session holding the
+     * second identification: the address of the first is on the row and not on the
+     * session.
+     *
+     * @return array{0: Address, 1: Address} the address of the buyer before, then the
+     *                                       address of the buyer in the session
+     */
+    private function aSharedRowWithTwoBuyers(): array
+    {
+        $fixtures = $this->createFixtureFactory();
+        $title = $fixtures->customerTitle();
+        $country = $fixtures->country();
+
+        $sharedRow = $fixtures->guestCustomer($title);
+
+        $foreignAddress = $fixtures->address($sharedRow, $country, $title, [
+            'address1' => self::FIRST_BUYER_STREET,
+        ]);
+        $ownAddress = $fixtures->address($sharedRow, $country, $title, [
+            'address1' => self::SECOND_BUYER_STREET,
+        ]);
+
+        $this->signInAs($sharedRow, [(int) $ownAddress->getId()]);
+
+        return [$foreignAddress, $ownAddress];
+    }
+
+    /**
+     * @param list<int> $identificationAddressIds
+     */
+    private function signInAs(Customer $guest, array $identificationAddressIds): void
+    {
+        /** @var GuestCheckoutGate $gate */
+        $gate = $this->getService(GuestCheckoutGate::class);
+        $gate->signIn($guest, $identificationAddressIds);
+    }
+
+    private function invoiceBlock(): InvoiceBlock
+    {
+        /** @var InvoiceBlock $block */
+        $block = $this->getService(InvoiceBlock::class);
+
+        return $block;
+    }
+
+    private function addressForm(): AddressForm
+    {
+        /** @var AddressForm $form */
+        $form = $this->getService(AddressForm::class);
+
+        return $form;
+    }
+}


### PR DESCRIPTION
Follow-ups on ordering without an account, found while walking the feature on a fresh install with the demo data.

### What changes

- **The tracking link stays usable until the account is really open.** It used to be signed with the password hash, so choosing a password killed it while the activation code was still pending. Between the two the buyer could neither sign in nor reopen their link, and a lost code left the order out of reach for good. The link now dies when the account becomes usable, not before.
- **Signing up on the address of an order placed without an account completes that record** instead of opening a second one beside it. The history follows the buyer, which is what the feature promises, and the back office stops listing two customers with the same name.
- **The personal data commands read every record an address carries.** An address may now hold both a passwordless record and an account; `customer:anonymize` and `customer:export-personal-data` used to resolve a single one, so an erasure could leave the other untouched. Both now walk them all and say how many they found.
- **The guest conversion endpoint answers the state the account is actually in.** It replied `201 Created` while the record was still passwordless and waiting on its activation code, which told a headless front the conversion was over when it was not.
- **The unused Webpack Encore dependency is gone.** Nothing calls `encore_entry_*` in the core or in either theme, which render their assets through AssetMapper. The require and the four bundles that came with it are removed.

### Tests

Ten test files, each written against the behaviour before the fix and seen failing there first: the tracking link across the account being opened, signing up on a passwordless address, the personal data commands on an address with two records, the conversion answer, the refusal of a cart that requires an account, and the address scope of the checkout steps.

### Checks

- `composer test`, five suites
- `composer cs-diff`
- `composer phpstan`
- `./vendor/bin/phpstan analyse -c phpstan-botwig.neon`
