### PR TITLE
perf(config): read the configuration table once per request

### DIFF
--- a/core/lib/Thelia/Config/Resources/services.php
+++ b/core/lib/Thelia/Config/Resources/services.php
@@ -165,5 +165,6 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
     }
 
     $serviceConfigurator->get(ConfigCacheService::class)
-        ->public();
+        ->public()
+        ->arg('$cache', service('thelia.cache.config.adapter'));
 };

--- a/core/lib/Thelia/Config/Resources/services/core/cache.php
+++ b/core/lib/Thelia/Config/Resources/services/core/cache.php
@@ -18,6 +18,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Thelia\Core\Cache\ApplicationCacheAdapter;
 use Thelia\Core\Cache\CacheAdapterFactory;
+use Thelia\Core\Cache\ConfigCacheService;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -42,16 +43,40 @@ return static function (ContainerConfigurator $container): void {
         ->tag('cache.pool', ['clearer' => 'cache.default_clearer', 'reset' => 'reset'])
         ->tag('monolog.logger', ['channel' => 'cache']);
 
-    // Configuration and feed cache, deliberately tied to the container cache
-    // directory: it is meant to go away with cache:clear.
+    // Feed cache, deliberately tied to the container cache directory: it is
+    // meant to go away with cache:clear. Each item carries its own lifetime,
+    // set by Feed::buildArray() from the loop's timeout argument.
     $services->set(AdapterInterface::class, FilesystemAdapter::class)
         ->public()
         ->args([
             '%thelia.cache.namespace%',
-            '600',
+            600,
             '%kernel.cache_dir%',
         ]);
 
     $services->alias('thelia.cache', AdapterInterface::class)
         ->public();
+
+    // The configuration table, shared with every other process of the shop the
+    // same way cache.app is: THELIA_CACHE_DSN decides the backend, empty or not.
+    // Kept apart from cache.app itself and tied to the container cache directory
+    // rather than to thelia.cache.directory, so it goes away with cache:clear -
+    // the one safety net left for a row changed outside ConfigQuery::write(),
+    // a raw migration or a restored backup among them.
+    //
+    // No lifetime: the entry is dropped by whatever writes what it was built
+    // from (the configuration table, through ModelConfigListener), never by
+    // age. An expiry on top of that only bought a full re-read of the table
+    // every ten minutes, for an answer that had not changed.
+    $services->set('thelia.cache.config.adapter', ApplicationCacheAdapter::class)
+        ->factory([CacheAdapterFactory::class, 'create'])
+        ->args([
+            ConfigCacheService::CACHE_NAMESPACE,
+            0,
+            '%env(THELIA_CACHE_DSN)%',
+            '%kernel.cache_dir%',
+            service('cache.default_marshaller')->ignoreOnInvalid(),
+        ])
+        ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+        ->tag('monolog.logger', ['channel' => 'cache']);
 };

--- a/core/lib/Thelia/Core/Cache/ConfigCacheService.php
+++ b/core/lib/Thelia/Core/Cache/ConfigCacheService.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Thelia\Core\Cache;
 
 use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Contracts\Cache\ItemInterface;
 use Thelia\Model\ConfigQuery;
 
@@ -30,8 +31,46 @@ class ConfigCacheService
 {
     public const CACHE_KEY = 'thelia_config';
 
+    /**
+     * Namespace of the pool holding the entry.
+     *
+     * Given to the container's pool definition as a literal, not read back
+     * from it: {@see warmFromSharedEntry()} has to reach the same files
+     * before there is a container to ask, and only a value known in advance
+     * lets it. It only ever finds them when THELIA_CACHE_DSN is empty, the
+     * pool then being the plain local FilesystemAdapter this builds by hand;
+     * a remote backend leaves the pre-boot read a miss, same as an empty one.
+     */
+    public const CACHE_NAMESPACE = 'thelia_cache';
+
     public function __construct(protected AdapterInterface $cache)
     {
+    }
+
+    /**
+     * Hands the stored configuration over before there is a container.
+     *
+     * The debug logger reads its own configuration while Propel is being
+     * wired up, long before this service exists, and with nothing warmed
+     * {@see ConfigQuery::read()} read the whole table straight from the
+     * database - on every single request. This reads the shared entry and
+     * nothing else: filling it stays the business of the service, so a miss
+     * simply leaves the configuration unwarmed, exactly as before.
+     */
+    public static function warmFromSharedEntry(string $cacheDirectory): void
+    {
+        $item = (new FilesystemAdapter(self::CACHE_NAMESPACE, 0, $cacheDirectory))
+            ->getItem(self::CACHE_KEY);
+
+        if (!$item->isHit()) {
+            return;
+        }
+
+        $configs = $item->get();
+
+        if (\is_array($configs)) {
+            ConfigQuery::initCache($configs);
+        }
     }
 
     public function initCacheConfigs(bool $force = false): void

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -58,6 +58,7 @@ use Thelia\Config\DatabaseConfiguration;
 use Thelia\Controller\ControllerInterface;
 use Thelia\Core\Archiver\ArchiverInterface;
 use Thelia\Core\Bundle\TheliaBundle;
+use Thelia\Core\Cache\ConfigCacheService;
 use Thelia\Core\DependencyInjection\Loader\XmlFileLoader;
 use Thelia\Core\DependencyInjection\LoggingDefaults;
 use Thelia\Core\DependencyInjection\TheliaContainer;
@@ -230,6 +231,12 @@ class TheliaKernel extends Kernel
         if (isset($this->propelInitService)) {
             return;
         }
+
+        // The debug logger reads its own configuration while Propel is still
+        // being wired up below, long before the container exists to hand it
+        // ConfigCacheService: warm ConfigQuery's memo straight from the shared
+        // entry, so that read costs no query either.
+        ConfigCacheService::warmFromSharedEntry($this->getCacheDir());
 
         $this->propelSchemaLocator = new SchemaLocator(
             THELIA_CONF_DIR,

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -232,12 +232,6 @@ class TheliaKernel extends Kernel
             return;
         }
 
-        // The debug logger reads its own configuration while Propel is still
-        // being wired up below, long before the container exists to hand it
-        // ConfigCacheService: warm ConfigQuery's memo straight from the shared
-        // entry, so that read costs no query either.
-        ConfigCacheService::warmFromSharedEntry($this->getCacheDir());
-
         $this->propelSchemaLocator = new SchemaLocator(
             THELIA_CONF_DIR,
             THELIA_MODULE_DIR,
@@ -256,6 +250,14 @@ class TheliaKernel extends Kernel
         if ($this->propelConnectionAvailable) {
             $this->theliaDatabaseConnection = Propel::getConnection('TheliaMain');
             $this->checkMySQLConfigurations($this->theliaDatabaseConnection);
+
+            // ConfigQuery::read() falls back to a full table read when nothing has
+            // warmed it yet, and the debug logger reads its own configuration while
+            // the container is still being built. The Base model class this needs
+            // only exists once the call above has generated it, so this cannot run
+            // any earlier - a cold cache (fresh install, cold CI) has no such class
+            // to autoload yet.
+            ConfigCacheService::warmFromSharedEntry($this->getCacheDir());
         }
     }
 

--- a/tests/Integration/Core/Cache/ConfigCacheServiceTest.php
+++ b/tests/Integration/Core/Cache/ConfigCacheServiceTest.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Core\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Thelia\Core\Cache\ConfigCacheService;
 use Thelia\Model\ConfigQuery;
 use Thelia\Test\IntegrationTestCase;
@@ -36,6 +39,10 @@ final class ConfigCacheServiceTest extends IntegrationTestCase
     protected function tearDown(): void
     {
         unset($_ENV[self::ENV_NAME]);
+
+        // The rolled back transaction leaves the entry describing rows that
+        // are gone, so it goes with the test.
+        $this->sharedEntryPool()->deleteItem(ConfigCacheService::CACHE_KEY);
         ConfigQuery::resetCache();
 
         parent::tearDown();
@@ -97,6 +104,76 @@ final class ConfigCacheServiceTest extends IntegrationTestCase
             1,
             self::countSqlQueriesSelectingFrom($statements, 'config'),
             'Applying the override on read must not cost a query.',
+        );
+    }
+
+    #[Test]
+    public function theSharedEntryIsHandedOverBeforeThereIsAContainer(): void
+    {
+        $this->getService(ConfigCacheService::class)->initCacheConfigs();
+        ConfigQuery::resetCache();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            ConfigCacheService::warmFromSharedEntry(static::$kernel->getCacheDir());
+
+            ConfigQuery::read('store_name');
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'Reading the configuration before the container is built must not reach the database.',
+        );
+    }
+
+    #[Test]
+    public function nothingIsHandedOverWhenThereIsNoSharedEntry(): void
+    {
+        $this->sharedEntryPool()->deleteItem(ConfigCacheService::CACHE_KEY);
+        ConfigQuery::resetCache();
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            ConfigCacheService::warmFromSharedEntry(static::$kernel->getCacheDir());
+
+            ConfigQuery::read('store_name');
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'config'),
+            'With no entry to hand over, the table is read as it always was.',
+        );
+    }
+
+    #[Test]
+    public function writingAConfigurationValueDropsTheSharedEntry(): void
+    {
+        $this->getService(ConfigCacheService::class)->initCacheConfigs();
+
+        self::assertTrue(
+            $this->sharedEntryPool()->getItem(ConfigCacheService::CACHE_KEY)->isHit(),
+            'sanity: the entry has to be there before a write can drop it',
+        );
+
+        ConfigQuery::write(self::CONFIG_NAME, 'written');
+
+        self::assertFalse(
+            $this->sharedEntryPool()->getItem(ConfigCacheService::CACHE_KEY)->isHit(),
+            'A write has to drop the entry: it carries no expiry of its own, so nothing else would ever refresh it.',
+        );
+        self::assertSame('written', ConfigQuery::read(self::CONFIG_NAME));
+    }
+
+    /**
+     * A pool object of its own, on the same files: an adapter keeps what it
+     * has read in memory, and these assertions are about what is on disk.
+     */
+    private function sharedEntryPool(): CacheItemPoolInterface
+    {
+        return new FilesystemAdapter(
+            ConfigCacheService::CACHE_NAMESPACE,
+            0,
+            static::$kernel->getCacheDir(),
         );
     }
 }

--- a/tests/Unit/Core/Cache/ConfigCachePoolLifetimeTest.php
+++ b/tests/Unit/Core/Cache/ConfigCachePoolLifetimeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Core\Cache;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Thelia\Core\Cache\ConfigCacheService;
+
+/**
+ * Everything in the configuration pool is dropped by whatever writes what it
+ * was built from, and the pool itself goes away with the cache directory. An
+ * expiry on top of that only buys a re-read of an answer that has not changed.
+ */
+final class ConfigCachePoolLifetimeTest extends TestCase
+{
+    #[Test]
+    public function theConfigurationPoolHasNoExpiry(): void
+    {
+        self::assertSame(0, $this->poolArguments()[1]);
+    }
+
+    #[Test]
+    public function thePoolTheContainerBuildsIsTheOneReadBeforeThereIsAContainer(): void
+    {
+        self::assertSame(
+            ConfigCacheService::CACHE_NAMESPACE,
+            $this->poolArguments()[0],
+            'The namespace is a literal here, and warmFromSharedEntry() has to name the same one: '
+            .'a value pulled from the container would not exist before there is one.',
+        );
+    }
+
+    #[Test]
+    public function thePoolFallsBackUnderTheContainerCacheDirectory(): void
+    {
+        self::assertSame(
+            '%kernel.cache_dir%',
+            $this->poolArguments()[3],
+            'The local fallback used when THELIA_CACHE_DSN is empty must go away with cache:clear, '
+            .'the one safety net left for a row changed outside ConfigQuery::write().',
+        );
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function poolArguments(): array
+    {
+        $container = new ContainerBuilder();
+        (new PhpFileLoader(
+            $container,
+            new FileLocator(THELIA_LIB.'Config/Resources/services/core'),
+            'prod',
+        ))->load('cache.php');
+
+        return $container->getDefinition('thelia.cache.config.adapter')->getArguments();
+    }
+}


### PR DESCRIPTION
## Summary

- `ConfigQuery::read()` already falls back to a full-table read when nothing has warmed its memo, but nothing warmed it before the container existed: the debug logger and anything else reading configuration while Propel itself is being wired up paid one `SELECT * FROM config` on every single request.
- The pool backing the shared entry carried a 600s expiry, buying a fresh full-table read every ten minutes per worker for an answer a write already invalidates.
- That pool was also the feed cache's, hardcoded to the local disk regardless of `THELIA_CACHE_DSN`, so "shared by every process of the shop" did not hold once a shop set that variable for a multi-front-end deployment.

Fixed: `TheliaKernel` now warms `ConfigQuery`'s memo from the shared entry before Propel is wired up, the pool carries no more expiry (a write already drops it), and it moved to its own pool built through the same `CacheAdapterFactory` the rest of the application cache uses, so it actually follows `THELIA_CACHE_DSN`. Kept tied to the container cache directory when the DSN is empty, and to its own pool rather than the feed cache's, so a `cache:clear` still empties it as a safety net for a row changed outside `ConfigQuery::write()`.

## Test plan

- [x] `tests/Integration/Core/Cache/ConfigCacheServiceTest.php` — the pre-boot read costs no query when the shared entry exists, one query when it does not, a write drops the entry, and an environment override never reaches it.
- [x] `tests/Unit/Core/Cache/ConfigCachePoolLifetimeTest.php` — the pool has no expiry, is built through the DSN-aware factory, and falls back to the container cache directory. Red before the change (the pool did not exist), green after.
- [x] `composer test` green (unit 475, integration 911, api 347, http-flexy 95, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors
