### PR TITLE
perf(model): keep the active-langs and country memos across requests

### DIFF
--- a/core/lib/Thelia/Core/EventListener/ActiveLangsCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/ActiveLangsCacheListener.php
@@ -17,14 +17,18 @@ namespace Thelia\Core\EventListener;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Model\Event\LangEvent;
 use Thelia\Model\Lang;
 
 /**
- * Keeps {@see Lang::getActiveLangs()} honest: the memoized list never outlives a request or
- * a console command, and a write on a language drops it at once.
+ * Keeps {@see Lang::getActiveLangs()} answering from the database of the
+ * current process, not the current request.
+ *
+ * A write on a language is what actually changes the answer, and that already
+ * drops the memo; a persistent worker runtime (FrankenPHP, RoadRunner) serves
+ * every other request from the same one, at no cost. Only a chain of separate
+ * console command processes needs the reset below, since nothing here can
+ * assume they share a runtime.
  */
 readonly class ActiveLangsCacheListener
 {
@@ -33,14 +37,6 @@ readonly class ActiveLangsCacheListener
     public function onLangWrite(): void
     {
         Lang::resetActiveLangsCache();
-    }
-
-    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
-    public function onKernelRequest(RequestEvent $event): void
-    {
-        if ($event->isMainRequest()) {
-            Lang::resetActiveLangsCache();
-        }
     }
 
     #[AsEventListener(event: ConsoleEvents::COMMAND)]

--- a/core/lib/Thelia/Core/EventListener/DefaultCountryCacheListener.php
+++ b/core/lib/Thelia/Core/EventListener/DefaultCountryCacheListener.php
@@ -17,8 +17,6 @@ namespace Thelia\Core\EventListener;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Thelia\Model\Country;
 use Thelia\Model\Event\CountryEvent;
 
@@ -27,11 +25,12 @@ use Thelia\Model\Event\CountryEvent;
  *
  * The lookup it wraps is read constantly (once per product card that falls
  * back to the shop's default delivery country) and almost never written, so
- * a plain static holding the resolved model is the right cache. It still
- * needs two safety nets: a write to the row that carries `by_default` must
- * not leave the memo stale for the rest of the request, and a persistent
- * worker runtime (FrankenPHP, RoadRunner) must not carry it over from one
- * request, or one console command, to the next.
+ * a plain static holding the resolved model is the right cache. A write to
+ * the row that carries `by_default` drops it at once, and that is the only
+ * thing that needs to: a persistent worker runtime (FrankenPHP, RoadRunner)
+ * serves every other request from the same memo, at no cost. Only a chain of
+ * separate console command processes needs the reset below, since nothing
+ * here can assume they share a runtime.
  */
 readonly class DefaultCountryCacheListener
 {
@@ -40,14 +39,6 @@ readonly class DefaultCountryCacheListener
     public function onCountryWrite(): void
     {
         Country::resetDefaultCountryCache();
-    }
-
-    #[AsEventListener(event: KernelEvents::REQUEST, priority: 4096)]
-    public function onKernelRequest(RequestEvent $event): void
-    {
-        if ($event->isMainRequest()) {
-            Country::resetDefaultCountryCache();
-        }
     }
 
     #[AsEventListener(event: ConsoleEvents::COMMAND)]

--- a/core/lib/Thelia/Model/Lang.php
+++ b/core/lib/Thelia/Model/Lang.php
@@ -51,12 +51,14 @@ class Lang extends BaseLang
     }
 
     /**
-     * The active languages, read once per request.
+     * The active languages, read once per process.
      *
      * The API bridge asks for them every time it transforms a model or eager-loads a
-     * collection: a page rendering a dozen resources reread the same rows a dozen times.
-     * Reset by {@see \Thelia\Core\EventListener\ActiveLangsCacheListener} at the start of
-     * every request and console command, and whenever a language is saved or deleted.
+     * collection: a page rendering a dozen resources reread the same rows a dozen times,
+     * and so would every request after it in a persistent worker runtime (FrankenPHP,
+     * RoadRunner) with nothing memoized across them. Dropped by
+     * {@see \Thelia\Core\EventListener\ActiveLangsCacheListener} whenever a language is
+     * saved or deleted, and between console commands sharing one process.
      *
      * @return ObjectCollection<Lang>
      */

--- a/tests/Integration/Core/EventListener/ActiveLangsCacheListenerTest.php
+++ b/tests/Integration/Core/EventListener/ActiveLangsCacheListenerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Core\EventListener\ActiveLangsCacheListener;
+use Thelia\Model\Lang;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A persistent worker runtime (FrankenPHP, RoadRunner) keeps the same process,
+ * and with it the same memo, across every request it serves. Resetting it at
+ * the start of each one bought a full read of the lang table for an answer a
+ * write already invalidates.
+ */
+final class ActiveLangsCacheListenerTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    protected function tearDown(): void
+    {
+        Lang::resetActiveLangsCache();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theMemoSurvivesASecondRequestInTheSameProcess(): void
+    {
+        Lang::resetActiveLangsCache();
+        Lang::getActiveLangs();
+
+        $dispatcher = $this->listenerDispatcher();
+        $request = Request::create('http://localhost');
+
+        $statements = $this->recordSqlQueries(static function () use ($dispatcher, $request): void {
+            $dispatcher->dispatch(
+                new RequestEvent(
+                    new class implements HttpKernelInterface {
+                        public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): never
+                        {
+                            throw new \LogicException('not called');
+                        }
+                    },
+                    $request,
+                    HttpKernelInterface::MAIN_REQUEST,
+                ),
+                KernelEvents::REQUEST,
+            );
+
+            Lang::getActiveLangs();
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'lang'),
+            'A second request in the same process must not pay for the memo again: only a write drops it.',
+        );
+    }
+
+    #[Test]
+    public function aConsoleCommandStillDropsTheMemo(): void
+    {
+        Lang::getActiveLangs();
+
+        $listener = new ActiveLangsCacheListener();
+        $listener->onConsoleCommand(new ConsoleCommandEvent(
+            new Command('demo:command'),
+            new ArrayInput([]),
+            new NullOutput(),
+        ));
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            Lang::getActiveLangs();
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'lang'),
+            'A command boundary must still force a fresh read: nothing here can assume two commands share a runtime.',
+        );
+    }
+
+    /**
+     * Wires only the attributes the listener actually declares, the way the
+     * container does: a method with no #[AsEventListener] for an event never
+     * runs for it, whatever its name.
+     */
+    private function listenerDispatcher(): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+        $listener = new ActiveLangsCacheListener();
+
+        foreach ((new \ReflectionClass(ActiveLangsCacheListener::class))->getMethods() as $method) {
+            foreach ($method->getAttributes(AsEventListener::class) as $attribute) {
+                $arguments = $attribute->getArguments();
+                $dispatcher->addListener(
+                    $arguments['event'],
+                    [$listener, $method->getName()],
+                    $arguments['priority'] ?? 0,
+                );
+            }
+        }
+
+        return $dispatcher;
+    }
+}

--- a/tests/Integration/Core/EventListener/DefaultCountryCacheListenerTest.php
+++ b/tests/Integration/Core/EventListener/DefaultCountryCacheListenerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\EventListener;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Thelia\Core\EventListener\DefaultCountryCacheListener;
+use Thelia\Model\Country;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A persistent worker runtime (FrankenPHP, RoadRunner) keeps the same process,
+ * and with it the same memo, across every request it serves. Resetting it at
+ * the start of each one bought a full read of the country table for an answer
+ * a write already invalidates.
+ */
+final class DefaultCountryCacheListenerTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    protected function tearDown(): void
+    {
+        Country::resetDefaultCountryCache();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theMemoSurvivesASecondRequestInTheSameProcess(): void
+    {
+        Country::resetDefaultCountryCache();
+        Country::getDefaultCountry();
+
+        $dispatcher = $this->listenerDispatcher();
+        $request = Request::create('http://localhost');
+
+        $statements = $this->recordSqlQueries(static function () use ($dispatcher, $request): void {
+            $dispatcher->dispatch(
+                new RequestEvent(
+                    new class implements HttpKernelInterface {
+                        public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): never
+                        {
+                            throw new \LogicException('not called');
+                        }
+                    },
+                    $request,
+                    HttpKernelInterface::MAIN_REQUEST,
+                ),
+                KernelEvents::REQUEST,
+            );
+
+            Country::getDefaultCountry();
+        });
+
+        self::assertSame(
+            0,
+            self::countSqlQueriesSelectingFrom($statements, 'country'),
+            'A second request in the same process must not pay for the memo again: only a write drops it.',
+        );
+    }
+
+    #[Test]
+    public function aConsoleCommandStillDropsTheMemo(): void
+    {
+        Country::getDefaultCountry();
+
+        $listener = new DefaultCountryCacheListener();
+        $listener->onConsoleCommand(new ConsoleCommandEvent(
+            new Command('demo:command'),
+            new ArrayInput([]),
+            new NullOutput(),
+        ));
+
+        $statements = $this->recordSqlQueries(static function (): void {
+            Country::getDefaultCountry();
+        });
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'country'),
+            'A command boundary must still force a fresh read: nothing here can assume two commands share a runtime.',
+        );
+    }
+
+    /**
+     * Wires only the attributes the listener actually declares, the way the
+     * container does: a method with no #[AsEventListener] for an event never
+     * runs for it, whatever its name.
+     */
+    private function listenerDispatcher(): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+        $listener = new DefaultCountryCacheListener();
+
+        foreach ((new \ReflectionClass(DefaultCountryCacheListener::class))->getMethods() as $method) {
+            foreach ($method->getAttributes(AsEventListener::class) as $attribute) {
+                $arguments = $attribute->getArguments();
+                $dispatcher->addListener(
+                    $arguments['event'],
+                    [$listener, $method->getName()],
+                    $arguments['priority'] ?? 0,
+                );
+            }
+        }
+
+        return $dispatcher;
+    }
+}


### PR DESCRIPTION
## Summary

- `Lang::getActiveLangs()` and `Country::getDefaultCountry()` are backed by a static memo (#3814, #3823), but a listener emptied it at the start of every single request.
- That reset costs nothing on classic PHP-FPM, where the process dies with the request anyway, but on a persistent worker runtime (FrankenPHP, RoadRunner) it turns the memo into a per-request one again: a full read of the `lang` or `country` table on every request the worker serves.
- A write on a language or a country already drops the memo, and that is the only thing that actually changes the answer.

Dropped the per-request reset in both listeners, kept the per-console-command one: nothing here can assume a chain of separate CLI processes shares a runtime.

## Test plan

- [x] `tests/Integration/Core/EventListener/ActiveLangsCacheListenerTest.php` and `DefaultCountryCacheListenerTest.php` — a second simulated request in the same process costs no query, a console command boundary still forces one. Red before the change (the removed listener method reset it every time), green after.
- [x] `composer test` green (unit 472, integration 925, api 349, http-flexy 113, http-backoffice 17)
- [x] `composer cs-diff` clean
- [x] `composer phpstan` no errors
