### PR TITLE
feat(sale): reserved sales and countdown display settings

### DIFF
--- a/.github/workflows/phpstan-botwig.yml
+++ b/.github/workflows/phpstan-botwig.yml
@@ -54,6 +54,8 @@ jobs:
           git checkout -- local/config/schema.xml
           grep -q is_guest local/config/schema.xml \
             || { echo "::error::local/config/schema.xml has no is_guest column after the restore"; exit 1; }
+          grep -q audience_mode local/config/schema.xml \
+            || { echo "::error::local/config/schema.xml has no audience_mode column after the restore"; exit 1; }
 
       - name: Prepare test env (builds the Propel models via App\Kernel)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
           git checkout -- local/config/schema.xml
           grep -q is_guest local/config/schema.xml \
             || { echo "::error::local/config/schema.xml has no is_guest column after the restore"; exit 1; }
+          grep -q audience_mode local/config/schema.xml \
+            || { echo "::error::local/config/schema.xml has no audience_mode column after the restore"; exit 1; }
 
       - name: Prepare the test database credentials
         # bin/test-prepare (run by `composer test`) reads these to create the test

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -25,6 +25,7 @@ build:
                     # local/config/schema.xml on install; the committed file is the source
                     # of truth, and models built without it turn into phantom issues.
                     - git checkout -- local/config/schema.xml
+                    - grep -q audience_mode local/config/schema.xml
                     - php bin/test-prepare || true
                     - php-scrutinizer-run
                     - command: composer phpstan

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -279,6 +279,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
             $cartItem = $this->doAddItem($dispatcher, $cart, $productId, $productSaleElements, $quantity, $productPrices);
         }
 
+        $this->settleReservedPrices($cart);
+
         $event->setCartItem($cartItem);
     }
 
@@ -331,6 +333,9 @@ class Cart extends BaseAction implements EventSubscriberInterface
                 $event->setCartItem(
                     $this->updateQuantity($dispatcher, $cartItem, $quantity),
                 );
+
+                $cart->clearCartItems();
+                $this->settleReservedPrices($cart);
             }
         }
     }
@@ -413,6 +418,25 @@ class Cart extends BaseAction implements EventSubscriberInterface
                 ->setPromo($promo)
                 ->save();
         }
+    }
+
+    /**
+     * Settle the reserved prices of a cart that the visitor just changed.
+     *
+     * Signing in is not the only moment entitlement moves: a customer taken out of a
+     * selection, or an operation that ends, while the cart sits open must not keep the
+     * reserved price on the next line the visitor touches — and a customer who has just
+     * become entitled should get it there. Guarded by the same indexed, per-request
+     * memoised check as the sign-in path, so a shop with no reserved operation running
+     * keeps the behaviour, and the queries, it had.
+     */
+    private function settleReservedPrices(CartModel $cart): void
+    {
+        if (!$this->saleAudienceChecker->hasActiveReservedSale()) {
+            return;
+        }
+
+        $this->refreshCartItemPrices($cart, $this->currencyOf($cart));
     }
 
     /**

--- a/core/lib/Thelia/Action/Cart.php
+++ b/core/lib/Thelia/Action/Cart.php
@@ -32,6 +32,9 @@ use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Domain\Cart\Exception\NotEnoughStockException;
 use Thelia\Domain\Cart\Service\CartAddressService;
+use Thelia\Domain\Sale\ReservedPrice;
+use Thelia\Domain\Sale\ReservedSalePriceResolver;
+use Thelia\Domain\Sale\SaleAudienceChecker;
 use Thelia\Domain\Shipping\Service\PostageTaxBreakdownCalculator;
 use Thelia\Model\AddressQuery;
 use Thelia\Model\Base\CustomerQuery;
@@ -67,6 +70,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
         protected ContainerInterface $container,
         protected CartAddressService $cartAddressService,
         protected PostageTaxBreakdownCalculator $postageTaxBreakdownCalculator,
+        protected ReservedSalePriceResolver $reservedSalePriceResolver,
+        protected SaleAudienceChecker $saleAudienceChecker,
     ) {
     }
 
@@ -227,7 +232,6 @@ class Cart extends BaseAction implements EventSubscriberInterface
         $cart = $event->getCart();
         $append = $event->getAppend();
         $quantity = $event->getQuantity();
-        $currency = $cart->getCurrency();
         $customer = $cart->getCustomer();
         $discount = 0.0;
 
@@ -268,7 +272,7 @@ class Cart extends BaseAction implements EventSubscriberInterface
             $cartItem->addQuantity($quantity)->save();
         } else {
             $productPrices = $productSaleElements->getPricesByCurrency(
-                $currency ?? CurrencyModel::getDefaultCurrency(),
+                $this->currencyOf($cart),
                 $discount,
             );
 
@@ -355,6 +359,11 @@ class Cart extends BaseAction implements EventSubscriberInterface
     /**
      * Update the price, the promo price and the special offer status of the items of a cart, so that
      * they always reflect the current catalog prices, in the given currency.
+     *
+     * The reserved operations of the cart's customer are settled here too, in one
+     * batch for the whole cart: a customer taken out of a selection, or an operation
+     * that has ended, falls back to the catalog price on the next refresh, which is
+     * what makes a line written weeks ago a price the shop still stands behind.
      */
     protected function refreshCartItemPrices(CartModel $cart, CurrencyModel $currency): void
     {
@@ -366,6 +375,12 @@ class Cart extends BaseAction implements EventSubscriberInterface
             $discount = (float) $customer->getDiscount();
         }
 
+        $reservedPrices = $this->reservedSalePriceResolver->resolve(
+            $this->saleElementIdsOf($cart),
+            $currency,
+            $customer,
+        );
+
         // cart item
         foreach ($cart->getCartItems() as $cartItem) {
             $productSaleElements = $cartItem->getProductSaleElements();
@@ -376,19 +391,94 @@ class Cart extends BaseAction implements EventSubscriberInterface
 
             $productPrice = $productSaleElements->getPricesByCurrency($currency, $discount);
 
-            // Nothing changed in the catalog, leave this item alone.
+            [$promo, $promoPrice] = $this->promoOfLine(
+                $productSaleElements,
+                $productPrice,
+                $reservedPrices,
+                $discount,
+            );
+
+            // Nothing changed for this item, leave it alone. The comparison is made on
+            // the settled values, reserved price included: comparing the catalog ones
+            // would keep a line at a reserved price the customer has since lost.
             if ((float) $cartItem->getPrice() === (float) $productPrice->getPrice()
-                && (float) $cartItem->getPromoPrice() === (float) $productPrice->getPromoPrice()
-                && (int) $cartItem->getPromo() === (int) $productSaleElements->getPromo()) {
+                && (float) $cartItem->getPromoPrice() === $promoPrice
+                && (int) $cartItem->getPromo() === $promo) {
                 continue;
             }
 
             $cartItem
                 ->setPrice((string) $productPrice->getPrice())
-                ->setPromoPrice((string) $productPrice->getPromoPrice())
-                ->setPromo($productSaleElements->getPromo())
+                ->setPromoPrice((string) $promoPrice)
+                ->setPromo($promo)
                 ->save();
         }
+    }
+
+    /**
+     * The currency a cart is priced in, from the one place that decides it.
+     *
+     * The catalog prices of a line and the reserved price it is compared against are
+     * read through this, so the two can never come from different currencies.
+     */
+    private function currencyOf(CartModel $cart): CurrencyModel
+    {
+        return $cart->getCurrency() ?? CurrencyModel::getDefaultCurrency();
+    }
+
+    /**
+     * @return list<int> the sale elements the cart holds a line for
+     */
+    private function saleElementIdsOf(CartModel $cart): array
+    {
+        $saleElementIds = [];
+
+        foreach ($cart->getCartItems() as $cartItem) {
+            if (null !== $saleElementId = $cartItem->getProductSaleElementsId()) {
+                $saleElementIds[] = (int) $saleElementId;
+            }
+        }
+
+        return $saleElementIds;
+    }
+
+    /**
+     * The special offer a cart line carries: the catalog one, unless a reserved
+     * operation resolved a better price for this customer.
+     *
+     * The resolver only hands back a price that beats the one the sale element is
+     * on sale for right now, so a public special offer cheaper than the reserved
+     * operation simply stays.
+     *
+     * @param array<int, ReservedPrice> $reservedPrices as resolved for the whole batch
+     *
+     * @return array{0: int, 1: float} the promo flag, and the untaxed promo price
+     */
+    private function promoOfLine(
+        ProductSaleElements $productSaleElements,
+        ProductPriceTools $catalogPrices,
+        array $reservedPrices,
+        float $discount,
+    ): array {
+        $reservedPrice = $reservedPrices[(int) $productSaleElements->getId()] ?? null;
+
+        if (null === $reservedPrice) {
+            return [(int) $productSaleElements->getPromo(), round((float) $catalogPrices->getPromoPrice(), 6)];
+        }
+
+        $promoPrice = $reservedPrice->untaxedPromoPrice;
+
+        // A customer discount rate applies on top, the way getPricesByCurrency()
+        // applies it to the catalog prices. It scales both prices by the same
+        // factor, so it never changes which of the two is the lower one.
+        if ($discount > 0) {
+            $promoPrice *= 1 - $discount / 100;
+        }
+
+        // `cart_item.promo_price` is a DECIMAL(16,6): rounding here is what makes
+        // the value written and the value read back compare equal, so a refresh
+        // that changes nothing writes nothing.
+        return [1, round($promoPrice, 6)];
     }
 
     /**
@@ -418,6 +508,26 @@ class Cart extends BaseAction implements EventSubscriberInterface
         float $quantity,
         ProductPriceTools $productPrices,
     ): CartItem {
+        // The line is the proof of the price the shop agreed to: an order is built
+        // from it, so a reserved price has to be written down here and not worked
+        // out again later, when the operation may well be over.
+        $customer = $cart->getCustomer();
+        $discount = null !== $customer && $customer->getDiscount() > 0 ? (float) $customer->getDiscount() : 0.0;
+
+        [$promo, $promoPrice] = $this->promoOfLine(
+            $productSaleElements,
+            $productPrices,
+            // The same currency the catalog prices of this line were read in: the two
+            // are compared against each other, so resolving them apart would let a
+            // reserved price in one currency undercut a catalog price in another.
+            $this->reservedSalePriceResolver->resolve(
+                [(int) $productSaleElements->getId()],
+                $this->currencyOf($cart),
+                $customer,
+            ),
+            $discount,
+        );
+
         $cartItem = new CartItem();
         $cartItem->setDispatcher($dispatcher);
         $cartItem
@@ -426,8 +536,8 @@ class Cart extends BaseAction implements EventSubscriberInterface
             ->setProductSaleElementsId($productSaleElements->getId())
             ->setQuantity($quantity)
             ->setPrice((string) $productPrices->getPrice())
-            ->setPromoPrice((string) $productPrices->getPromoPrice())
-            ->setPromo($productSaleElements->getPromo())
+            ->setPromoPrice((string) $promoPrice)
+            ->setPromo($promo)
             ->setPriceEndOfLife(time() + ConfigQuery::read('cart.priceEOF', 60 * 60 * 24 * 30))
             ->save();
 
@@ -577,8 +687,17 @@ class Cart extends BaseAction implements EventSubscriberInterface
             // If the customer has a discount, whe have to duplicate the cart,
             // so that the discount will be applied to the products in cart.
             // getDiscount() maps a DECIMAL column, so it returns a string such as '0.000000'.
-            if (null === $cart->getCustomerId() && (0.0 === (float) $customer->getDiscount() || 0 === $cart->countCartItems())) {
-                // If no discount, or an empty cart, there's no need to duplicate.
+            //
+            // A shop running a reserved operation has to reprice the cart at sign-in
+            // for the same reason: what the visitor filled it with is the public
+            // price, and the customer they turned out to be may be entitled to
+            // better. The check is one indexed query, memoised for the request, so a
+            // shop with no reserved operation keeps the behaviour it had.
+            $needsRepricing = 0.0 !== (float) $customer->getDiscount()
+                || $this->saleAudienceChecker->hasActiveReservedSale();
+
+            if (null === $cart->getCustomerId() && (!$needsRepricing || 0 === $cart->countCartItems())) {
+                // Nothing to reprice, or an empty cart: there's no need to duplicate.
                 $duplicateCart = false;
             }
 

--- a/core/lib/Thelia/Action/Product.php
+++ b/core/lib/Thelia/Action/Product.php
@@ -44,6 +44,7 @@ use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Event\UpdatePositionEvent;
 use Thelia\Core\Event\UpdateSeoEvent;
 use Thelia\Core\Event\ViewCheckEvent;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
 use Thelia\Model\Accessory;
 use Thelia\Model\AccessoryQuery;
 use Thelia\Model\AttributeTemplateQuery;
@@ -77,8 +78,10 @@ use Thelia\Model\TaxRuleQuery;
 
 class Product extends BaseAction implements EventSubscriberInterface
 {
-    public function __construct(protected EventDispatcherInterface $eventDispatcher)
-    {
+    public function __construct(
+        protected EventDispatcherInterface $eventDispatcher,
+        private readonly ReservedSaleVisibility $reservedSaleVisibility,
+    ) {
     }
 
     public function create(ProductCreateEvent $event): void
@@ -866,12 +869,15 @@ class Product extends BaseAction implements EventSubscriberInterface
     public function viewCheck(ViewCheckEvent $event, string $eventName, EventDispatcherInterface $dispatcher): void
     {
         if ('product' === $event->getView()) {
-            $product = ProductQuery::create()
+            $query = ProductQuery::create()
                 ->filterById($event->getViewId())
-                ->filterByVisible(1)
-                ->count();
+                ->filterByVisible(1);
 
-            if (0 === $product) {
+            // A product hidden by a reserved operation answers the same 404 as an
+            // invisible one: the page template renders a null product otherwise.
+            $this->reservedSaleVisibility->applyTo($query, ProductTableMap::COL_ID);
+
+            if (0 === $query->count()) {
                 $dispatcher->dispatch($event, TheliaEvents::VIEW_PRODUCT_ID_NOT_VISIBLE);
             }
         }

--- a/core/lib/Thelia/Action/Sale.php
+++ b/core/lib/Thelia/Action/Sale.php
@@ -28,6 +28,7 @@ use Thelia\Core\Event\Sale\SaleDeleteEvent;
 use Thelia\Core\Event\Sale\SaleToggleActivityEvent;
 use Thelia\Core\Event\Sale\SaleUpdateEvent;
 use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Sale\SaleDiscountCalculator;
 use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
 use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
 use Thelia\Model\Country as CountryModel;
@@ -36,6 +37,8 @@ use Thelia\Model\ProductPriceQuery;
 use Thelia\Model\ProductSaleElements;
 use Thelia\Model\ProductSaleElementsQuery;
 use Thelia\Model\Sale as SaleModel;
+use Thelia\Model\SaleCustomer;
+use Thelia\Model\SaleCustomerQuery;
 use Thelia\Model\SaleOffsetCurrency;
 use Thelia\Model\SaleOffsetCurrencyQuery;
 use Thelia\Model\SaleProduct;
@@ -51,6 +54,7 @@ class Sale extends BaseAction implements EventSubscriberInterface
 {
     public function __construct(
         private readonly TaxCalculatorFactoryInterface $taxCalculatorFactory,
+        private readonly SaleDiscountCalculator $saleDiscountCalculator,
     ) {
     }
 
@@ -90,18 +94,12 @@ class Sale extends BaseAction implements EventSubscriberInterface
                     ->findOne($con);
 
                 if (null !== $productPrice) {
-                    // Get the taxed price
-                    $priceWithTax = $taxCalculator->getTaxedPrice((float) $productPrice->getPrice());
-
-                    // Remove the price offset to get the taxed promo price
-                    $promoPrice = match ($offsetType) {
-                        SaleModel::OFFSET_TYPE_AMOUNT => max(0, $priceWithTax - $offset),
-                        SaleModel::OFFSET_TYPE_PERCENTAGE => $priceWithTax * (1 - $offset / 100),
-                        default => $priceWithTax,
-                    };
-
-                    // and then get the untaxed promo price.
-                    $promoPrice = $taxCalculator->getUntaxedPrice($promoPrice);
+                    $promoPrice = $this->saleDiscountCalculator->computeUntaxedPromoPrice(
+                        (float) $productPrice->getPrice(),
+                        $offsetType,
+                        (float) $offset,
+                        $taxCalculator,
+                    );
 
                     $productPrice
                         ->setPromoPrice((string) $promoPrice)
@@ -120,12 +118,28 @@ class Sale extends BaseAction implements EventSubscriberInterface
      */
     public function updateProductsSaleStatus(ProductSaleStatusUpdateEvent $event): void
     {
-        $taxCalculator = $this->taxCalculatorFactory->createTaxCalculator();
-
         $sale = $event->getSale();
 
+        if (null === $sale) {
+            return;
+        }
+
+        // A reserved operation is not a catalog price: `product_sale_elements.promo` and
+        // `product_price.promo_price` are what every visitor reads, and its discount is
+        // resolved per customer instead (see Thelia\Domain\Sale\ReservedSalePriceResolver).
+        //
+        // The whole method is skipped, the reset of `promo` below included: that reset
+        // covers every sale element of every product of the operation, so running it for
+        // a reserved one would wipe the discount a public operation wrote on a product
+        // both of them include.
+        if ($sale->isReserved()) {
+            return;
+        }
+
+        $taxCalculator = $this->taxCalculatorFactory->createTaxCalculator();
+
         // Get all selected product sale elements for this sale
-        if (null === $sale || null === $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()->find()) {
+        if (null === $saleProducts = SaleProductQuery::create()->filterBySale($sale)->orderByProductId()->find()) {
             return;
         }
         $saleOffsetByCurrency = $sale->getPriceOffsets();
@@ -214,9 +228,45 @@ class Sale extends BaseAction implements EventSubscriberInterface
             ->setLocale($event->getLocale())
             ->setTitle($event->getTitle())
             ->setSaleLabel($event->getSaleLabel())
+            ->setAudienceMode($event->getAudienceMode())
+            ->setHideProducts($event->getHideProducts())
+            ->setCountdownMode($event->getCountdownMode())
+            ->setCountdownLeadHours($event->getCountdownLeadHours())
             ->save();
 
+        $this->syncTargetedCustomers($sale, $event->getAudienceMode(), $event->getCustomerIds());
+
         $event->setSale($sale);
+    }
+
+    /**
+     * Bring `sale_customer` in line with the selection, the way update() does for
+     * `sale_product`: delete then insert, so a customer taken out of the selection
+     * loses the row and not just the reading of it.
+     *
+     * An operation open to everyone keeps no audience at all: leaving the rows behind
+     * would silently make it reserved again the moment someone flips the mode back.
+     *
+     * @param array<int|string, int|string> $customerIds
+     */
+    private function syncTargetedCustomers(
+        SaleModel $sale,
+        int $audienceMode,
+        array $customerIds,
+        ?ConnectionInterface $con = null,
+    ): void {
+        SaleCustomerQuery::create()->filterBySaleId($sale->getId())->delete($con);
+
+        if (SaleModel::AUDIENCE_MODE_CUSTOMERS !== $audienceMode) {
+            return;
+        }
+
+        foreach (array_unique(array_map('intval', $customerIds)) as $customerId) {
+            (new SaleCustomer())
+                ->setSaleId($sale->getId())
+                ->setCustomerId($customerId)
+                ->save($con);
+        }
     }
 
     /**
@@ -247,6 +297,10 @@ class Sale extends BaseAction implements EventSubscriberInterface
                     ->setEndDate($event->getEndDate())
                     ->setPriceOffsetType($event->getPriceOffsetType())
                     ->setDisplayInitialPrice($event->getDisplayInitialPrice())
+                    ->setAudienceMode($event->getAudienceMode())
+                    ->setHideProducts($event->getHideProducts())
+                    ->setCountdownMode($event->getCountdownMode())
+                    ->setCountdownLeadHours($event->getCountdownLeadHours())
                     ->setLocale($event->getLocale())
                     ->setSaleLabel($event->getSaleLabel())
                     ->setTitle($event->getTitle())
@@ -269,6 +323,9 @@ class Sale extends BaseAction implements EventSubscriberInterface
                         ->setPriceOffsetValue((float) $priceOffset)
                         ->save($con);
                 }
+
+                // Update the audience the operation is reserved for
+                $this->syncTargetedCustomers($sale, $event->getAudienceMode(), $event->getCustomerIds(), $con);
 
                 // Update products
                 SaleProductQuery::create()->filterBySaleId($sale->getId())->delete($con);

--- a/core/lib/Thelia/Api/Bridge/Propel/Extension/ReservedSaleVisibilityExtension.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Extension/ReservedSaleVisibilityExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Extension;
+
+use ApiPlatform\Metadata\Operation;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Thelia\Api\Resource\Product;
+use Thelia\Api\Resource\ProductSaleElements;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
+use Thelia\Model\Map\ProductSaleElementsTableMap;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\ProductSaleElementsQuery;
+
+/**
+ * Hides the products of a reserved operation from the front callers it is not
+ * open to, when the operation asked for it.
+ *
+ * Filtering in the query means the collection, the item read and the count are
+ * bounded by the same rule: a product left reachable by its id is not hidden,
+ * it is only harder to find. The sale elements are scoped too, since a caller
+ * reading /front/product_sale_elements/{id} reaches the price without ever
+ * naming the product.
+ *
+ * The admin endpoints are left alone: they sit behind ROLE_ADMIN, and a
+ * back-office user setting an operation up has to see what is in it.
+ */
+final readonly class ReservedSaleVisibilityExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(
+        private ReservedSaleVisibility $reservedSaleVisibility,
+    ) {
+    }
+
+    public function applyToCollection(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        $this->scopeToVisibleProducts($query, $resourceClass, $operation);
+    }
+
+    public function applyToItem(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        $this->scopeToVisibleProducts($query, $resourceClass, $operation);
+    }
+
+    private function scopeToVisibleProducts(ModelCriteria $query, string $resourceClass, ?Operation $operation): void
+    {
+        if (!str_starts_with((string) $operation?->getUriTemplate(), '/front/')) {
+            return;
+        }
+
+        $productIdColumn = $this->productIdColumnOf($query, $resourceClass);
+
+        if (null === $productIdColumn) {
+            return;
+        }
+
+        $this->reservedSaleVisibility->applyTo($query, $productIdColumn);
+    }
+
+    private function productIdColumnOf(ModelCriteria $query, string $resourceClass): ?string
+    {
+        if (Product::class === $resourceClass && $query instanceof ProductQuery) {
+            return ProductTableMap::COL_ID;
+        }
+
+        if (ProductSaleElements::class === $resourceClass && $query instanceof ProductSaleElementsQuery) {
+            return ProductSaleElementsTableMap::COL_PRODUCT_ID;
+        }
+
+        return null;
+    }
+}

--- a/core/lib/Thelia/Api/Bridge/Propel/Extension/SaleAudienceExtension.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/Extension/SaleAudienceExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Bridge\Propel\Extension;
+
+use ApiPlatform\Metadata\Operation;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Thelia\Api\Resource\Sale;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
+use Thelia\Model\SaleQuery;
+
+/**
+ * Scopes the front sale endpoints to the operations the caller is part of.
+ *
+ * An operation is reached by a sequential numeric id: without this, guessing one
+ * is enough to read a private drop the shop has not opened yet, its dates and the
+ * products it holds. Filtering in the query means the collection and the item
+ * read are bounded by the same rule, and an operation out of reach answers 404
+ * rather than an empty-looking 200.
+ *
+ * A draft is out too. `sale.active` is what the back office and the scheduled
+ * command maintain, and an inactive operation is not part of the shop yet.
+ *
+ * The admin endpoints are left alone: they sit behind ROLE_ADMIN, and a
+ * back-office user reads every operation, drafts included.
+ */
+final readonly class SaleAudienceExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(
+        private ReservedSaleVisibility $reservedSaleVisibility,
+    ) {
+    }
+
+    public function applyToCollection(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        $this->scopeToVisibleSales($query, $resourceClass, $operation);
+    }
+
+    public function applyToItem(ModelCriteria $query, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        $this->scopeToVisibleSales($query, $resourceClass, $operation);
+    }
+
+    private function scopeToVisibleSales(ModelCriteria $query, string $resourceClass, ?Operation $operation): void
+    {
+        if (Sale::class !== $resourceClass || !$query instanceof SaleQuery) {
+            return;
+        }
+
+        if (!str_starts_with((string) $operation?->getUriTemplate(), '/front/')) {
+            return;
+        }
+
+        $query->filterByActive(true);
+
+        $this->reservedSaleVisibility->applyToSales($query);
+    }
+}

--- a/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
+++ b/core/lib/Thelia/Api/Bridge/Propel/State/PropelCollectionProvider.php
@@ -24,6 +24,7 @@ use Thelia\Api\Bridge\Propel\Extension\QueryResultCollectionExtensionInterface;
 use Thelia\Api\Bridge\Propel\Service\ApiResourcePropelTransformerService;
 use Thelia\Api\Bridge\Propel\Service\PropelRelationPreloader;
 use Thelia\Api\Bridge\Propel\State\Pagination\PropelPaginator;
+use Thelia\Api\Resource\CollectionPreloadableInterface;
 use Thelia\Api\Resource\PropelResourceInterface;
 use Thelia\Api\Service\API\PublicUrlPreloader;
 use Thelia\Model\Lang;
@@ -91,6 +92,13 @@ readonly class PropelCollectionProvider implements ProviderInterface
             ),
             iterator_to_array($results instanceof PropelModelPager ? $results->getResults() : $results),
         );
+
+        // A resource answering a field out of a query of its own reads it for the
+        // whole page here, for the same reason: the serializer is about to ask each
+        // member, and one statement per member grows with the page.
+        if (is_subclass_of($resourceClass, CollectionPreloadableInterface::class)) {
+            $resourceClass::preloadCollection($resources);
+        }
 
         // The serializer is about to ask each resource for its public url, and
         // each of those resolves a rewritten url of its own. Filling the memo

--- a/core/lib/Thelia/Api/EventListener/ReservedSalePriceListener.php
+++ b/core/lib/Thelia/Api/EventListener/ReservedSalePriceListener.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Thelia\Api\Bridge\Propel\Event\ModelToResourceEvent;
+use Thelia\Api\Resource\ProductPrice as ProductPriceResource;
+use Thelia\Api\Resource\ProductSaleElements as ProductSaleElementsResource;
+use Thelia\Domain\Sale\CurrentCustomerProvider;
+use Thelia\Domain\Sale\ReservedSalePriceCatalog;
+
+/**
+ * Serves the price a reserved operation gives the caller, on the front read of a
+ * sale element.
+ *
+ * A reserved operation writes nothing in the catalog — no `promo` flag, no
+ * `promo_price` — because those two are what every visitor reads. Its price is
+ * therefore added here, to the caller's own read, and to nobody else's.
+ *
+ * It runs after {@see ProductPriceCurrencyListener} has picked the price row of
+ * the currency being browsed: the reserved price is resolved in that same
+ * currency, so the two have to be the same row.
+ *
+ * Admin reads are left alone: the back office edits the catalog, which a reserved
+ * price is deliberately not part of.
+ */
+class ReservedSalePriceListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ReservedSalePriceCatalog $reservedSalePriceCatalog,
+        private readonly CurrentCustomerProvider $currentCustomerProvider,
+        private readonly ProductPriceCurrencyListener $productPriceCurrencyListener,
+    ) {
+    }
+
+    public function applyReservedPrice(ModelToResourceEvent $modelToResourceEvent): void
+    {
+        $resource = $modelToResourceEvent->getResource();
+
+        if (!$resource instanceof ProductSaleElementsResource) {
+            return;
+        }
+
+        $saleElementsId = $resource->getId();
+        $prices = $resource->getProductPrices();
+
+        if (null === $saleElementsId || [] === $prices || !$this->isFrontRead($modelToResourceEvent->getContext())) {
+            return;
+        }
+
+        $customer = $this->currentCustomerProvider->getCurrentCustomer();
+
+        if (null === $customer) {
+            return;
+        }
+
+        $currency = $this->productPriceCurrencyListener->currentCurrency();
+        $reservedPrice = $this->reservedSalePriceCatalog->priceFor($saleElementsId, $currency, $customer);
+
+        if (null === $reservedPrice) {
+            return;
+        }
+
+        foreach ($prices as $price) {
+            if (!$price instanceof ProductPriceResource) {
+                continue;
+            }
+
+            $price->setPromoPrice($reservedPrice->untaxedPromoPrice);
+        }
+
+        // The reserved price only ever reaches here when it beats the price the sale
+        // element was on sale for, so the flag the theme reads to strike the catalog
+        // price through is now true whatever the catalog says.
+        $resource->setPromo(true);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ModelToResourceEvent::AFTER_TRANSFORM => [
+                ['applyReservedPrice', -10],
+            ],
+        ];
+    }
+
+    /**
+     * A front read is one no admin group takes part in — the same rule
+     * {@see ProductPriceCurrencyListener} applies, so a module resource embedding
+     * sale elements is covered too.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function isFrontRead(array $context): bool
+    {
+        $groups = $context['groups'] ?? [];
+
+        if (!\is_array($groups)) {
+            $groups = [$groups];
+        }
+
+        $isFrontRead = false;
+
+        foreach ($groups as $group) {
+            if (!\is_string($group)) {
+                continue;
+            }
+
+            if (str_starts_with($group, 'admin:')) {
+                return false;
+            }
+
+            $isFrontRead = $isFrontRead || str_starts_with($group, 'front:');
+        }
+
+        return $isFrontRead;
+    }
+}

--- a/core/lib/Thelia/Api/Resource/CollectionPreloadableInterface.php
+++ b/core/lib/Thelia/Api/Resource/CollectionPreloadableInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Resource;
+
+/**
+ * A resource serving something its own row does not hold, and that a whole page
+ * of them can read in one go.
+ *
+ * {@see \Thelia\Api\Bridge\Propel\Service\PropelRelationPreloader} covers the
+ * relations a resource declares, because those are rows Propel knows how to read
+ * for a collection. A field answered by a query of the resource's own — a select
+ * with a group by, a computed list — is outside that, and the serializer asks for
+ * it once per member: the cost of the page grows with its size.
+ *
+ * A resource implementing this is handed the page it belongs to, once, before the
+ * serializer reads any of it, so that the reading is one statement rather than
+ * one per member.
+ */
+interface CollectionPreloadableInterface
+{
+    /**
+     * Fills whatever the serializer is about to ask each of these for.
+     *
+     * Called with one page of resources of this class, before any of them is
+     * serialized. Never called for an item read: one member is already one query.
+     *
+     * @param list<PropelResourceInterface> $resources
+     */
+    public static function preloadCollection(array $resources): void;
+}

--- a/core/lib/Thelia/Api/Resource/Sale.php
+++ b/core/lib/Thelia/Api/Resource/Sale.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Resource;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Map\TableMap;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Thelia\Api\Bridge\Propel\Filter\BooleanFilter;
+use Thelia\Api\Bridge\Propel\Filter\OrderFilter;
+use Thelia\Api\Bridge\Propel\Filter\SearchFilter;
+use Thelia\Model\Map\SaleTableMap;
+use Thelia\Model\Sale as SaleModel;
+use Thelia\Model\SaleProductQuery;
+use Thelia\Model\Tools\UrlRewritingTrait;
+
+/**
+ * A sale operation, read only.
+ *
+ * The front block is what a theme builds the page of an operation from: its
+ * texts, its window, the products it covers, and whether a countdown to its end
+ * is due right now. The countdown is answered as a number of seconds rather than
+ * as a date so that a theme has nothing to work out — and nothing to get wrong
+ * about the shop's timezone.
+ *
+ * What is deliberately absent, in the front groups and everywhere near them: the
+ * customers a reserved operation is open to. That list is the operation's private
+ * guest list, and a customer reading their own operation must not be handed the
+ * names of the others.
+ *
+ * Nothing writes through here. The back office drives an operation through its
+ * events — they are what recomputes the catalog prices of a public one — and a
+ * write endpoint would let a caller change an operation without any of that
+ * happening.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/admin/sales',
+        ),
+        new Get(
+            uriTemplate: '/admin/sales/{id}',
+            normalizationContext: ['groups' => [self::GROUP_ADMIN_READ, self::GROUP_ADMIN_READ_SINGLE]],
+        ),
+    ],
+    normalizationContext: ['groups' => [self::GROUP_ADMIN_READ]],
+)]
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/front/sales',
+        ),
+        new Get(
+            uriTemplate: '/front/sales/{id}',
+            normalizationContext: ['groups' => [self::GROUP_FRONT_READ, self::GROUP_FRONT_READ_SINGLE]],
+        ),
+    ],
+    normalizationContext: ['groups' => [self::GROUP_FRONT_READ]],
+)]
+#[ApiFilter(
+    filterClass: SearchFilter::class,
+    properties: [
+        'id',
+    ],
+)]
+#[ApiFilter(
+    filterClass: BooleanFilter::class,
+    properties: [
+        'active',
+    ],
+)]
+#[ApiFilter(
+    filterClass: OrderFilter::class,
+    properties: [
+        'startDate',
+        'endDate',
+    ],
+)]
+class Sale extends AbstractTranslatableResource implements CollectionPreloadableInterface
+{
+    use UrlRewritingTrait;
+
+    public const GROUP_ADMIN_READ = 'admin:sale:read';
+    public const GROUP_ADMIN_READ_SINGLE = 'admin:sale:read:single';
+    public const GROUP_FRONT_READ = 'front:sale:read';
+    public const GROUP_FRONT_READ_SINGLE = 'front:sale:read:single';
+
+    /**
+     * The product ids read for the whole page, when this resource is part of one.
+     *
+     * @var list<int>|null
+     */
+    private ?array $preloadedProductIds = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?int $id = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?bool $active = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?\DateTime $startDate = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?\DateTime $endDate = null;
+
+    /** Whether the theme is asked to strike the catalog price through next to the discounted one. */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?bool $displayInitialPrice = null;
+
+    /** One of the SaleModel::OFFSET_TYPE_* constants. */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?int $priceOffsetType = null;
+
+    /** One of the SaleModel::AUDIENCE_MODE_* constants. */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?int $audienceMode = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?bool $hideProducts = null;
+
+    /** One of the SaleModel::COUNTDOWN_MODE_* constants. */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?int $countdownMode = null;
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public ?int $countdownLeadHours = null;
+
+    #[ApiProperty(types: 'object')]
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public I18nCollection $i18ns;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getActive(): ?bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(?bool $active): self
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    public function getStartDate(): ?\DateTime
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(?\DateTime $startDate): self
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+
+    public function getEndDate(): ?\DateTime
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(?\DateTime $endDate): self
+    {
+        $this->endDate = $endDate;
+
+        return $this;
+    }
+
+    public function getDisplayInitialPrice(): ?bool
+    {
+        return $this->displayInitialPrice;
+    }
+
+    public function setDisplayInitialPrice(?bool $displayInitialPrice): self
+    {
+        $this->displayInitialPrice = $displayInitialPrice;
+
+        return $this;
+    }
+
+    public function getPriceOffsetType(): ?int
+    {
+        return $this->priceOffsetType;
+    }
+
+    public function setPriceOffsetType(?int $priceOffsetType): self
+    {
+        $this->priceOffsetType = $priceOffsetType;
+
+        return $this;
+    }
+
+    public function getAudienceMode(): ?int
+    {
+        return $this->audienceMode;
+    }
+
+    public function setAudienceMode(?int $audienceMode): self
+    {
+        $this->audienceMode = $audienceMode;
+
+        return $this;
+    }
+
+    public function getHideProducts(): ?bool
+    {
+        return $this->hideProducts;
+    }
+
+    public function setHideProducts(?bool $hideProducts): self
+    {
+        $this->hideProducts = $hideProducts;
+
+        return $this;
+    }
+
+    public function getCountdownMode(): ?int
+    {
+        return $this->countdownMode;
+    }
+
+    public function setCountdownMode(?int $countdownMode): self
+    {
+        $this->countdownMode = $countdownMode;
+
+        return $this;
+    }
+
+    public function getCountdownLeadHours(): ?int
+    {
+        return $this->countdownLeadHours;
+    }
+
+    public function setCountdownLeadHours(?int $countdownLeadHours): self
+    {
+        $this->countdownLeadHours = $countdownLeadHours;
+
+        return $this;
+    }
+
+    /**
+     * Whether the countdown to the end of the operation is due right now — which
+     * depends on the mode, on the end date, and on the instant being asked about.
+     */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public function getShouldDisplayCountdown(): bool
+    {
+        return $this->propelSale()?->shouldDisplayCountdown(new \DateTime()) ?? false;
+    }
+
+    /**
+     * How long the operation still has to run, in seconds, or null when no countdown
+     * is due. Never negative: an operation whose end date has passed has nothing
+     * left to count down, and a theme reading a negative number would render it.
+     */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public function getCountdownRemainingSeconds(): ?int
+    {
+        $sale = $this->propelSale();
+
+        if (null === $sale || !$sale->shouldDisplayCountdown($now = new \DateTime())) {
+            return null;
+        }
+
+        $endDate = $sale->getEndDate();
+
+        if (null === $endDate) {
+            return null;
+        }
+
+        return max(0, $endDate->getTimestamp() - $now->getTimestamp());
+    }
+
+    /**
+     * The products the operation covers, so a theme lays out its grid from one read
+     * instead of querying the catalog for the operation first.
+     *
+     * On a page of operations the answer is already in hand — see
+     * {@see preloadCollection()} — and only an operation read on its own goes to the
+     * database for it.
+     *
+     * @return list<int>
+     */
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public function getProductIds(): array
+    {
+        if (null !== $this->preloadedProductIds) {
+            return $this->preloadedProductIds;
+        }
+
+        $sale = $this->propelSale();
+
+        if (null === $sale) {
+            return [];
+        }
+
+        $productIds = [];
+
+        foreach ($sale->getSaleProductList() as $saleProduct) {
+            $productIds[] = (int) $saleProduct->getProductId();
+        }
+
+        return $productIds;
+    }
+
+    /**
+     * Reads the products of every operation of a page in one statement.
+     *
+     * `productIds` belongs to both read groups, so the serializer asks each member of
+     * a collection for it, and each answer used to be a `sale_product` select of its
+     * own: a shop listing thirty operations paid thirty statements for a field its
+     * theme reads on every one of them.
+     *
+     * @param list<PropelResourceInterface> $resources
+     */
+    public static function preloadCollection(array $resources): void
+    {
+        $saleIds = [];
+
+        foreach ($resources as $resource) {
+            if ($resource instanceof self && null !== $resource->id) {
+                $saleIds[] = $resource->id;
+            }
+        }
+
+        if ([] === $saleIds) {
+            return;
+        }
+
+        // One row per (operation, product): an operation covering a product through
+        // several attribute values holds several rows for it, and the field is a list
+        // of products.
+        $rows = SaleProductQuery::create()
+            ->filterBySaleId($saleIds, Criteria::IN)
+            ->select(['SaleId', 'ProductId'])
+            ->distinct()
+            ->orderBySaleId()
+            ->orderByProductId()
+            ->find()
+            ->getData();
+
+        $productIdsBySale = [];
+
+        foreach ($rows as $row) {
+            $productIdsBySale[(int) $row['SaleId']][] = (int) $row['ProductId'];
+        }
+
+        foreach ($resources as $resource) {
+            if ($resource instanceof self && null !== $resource->id) {
+                $resource->preloadedProductIds = $productIdsBySale[$resource->id] ?? [];
+            }
+        }
+    }
+
+    #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ])]
+    public function getPublicUrl(): ?string
+    {
+        $sale = $this->propelSale();
+
+        if (null === $sale) {
+            return null;
+        }
+
+        return $this->getUrl($sale->getLocale() ?: $this->getDefaultLocale());
+    }
+
+    public function getRewrittenUrlViewName(): string
+    {
+        return $this->propelSale()?->getRewrittenUrlViewName() ?: '';
+    }
+
+    public static function getPropelRelatedTableMap(): ?TableMap
+    {
+        return new SaleTableMap();
+    }
+
+    public static function getI18nResourceClass(): string
+    {
+        return SaleI18n::class;
+    }
+
+    private function propelSale(): ?SaleModel
+    {
+        $propelModel = $this->getPropelModel();
+
+        return $propelModel instanceof SaleModel ? $propelModel : null;
+    }
+}

--- a/core/lib/Thelia/Api/Resource/SaleI18n.php
+++ b/core/lib/Thelia/Api/Resource/SaleI18n.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Api\Resource;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class SaleI18n extends I18n
+{
+    #[Groups([Sale::GROUP_ADMIN_READ, Sale::GROUP_FRONT_READ])]
+    protected ?string $title = null;
+
+    /**
+     * The short badge a theme prints on the products of the operation — "-20%",
+     * "Private sale" — as opposed to the title of its page.
+     */
+    #[Groups([Sale::GROUP_ADMIN_READ, Sale::GROUP_FRONT_READ])]
+    protected ?string $saleLabel = null;
+
+    #[Groups([Sale::GROUP_ADMIN_READ, Sale::GROUP_FRONT_READ])]
+    protected ?string $chapo = null;
+
+    #[Groups([Sale::GROUP_ADMIN_READ, Sale::GROUP_FRONT_READ])]
+    protected ?string $description = null;
+
+    #[Groups([Sale::GROUP_ADMIN_READ, Sale::GROUP_FRONT_READ])]
+    protected ?string $postscriptum = null;
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getSaleLabel(): ?string
+    {
+        return $this->saleLabel;
+    }
+
+    public function setSaleLabel(?string $saleLabel): self
+    {
+        $this->saleLabel = $saleLabel;
+
+        return $this;
+    }
+
+    public function getChapo(): ?string
+    {
+        return $this->chapo;
+    }
+
+    public function setChapo(?string $chapo): self
+    {
+        $this->chapo = $chapo;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getPostscriptum(): ?string
+    {
+        return $this->postscriptum;
+    }
+
+    public function setPostscriptum(?string $postscriptum): self
+    {
+        $this->postscriptum = $postscriptum;
+
+        return $this;
+    }
+}

--- a/core/lib/Thelia/Api/Security/AdminApiResourcePermissions.php
+++ b/core/lib/Thelia/Api/Security/AdminApiResourcePermissions.php
@@ -64,6 +64,7 @@ use Thelia\Api\Resource\ProductImage;
 use Thelia\Api\Resource\ProductPrice;
 use Thelia\Api\Resource\ProductSaleElements;
 use Thelia\Api\Resource\ProductSaleElementsProductImage;
+use Thelia\Api\Resource\Sale;
 use Thelia\Api\Resource\State;
 use Thelia\Api\Resource\Tax;
 use Thelia\Api\Resource\TaxRule;
@@ -132,6 +133,7 @@ final readonly class AdminApiResourcePermissions
         ProductPrice::class => AdminResources::PRODUCT,
         ProductSaleElements::class => AdminResources::PRODUCT,
         ProductSaleElementsProductImage::class => AdminResources::PRODUCT,
+        Sale::class => AdminResources::SALES,
         State::class => AdminResources::STATE,
         Tax::class => AdminResources::TAX,
         TaxRule::class => AdminResources::TAX,

--- a/core/lib/Thelia/Api/Service/API/ResourceCache.php
+++ b/core/lib/Thelia/Api/Service/API/ResourceCache.php
@@ -16,6 +16,7 @@ namespace Thelia\Api\Service\API;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Thelia\Domain\Sale\SaleAudienceChecker;
 
 /**
  * Cross-request cache for the data access layer.
@@ -25,11 +26,19 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * survives across requests. Disabled by default; only user-independent paths
  * (the configured allow list) are eligible, and the whole pool is flushed on
  * any catalog change (see ResourceCacheInvalidationListener).
+ *
+ * The key holds the path, the format and the locale, and deliberately not who
+ * is asking — which is only sound while the answer is the same for everybody.
+ * A running reserved operation breaks that for the catalog: two visitors asking
+ * for the same product are owed two different prices. Those paths are therefore
+ * bypassed for as long as such an operation runs, and cached again the moment
+ * none does, so a shop that never runs one keeps every bit of its cache.
  */
 readonly class ResourceCache
 {
     /**
      * @param string[] $allowedPrefixes
+     * @param string[] $reservedSaleSensitivePrefixes
      */
     public function __construct(
         #[Autowire(service: 'thelia.cache.data_access')]
@@ -40,6 +49,9 @@ readonly class ResourceCache
         private int $ttl,
         #[Autowire(param: 'thelia.api.data_access.cache.allowed_prefixes')]
         private array $allowedPrefixes,
+        #[Autowire(param: 'thelia.api.data_access.cache.reserved_sale_sensitive_prefixes')]
+        private array $reservedSaleSensitivePrefixes,
+        private SaleAudienceChecker $saleAudienceChecker,
     ) {
     }
 
@@ -78,7 +90,25 @@ readonly class ResourceCache
     {
         foreach ($this->allowedPrefixes as $prefix) {
             if (str_starts_with($path, $prefix)) {
-                return true;
+                return !$this->answerDependsOnWhoIsAsking($path);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the answer to this path stopped being the same for everybody.
+     *
+     * The operations are only asked about for a path a reserved price can travel
+     * on, and the answer is memoised for the request: a shop with no reserved
+     * operation pays one indexed existence check per request for its whole cache.
+     */
+    private function answerDependsOnWhoIsAsking(string $path): bool
+    {
+        foreach ($this->reservedSaleSensitivePrefixes as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return $this->saleAudienceChecker->hasActiveReservedSale();
             }
         }
 

--- a/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
+++ b/core/lib/Thelia/Api/Service/DataAccess/ProductSaleElementsAccessService.php
@@ -23,12 +23,15 @@ use Thelia\Core\HttpFoundation\Request;
 use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Domain\Localization\Service\LangService;
+use Thelia\Domain\Sale\ReservedSalePriceCatalog;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
 use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 use Thelia\Model\AttributeAvQuery;
 use Thelia\Model\AttributeQuery;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Currency;
 use Thelia\Model\Lang;
+use Thelia\Model\Map\ProductSaleElementsTableMap;
 use Thelia\Model\ProductSaleElementsQuery;
 
 class ProductSaleElementsAccessService
@@ -41,6 +44,8 @@ class ProductSaleElementsAccessService
         private readonly SecurityContext $securityContext,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly LangService $langService,
+        private readonly ReservedSaleVisibility $reservedSaleVisibility,
+        private readonly ReservedSalePriceCatalog $reservedSalePriceCatalog,
     ) {
         $this->request = $requestStack->getMainRequest();
     }
@@ -61,8 +66,24 @@ class ProductSaleElementsAccessService
             $discount = $this->securityContext->getCustomerUser()->getDiscount();
         }
 
-        foreach (ProductSaleElementsQuery::create()->filterByVisible(true)->orderByPosition()->findByProductId($productId) as $pse) {
+        // Reached by a product id, so the private drop rule has to be enforced here
+        // too: the page of such a product is out of reach for this visitor, and its
+        // prices must not be readable behind it.
+        $query = ProductSaleElementsQuery::create()
+            ->filterByVisible(true)
+            ->filterByProductId($productId)
+            ->orderByPosition();
+
+        $this->reservedSaleVisibility->applyTo($query, ProductSaleElementsTableMap::COL_PRODUCT_ID);
+
+        $reservedPrices = $this->reservedSalePriceCatalog->prices(
+            $currency,
+            $this->reservedSaleVisibility->currentCustomer(),
+        );
+
+        foreach ($query->find() as $pse) {
             $attributes = [];
+            $isPromo = (bool) $pse->getPromo();
 
             // Reading the first price row priced the sale element in whichever
             // currency the database answered first. The model knows the rule:
@@ -73,6 +94,20 @@ class ProductSaleElementsAccessService
             $pse->setVirtualColumn('price_PRICE', $prices->getPrice());
             $pse->setVirtualColumn('price_PROMO_PRICE', $prices->getPromoPrice());
 
+            // A reserved operation writes nothing in the catalog, so its price is
+            // substituted in the virtual column the getters below read: the customer
+            // discount and the tax are then applied to it exactly the way they are
+            // applied to a public promo price.
+            $reservedPrice = $reservedPrices[$pse->getId()] ?? null;
+
+            if (null !== $reservedPrice) {
+                $pse->setVirtualColumn(
+                    'price_PROMO_PRICE',
+                    $reservedPrice->untaxedPromoPrice * (1 - ((float) $discount / 100)),
+                );
+                $isPromo = true;
+            }
+
             foreach ($pse->getAttributeCombinations() as $attribute) {
                 $attributes[$attribute->getAttributeId()] = $attribute->getAttributeAvId();
             }
@@ -82,7 +117,7 @@ class ProductSaleElementsAccessService
             $result[] = [
                 'id' => $pse->getId(),
                 'isDefault' => $pse->isDefault(),
-                'isPromo' => $pse->getPromo() ? true : false,
+                'isPromo' => $isPromo,
                 'isNew' => $pse->getNewness() ? true : false,
                 'ref' => $pse->getRef(),
                 'ean' => $pse->getEanCode(),

--- a/core/lib/Thelia/Config/Resources/parameters/data_access_cache.php
+++ b/core/lib/Thelia/Config/Resources/parameters/data_access_cache.php
@@ -43,5 +43,13 @@ return static function (ContainerConfigurator $container): void {
             '/api/front/countries',
             '/api/front/currencies',
             '/api/front/taxes',
+        ])
+        // Of the paths above, the ones a reserved price travels on: a running
+        // reserved operation owes two visitors two different prices for the same
+        // product, and the cache key holds no customer. They are bypassed for as
+        // long as such an operation runs, and cached again as soon as none does.
+        ->set('thelia.api.data_access.cache.reserved_sale_sensitive_prefixes', [
+            '/api/front/products',
+            '/api/front/product_sale_elements',
         ]);
 };

--- a/core/lib/Thelia/Controller/Admin/SessionController.php
+++ b/core/lib/Thelia/Controller/Admin/SessionController.php
@@ -334,7 +334,13 @@ class SessionController extends BaseAdminController
     }
 
     /**
-     * Save user locale preference in session.
+     * Give the session the interface language of the administrator who just signed in.
+     *
+     * The admin language and the shop language are two different session keys, and this
+     * used to write the shop one: an administrator whose locale is French was served an
+     * English back-office — the back-office reads the admin key, which the anonymous
+     * login page had already pinned to the default language — while the storefront they
+     * browsed in the same browser was switched to French behind their back.
      */
     protected function applyUserLocale(UserInterface $user): void
     {
@@ -345,7 +351,7 @@ class SessionController extends BaseAdminController
             $lang = Lang::getDefaultLanguage();
         }
 
-        $this->langService->setLang($lang);
+        $this->langService->setAdminLang($lang);
     }
 
     protected function getRememberMeCookieName()

--- a/core/lib/Thelia/Core/Event/Sale/SaleCreateEvent.php
+++ b/core/lib/Thelia/Core/Event/Sale/SaleCreateEvent.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Thelia\Core\Event\Sale;
 
+use Thelia\Model\Sale;
+
 /**
  * Class SaleCreateEvent.
  *
@@ -24,6 +26,22 @@ class SaleCreateEvent extends SaleEvent
     protected $title;
     protected $saleLabel;
     protected $locale;
+
+    /**
+     * The audience of a new operation, and its countdown, default to what a shop that
+     * knows nothing about either would get: open to everyone, no countdown. A back
+     * office or an API client that does not post these fields keeps the old behaviour.
+     */
+    protected int $audienceMode = Sale::AUDIENCE_MODE_PUBLIC;
+
+    protected bool $hideProducts = false;
+
+    protected int $countdownMode = Sale::COUNTDOWN_MODE_NONE;
+
+    protected ?int $countdownLeadHours = null;
+
+    /** @var array<int|string, int|string> the IDs of the customers the operation is reserved for */
+    protected array $customerIds = [];
 
     /**
      * @return SaleCreateEvent $this
@@ -68,5 +86,89 @@ class SaleCreateEvent extends SaleEvent
     public function getSaleLabel(): string
     {
         return $this->saleLabel;
+    }
+
+    /**
+     * @param int $audienceMode one of the Sale::AUDIENCE_MODE_* constants
+     *
+     * @return $this
+     */
+    public function setAudienceMode(int $audienceMode): static
+    {
+        $this->audienceMode = $audienceMode;
+
+        return $this;
+    }
+
+    public function getAudienceMode(): int
+    {
+        return $this->audienceMode;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHideProducts(bool $hideProducts): static
+    {
+        $this->hideProducts = $hideProducts;
+
+        return $this;
+    }
+
+    public function getHideProducts(): bool
+    {
+        return $this->hideProducts;
+    }
+
+    /**
+     * @param int $countdownMode one of the Sale::COUNTDOWN_MODE_* constants
+     *
+     * @return $this
+     */
+    public function setCountdownMode(int $countdownMode): static
+    {
+        $this->countdownMode = $countdownMode;
+
+        return $this;
+    }
+
+    public function getCountdownMode(): int
+    {
+        return $this->countdownMode;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setCountdownLeadHours(?int $countdownLeadHours): static
+    {
+        $this->countdownLeadHours = $countdownLeadHours;
+
+        return $this;
+    }
+
+    public function getCountdownLeadHours(): ?int
+    {
+        return $this->countdownLeadHours;
+    }
+
+    /**
+     * @param array<int|string, int|string> $customerIds the IDs of the customers the operation is reserved for
+     *
+     * @return $this
+     */
+    public function setCustomerIds(array $customerIds): static
+    {
+        $this->customerIds = $customerIds;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int|string, int|string>
+     */
+    public function getCustomerIds(): array
+    {
+        return $this->customerIds;
     }
 }

--- a/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/Session.php
@@ -288,6 +288,15 @@ class Session extends BaseSession
             ? CartQuery::create()->findPk($cartId)
             : self::$transientCart;
 
+        // A cart that has been deleted is no cart at all. The transient cart is held
+        // in a static, so nothing invalidates it when the cart it points at goes:
+        // handing it back gives the caller an object every save() on it rejects.
+        if (null !== $cart && $cart->isDeleted()) {
+            self::$transientCart = null;
+            $this->remove(self::SESSION_CART_ID_NAME);
+            $cart = null;
+        }
+
         if (null !== $cart && $this->isValidCart($cart)) {
             return $cart;
         }

--- a/core/lib/Thelia/Core/HttpFoundation/Session/SessionManager.php
+++ b/core/lib/Thelia/Core/HttpFoundation/Session/SessionManager.php
@@ -133,6 +133,13 @@ class SessionManager
         }
     }
 
+    /**
+     * Give the session the interface language of the administrator a remember-me
+     * cookie just signed in. Only ever called for an administrator, so it writes the
+     * admin language: writing the shop one, as it used to, left the back-office in
+     * whatever language the anonymous request had settled on and switched the
+     * storefront of the same browser instead.
+     */
     protected function applyUserLocale(UserInterface $user, Session $session): void
     {
         // Set the current language according to locale preference
@@ -145,6 +152,6 @@ class SessionManager
             $lang = Lang::getDefaultLanguage();
         }
 
-        $session->setLang($lang);
+        $session->setAdminLang($lang);
     }
 }

--- a/core/lib/Thelia/Core/Template/Loop/Product.php
+++ b/core/lib/Thelia/Core/Template/Loop/Product.php
@@ -27,6 +27,8 @@ use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+use Thelia\Domain\Sale\ReservedSalePriceCatalog;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
 use Thelia\Domain\Taxation\TaxEngine\Exception\TaxEngineException;
 use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 use Thelia\Log\Tlog;
@@ -97,8 +99,12 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
     protected $timestampable = true;
     protected $versionable = true;
 
+    private ?CurrencyModel $currency = null;
+
     public function __construct(
         protected readonly TaxEngine $taxEngine,
+        protected readonly ReservedSaleVisibility $reservedSaleVisibility,
+        protected readonly ReservedSalePriceCatalog $reservedSalePriceCatalog,
     ) {
     }
 
@@ -251,10 +257,26 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $taxState = $this->taxEngine->getDeliveryState();
 
         $securityContext = $this->securityContext;
+        $reservedPrices = $this->reservedPrices();
 
         /** @var ProductModel $product */
         foreach ($loopResult->getResultDataCollection() as $product) {
             $loopResultRow = new LoopResultRow($product);
+
+            // A reserved operation writes nothing in the catalog, so its price is
+            // substituted here — in the virtual columns the rest of this method
+            // reads, so that the customer discount and the tax are applied to it
+            // exactly the way they are applied to a public promo price.
+            //
+            // Only the display is corrected: the `min_price` / `max_price` filters
+            // and the price orders stay on the raw columns, so a page ordered by
+            // price orders a named customer's catalog by its public prices.
+            $reservedPrice = $reservedPrices[(int) $product->getVirtualColumn('pse_id')] ?? null;
+
+            if (null !== $reservedPrice) {
+                $product->setVirtualColumn('promo_price', $reservedPrice->untaxedPromoPrice);
+                $product->setVirtualColumn('is_promo', 1);
+            }
 
             $price = $product->getVirtualColumn('price');
 
@@ -338,6 +360,17 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             $loopResultRow = new LoopResultRow($product);
 
             $price = $product->getRealLowestPrice();
+            $isPromo = $product->getVirtualColumn('main_product_is_promo');
+
+            // The complex loop prices a product by the lowest of its sale elements,
+            // so a reserved operation only changes that price when it beats it — the
+            // operation may well cover one combination out of five.
+            $reservedLowestPrice = $this->reservedLowestPriceFor($product);
+
+            if (null !== $reservedLowestPrice && $reservedLowestPrice < (float) $price) {
+                $price = $reservedLowestPrice;
+                $isPromo = 1;
+            }
 
             if ($securityContext->hasCustomerUser() && $securityContext->getCustomerUser()->getDiscount() > 0) {
                 $price *= (1 - ($securityContext->getCustomerUser()->getDiscount() / 100));
@@ -359,7 +392,7 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
                 ->set('BEST_PRICE', $price)
                 ->set('BEST_PRICE_TAX', $taxedPrice - $price)
                 ->set('BEST_TAXED_PRICE', $taxedPrice)
-                ->set('IS_PROMO', $product->getVirtualColumn('main_product_is_promo'))
+                ->set('IS_PROMO', $isPromo)
                 ->set('IS_NEW', $product->getVirtualColumn('main_product_is_new'));
 
             $this->associateValues($loopResultRow, $product, $defaultCategoryId);
@@ -560,6 +593,10 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
 
         $currency = $this->resolveCurrency();
 
+        // parseResults() prices the rows in the same currency the query selected
+        // them in, and has no argument of its own to read it from.
+        $this->currency = $currency;
+
         $defaultCurrency = CurrencyModel::getDefaultCurrency();
         $defaultCurrencySuffix = '_default_currency';
 
@@ -568,6 +605,12 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $isProductPriceFirstLeftJoin = [];
 
         $search = ProductQuery::create();
+
+        // A private drop hides its products from the front, and from the front only:
+        // an administrator setting the operation up has to see what is in it.
+        if (!$this->getBackendContext()) {
+            $this->reservedSaleVisibility->applyTo($search, ProductTableMap::COL_ID);
+        }
 
         $complex = $this->getComplex();
 
@@ -980,6 +1023,17 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
             ->addJoinObject($salesJoin, 'SalePriceDisplay')
             ->addJoinCondition('SalePriceDisplay', '`SalePriceDisplay`.`active` = 1');
 
+        // An operation the visitor is not part of has nothing to say about the price
+        // they are shown: without this, a reserved operation could turn the struck
+        // through catalog price off for a visitor who is not getting its discount.
+        // The back office keeps reading whatever operation covers the product.
+        if (!$this->getBackendContext() && $this->reservedSaleVisibility->hasActiveReservedSale()) {
+            $search->addJoinCondition(
+                'SalePriceDisplay',
+                $this->reservedSaleVisibility->saleIsOpenToVisitorClause('SalePriceDisplay'),
+            );
+        }
+
         // ... to get the DISPLAY_INITIAL_PRICE column !
         $search->withColumn('`SalePriceDisplay`.DISPLAY_INITIAL_PRICE', 'display_initial_price');
 
@@ -1049,6 +1103,40 @@ class Product extends BaseI18nLoop implements PropelSearchLoopInterface, SearchL
         $search->withColumn('`CategorySelect`.DEFAULT_CATEGORY', 'is_default_category');
 
         return $manualOrderAllowed;
+    }
+
+    /**
+     * The reserved prices of the current visitor, resolved once for the whole
+     * request rather than once per row.
+     *
+     * Empty in the back office: the catalog is what it edits, and a reserved price
+     * is deliberately not part of the catalog.
+     *
+     * @return array<int, \Thelia\Domain\Sale\ReservedPrice>
+     */
+    private function reservedPrices(): array
+    {
+        if ($this->getBackendContext() || !$this->currency instanceof CurrencyModel) {
+            return [];
+        }
+
+        return $this->reservedSalePriceCatalog->prices(
+            $this->currency,
+            $this->reservedSaleVisibility->currentCustomer(),
+        );
+    }
+
+    private function reservedLowestPriceFor(ProductModel $product): ?float
+    {
+        if ($this->getBackendContext() || !$this->currency instanceof CurrencyModel) {
+            return null;
+        }
+
+        return $this->reservedSalePriceCatalog->lowestPriceForProduct(
+            (int) $product->getId(),
+            $this->currency,
+            $this->reservedSaleVisibility->currentCustomer(),
+        );
     }
 
     private function resolveCurrency(): CurrencyModel

--- a/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
+++ b/core/lib/Thelia/Core/Template/Loop/ProductSaleElements.php
@@ -24,6 +24,8 @@ use Thelia\Core\Template\Element\PropelSearchLoopInterface;
 use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+use Thelia\Domain\Sale\ReservedSalePriceCatalog;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
 use Thelia\Domain\Taxation\TaxEngine\Exception\TaxEngineException;
 use Thelia\Domain\Taxation\TaxEngine\TaxEngine;
 use Thelia\Model\Currency as CurrencyModel;
@@ -59,8 +61,12 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
 {
     protected $timestampable = true;
 
+    private ?CurrencyModel $currency = null;
+
     public function __construct(
         protected readonly TaxEngine $taxEngine,
+        protected readonly ReservedSaleVisibility $reservedSaleVisibility,
+        protected readonly ReservedSalePriceCatalog $reservedSalePriceCatalog,
     ) {
     }
 
@@ -108,6 +114,13 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
     public function buildModelCriteria(): ModelCriteria
     {
         $search = ProductSaleElementsQuery::create();
+
+        // A private drop hides its products from the front, the back office
+        // included in nothing: an administrator setting it up has to see what is
+        // in it.
+        if (!$this->getBackendContext()) {
+            $this->reservedSaleVisibility->applyTo($search, ProductSaleElementsTableMap::COL_PRODUCT_ID);
+        }
 
         $id = $this->getId();
         $product = $this->getProduct();
@@ -226,6 +239,10 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
             $currency = $this->getMainRequest()->getSession()->getCurrency();
         }
 
+        // parseResults() prices the rows in the same currency the query selected
+        // them in, and has no argument of its own to read it from.
+        $this->currency = $currency;
+
         $defaultCurrency = CurrencyModel::getDefaultCurrency();
         $defaultCurrencySuffix = '_default_currency';
 
@@ -261,9 +278,26 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
             $discount = (float) $securityContext->getCustomerUser()->getDiscount();
         }
 
+        $reservedPrices = $this->reservedPrices();
+
         /** @var \Thelia\Model\ProductSaleElements $PSEValue */
         foreach ($loopResult->getResultDataCollection() as $PSEValue) {
             $loopResultRow = new LoopResultRow($PSEValue);
+
+            $isPromo = 1 === $PSEValue->getPromo() ? 1 : 0;
+
+            // A reserved operation writes nothing in the catalog, so its price is
+            // substituted here — in the virtual column the price getters read, so
+            // that the customer discount and the tax are applied to it exactly the
+            // way they are applied to a public promo price. The promo flag itself is
+            // only raised for the row: the model belongs to the catalog, and the
+            // catalog is where a reserved price deliberately leaves no trace.
+            $reservedPrice = $reservedPrices[$PSEValue->getId()] ?? null;
+
+            if (null !== $reservedPrice) {
+                $PSEValue->setVirtualColumn('price_PROMO_PRICE', $reservedPrice->untaxedPromoPrice);
+                $isPromo = 1;
+            }
 
             $price = $PSEValue->getPrice('price_PRICE', $discount);
 
@@ -292,7 +326,7 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
             $loopResultRow
                 ->set('ID', $PSEValue->getId())
                 ->set('QUANTITY', $PSEValue->getQuantity())
-                ->set('IS_PROMO', 1 === $PSEValue->getPromo() ? 1 : 0)
+                ->set('IS_PROMO', $isPromo)
                 ->set('VISIBLE', $PSEValue->getVisible())
                 ->set('POSITION', $PSEValue->getPosition())
                 ->set('IS_NEW', 1 === $PSEValue->getNewness() ? 1 : 0)
@@ -313,6 +347,27 @@ class ProductSaleElements extends BaseLoop implements PropelSearchLoopInterface,
         }
 
         return $loopResult;
+    }
+
+    /**
+     * The reserved prices of the current visitor, resolved once for the whole
+     * request rather than once per row.
+     *
+     * Empty in the back office: the catalog is what it edits, and a reserved price
+     * is deliberately not part of the catalog.
+     *
+     * @return array<int, \Thelia\Domain\Sale\ReservedPrice>
+     */
+    private function reservedPrices(): array
+    {
+        if ($this->getBackendContext() || !$this->currency instanceof CurrencyModel) {
+            return [];
+        }
+
+        return $this->reservedSalePriceCatalog->prices(
+            $this->currency,
+            $this->reservedSaleVisibility->currentCustomer(),
+        );
     }
 
     /**

--- a/core/lib/Thelia/Core/Template/Loop/Sale.php
+++ b/core/lib/Thelia/Core/Template/Loop/Sale.php
@@ -24,6 +24,7 @@ use Thelia\Core\Template\Element\SearchLoopInterface;
 use Thelia\Core\Template\Element\StandardI18nFieldsSearchTrait;
 use Thelia\Core\Template\Loop\Argument\Argument;
 use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+use Thelia\Domain\Sale\ReservedSaleVisibility;
 use Thelia\Model\SaleQuery;
 use Thelia\Type\BooleanOrBothType;
 use Thelia\Type\EnumListType;
@@ -48,6 +49,11 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
     use StandardI18nFieldsSearchTrait;
 
     protected $timestampable = true;
+
+    public function __construct(
+        protected readonly ReservedSaleVisibility $reservedSaleVisibility,
+    ) {
+    }
 
     protected function getArgDefinitions(): ArgumentCollection
     {
@@ -117,6 +123,12 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
     public function buildModelCriteria(): ModelCriteria
     {
         $search = SaleQuery::create();
+
+        // A reserved operation is only part of the front for the customers it names.
+        // The back office lists every one of them: that is where they are set up.
+        if (!$this->getBackendContext()) {
+            $this->reservedSaleVisibility->applyToSales($search);
+        }
 
         /* manage translations */
         $this->configureI18nProcessing($search, ['TITLE', 'SALE_LABEL', 'CHAPO', 'DESCRIPTION', 'POSTSCRIPTUM']);
@@ -215,9 +227,12 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
 
     public function parseResults(LoopResult $loopResult): LoopResult
     {
+        $now = new \DateTime();
+
         /** @var \Thelia\Model\Sale $sale */
         foreach ($loopResult->getResultDataCollection() as $sale) {
             $loopResultRow = new LoopResultRow($sale);
+            $shouldDisplayCountdown = $sale->shouldDisplayCountdown($now);
 
             switch ($sale->getPriceOffsetType()) {
                 case \Thelia\Model\Sale::OFFSET_TYPE_AMOUNT:
@@ -249,7 +264,23 @@ class Sale extends BaseI18nLoop implements PropelSearchLoopInterface, SearchLoop
                 ->set('HAS_END_DATE', $sale->hasEndDate() ? 1 : 0)
                 ->set('PRICE_OFFSET_TYPE', $priceOffsetType)
                 ->set('PRICE_OFFSET_SYMBOL', $priceOffsetSymbol)
-                ->set('PRICE_OFFSET_VALUE', $sale->getVirtualColumn('price_offset_value'));
+                ->set('PRICE_OFFSET_VALUE', $sale->getVirtualColumn('price_offset_value'))
+                ->set('URL', $this->getReturnUrl() ? $sale->getUrl($this->locale) : null)
+                ->set('AUDIENCE_MODE', $sale->getAudienceMode())
+                ->set('HIDE_PRODUCTS', $sale->getHideProducts() ? 1 : 0)
+                ->set('COUNTDOWN_MODE', $sale->getCountdownMode())
+                ->set('COUNTDOWN_LEAD_HOURS', $sale->getCountdownLeadHours())
+                ->set('SHOULD_DISPLAY_COUNTDOWN', $shouldDisplayCountdown ? 1 : 0)
+                // How long the operation still has to run, or null when no countdown
+                // is due. Never negative: a template printing a negative number
+                // would render it, and an operation that is over has nothing left
+                // to count down.
+                ->set(
+                    'COUNTDOWN_REMAINING_SECONDS',
+                    $shouldDisplayCountdown
+                        ? max(0, $sale->getEndDate()->getTimestamp() - $now->getTimestamp())
+                        : null,
+                );
 
             $this->addOutputFields($loopResultRow, $sale);
             $loopResult->addRow($loopResultRow);

--- a/core/lib/Thelia/Domain/Localization/Service/LangService.php
+++ b/core/lib/Thelia/Domain/Localization/Service/LangService.php
@@ -24,6 +24,7 @@ use Thelia\Core\HttpFoundation\Session\Session;
 use Thelia\Core\Routing\Rewriting\Exception\UrlRewritingException;
 use Thelia\Core\Routing\Rewriting\RewritingResolver;
 use Thelia\Model\Admin;
+use Thelia\Model\AdminQuery;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Lang;
 use Thelia\Model\LangQuery;
@@ -60,11 +61,30 @@ readonly class LangService
         $request->setLocale($lang->getLocale());
     }
 
+    /**
+     * The language of the back-office interface, which is not the language of the
+     * shop: they live under two different session keys, and a session serves both
+     * at once — an admin who switches their interface to English must not see the
+     * storefront they browse in the same browser switch with it.
+     */
+    public function setAdminLang(Lang $lang): void
+    {
+        $request = $this->requestStack->getMainRequest();
+
+        if (!$request instanceof Request || !$request->hasSession()) {
+            return;
+        }
+
+        $request->getSession()->setAdminLang($lang);
+        $request->setLocale($lang->getLocale());
+    }
+
     public function handleLang(Session $session, Request $request): Response|Lang|null
     {
         if (true === Request::$isAdminEnv) {
             $lang = $this->resolveAdminLanguageFromRequest($request);
             $session->setAdminLang($lang);
+            $this->persistAdminInterfaceLanguage($session, $request, $lang);
 
             return $lang;
         }
@@ -111,8 +131,14 @@ readonly class LangService
     {
         $requestedLangCodeOrLocale = $request->query->get('lang');
 
-        if (null !== $requestedLangCodeOrLocale) {
-            $lang = LangQuery::create()->findOneByCode($requestedLangCodeOrLocale);
+        if (\is_string($requestedLangCodeOrLocale) && '' !== $requestedLangCodeOrLocale) {
+            // A code ("fr") is what the back-office language switcher sends, a locale
+            // ("fr_FR") is what a hand-written url or a module link may send, and the
+            // front-office resolver has always taken both: reading only the code here
+            // silently answered such a request with the language already in place.
+            $lang = \strlen($requestedLangCodeOrLocale) > 2
+                ? LangQuery::create()->findOneByLocale($requestedLangCodeOrLocale)
+                : LangQuery::create()->findOneByCode($requestedLangCodeOrLocale);
 
             if ($lang instanceof Lang) {
                 return $lang;
@@ -155,6 +181,41 @@ readonly class LangService
                 }
             }
         }
+    }
+
+    /**
+     * The interface language an administrator picks is a preference of theirs, and
+     * admin.locale is where that preference already lives: it is what
+     * resolveAdminLanguageFromAdmin() reads back when a session starts with no
+     * language of its own. Writing it here is what makes the choice outlive the
+     * session it was made in — until now the switch was session-deep only, and a
+     * logout took it away.
+     *
+     * Only an explicit switch writes: a plain page view carries no "lang" and
+     * resolves to the language that is already stored.
+     */
+    private function persistAdminInterfaceLanguage(Session $session, Request $request, Lang $lang): void
+    {
+        if (null === $request->query->get('lang')) {
+            return;
+        }
+
+        $adminUser = $session->getAdminUser();
+
+        if (!$adminUser instanceof Admin) {
+            return;
+        }
+
+        // The administrator carried by the session was deserialized from it and may
+        // hold stale columns: the row is read again so that saving the locale cannot
+        // write anything else back with it.
+        $admin = AdminQuery::create()->findPk($adminUser->getId());
+
+        if (!$admin instanceof Admin || $admin->getLocale() === $lang->getLocale()) {
+            return;
+        }
+
+        $admin->setLocale($lang->getLocale())->save();
     }
 
     private function getLanguageFromRequestParameters(Request $request): ?Lang

--- a/core/lib/Thelia/Domain/Sale/CurrentCustomerProvider.php
+++ b/core/lib/Thelia/Domain/Sale/CurrentCustomerProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Model\Customer;
+
+/**
+ * The customer the reserved prices of the current request are resolved for.
+ *
+ * Thelia's own SecurityContext comes first: the front-office theme calls the API
+ * in-process, where the stateless `api` firewall is never traversed and the token
+ * storage is therefore empty, while the Thelia session still holds the customer
+ * who signed in.
+ *
+ * The token storage is the second answer, not the first, and it is what a caller
+ * reaching /api/front/... over HTTP with a bearer token authenticates as: that
+ * firewall opens no session at all, so the session has nobody to offer. Reading
+ * only one of the two would leave one of the two front paths priceless.
+ *
+ * Outside a request — the scheduled command that opens and closes operations,
+ * a console command, a worker — there is neither, and this answers null, which
+ * is exactly what a caller with no customer should get.
+ */
+class CurrentCustomerProvider
+{
+    public function __construct(
+        private readonly SecurityContext $securityContext,
+        private readonly TokenStorageInterface $tokenStorage,
+    ) {
+    }
+
+    public function getCurrentCustomer(): ?Customer
+    {
+        $customer = $this->securityContext->getCustomerUser();
+
+        if (!$customer instanceof Customer) {
+            $customer = $this->tokenStorage->getToken()?->getUser();
+        }
+
+        if (!$customer instanceof Customer) {
+            return null;
+        }
+
+        // A guest is never entitled to a reserved operation. The shop reuses the guest
+        // row behind an address, so it is shared with every earlier visitor who ordered
+        // from that address: naming it on an operation would hand its price to anyone
+        // who guest-checks-out with the same email.
+        return $customer->isGuest() ? null : $customer;
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/ReservedPrice.php
+++ b/core/lib/Thelia/Domain/Sale/ReservedPrice.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+/**
+ * The price one reserved operation gives one sale element, for the customer it was
+ * resolved for.
+ *
+ * The price is untaxed, like every price in `product_price` and in `cart_item`:
+ * it is written straight into the cart line, and the tax is added on the way out
+ * by the same calculator as any other price.
+ *
+ * The operation is carried along because whoever shows the price also shows where
+ * it comes from — its end date for the countdown, and whether the shopkeeper asked
+ * for the original price to be struck through next to it.
+ */
+final readonly class ReservedPrice
+{
+    public function __construct(
+        public int $productSaleElementsId,
+        public float $untaxedPromoPrice,
+        public int $saleId,
+        public ?\DateTimeInterface $saleEndDate,
+        public bool $displayInitialPrice,
+    ) {
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/ReservedSalePriceCatalog.php
+++ b/core/lib/Thelia/Domain/Sale/ReservedSalePriceCatalog.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Contracts\Service\ResetInterface;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\SaleProductQuery;
+
+/**
+ * The reserved prices of the current visitor, for the whole request.
+ *
+ * {@see ReservedSalePriceResolver} prices a batch, which is what a cart hands it.
+ * A read does not: the API transforms one sale element at a time, and the product
+ * loop parses one row at a time, so a resolution hanging off each of them would
+ * cost one statement per row and grow with the catalog.
+ *
+ * This resolves once, for everything the visitor's reserved operations cover, and
+ * answers every later question from memory. The work is therefore bounded by the
+ * size of the operations the visitor is entitled to — not by the size of the page
+ * being read, and not by the number of times it is asked.
+ *
+ * A visitor entitled to no reserved operation — every visitor of most shops —
+ * asks the database nothing at all beyond the indexed existence check.
+ */
+class ReservedSalePriceCatalog implements ResetInterface
+{
+    /** @var array<string, array<int, ReservedPrice>> resolved prices per customer and currency */
+    private array $pricesByCustomerAndCurrency = [];
+
+    /** @var array<string, array<int, list<int>>> the sale elements of each product, per customer and currency */
+    private array $saleElementsByProduct = [];
+
+    public function __construct(
+        private readonly ReservedSalePriceResolver $resolver,
+        private readonly SaleAudienceChecker $saleAudienceChecker,
+    ) {
+    }
+
+    /**
+     * What the customer pays for this sale element under a reserved operation, or
+     * null when no operation of theirs beats the price it is on sale for.
+     */
+    public function priceFor(int $productSaleElementsId, Currency $currency, ?Customer $customer): ?ReservedPrice
+    {
+        return $this->prices($currency, $customer)[$productSaleElementsId] ?? null;
+    }
+
+    /**
+     * The cheapest a reserved operation makes any sale element of the product, or
+     * null when none of them is discounted for this customer.
+     *
+     * This is what a reader showing one price per product needs — the product loop
+     * in its "complex" form, which prices a product by the lowest of its sale
+     * elements rather than by the default one.
+     */
+    public function lowestPriceForProduct(int $productId, Currency $currency, ?Customer $customer): ?float
+    {
+        $prices = $this->prices($currency, $customer);
+
+        if ([] === $prices) {
+            return null;
+        }
+
+        $lowest = null;
+
+        foreach ($this->saleElementsOf($productId, $currency, $customer) as $productSaleElementsId) {
+            $reservedPrice = $prices[$productSaleElementsId] ?? null;
+
+            if (null === $reservedPrice) {
+                continue;
+            }
+
+            $lowest = null === $lowest ? $reservedPrice->untaxedPromoPrice : min($lowest, $reservedPrice->untaxedPromoPrice);
+        }
+
+        return $lowest;
+    }
+
+    /**
+     * @return array<int, ReservedPrice> keyed by sale element id
+     */
+    public function prices(Currency $currency, ?Customer $customer): array
+    {
+        if (null === $customer || !$this->saleAudienceChecker->hasActiveReservedSale()) {
+            return [];
+        }
+
+        $key = $this->keyOf($currency, $customer);
+
+        return $this->pricesByCustomerAndCurrency[$key] ??= $this->resolve($currency, $customer);
+    }
+
+    public function reset(): void
+    {
+        $this->pricesByCustomerAndCurrency = [];
+        $this->saleElementsByProduct = [];
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function saleElementsOf(int $productId, Currency $currency, ?Customer $customer): array
+    {
+        if (null === $customer) {
+            return [];
+        }
+
+        return $this->saleElementsByProduct[$this->keyOf($currency, $customer)][$productId] ?? [];
+    }
+
+    private function keyOf(Currency $currency, Customer $customer): string
+    {
+        return $customer->getId().'|'.$currency->getId();
+    }
+
+    /**
+     * @return array<int, ReservedPrice>
+     */
+    private function resolve(Currency $currency, Customer $customer): array
+    {
+        $saleIds = $this->saleAudienceChecker->getEntitledReservedSaleIds($customer);
+
+        if ([] === $saleIds) {
+            return [];
+        }
+
+        /** @var list<int> $productIds */
+        $productIds = array_map('intval', SaleProductQuery::create()
+            ->filterBySaleId($saleIds, Criteria::IN)
+            ->groupByProductId()
+            ->select('ProductId')
+            ->find()
+            ->getData());
+
+        if ([] === $productIds) {
+            return [];
+        }
+
+        // Every sale element of those products, not only the ones an attribute value
+        // narrows the operation down to: the resolver applies that selection itself,
+        // and a superset costs one statement either way.
+        $rows = ProductSaleElementsQuery::create()
+            ->filterByProductId($productIds, Criteria::IN)
+            ->select(['Id', 'ProductId'])
+            ->find()
+            ->getData();
+
+        $productSaleElementsIds = [];
+        $saleElementsByProduct = [];
+
+        foreach ($rows as $row) {
+            $productSaleElementsIds[] = (int) $row['Id'];
+            $saleElementsByProduct[(int) $row['ProductId']][] = (int) $row['Id'];
+        }
+
+        $this->saleElementsByProduct[$this->keyOf($currency, $customer)] = $saleElementsByProduct;
+
+        if ([] === $productSaleElementsIds) {
+            return [];
+        }
+
+        return $this->resolver->resolve($productSaleElementsIds, $currency, $customer);
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/ReservedSalePriceResolver.php
+++ b/core/lib/Thelia/Domain/Sale/ReservedSalePriceResolver.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Propel;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorFactoryInterface;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\Country;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Map\SaleTableMap;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\Sale;
+
+/**
+ * Works out what a reserved operation charges a given customer for a batch of
+ * sale elements.
+ *
+ * A reserved operation writes nothing in the catalog — no `promo` flag, no
+ * `promo_price` — because those two are what every visitor reads. Its price only
+ * exists as the answer to "what does this customer pay", which is what this
+ * resolves.
+ *
+ * It resolves a BATCH: a catalog page, a cart or an API collection asks once for
+ * all the sale elements it is about to show, and the work costs the same whether
+ * there is one of them or fifty. One statement joins the operations, their
+ * audience, their offset and the prices; the products are then loaded in one more
+ * so that each gets a tax calculator. Nothing is read per sale element.
+ */
+class ReservedSalePriceResolver
+{
+    public function __construct(
+        private readonly SaleDiscountCalculator $saleDiscountCalculator,
+        private readonly TaxCalculatorFactoryInterface $taxCalculatorFactory,
+    ) {
+    }
+
+    /**
+     * @param list<int> $productSaleElementsIds
+     *
+     * @return array<int, ReservedPrice> keyed by sale element ID; a sale element with
+     *                                   no reserved price of its own is absent
+     */
+    public function resolve(
+        array $productSaleElementsIds,
+        Currency $currency,
+        ?Customer $customer,
+        ?\DateTimeInterface $now = null,
+    ): array {
+        // A visitor is entitled to no reserved operation, so there is nothing to
+        // ask the database in the first place.
+        if ([] === $productSaleElementsIds || null === $customer) {
+            return [];
+        }
+
+        $rows = $this->fetchCandidateRows(
+            array_values(array_unique(array_map('intval', $productSaleElementsIds))),
+            $currency,
+            $customer,
+            $now ?? new \DateTime(),
+        );
+
+        if ([] === $rows) {
+            return [];
+        }
+
+        $taxCalculators = $this->loadTaxCalculators($rows);
+        $defaultCurrency = Currency::getDefaultCurrency();
+        $conversionRate = $currency->getRate() / $defaultCurrency->getRate();
+
+        $resolved = [];
+
+        foreach ($rows as $row) {
+            $prices = $this->basePricesOf($row, $conversionRate);
+
+            if (null === $prices) {
+                continue;
+            }
+
+            [$untaxedPrice, $untaxedPromoPrice] = $prices;
+
+            $taxCalculator = $taxCalculators[(int) $row['product_id']] ?? null;
+
+            if (null === $taxCalculator) {
+                continue;
+            }
+
+            $reservedPrice = $this->saleDiscountCalculator->computeUntaxedPromoPrice(
+                $untaxedPrice,
+                (int) $row['price_offset_type'],
+                (float) $row['price_offset_value'],
+                $taxCalculator,
+            );
+
+            // Frozen decision: a reserved price only applies when it beats the price
+            // the sale element is on sale for right now, public special offer
+            // included. The customer sees the better of the two — the shop never
+            // charges a named customer more than a passing visitor, and a reserved
+            // operation never has to be coordinated with the public ones.
+            $currentPrice = $row['pse_promo'] ? $untaxedPromoPrice : $untaxedPrice;
+
+            if ($reservedPrice >= $currentPrice) {
+                continue;
+            }
+
+            $saleElementsId = (int) $row['pse_id'];
+            $alreadyResolved = $resolved[$saleElementsId] ?? null;
+
+            // Two reserved operations can cover the same sale element: the lowest
+            // price wins, not the row the database happened to return last.
+            if (null !== $alreadyResolved && $alreadyResolved->untaxedPromoPrice <= $reservedPrice) {
+                continue;
+            }
+
+            $resolved[$saleElementsId] = new ReservedPrice(
+                $saleElementsId,
+                $reservedPrice,
+                (int) $row['sale_id'],
+                null === $row['sale_end_date'] ? null : new \DateTime((string) $row['sale_end_date']),
+                (bool) $row['display_initial_price'],
+            );
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Every (sale element, reserved operation) pair the customer is entitled to,
+     * in one statement.
+     *
+     * The date window is evaluated here rather than trusted to `sale.active`: the
+     * flag is only as fresh as the last run of the scheduled command, and an
+     * operation that ended ten minutes ago must not price a cart. A missing bound
+     * is an open one.
+     *
+     * @param list<int> $productSaleElementsIds
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fetchCandidateRows(
+        array $productSaleElementsIds,
+        Currency $currency,
+        Customer $customer,
+        \DateTimeInterface $now,
+    ): array {
+        $placeholders = [];
+        $parameters = [
+            ':publicAudienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+            ':now' => $now->format('Y-m-d H:i:s'),
+            ':customerId' => $customer->getId(),
+            ':currencyId' => $currency->getId(),
+            ':defaultCurrencyId' => Currency::getDefaultCurrency()->getId(),
+        ];
+
+        foreach ($productSaleElementsIds as $index => $productSaleElementsId) {
+            $placeholders[] = ':pse'.$index;
+            $parameters[':pse'.$index] = $productSaleElementsId;
+        }
+
+        // The selection of sale elements reproduces the one Action\Sale makes for a
+        // public operation: a `sale_product` row without an attribute value covers
+        // every combination of the product, one with an attribute value covers only
+        // the combinations carrying it.
+        $sql = <<<SQL
+            SELECT
+                pse.id AS pse_id,
+                pse.product_id AS product_id,
+                pse.promo AS pse_promo,
+                s.id AS sale_id,
+                s.end_date AS sale_end_date,
+                s.display_initial_price AS display_initial_price,
+                s.price_offset_type AS price_offset_type,
+                soc.price_offset_value AS price_offset_value,
+                pp.price AS currency_price,
+                pp.promo_price AS currency_promo_price,
+                pp.from_default_currency AS from_default_currency,
+                dpp.price AS default_price,
+                dpp.promo_price AS default_promo_price
+            FROM product_sale_elements pse
+            INNER JOIN sale_product sp
+                    ON sp.product_id = pse.product_id
+                   AND (
+                        sp.attribute_av_id IS NULL
+                        OR EXISTS (
+                            SELECT 1
+                            FROM attribute_combination ac
+                            WHERE ac.product_sale_elements_id = pse.id
+                              AND ac.attribute_av_id = sp.attribute_av_id
+                        )
+                   )
+            INNER JOIN sale s
+                    ON s.id = sp.sale_id
+                   AND s.active = 1
+                   AND s.audience_mode <> :publicAudienceMode
+                   AND (s.start_date IS NULL OR s.start_date <= :now)
+                   AND (s.end_date IS NULL OR s.end_date >= :now)
+            INNER JOIN sale_customer sc
+                    ON sc.sale_id = s.id
+                   AND sc.customer_id = :customerId
+            INNER JOIN sale_offset_currency soc
+                    ON soc.sale_id = s.id
+                   AND soc.currency_id = :currencyId
+            LEFT JOIN product_price pp
+                   ON pp.product_sale_elements_id = pse.id
+                  AND pp.currency_id = :currencyId
+            LEFT JOIN product_price dpp
+                   ON dpp.product_sale_elements_id = pse.id
+                  AND dpp.currency_id = :defaultCurrencyId
+            WHERE pse.id IN (%s)
+            SQL;
+
+        $statement = Propel::getConnection(SaleTableMap::DATABASE_NAME)
+            ->prepare(\sprintf($sql, implode(', ', $placeholders)));
+
+        foreach ($parameters as $name => $value) {
+            $statement->bindValue($name, $value);
+        }
+
+        $statement->execute();
+
+        return $statement->fetchAll(\PDO::FETCH_ASSOC) ?: [];
+    }
+
+    /**
+     * The untaxed catalog price and promo price of the sale element in the asked
+     * currency, or null when it has no price at all.
+     *
+     * A currency with no row of its own — or a row flagged `from_default_currency`,
+     * which means it was converted rather than typed in — is converted from the
+     * default currency, exactly as ProductSaleElements::getPricesByCurrency() does.
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array{0: float, 1: float}|null
+     */
+    private function basePricesOf(array $row, float $conversionRate): ?array
+    {
+        if (null !== $row['currency_price'] && !$row['from_default_currency']) {
+            return [(float) $row['currency_price'], (float) $row['currency_promo_price']];
+        }
+
+        if (null === $row['default_price']) {
+            return null;
+        }
+
+        return [
+            (float) $row['default_price'] * $conversionRate,
+            (float) $row['default_promo_price'] * $conversionRate,
+        ];
+    }
+
+    /**
+     * One tax calculator per product of the batch, all products loaded at once.
+     *
+     * The calculator is loaded on the shop location, the same country
+     * Thelia\Action\Sale uses to write a public promo price — which is what makes
+     * the two paths agree to the cent.
+     *
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<int, TaxCalculatorInterface>
+     */
+    private function loadTaxCalculators(array $rows): array
+    {
+        $productIds = array_values(array_unique(array_map(
+            static fn (array $row): int => (int) $row['product_id'],
+            $rows,
+        )));
+
+        $shopLocation = Country::getShopLocation();
+        $calculators = [];
+
+        /** @var Product $product */
+        foreach (ProductQuery::create()->filterById($productIds, Criteria::IN)->find() as $product) {
+            $calculators[(int) $product->getId()] = $this->taxCalculatorFactory
+                ->createTaxCalculator()
+                ->load($product, $shopLocation);
+        }
+
+        return $calculators;
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/ReservedSaleVisibility.php
+++ b/core/lib/Thelia/Domain/Sale/ReservedSaleVisibility.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Symfony\Contracts\Service\ResetInterface;
+use Thelia\Model\Customer;
+use Thelia\Model\Map\SaleProductTableMap;
+use Thelia\Model\Map\SaleTableMap;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleQuery;
+
+/**
+ * Who gets to see a reserved operation, and the products it holds.
+ *
+ * Two rules, one place, so that the API extensions and the legacy loops can
+ * never disagree on them:
+ *
+ *  - an operation reserved for named customers is only part of the shop for the
+ *    customers it names;
+ *  - a shopkeeper can go further and make it a private drop — `hide_products` —
+ *    and then its products do not exist at all for anybody else.
+ *
+ * Both are enforced in the query rather than on the way out, so that a
+ * collection, an item read and a count all agree on what the catalog holds: a
+ * product left reachable by its id is not hidden, it is only harder to find.
+ *
+ * A shop with no running reserved operation pays one indexed existence check per
+ * request and nothing more — no criterion is added to any query, and the
+ * statements are the ones it ran before the feature existed.
+ */
+class ReservedSaleVisibility implements ResetInterface
+{
+    /** @var array<int, array{hidden: list<int>, entitled: list<int>}> the hiding operations each customer is out of, and in */
+    private array $hidingSaleIdsByCustomer = [];
+
+    public function __construct(
+        private readonly SaleAudienceChecker $saleAudienceChecker,
+        private readonly CurrentCustomerProvider $currentCustomerProvider,
+    ) {
+    }
+
+    /**
+     * Whether any reserved operation is running in the shop at all — the gate every
+     * caller reads before doing anything more expensive.
+     */
+    public function hasActiveReservedSale(): bool
+    {
+        return $this->saleAudienceChecker->hasActiveReservedSale();
+    }
+
+    /**
+     * Narrows a catalog query to the products the current visitor is allowed to see.
+     *
+     * A product is out of the catalog when a hidden operation covers it and none of
+     * the hidden operations covering it is open to the visitor. Being left out of one
+     * private drop is not what hides a product from somebody — being left out of every
+     * one of them is, and a customer named on one of two overlapping operations reads
+     * their catalog through the one they are part of.
+     *
+     * @param string $productIdColumn the qualified column holding the product id in
+     *                                the query being narrowed — `product.id` for the
+     *                                catalog itself, `product_sale_elements.product_id`
+     *                                for its sale elements
+     */
+    public function applyTo(ModelCriteria $query, string $productIdColumn): void
+    {
+        $hiddenSaleIds = $this->hiddenSaleIds();
+
+        if ([] === $hiddenSaleIds) {
+            return;
+        }
+
+        $clause = \sprintf(
+            'NOT %s',
+            $this->coveredByAnyOfClause($productIdColumn, $hiddenSaleIds),
+        );
+
+        $entitledHidingSaleIds = $this->entitledHidingSaleIds();
+
+        if ([] !== $entitledHidingSaleIds) {
+            $clause = \sprintf(
+                '(%s OR %s)',
+                $clause,
+                $this->coveredByAnyOfClause($productIdColumn, $entitledHidingSaleIds),
+            );
+        }
+
+        $query->where($clause);
+    }
+
+    /**
+     * Narrows a query over the operations themselves to the ones the current visitor
+     * is part of: every public one, and the reserved ones they are named on.
+     */
+    public function applyToSales(SaleQuery $query): void
+    {
+        if (!$this->hasActiveReservedSale()) {
+            return;
+        }
+
+        $entitledSaleIds = $this->entitledSaleIds();
+
+        if ([] === $entitledSaleIds) {
+            $query->filterByAudienceMode(Sale::AUDIENCE_MODE_PUBLIC);
+
+            return;
+        }
+
+        $query
+            ->condition('openToEverybody', SaleTableMap::COL_AUDIENCE_MODE.' = ?', Sale::AUDIENCE_MODE_PUBLIC)
+            ->condition('openToThisCustomer', SaleTableMap::COL_ID.' IN ('.implode(', ', $entitledSaleIds).')')
+            ->combine(['openToEverybody', 'openToThisCustomer'], Criteria::LOGICAL_OR);
+    }
+
+    /**
+     * The same rule as {@see applyToSales()}, as a fragment for a join condition:
+     * a query joining the operations of a product to read something off them has to
+     * skip the ones the visitor is not part of, and a join has no criteria of its own.
+     *
+     * @param string $saleAlias the alias the `sale` table is joined under
+     */
+    public function saleIsOpenToVisitorClause(string $saleAlias): string
+    {
+        $entitledSaleIds = $this->entitledSaleIds();
+        $isPublic = \sprintf('`%s`.`audience_mode` = %d', $saleAlias, Sale::AUDIENCE_MODE_PUBLIC);
+
+        if ([] === $entitledSaleIds) {
+            return $isPublic;
+        }
+
+        return \sprintf(
+            '(%s OR `%s`.`id` IN (%s))',
+            $isPublic,
+            $saleAlias,
+            implode(', ', $entitledSaleIds),
+        );
+    }
+
+    /**
+     * The running reserved operations the current visitor is named on.
+     *
+     * @return list<int>
+     */
+    public function entitledSaleIds(): array
+    {
+        return $this->saleAudienceChecker->getEntitledReservedSaleIds($this->currentCustomer());
+    }
+
+    /**
+     * The running reserved operations that hide their products from the current
+     * visitor: the ones they are not named on.
+     *
+     * @return list<int>
+     */
+    public function hiddenSaleIds(): array
+    {
+        return $this->hidingSaleIds()['hidden'];
+    }
+
+    /**
+     * The running operations that hide their products and that the current visitor
+     * is named on — the ones that hand them a product back.
+     *
+     * @return list<int>
+     */
+    public function entitledHidingSaleIds(): array
+    {
+        return $this->hidingSaleIds()['entitled'];
+    }
+
+    public function currentCustomer(): ?Customer
+    {
+        return $this->currentCustomerProvider->getCurrentCustomer();
+    }
+
+    public function reset(): void
+    {
+        $this->hidingSaleIdsByCustomer = [];
+    }
+
+    /**
+     * Every running operation hiding its products, split into the ones the current
+     * visitor is out of and the ones they are part of.
+     *
+     * Answered from an indexed existence check first — most shops run no reserved
+     * operation at all, and those must not pay for a list nobody will read. The split
+     * is made here rather than by the database, so that both halves cost the one
+     * statement the single half used to.
+     *
+     * @return array{hidden: list<int>, entitled: list<int>}
+     */
+    private function hidingSaleIds(): array
+    {
+        if (!$this->hasActiveReservedSale()) {
+            return ['hidden' => [], 'entitled' => []];
+        }
+
+        $customer = $this->currentCustomer();
+        $customerId = (int) ($customer?->getId() ?? 0);
+
+        if (isset($this->hidingSaleIdsByCustomer[$customerId])) {
+            return $this->hidingSaleIdsByCustomer[$customerId];
+        }
+
+        $query = SaleQuery::create()
+            ->filterByActive(true)
+            ->filterByHideProducts(true)
+            ->filterByAudienceMode(Sale::AUDIENCE_MODE_PUBLIC, Criteria::NOT_EQUAL);
+
+        // The dates decide, not the active flag alone: the flag is only as fresh as
+        // the last run of the scheduled command, and an operation that ended ten
+        // minutes ago must not keep a product out of the catalog.
+        $this->saleAudienceChecker->filterByRunningDates($query);
+
+        /** @var list<int> $hidingSaleIds */
+        $hidingSaleIds = array_map('intval', $query->select(SaleTableMap::COL_ID)->find()->getData());
+
+        $entitledSaleIds = $this->saleAudienceChecker->getEntitledReservedSaleIds($customer);
+
+        return $this->hidingSaleIdsByCustomer[$customerId] = [
+            'hidden' => array_values(array_diff($hidingSaleIds, $entitledSaleIds)),
+            'entitled' => array_values(array_intersect($hidingSaleIds, $entitledSaleIds)),
+        ];
+    }
+
+    /**
+     * Whether the product the query is reading is part of any of these operations.
+     *
+     * The ids are read back from the database as integers, so they go into the
+     * statement as they are: there is no value here to bind, and a raw clause is what
+     * lets the same criterion be expressed against either column.
+     *
+     * @param list<int> $saleIds
+     */
+    private function coveredByAnyOfClause(string $productIdColumn, array $saleIds): string
+    {
+        return \sprintf(
+            'EXISTS (SELECT 1 FROM `%s` WHERE `%s`.`product_id` = %s AND `%s`.`sale_id` IN (%s))',
+            SaleProductTableMap::TABLE_NAME,
+            SaleProductTableMap::TABLE_NAME,
+            $productIdColumn,
+            SaleProductTableMap::TABLE_NAME,
+            implode(', ', $saleIds),
+        );
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/SaleAudienceChecker.php
+++ b/core/lib/Thelia/Domain/Sale/SaleAudienceChecker.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Symfony\Contracts\Service\ResetInterface;
+use Thelia\Model\Customer;
+use Thelia\Model\Map\SaleTableMap;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleCustomerQuery;
+use Thelia\Model\SaleQuery;
+
+/**
+ * Answers who a sale operation is open to.
+ *
+ * Every answer is memoised for the request: the catalog asks the same questions
+ * once per product otherwise, and the cache bypass of the front asks
+ * hasActiveReservedSale() on every single page.
+ *
+ * The customer is always a parameter, never read from the session here: the
+ * scheduled command that opens and closes operations runs with no session at
+ * all, and the API is called in-process by the front-office theme, where the
+ * token storage is empty. Callers with no customer at hand ask
+ * {@see CurrentCustomerProvider} for the one in the session.
+ */
+class SaleAudienceChecker implements ResetInterface
+{
+    private ?bool $hasActiveReservedSale = null;
+
+    /** @var array<int, list<int>> the sale IDs each customer is named on, whatever their state */
+    private array $targetedSaleIdsByCustomer = [];
+
+    /** @var array<int, list<int>> the running reserved sale IDs each customer is entitled to */
+    private array $entitledReservedSaleIdsByCustomer = [];
+
+    /**
+     * Whether the customer gets the price of this operation.
+     *
+     * An operation open to everyone entitles everyone, a visitor with no account
+     * included. A reserved one entitles only the customers it names, so an
+     * operation reserved for customer groups (US #122, whose groups nothing reads
+     * yet) entitles nobody — which is the safe way round.
+     */
+    public function isCustomerEntitled(Sale $sale, ?Customer $customer): bool
+    {
+        if (!$sale->isReserved()) {
+            return true;
+        }
+
+        if (null === $customer) {
+            return false;
+        }
+
+        return \in_array($sale->getId(), $this->getTargetedSaleIds($customer), true);
+    }
+
+    /**
+     * Whether any reserved operation is running in the shop right now.
+     *
+     * One indexed query on (`active`, `audience_mode`), once per request: this is
+     * the gate the front-office cache reads to decide whether a page can be
+     * shared between visitors at all, so it has to be cheap on a shop that has no
+     * reserved operation — which is most shops, most of the time.
+     */
+    public function hasActiveReservedSale(): bool
+    {
+        return $this->hasActiveReservedSale ??= SaleQuery::create()
+            ->filterByActive(true)
+            ->filterByAudienceMode(Sale::AUDIENCE_MODE_PUBLIC, Criteria::NOT_EQUAL)
+            ->exists();
+    }
+
+    /**
+     * The reserved operations the customer is entitled to and that are running now:
+     * active, started, and not over.
+     *
+     * The dates are evaluated in SQL rather than trusted to the `active` flag alone:
+     * the flag is only as fresh as the last run of the scheduled command, and an
+     * operation whose end date passed ten minutes ago must not price a cart.
+     *
+     * @return list<int>
+     */
+    public function getEntitledReservedSaleIds(?Customer $customer): array
+    {
+        if (null === $customer) {
+            return [];
+        }
+
+        $customerId = (int) $customer->getId();
+
+        if (isset($this->entitledReservedSaleIdsByCustomer[$customerId])) {
+            return $this->entitledReservedSaleIdsByCustomer[$customerId];
+        }
+
+        $query = SaleQuery::create()
+            ->filterByActive(true)
+            ->filterByAudienceMode(Sale::AUDIENCE_MODE_PUBLIC, Criteria::NOT_EQUAL)
+            ->useSaleCustomerQuery()
+                ->filterByCustomerId($customerId)
+            ->endUse();
+
+        $this->filterByRunningDates($query);
+
+        /** @var list<int> $saleIds */
+        $saleIds = array_map('intval', $query->select(SaleTableMap::COL_ID)->find()->getData());
+
+        return $this->entitledReservedSaleIdsByCustomer[$customerId] = $saleIds;
+    }
+
+    /**
+     * Narrows the query to the operations whose date window contains the current
+     * instant. A missing bound is an open one: an operation with no end date runs
+     * for as long as its active flag says so.
+     */
+    public function filterByRunningDates(SaleQuery $query, ?\DateTimeInterface $now = null): SaleQuery
+    {
+        $now ??= new \DateTime();
+
+        return $query
+            ->condition('startIsOpen', SaleTableMap::COL_START_DATE.' IS NULL')
+            ->condition('startHasPassed', SaleTableMap::COL_START_DATE.' <= ?', $now)
+            ->combine(['startIsOpen', 'startHasPassed'], Criteria::LOGICAL_OR)
+            ->condition('endIsOpen', SaleTableMap::COL_END_DATE.' IS NULL')
+            ->condition('endIsAhead', SaleTableMap::COL_END_DATE.' >= ?', $now)
+            ->combine(['endIsOpen', 'endIsAhead'], Criteria::LOGICAL_OR);
+    }
+
+    public function reset(): void
+    {
+        $this->hasActiveReservedSale = null;
+        $this->targetedSaleIdsByCustomer = [];
+        $this->entitledReservedSaleIdsByCustomer = [];
+    }
+
+    /**
+     * Every operation the customer is named on, in one query, so that a catalog
+     * page asking about fifty operations does not ask the database fifty times.
+     *
+     * @return list<int>
+     */
+    private function getTargetedSaleIds(Customer $customer): array
+    {
+        $customerId = (int) $customer->getId();
+
+        if (isset($this->targetedSaleIdsByCustomer[$customerId])) {
+            return $this->targetedSaleIdsByCustomer[$customerId];
+        }
+
+        /** @var list<int> $saleIds */
+        $saleIds = array_map(
+            'intval',
+            SaleCustomerQuery::create()
+                ->filterByCustomerId($customerId)
+                ->select('SaleId')
+                ->find()
+                ->getData(),
+        );
+
+        return $this->targetedSaleIdsByCustomer[$customerId] = $saleIds;
+    }
+}

--- a/core/lib/Thelia/Domain/Sale/SaleDiscountCalculator.php
+++ b/core/lib/Thelia/Domain/Sale/SaleDiscountCalculator.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Domain\Sale;
+
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\Sale;
+
+/**
+ * The single place where the discount of a sale operation is applied to a price.
+ *
+ * The offset a shopkeeper types in the back office is what the customer sees taken
+ * off, so it applies to the TAXED price: the untaxed price goes up through the tax
+ * rule, the offset comes off there, and the result comes back down. Taking a
+ * percentage off the untaxed price instead would not give the same taxed figure.
+ *
+ * Both the public price write of Thelia\Action\Sale and the reserved price resolved
+ * for one customer go through this, so a reserved operation and a public one with
+ * the same offset always agree to the cent.
+ */
+class SaleDiscountCalculator
+{
+    /**
+     * @param float                  $untaxedPrice  the catalog price, excluding tax
+     * @param int                    $offsetType    one of the Sale::OFFSET_TYPE_* constants
+     * @param float                  $offset        the offset value, an amount or a percentage depending on $offsetType
+     * @param TaxCalculatorInterface $taxCalculator a calculator already loaded with the product and the shop country
+     *
+     * @return float the discounted price, excluding tax
+     */
+    public function computeUntaxedPromoPrice(
+        float $untaxedPrice,
+        int $offsetType,
+        float $offset,
+        TaxCalculatorInterface $taxCalculator,
+    ): float {
+        $priceWithTax = $taxCalculator->getTaxedPrice($untaxedPrice);
+
+        // An unknown offset type gives no discount at all: a stray value in
+        // `sale.price_offset_type` must never hand products out for free.
+        $promoPriceWithTax = match ($offsetType) {
+            Sale::OFFSET_TYPE_AMOUNT => max(0, $priceWithTax - $offset),
+            Sale::OFFSET_TYPE_PERCENTAGE => $priceWithTax * (1 - $offset / 100),
+            default => $priceWithTax,
+        };
+
+        return (float) $taxCalculator->getUntaxedPrice($promoPriceWithTax);
+    }
+}

--- a/core/lib/Thelia/Model/Sale.php
+++ b/core/lib/Thelia/Model/Sale.php
@@ -16,13 +16,97 @@ namespace Thelia\Model;
 
 use Propel\Runtime\Collection\ObjectCollection;
 use Thelia\Model\Base\Sale as BaseSale;
+use Thelia\Model\Tools\UrlRewritingTrait;
 
 class Sale extends BaseSale
 {
+    use UrlRewritingTrait;
+
+    /**
+     * An operation is a page of the shop: the one its countdown is shown on, and the
+     * only address a private drop can be linked from. The view name is what the
+     * rewriting router puts in `_view` and what `sale_id` is then read against.
+     */
+    public function getRewrittenUrlViewName(): string
+    {
+        return 'sale';
+    }
+
     /** The price offsets types, either amount or percentage. */
     public const OFFSET_TYPE_PERCENTAGE = 10;
 
     public const OFFSET_TYPE_AMOUNT = 20;
+
+    /** Who the operation is open to. */
+    public const AUDIENCE_MODE_PUBLIC = 0;
+
+    public const AUDIENCE_MODE_CUSTOMERS = 1;
+
+    /** Customer groups are US #122: the mode exists, nothing reads the groups yet. */
+    public const AUDIENCE_MODE_CUSTOMER_GROUPS = 2;
+
+    /** When the countdown to the end of the operation is shown. */
+    public const COUNTDOWN_MODE_NONE = 0;
+
+    public const COUNTDOWN_MODE_LEAD_HOURS = 1;
+
+    public const COUNTDOWN_MODE_FROM_OPENING = 2;
+
+    /**
+     * Whether the operation is open to a named audience rather than to everyone.
+     *
+     * This is the one question the price chain asks: a reserved operation never
+     * writes a public promo flag or promo price, its discount is resolved for the
+     * customer who is entitled to it instead.
+     */
+    public function isReserved(): bool
+    {
+        return self::AUDIENCE_MODE_PUBLIC !== $this->getAudienceMode();
+    }
+
+    /**
+     * Whether the countdown to the end of the operation shows at the given instant.
+     *
+     * A countdown counts down to something, so an operation with no end date never
+     * shows one, whatever its mode says. The lead-hours mode needs a number of hours
+     * for the same reason: without it there is no threshold to compare against, and a
+     * misconfigured row must not read as "start counting now".
+     *
+     * An operation that has not opened yet shows nothing either, in either mode: its
+     * products are not on offer, so a countdown next to them would be counting down
+     * to the end of something that has not begun. A window shorter than the lead time
+     * is what makes the two disagree, and the start date is the one that wins.
+     */
+    public function shouldDisplayCountdown(\DateTimeInterface $now): bool
+    {
+        if (self::COUNTDOWN_MODE_NONE === $this->getCountdownMode()) {
+            return false;
+        }
+
+        if (!$this->hasEndDate()) {
+            return false;
+        }
+
+        $startDate = $this->getStartDate();
+
+        if (null !== $startDate && $startDate > $now) {
+            return false;
+        }
+
+        if (self::COUNTDOWN_MODE_FROM_OPENING === $this->getCountdownMode()) {
+            return true;
+        }
+
+        $leadHours = $this->getCountdownLeadHours();
+
+        if (self::COUNTDOWN_MODE_LEAD_HOURS !== $this->getCountdownMode() || null === $leadHours) {
+            return false;
+        }
+
+        $threshold = (clone $this->getEndDate())->modify(\sprintf('-%d hours', $leadHours));
+
+        return $now >= $threshold;
+    }
 
     /**
      * @return bool true if the sale has an end date, false otherwise

--- a/core/lib/Thelia/Model/SaleCustomer.php
+++ b/core/lib/Thelia/Model/SaleCustomer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\SaleCustomer as BaseSaleCustomer;
+
+class SaleCustomer extends BaseSaleCustomer
+{
+}

--- a/core/lib/Thelia/Model/SaleCustomerQuery.php
+++ b/core/lib/Thelia/Model/SaleCustomerQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Model;
+
+use Thelia\Model\Base\SaleCustomerQuery as BaseSaleCustomerQuery;
+
+class SaleCustomerQuery extends BaseSaleCustomerQuery
+{
+}

--- a/core/lib/Thelia/Model/SaleI18n.php
+++ b/core/lib/Thelia/Model/SaleI18n.php
@@ -14,10 +14,26 @@ declare(strict_types=1);
 
 namespace Thelia\Model;
 
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
 use Thelia\Model\Base\SaleI18n as BaseSaleI18n;
 use Thelia\Model\Tools\I18nTimestampableTrait;
 
 class SaleI18n extends BaseSaleI18n
 {
     use I18nTimestampableTrait;
+
+    /**
+     * The address of an operation is built from its title, so it can only be
+     * generated once the translation carrying that title exists — one per locale,
+     * exactly as ProductI18n does it.
+     *
+     * @throws PropelException
+     */
+    public function postInsert(?ConnectionInterface $con = null): void
+    {
+        parent::postInsert($con);
+
+        $this->getSale()->generateRewrittenUrl($this->getLocale(), $con);
+    }
 }

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -47,11 +47,16 @@ use Thelia\Model\OrderAddress;
 use Thelia\Model\OrderStatus;
 use Thelia\Model\OrderStatusQuery;
 use Thelia\Model\Product;
+use Thelia\Model\ProductPrice;
 use Thelia\Model\ProductSaleElements;
 use Thelia\Model\Profile;
 use Thelia\Model\ProfileResource;
 use Thelia\Model\Resource;
 use Thelia\Model\ResourceQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleCustomer;
+use Thelia\Model\SaleOffsetCurrency;
+use Thelia\Model\SaleProduct;
 use Thelia\Model\Tax;
 use Thelia\Model\TaxRule;
 use Thelia\Model\TaxRuleQuery;
@@ -625,6 +630,31 @@ final class FixtureFactory
     }
 
     /**
+     * Gives a sale element a price in a currency. Product::create() already writes
+     * one for the product's default sale element in the currency it was created
+     * with — call this for an additional sale element, or an additional currency.
+     *
+     * `fromDefaultCurrency` says the row is a conversion rather than a price the
+     * shopkeeper typed, which is what makes the reader convert it again from the
+     * default currency instead of using it as is.
+     */
+    public function productPrice(
+        ProductSaleElements $productSaleElements,
+        Currency $currency,
+        array $overrides = [],
+    ): ProductPrice {
+        $price = new ProductPrice();
+        $price->setProductSaleElementsId($productSaleElements->getId());
+        $price->setCurrencyId($currency->getId());
+        $price->setPrice($overrides['price'] ?? '10.000000');
+        $price->setPromoPrice($overrides['promoPrice'] ?? '10.000000');
+        $price->setFromDefaultCurrency($overrides['fromDefaultCurrency'] ?? false);
+        $price->save($this->connection);
+
+        return $price;
+    }
+
+    /**
      * Creates a Cart. Mostly used as a structural dependency for Order.
      */
     public function cart(?Customer $customer = null, array $overrides = []): Cart
@@ -664,6 +694,87 @@ final class FixtureFactory
         $cartItem->save($this->connection);
 
         return $cartItem;
+    }
+
+    /**
+     * Creates a sale operation. It is INACTIVE and open to everyone by default:
+     * a test that wants a running operation says so, and one that wants a reserved
+     * one passes `audienceMode` plus the customers through saleCustomer().
+     *
+     * The operation discounts nothing on its own — link the products with
+     * saleProduct() and give it an offset per currency with saleOffsetCurrency().
+     */
+    public function sale(array $overrides = []): Sale
+    {
+        $n = $this->next();
+
+        $sale = new Sale();
+        $sale->setActive($overrides['active'] ?? false);
+        $sale->setStartDate($overrides['startDate'] ?? null);
+        $sale->setEndDate($overrides['endDate'] ?? null);
+        $sale->setPriceOffsetType($overrides['priceOffsetType'] ?? Sale::OFFSET_TYPE_PERCENTAGE);
+        $sale->setDisplayInitialPrice($overrides['displayInitialPrice'] ?? true);
+        $sale->setAudienceMode($overrides['audienceMode'] ?? Sale::AUDIENCE_MODE_PUBLIC);
+        $sale->setHideProducts($overrides['hideProducts'] ?? false);
+        $sale->setCountdownMode($overrides['countdownMode'] ?? Sale::COUNTDOWN_MODE_NONE);
+        $sale->setCountdownLeadHours($overrides['countdownLeadHours'] ?? null);
+        $sale->setLocale($overrides['locale'] ?? 'en_US');
+        $sale->setTitle($overrides['title'] ?? 'Sale '.$n);
+        $sale->setSaleLabel($overrides['saleLabel'] ?? 'SALE-'.$n);
+        $sale->save($this->connection);
+
+        return $sale;
+    }
+
+    /**
+     * Puts a product in a sale operation. Pass an attribute value to discount only
+     * the sale elements carrying it, the way the back office selection does; without
+     * one, every sale element of the product is included.
+     */
+    public function saleProduct(
+        Sale $sale,
+        Product $product,
+        ?AttributeAv $attributeAv = null,
+    ): SaleProduct {
+        $saleProduct = new SaleProduct();
+        $saleProduct->setSaleId($sale->getId());
+        $saleProduct->setProductId($product->getId());
+        $saleProduct->setAttributeAvId($attributeAv?->getId());
+        $saleProduct->save($this->connection);
+
+        return $saleProduct;
+    }
+
+    /**
+     * Names a customer a reserved operation is open to. Only read when the
+     * operation's audience mode is Sale::AUDIENCE_MODE_CUSTOMERS.
+     */
+    public function saleCustomer(Sale $sale, Customer $customer): SaleCustomer
+    {
+        $saleCustomer = new SaleCustomer();
+        $saleCustomer->setSaleId($sale->getId());
+        $saleCustomer->setCustomerId($customer->getId());
+        $saleCustomer->save($this->connection);
+
+        return $saleCustomer;
+    }
+
+    /**
+     * The discount the operation gives in one currency: an amount or a percentage,
+     * depending on the operation's own price offset type.
+     */
+    public function saleOffsetCurrency(
+        Sale $sale,
+        Currency $currency,
+        float $priceOffsetValue,
+    ): SaleOffsetCurrency {
+        $offset = new SaleOffsetCurrency();
+        $offset->setSaleId($sale->getId());
+        $offset->setCurrencyId($currency->getId());
+        $offset->setPriceOffsetValue($priceOffsetValue);
+        $offset->save($this->connection);
+
+        return $offset;
     }
 
     /**

--- a/docs/reserved-sales.md
+++ b/docs/reserved-sales.md
@@ -1,0 +1,136 @@
+# Reserved sales and countdown display
+
+A sale (commercial operation) can be public, as it always was, or reserved for
+named customers. A reserved sale is invisible to anyone it is not open to: its
+page answers 404, its discount is never served, and — when the merchant enables
+`hide_products` — the products it covers disappear from listings, the front API,
+the sitemap and the product page. A dated sale can also display a countdown on
+the storefront: never, from N hours before the end date, or from its opening.
+
+This document is the map for developers who work on the feature. The behavior
+itself is specified by the test suites named below.
+
+## Data model
+
+Two things changed in the schema: four settings columns on `sale`, and the
+`sale_customer` link table. The reserved price is deliberately absent from this
+model — see the next section.
+
+```mermaid
+erDiagram
+    sale ||--o{ sale_customer : "audience (mode 1)"
+    sale ||--o{ sale_product : "covered products"
+    sale ||--o{ sale_offset_currency : "discount per currency"
+    sale ||--|| sale_i18n : "texts + rewritten URL"
+    customer ||--o{ sale_customer : ""
+    product ||--o{ sale_product : ""
+
+    sale {
+        tinyint audience_mode "0 public, 1 named customers, 2 groups (reserved for a later story)"
+        bool hide_products "hide covered products from everyone else"
+        tinyint countdown_mode "0 never, 1 lead hours before the end, 2 from the opening"
+        int countdown_lead_hours "nullable, read only when countdown_mode = 1"
+    }
+    sale_customer {
+        int sale_id FK "ON DELETE CASCADE"
+        int customer_id FK "ON DELETE CASCADE"
+    }
+```
+
+Both foreign keys cascade: deleting the last targeted customer (a GDPR purge,
+for instance) silently empties the audience. The back office list therefore
+shows the recipient count on every reserved sale and turns it into an alert at
+zero. The `(active, audience_mode)` index carries the "is any reserved sale
+running" short-circuit that keeps shops without reserved sales on their
+historical query plans.
+
+`audience_mode = 2` (customer groups) is modeled but not implemented: customer
+groups do not exist in the core yet.
+
+## Where the reserved price lives
+
+A public sale writes its discount into the catalog
+(`product_sale_elements.promo`, `product_price.promo_price`) when it activates.
+A reserved sale never does: those two columns are what every visitor sees. Its
+price is resolved at read time, for entitled customers only, and is only
+persisted once the customer acts on it.
+
+```mermaid
+flowchart LR
+    V[Visitor request\npage, listing, API] --> R{Reserved\nsale?}
+    R -- no --> P[Public path, unchanged:\ndiscount written to the catalog]
+    R -- yes --> E{Named on it?\nSaleAudienceChecker}
+    E -- no --> H[Invisible:\npage 404, products hidden\nwhen hide_products, public price]
+    E -- yes --> RP[Price resolved at read time\nReservedSalePriceResolver\nbest price wins]
+    RP -- add to cart --> C[cart_item.promo_price\nthen order_product: frozen]
+```
+
+The moving parts, all under `Thelia\Domain\Sale`:
+
+- `SaleDiscountCalculator` — the taxed-offset formula (taxed price, minus the
+  offset, back to untaxed), extracted so the written path (`Action\Sale`) and
+  the resolved path share one implementation to the cent.
+- `SaleAudienceChecker` — is this customer named on that sale; is any reserved
+  sale running. Memoized per request (`ResetInterface`).
+- `ReservedSalePriceResolver` / `ReservedSalePriceCatalog` — batch resolution;
+  the catalog memoizes the visitor's whole entitled set once per request so a
+  listing costs no query per card.
+- `ReservedSaleVisibility` — the single owner of the hiding rule, applied by the
+  product loops, the front API extensions, the product view check and the theme
+  sitemap. A product covered by two hidden sales stays visible to a customer
+  named on either one.
+- `CurrentCustomerProvider` — the visitor, read from the session first (the
+  theme calls the API in process, where the token storage is empty), then from
+  the JWT token storage (direct `/api/front` calls). Guest accounts are never
+  entitled: a guest row is reusable by e-mail.
+
+Entitlement is re-evaluated on every request, and the cart re-resolves on
+login, on change and on restore: a customer who loses the right falls back to
+the public price at the next cart refresh. An order keeps the price it was
+placed at (`order_product.promo_price`, `was_in_promo`) — that is the proof of
+the granted price.
+
+The shared data-access cache would leak a per-customer price, so the
+`/api/front/products` and `/api/front/product_sale_elements` prefixes bypass it
+while a reserved sale is running — and only then. `/api/front/sales` is never in
+the shared cache.
+
+## Countdown
+
+```mermaid
+flowchart LR
+    A[programmed\nnothing shows] -- start_date --> B[open]
+    B -- "mode 2: from the opening" --> C[countdown showing]
+    B -- "mode 1: end_date − N hours" --> C
+    C -- end_date --> D[zero: one reload,\npublic price back]
+```
+
+The decision is made on the server (`Sale::shouldDisplayCountdown()`): never
+without an end date, never before the start date. What reaches the browser is a
+remaining duration in seconds, not a date, so a wrong local clock cannot show a
+negative countdown. The theme counts down on a monotonic clock
+(`performance.now()`), one shared interval per page, resyncs when a throttled
+background tab becomes visible again, and reloads once at zero. Closing the
+sale (price back to normal) remains the job of the `sale:check-activation`
+cron, as for every public sale.
+
+## Surfaces
+
+| Surface | What changed |
+| --- | --- |
+| `/api/front/sales` | New read-only resource: settings, remaining seconds, `productIds` (batch-preloaded), rewritten URL. The customer list never leaves the back office. Reserved sales are absent for anyone not named, 404 on item access. |
+| `/api/front/products`, PSE | Hidden products filtered out (collection and item); reserved price served to entitled customers. |
+| Product/PSE loops, `sale` loop | Same filters; the `sale` loop also exposes `URL` and the countdown outputs. Price *sorting* still uses the raw columns. |
+| Rewritten URL | `sale` is a rewriting view; the URL is generated when the sale is created. |
+| Product view | The view check answers 404 for a hidden product, like an invisible one. |
+| Theme sitemap | Hidden products excluded. |
+| Back office | Targeting block (public / named customers), shared customer picker (gated by the CUSTOMER right), countdown settings (refused without an end date), reserved badge with the recipient count. |
+
+## Test map
+
+- `tests/Unit/Domain/Sale/SaleDiscountCalculatorTest`, `tests/Unit/Model/SaleTest`
+- `tests/Integration/Domain/Sale/` (audience, resolver, visibility)
+- `tests/Integration/Action/ReservedSale*`, `ReservedProductViewCheckTest`
+- `tests/Api/Front/{SaleApiTest, ReservedSaleVisibilityApiTest, ReservedSalePriceApiTest}`
+- `tests/Http/Flexy/SaleShowcaseTest`, `tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest`
+- `tests/Playwright/specs/backoffice/sale-edit-twig.spec.ts`

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -1775,6 +1775,10 @@
     <column defaultValue="NULL" name="start_date" type="TIMESTAMP" />
     <column defaultValue="NULL" name="end_date" type="TIMESTAMP" />
     <column defaultValue="NULL" name="price_offset_type" type="TINYINT" />
+    <column defaultValue="0" description="who the operation is open to: 0 everyone, 1 the customers named on it, 2 the customer groups named on it" name="audience_mode" required="true" type="TINYINT" />
+    <column defaultValue="0" description="the products of a reserved operation are hidden from the visitors it is not open to, instead of being shown at their usual price" name="hide_products" required="true" type="BOOLEAN" />
+    <column defaultValue="0" description="when the countdown is shown: 0 never, 1 from countdown_lead_hours before the end, 2 from the opening" name="countdown_mode" required="true" type="TINYINT" />
+    <column defaultValue="NULL" description="how many hours before the end date the countdown starts showing, read only when countdown_mode is 1" name="countdown_lead_hours" type="INTEGER" />
     <index name="idx_sales_active_start_end_date">
       <index-column name="active" />
       <index-column name="start_date" />
@@ -1782,6 +1786,10 @@
     </index>
     <index name="idx_sales_active">
       <index-column name="active" />
+    </index>
+    <index name="idx_sales_active_audience_mode">
+      <index-column name="active" />
+      <index-column name="audience_mode" />
     </index>
     <behavior name="i18n">
       <parameter name="i18n_columns" value="title, description, chapo, postscriptum,sale_label" />
@@ -1826,6 +1834,24 @@
       <index-column name="sale_id" />
       <index-column name="product_id" />
     </index>
+  </table>
+  <table name="sale_customer" namespace="Thelia\Model">
+    <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />
+    <column name="sale_id" required="true" type="INTEGER" />
+    <column description="a customer the operation is reserved for, read when audience_mode is 1" name="customer_id" required="true" type="INTEGER" />
+    <foreign-key foreignTable="sale" name="fk_sale_customer_sales_id" onDelete="CASCADE" onUpdate="RESTRICT">
+      <reference foreign="id" local="sale_id" />
+    </foreign-key>
+    <foreign-key foreignTable="customer" name="fk_sale_customer_customer_id" onDelete="CASCADE" onUpdate="RESTRICT">
+      <reference foreign="id" local="customer_id" />
+    </foreign-key>
+    <index name="fk_sale_customer_customer_idx">
+      <index-column name="customer_id" />
+    </index>
+    <unique name="idx_sale_customer_sales_id_customer_id">
+      <unique-column name="sale_id" />
+      <unique-column name="customer_id" />
+    </unique>
   </table>
   <table name="export_category" namespace="Thelia\Model">
     <column autoIncrement="true" name="id" primaryKey="true" required="true" type="INTEGER" />

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,6 +25,30 @@ parameters:
 			path: core/lib/Thelia/Api/Bridge/Propel/Service/ApiResourcePropelTransformerService.php
 
 		-
+			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Sale\:\:getLocale\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: core/lib/Thelia/Api/Resource/Sale.php
+
+		-
+			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Sale\:\:getTitle\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: core/lib/Thelia/Api/Resource/Sale.php
+
+		-
+			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Sale\:\:isNew\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: core/lib/Thelia/Api/Resource/Sale.php
+
+		-
+			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Sale\:\:setLocale\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: core/lib/Thelia/Api/Resource/Sale.php
+
+		-
 			message: '#^Call to an undefined method Thelia\\Api\\Resource\\Brand\:\:getLocale\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -2157,11 +2157,16 @@ CREATE TABLE `sale`
     `start_date` DATETIME,
     `end_date` DATETIME,
     `price_offset_type` TINYINT,
+    `audience_mode` TINYINT DEFAULT 0 NOT NULL COMMENT 'who the operation is open to: 0 everyone, 1 the customers named on it, 2 the customer groups named on it',
+    `hide_products` TINYINT(1) DEFAULT 0 NOT NULL COMMENT 'the products of a reserved operation are hidden from the visitors it is not open to, instead of being shown at their usual price',
+    `countdown_mode` TINYINT DEFAULT 0 NOT NULL COMMENT 'when the countdown is shown: 0 never, 1 from countdown_lead_hours before the end, 2 from the opening',
+    `countdown_lead_hours` INTEGER COMMENT 'how many hours before the end date the countdown starts showing, read only when countdown_mode is 1',
     `created_at` DATETIME,
     `updated_at` DATETIME,
     PRIMARY KEY (`id`),
     INDEX `idx_sales_active_start_end_date` (`active`, `start_date`, `end_date`),
-    INDEX `idx_sales_active` (`active`)
+    INDEX `idx_sales_active` (`active`),
+    INDEX `idx_sales_active_audience_mode` (`active`, `audience_mode`)
 ) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
 
 -- ---------------------------------------------------------------------
@@ -2217,6 +2222,32 @@ CREATE TABLE `sale_product`
     CONSTRAINT `fk_sale_product_attribute_av_id`
         FOREIGN KEY (`attribute_av_id`)
         REFERENCES `attribute_av` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
+-- ---------------------------------------------------------------------
+-- sale_customer
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `sale_customer`;
+
+CREATE TABLE `sale_customer`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `sale_id` INTEGER NOT NULL,
+    `customer_id` INTEGER NOT NULL COMMENT 'a customer the operation is reserved for, read when audience_mode is 1',
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `idx_sale_customer_sales_id_customer_id` (`sale_id`, `customer_id`),
+    INDEX `fk_sale_customer_customer_idx` (`customer_id`),
+    CONSTRAINT `fk_sale_customer_sales_id`
+        FOREIGN KEY (`sale_id`)
+        REFERENCES `sale` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE,
+    CONSTRAINT `fk_sale_customer_customer_id`
+        FOREIGN KEY (`customer_id`)
+        REFERENCES `customer` (`id`)
         ON UPDATE RESTRICT
         ON DELETE CASCADE
 ) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;

--- a/setup/update/sql/3.0.1.sql
+++ b/setup/update/sql/3.0.1.sql
@@ -197,4 +197,80 @@ INSERT IGNORE INTO `resource_i18n` (`id`, `locale`, `title`, `chapo`, `descripti
     SELECT `resource`.`id`, 'fr_FR', 'Configuration des consentements du tunnel de commande', NULL, NULL, NULL
     FROM `resource` WHERE `resource`.`code` = 'admin.configuration.consent';
 
+-- ---------------------------------------------------------------------
+-- Reserved sales and their countdown
+--
+-- A sale used to be for everyone: whoever saw the product got the discount.
+-- `audience_mode` is what opens an operation to a part of the customers only —
+-- 0 everyone, as every operation already on file, 1 the customers named on it
+-- in `sale_customer`, 2 the customer groups it is opened to (the groups
+-- themselves come later, the value is reserved here so the meaning of the
+-- column never shifts). `hide_products` decides what a visitor the operation
+-- is not open to sees: nothing at all, or the products at their usual price.
+--
+-- `countdown_mode` drives the urgency shown to the buyer: 0 no countdown,
+-- 1 from `countdown_lead_hours` before the end date, 2 from the opening. The
+-- lead is nullable because it is only read in mode 1.
+--
+-- `sale` is not versionable, so nothing is mirrored in a _version table.
+--
+-- Existing rows take the defaults: every operation already on file stays
+-- public, keeps showing its products and shows no countdown.
+-- ---------------------------------------------------------------------
+
+SET @add_column := (SELECT COUNT(*) = 0 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'sale' AND `COLUMN_NAME` = 'audience_mode');
+SET @statement := IF(@add_column, 'ALTER TABLE `sale` ADD `audience_mode` TINYINT DEFAULT 0 NOT NULL COMMENT \'who the operation is open to: 0 everyone, 1 the customers named on it, 2 the customer groups named on it\' AFTER `price_offset_type`', 'DO 0');
+PREPARE add_column_statement FROM @statement;
+EXECUTE add_column_statement;
+DEALLOCATE PREPARE add_column_statement;
+
+SET @add_column := (SELECT COUNT(*) = 0 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'sale' AND `COLUMN_NAME` = 'hide_products');
+SET @statement := IF(@add_column, 'ALTER TABLE `sale` ADD `hide_products` TINYINT(1) DEFAULT 0 NOT NULL COMMENT \'the products of a reserved operation are hidden from the visitors it is not open to, instead of being shown at their usual price\' AFTER `audience_mode`', 'DO 0');
+PREPARE add_column_statement FROM @statement;
+EXECUTE add_column_statement;
+DEALLOCATE PREPARE add_column_statement;
+
+SET @add_column := (SELECT COUNT(*) = 0 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'sale' AND `COLUMN_NAME` = 'countdown_mode');
+SET @statement := IF(@add_column, 'ALTER TABLE `sale` ADD `countdown_mode` TINYINT DEFAULT 0 NOT NULL COMMENT \'when the countdown is shown: 0 never, 1 from countdown_lead_hours before the end, 2 from the opening\' AFTER `hide_products`', 'DO 0');
+PREPARE add_column_statement FROM @statement;
+EXECUTE add_column_statement;
+DEALLOCATE PREPARE add_column_statement;
+
+SET @add_column := (SELECT COUNT(*) = 0 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'sale' AND `COLUMN_NAME` = 'countdown_lead_hours');
+SET @statement := IF(@add_column, 'ALTER TABLE `sale` ADD `countdown_lead_hours` INTEGER NULL COMMENT \'how many hours before the end date the countdown starts showing, read only when countdown_mode is 1\' AFTER `countdown_mode`', 'DO 0');
+PREPARE add_column_statement FROM @statement;
+EXECUTE add_column_statement;
+DEALLOCATE PREPARE add_column_statement;
+
+-- The front office asks on every product page whether an active operation is
+-- reserved, so the answer has to come from an index rather than a table scan.
+SET @add_index := (SELECT COUNT(*) = 0 FROM `information_schema`.`STATISTICS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'sale' AND `INDEX_NAME` = 'idx_sales_active_audience_mode');
+SET @statement := IF(@add_index, 'ALTER TABLE `sale` ADD INDEX `idx_sales_active_audience_mode` (`active`, `audience_mode`)', 'DO 0');
+PREPARE add_index_statement FROM @statement;
+EXECUTE add_index_statement;
+DEALLOCATE PREPARE add_index_statement;
+
+-- The customers an operation is reserved for, when `audience_mode` is 1. Both
+-- sides cascade: the list has no meaning without its operation, and a customer
+-- who is deleted or purged leaves no trace on the operations they were named on.
+CREATE TABLE IF NOT EXISTS `sale_customer`
+(
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `sale_id` INTEGER NOT NULL,
+    `customer_id` INTEGER NOT NULL COMMENT 'a customer the operation is reserved for, read when audience_mode is 1',
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `idx_sale_customer_sales_id_customer_id` (`sale_id`, `customer_id`),
+    INDEX `fk_sale_customer_customer_idx` (`customer_id`),
+    CONSTRAINT `fk_sale_customer_sales_id`
+        FOREIGN KEY (`sale_id`)
+        REFERENCES `sale` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE,
+    CONSTRAINT `fk_sale_customer_customer_id`
+        FOREIGN KEY (`customer_id`)
+        REFERENCES `customer` (`id`)
+        ON UPDATE RESTRICT
+        ON DELETE CASCADE
+) ENGINE=InnoDB CHARACTER SET='utf8mb4' COLLATE='utf8mb4_general_ci' ROW_FORMAT=DYNAMIC;
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/Api/Front/ReservedSalePriceApiTest.php
+++ b/tests/Api/Front/ReservedSalePriceApiTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A reserved operation writes nothing in the catalog, so the price it gives a
+ * named customer only exists as the answer to "what does this customer pay".
+ *
+ * The front read has to give that answer to the customer it belongs to, and the
+ * catalog price to everybody else.
+ */
+final class ReservedSalePriceApiTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = $this->createFixtureFactory();
+        $this->currency = $factory->currency();
+        $this->category = $factory->category();
+        $this->taxRule = $factory->taxRule();
+    }
+
+    public function testTheNamedCustomerIsChargedTheReservedPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer('password');
+        $this->reservedSaleOn([$product], $customer, offset: 10.0);
+
+        $payload = $this->readJson(
+            '/api/front/products/'.$product->getId(),
+            $this->authenticateAsCustomer($customer),
+        );
+
+        $saleElement = $payload['productSaleElements'][0];
+
+        self::assertTrue($saleElement['promo'], 'The reserved price is a promo for the customer it is resolved for.');
+        self::assertSame(90.0, (float) $saleElement['productPrices'][0]['promoPrice']);
+        self::assertSame(100.0, (float) $saleElement['productPrices'][0]['price'], 'The catalog price is untouched.');
+    }
+
+    public function testACustomerTheOperationDoesNotNameIsChargedTheCatalogPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn([$product], $this->newCustomer(), offset: 10.0);
+
+        $payload = $this->readJson(
+            '/api/front/products/'.$product->getId(),
+            $this->authenticateAsCustomer($this->newCustomer('password')),
+        );
+
+        $saleElement = $payload['productSaleElements'][0];
+
+        self::assertFalse($saleElement['promo']);
+        self::assertSame(100.0, (float) $saleElement['productPrices'][0]['promoPrice']);
+    }
+
+    public function testAVisitorIsChargedTheCatalogPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn([$product], $this->newCustomer(), offset: 10.0);
+
+        $payload = $this->readJson('/api/front/products/'.$product->getId());
+
+        self::assertFalse($payload['productSaleElements'][0]['promo']);
+        self::assertSame(100.0, (float) $payload['productSaleElements'][0]['productPrices'][0]['promoPrice']);
+    }
+
+    public function testTheSaleElementReadCarriesTheReservedPriceToo(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer('password');
+        $this->reservedSaleOn([$product], $customer, offset: 10.0);
+        $token = $this->authenticateAsCustomer($customer);
+        $saleElementId = $product->getDefaultSaleElements()->getId();
+
+        $collection = $this->readJson(
+            '/api/front/product_sale_elements?product.id='.$product->getId(),
+            $token,
+        );
+
+        self::assertTrue(
+            $collection['hydra:member'][0]['promo'],
+            'The collection flags the sale element as discounted for the customer it is reserved for.',
+        );
+
+        // The price rows themselves only travel with the single read: the collection
+        // serializes them as IRIs.
+        $item = $this->readJson('/api/front/product_sale_elements/'.$saleElementId, $token);
+
+        self::assertTrue($item['promo']);
+        self::assertSame(90.0, (float) $item['productPrices'][0]['promoPrice']);
+    }
+
+    /**
+     * The reserved price only ever applies when it beats the price the sale element
+     * is on sale for already: the shop never charges a named customer more than a
+     * passing visitor.
+     */
+    public function testAReservedPriceDearerThanThePublicOfferIsNotApplied(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer('password');
+        $this->reservedSaleOn([$product], $customer, offset: 5.0);
+        $this->publicOfferOn($product, promoPrice: 50.0);
+
+        $payload = $this->readJson(
+            '/api/front/products/'.$product->getId(),
+            $this->authenticateAsCustomer($customer),
+        );
+
+        self::assertSame(50.0, (float) $payload['productSaleElements'][0]['productPrices'][0]['promoPrice']);
+    }
+
+    /**
+     * The whole page has to be priced in one go. A resolution hanging off each sale
+     * element costs one statement per row, and the bill grows with the catalog.
+     */
+    public function testAPageOfProductsIsPricedWithoutOneStatementPerSaleElement(): void
+    {
+        $customer = $this->newCustomer('password');
+        $products = [
+            $this->catalogProduct(),
+            $this->catalogProduct(),
+            $this->catalogProduct(),
+            $this->catalogProduct(),
+            $this->catalogProduct(),
+        ];
+        $this->reservedSaleOn($products, $customer, offset: 10.0);
+        $token = $this->authenticateAsCustomer($customer);
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload, $token): void {
+            $payload = $this->readJson('/api/front/products', $token);
+        });
+
+        $priced = 0;
+
+        foreach ($payload['hydra:member'] as $member) {
+            foreach ($member['productSaleElements'] ?? [] as $saleElement) {
+                if (true === ($saleElement['promo'] ?? null)) {
+                    ++$priced;
+                }
+            }
+        }
+
+        self::assertSame(5, $priced, 'Every sale element of the operation has to come out priced.');
+
+        $resolutions = \count(array_filter(
+            $statements,
+            static fn (string $statement): bool => str_contains($statement, 'sale_offset_currency'),
+        ));
+
+        self::assertSame(
+            1,
+            $resolutions,
+            'The reserved prices of a whole page are resolved by a single statement.',
+        );
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->createFixtureFactory()->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0, 'title' => 'Reserved price product'],
+        );
+    }
+
+    /**
+     * @param list<Product> $products
+     */
+    private function reservedSaleOn(array $products, Customer $customer, float $offset): Sale
+    {
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'priceOffsetType' => Sale::OFFSET_TYPE_PERCENTAGE,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+
+        foreach ($products as $product) {
+            $factory->saleProduct($sale, $product);
+        }
+
+        $factory->saleCustomer($sale, $customer);
+        $factory->saleOffsetCurrency($sale, $this->currency, $offset);
+
+        return $sale;
+    }
+
+    /**
+     * A public special offer, written in the catalog the way Action\Sale writes one.
+     */
+    private function publicOfferOn(Product $product, float $promoPrice): void
+    {
+        foreach ($product->getProductSaleElementss() as $saleElement) {
+            $saleElement->setPromo(1)->save();
+
+            // product_price.promo_price is a DECIMAL, which Propel types as a string.
+            foreach ($saleElement->getProductPrices() as $price) {
+                $price->setPromoPrice(number_format($promoPrice, 6, '.', ''))->save();
+            }
+        }
+    }
+
+    private function newCustomer(?string $password = null): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer(
+            $factory->customerTitle(),
+            null === $password ? [] : ['password' => $password],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri, ?string $token = null): array
+    {
+        $response = $this->jsonRequest('GET', $uri, token: $token);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Api/Front/ReservedSaleVisibilityApiTest.php
+++ b/tests/Api/Front/ReservedSaleVisibilityApiTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * A reserved operation set to hide its products keeps them out of the catalog
+ * of everybody it is not open to.
+ *
+ * The rule has to hold on the collection and on the direct item read alike: a
+ * product left reachable by its id is not hidden, it is only harder to find.
+ */
+final class ReservedSaleVisibilityApiTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = $this->createFixtureFactory();
+        $this->currency = $factory->currency();
+        $this->category = $factory->category();
+        $this->taxRule = $factory->taxRule();
+    }
+
+    public function testAVisitorDoesNotSeeTheProductsOfAHiddenReservedOperation(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        $payload = $this->readJson('/api/front/products');
+
+        self::assertNull(
+            $this->memberOrNull($payload, $product->getId()),
+            'A hidden reserved operation keeps its products out of the anonymous collection.',
+        );
+    }
+
+    public function testAVisitorCannotReachThemByTheirIdEither(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        $response = $this->jsonRequest('GET', '/api/front/products/'.$product->getId());
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testTheSaleElementsOfAHiddenProductAreOutOfReachToo(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $pse = $this->defaultPseFor($product);
+
+        $collection = $this->readJson('/api/front/product_sale_elements');
+        $ids = array_column($collection['hydra:member'] ?? [], 'id');
+
+        self::assertNotContains($pse->getId(), $ids);
+        self::assertSame(
+            404,
+            $this->jsonRequest('GET', '/api/front/product_sale_elements/'.$pse->getId())->getStatusCode(),
+        );
+    }
+
+    public function testACustomerTheOperationDoesNotNameDoesNotSeeThemEither(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $token = $this->authenticateAsCustomer($this->newCustomer('password'));
+
+        $payload = $this->readJson('/api/front/products', $token);
+
+        self::assertNull($this->memberOrNull($payload, $product->getId()));
+        self::assertSame(
+            404,
+            $this->jsonRequest('GET', '/api/front/products/'.$product->getId(), token: $token)->getStatusCode(),
+        );
+    }
+
+    public function testTheCustomerTheOperationNamesSeesThem(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer('password');
+        $this->hiddenReservedSaleOn($product, $customer);
+        $token = $this->authenticateAsCustomer($customer);
+
+        $payload = $this->readJson('/api/front/products', $token);
+
+        self::assertNotNull(
+            $this->memberOrNull($payload, $product->getId()),
+            'The operation is open to this customer, so its products are part of their catalog.',
+        );
+        self::assertSame(
+            200,
+            $this->jsonRequest('GET', '/api/front/products/'.$product->getId(), token: $token)->getStatusCode(),
+        );
+    }
+
+    /**
+     * Two hidden operations covering the same product, and a customer named on one
+     * of them. Being left out of one private drop is not what hides a product: the
+     * operation they are part of is the one that decides.
+     */
+    public function testACustomerNamedOnOneOfTwoOverlappingHiddenOperationsStillSeesTheProduct(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer('password');
+        $this->hiddenReservedSaleOn($product, $customer);
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $token = $this->authenticateAsCustomer($customer);
+
+        $payload = $this->readJson('/api/front/products', $token);
+
+        self::assertNotNull(
+            $this->memberOrNull($payload, $product->getId()),
+            'The operation the customer is named on shows the product, whatever the other one says.',
+        );
+        self::assertSame(
+            200,
+            $this->jsonRequest('GET', '/api/front/products/'.$product->getId(), token: $token)->getStatusCode(),
+        );
+
+        // The rule is narrowed on the sale elements by the same clause, against the
+        // other column: the price has to be reachable too, or the product is a page
+        // with nothing to buy on it.
+        self::assertSame(
+            200,
+            $this->jsonRequest(
+                'GET',
+                '/api/front/product_sale_elements/'.$this->defaultPseFor($product)->getId(),
+                token: $token,
+            )->getStatusCode(),
+        );
+
+        // The same product, read by somebody named on neither of the two.
+        $anonymous = $this->readJson('/api/front/products');
+
+        self::assertNull($this->memberOrNull($anonymous, $product->getId()));
+        self::assertSame(
+            404,
+            $this->jsonRequest('GET', '/api/front/products/'.$product->getId())->getStatusCode(),
+        );
+    }
+
+    /**
+     * The setting only ever hides the products of an operation that is reserved:
+     * a public operation discounts for everybody, so there is nobody to hide from.
+     */
+    public function testAPublicOperationHidesNothingEvenWhenTheFlagIsOn(): void
+    {
+        $product = $this->catalogProduct();
+        $sale = $this->runningSale([
+            'audienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+            'hideProducts' => true,
+        ]);
+        $this->createFixtureFactory()->saleProduct($sale, $product);
+
+        $payload = $this->readJson('/api/front/products');
+
+        self::assertNotNull($this->memberOrNull($payload, $product->getId()));
+    }
+
+    public function testAReservedOperationThatDoesNotHideItsProductsShowsThemToEverybody(): void
+    {
+        $product = $this->catalogProduct();
+        $factory = $this->createFixtureFactory();
+        $sale = $this->runningSale([
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => false,
+        ]);
+        $factory->saleProduct($sale, $product);
+        $factory->saleCustomer($sale, $this->newCustomer());
+
+        $payload = $this->readJson('/api/front/products');
+
+        self::assertNotNull($this->memberOrNull($payload, $product->getId()));
+    }
+
+    /**
+     * An operation whose window has closed hides nothing, whatever its active flag
+     * still says: the flag is only as fresh as the last run of the scheduled command.
+     */
+    public function testAnOperationWhoseWindowHasClosedHidesNothing(): void
+    {
+        $product = $this->catalogProduct();
+        $sale = $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $sale->setEndDate(new \DateTime('-1 minute'))->save();
+
+        $payload = $this->readJson('/api/front/products');
+
+        self::assertNotNull($this->memberOrNull($payload, $product->getId()));
+    }
+
+    /**
+     * A shop with no reserved operation at all must pay nothing for the feature:
+     * no join, no subquery added to any catalog query, and nothing per product.
+     */
+    public function testAShopWithoutAnyReservedOperationGetsNoExtraSubquery(): void
+    {
+        $product = $this->catalogProduct();
+        $sale = $this->runningSale(['audienceMode' => Sale::AUDIENCE_MODE_PUBLIC]);
+        $this->createFixtureFactory()->saleProduct($sale, $product);
+        $this->catalogProduct();
+        $this->catalogProduct();
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/products');
+        });
+
+        self::assertNotNull($this->memberOrNull($payload, $product->getId()));
+
+        self::assertSame(
+            0,
+            \count(array_filter(
+                $statements,
+                static fn (string $statement): bool => str_contains($statement, 'NOT EXISTS'),
+            )),
+            'No reserved operation runs, so no catalog query is narrowed.',
+        );
+
+        self::assertSame(
+            0,
+            \count(array_filter(
+                $statements,
+                static fn (string $statement): bool => str_contains($statement, 'sale_customer'),
+            )),
+            'Nobody is entitled to anything, so the audience is never read.',
+        );
+
+        // The whole bill of the feature on such a shop: the indexed existence check
+        // that says there is no reserved operation, asked once for the request.
+        self::assertSame(
+            1,
+            \count(array_filter(
+                $statements,
+                static fn (string $statement): bool => str_contains($statement, 'FROM `sale`'),
+            )),
+        );
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->createFixtureFactory()->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0, 'title' => 'Reserved catalog product'],
+        );
+    }
+
+    private function hiddenReservedSaleOn(Product $product, Customer $customer): Sale
+    {
+        $factory = $this->createFixtureFactory();
+        $sale = $this->runningSale([
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+        ]);
+        $factory->saleProduct($sale, $product);
+        $factory->saleCustomer($sale, $customer);
+        $factory->saleOffsetCurrency($sale, $this->currency, 10.0);
+
+        return $sale;
+    }
+
+    private function runningSale(array $overrides): Sale
+    {
+        return $this->createFixtureFactory()->sale($overrides + [
+            'active' => true,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+    }
+
+    private function newCustomer(?string $password = null): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer(
+            $factory->customerTitle(),
+            null === $password ? [] : ['password' => $password],
+        );
+    }
+
+    private function defaultPseFor(Product $product): ProductSaleElements
+    {
+        return ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri, ?string $token = null): array
+    {
+        $response = $this->jsonRequest('GET', $uri, token: $token);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>|null
+     */
+    private function memberOrNull(array $payload, ?int $productId): ?array
+    {
+        foreach ($payload['hydra:member'] ?? [] as $member) {
+            if (($member['id'] ?? null) === $productId) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Api/Front/SaleApiTest.php
+++ b/tests/Api/Front/SaleApiTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Api\Front;
+
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\ApiTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The front read of a sale operation: what a theme needs to build the page of an
+ * operation and its countdown, and nothing else.
+ *
+ * "Nothing else" is the load-bearing half: the customers a reserved operation is
+ * open to are the operation's private guest list, and no front group may carry
+ * them.
+ */
+final class SaleApiTest extends ApiTestCase
+{
+    use RecordsSqlQueries;
+
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = $this->createFixtureFactory();
+        $this->currency = $factory->currency();
+        $this->category = $factory->category();
+        $this->taxRule = $factory->taxRule();
+    }
+
+    public function testAPublicOperationIsReadableByAnybody(): void
+    {
+        $product = $this->catalogProduct();
+        $sale = $this->runningSale(['audienceMode' => Sale::AUDIENCE_MODE_PUBLIC]);
+        $this->createFixtureFactory()->saleProduct($sale, $product);
+
+        $member = $this->memberOrNull($this->readJson('/api/front/sales'), $sale->getId());
+
+        self::assertNotNull($member);
+        self::assertTrue($member['active']);
+        self::assertSame(Sale::AUDIENCE_MODE_PUBLIC, $member['audienceMode']);
+        self::assertFalse($member['hideProducts']);
+        self::assertSame(Sale::OFFSET_TYPE_PERCENTAGE, $member['priceOffsetType']);
+        self::assertTrue($member['displayInitialPrice']);
+        self::assertSame([$product->getId()], $member['productIds']);
+        self::assertSame('Winter operation', $member['i18ns']['en_US']['title'] ?? null);
+        self::assertStringStartsWith('SALE-', (string) ($member['i18ns']['en_US']['saleLabel'] ?? ''));
+        self::assertStringEndsWith('winter-operation.html', $member['publicUrl']);
+    }
+
+    public function testAnInactiveOperationIsNotPartOfTheFrontCollection(): void
+    {
+        $sale = $this->createFixtureFactory()->sale(['active' => false, 'title' => 'Draft operation']);
+
+        self::assertNull($this->memberOrNull($this->readJson('/api/front/sales'), $sale->getId()));
+        self::assertSame(404, $this->jsonRequest('GET', '/api/front/sales/'.$sale->getId())->getStatusCode());
+    }
+
+    public function testAReservedOperationIsInvisibleToAVisitor(): void
+    {
+        $sale = $this->reservedSaleFor($this->newCustomer());
+
+        self::assertNull($this->memberOrNull($this->readJson('/api/front/sales'), $sale->getId()));
+        self::assertSame(404, $this->jsonRequest('GET', '/api/front/sales/'.$sale->getId())->getStatusCode());
+    }
+
+    public function testAReservedOperationIsInvisibleToACustomerItDoesNotName(): void
+    {
+        $sale = $this->reservedSaleFor($this->newCustomer());
+        $token = $this->authenticateAsCustomer($this->newCustomer('password'));
+
+        self::assertNull($this->memberOrNull($this->readJson('/api/front/sales', $token), $sale->getId()));
+        self::assertSame(
+            404,
+            $this->jsonRequest('GET', '/api/front/sales/'.$sale->getId(), token: $token)->getStatusCode(),
+        );
+    }
+
+    public function testAReservedOperationIsReadableByTheCustomerItNames(): void
+    {
+        $customer = $this->newCustomer('password');
+        $sale = $this->reservedSaleFor($customer);
+        $token = $this->authenticateAsCustomer($customer);
+
+        $member = $this->memberOrNull($this->readJson('/api/front/sales', $token), $sale->getId());
+
+        self::assertNotNull($member);
+        self::assertSame(Sale::AUDIENCE_MODE_CUSTOMERS, $member['audienceMode']);
+        self::assertSame(
+            200,
+            $this->jsonRequest('GET', '/api/front/sales/'.$sale->getId(), token: $token)->getStatusCode(),
+        );
+    }
+
+    public function testTheCountdownFieldsTravelWithTheOperation(): void
+    {
+        $sale = $this->runningSale([
+            'countdownMode' => Sale::COUNTDOWN_MODE_FROM_OPENING,
+            'endDate' => new \DateTime('+2 hours'),
+        ]);
+
+        $member = $this->memberOrNull($this->readJson('/api/front/sales'), $sale->getId());
+
+        self::assertTrue($member['shouldDisplayCountdown']);
+        self::assertGreaterThan(7100, $member['countdownRemainingSeconds']);
+        self::assertLessThanOrEqual(7200, $member['countdownRemainingSeconds']);
+        self::assertSame(Sale::COUNTDOWN_MODE_FROM_OPENING, $member['countdownMode']);
+        // A null field is left out of the payload altogether, the way the whole API
+        // serializes one: a consumer reads a missing countdownLeadHours as "none".
+        self::assertNull($member['countdownLeadHours'] ?? null);
+    }
+
+    public function testAnOperationWithNoCountdownAnswersNoRemainingSeconds(): void
+    {
+        $sale = $this->runningSale(['countdownMode' => Sale::COUNTDOWN_MODE_NONE]);
+
+        $member = $this->memberOrNull($this->readJson('/api/front/sales'), $sale->getId());
+
+        self::assertFalse($member['shouldDisplayCountdown']);
+        self::assertNull($member['countdownRemainingSeconds'] ?? null);
+    }
+
+    public function testTheCountdownOnlyStartsWithinItsLeadTime(): void
+    {
+        $tooEarly = $this->runningSale([
+            'countdownMode' => Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdownLeadHours' => 2,
+            'endDate' => new \DateTime('+5 hours'),
+            'title' => 'Too early',
+        ]);
+        $withinReach = $this->runningSale([
+            'countdownMode' => Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdownLeadHours' => 6,
+            'endDate' => new \DateTime('+5 hours'),
+            'title' => 'Within reach',
+        ]);
+
+        $payload = $this->readJson('/api/front/sales');
+
+        self::assertFalse($this->memberOrNull($payload, $tooEarly->getId())['shouldDisplayCountdown']);
+        self::assertNull($this->memberOrNull($payload, $tooEarly->getId())['countdownRemainingSeconds'] ?? null);
+        self::assertTrue($this->memberOrNull($payload, $withinReach->getId())['shouldDisplayCountdown']);
+        self::assertSame(6, $this->memberOrNull($payload, $withinReach->getId())['countdownLeadHours']);
+    }
+
+    /**
+     * The guest list of a reserved operation never leaves the back office. This
+     * asserts on the shape of the payload rather than on a field name, so a field
+     * added later cannot quietly bring it back.
+     */
+    public function testNoFrontFieldRevealsTheCustomersAnOperationIsReservedFor(): void
+    {
+        $customer = $this->newCustomer('password');
+        $sale = $this->reservedSaleFor($customer);
+        $token = $this->authenticateAsCustomer($customer);
+
+        $item = $this->readJson('/api/front/sales/'.$sale->getId(), $token);
+        $keys = $this->keysOf($item);
+        $payload = json_encode($item, \JSON_THROW_ON_ERROR);
+
+        foreach ($keys as $key) {
+            self::assertStringNotContainsStringIgnoringCase(
+                'customer',
+                $key,
+                'No front field of an operation may name who it is reserved for.',
+            );
+            self::assertStringNotContainsStringIgnoringCase(
+                'sale_customer',
+                $key,
+                'The join table holding the guest list has no business in a front payload.',
+            );
+        }
+
+        // The whole payload, not only its keys: a value carrying the name of the join
+        // table — an IRI, an embedded relation, a serialized column — leaks the same
+        // thing a field named after it would.
+        self::assertStringNotContainsString('sale_customer', $payload);
+        self::assertStringNotContainsStringIgnoringCase('saleCustomer', $payload);
+
+        self::assertStringNotContainsString((string) $customer->getEmail(), $payload);
+        self::assertStringNotContainsString('"'.$customer->getId().'"', $payload);
+    }
+
+    /**
+     * The whole point of the resource: a theme reads one operation and gets the
+     * product ids it has to lay out, without asking the catalog first.
+     */
+    public function testTheOperationHandsOutTheProductsItCovers(): void
+    {
+        $first = $this->catalogProduct();
+        $second = $this->catalogProduct();
+        $factory = $this->createFixtureFactory();
+        $sale = $this->runningSale([]);
+        $factory->saleProduct($sale, $first);
+        $factory->saleProduct($sale, $second);
+
+        $item = $this->readJson('/api/front/sales/'.$sale->getId());
+
+        self::assertSame([$first->getId(), $second->getId()], $item['productIds']);
+    }
+
+    /**
+     * `productIds` is part of every read group, so the serializer asks each member of
+     * a page for it. Read one operation at a time that is one sale_product statement
+     * per operation, and a shop listing its operations pays for the whole page.
+     */
+    public function testAPageOfOperationsReadsTheProductsTheyCoverInOneQuery(): void
+    {
+        $first = $this->catalogProduct();
+        $second = $this->catalogProduct();
+        $factory = $this->createFixtureFactory();
+        $sales = [];
+
+        for ($index = 0; $index < 6; ++$index) {
+            $sale = $this->runningSale(['title' => 'Operation '.$index]);
+            $factory->saleProduct($sale, $first);
+            $factory->saleProduct($sale, $second);
+            $sales[] = $sale;
+        }
+
+        $payload = [];
+        $statements = $this->recordSqlQueries(function () use (&$payload): void {
+            $payload = $this->readJson('/api/front/sales');
+        });
+
+        // The page still answers what it answered before: the ids, per operation.
+        foreach ($sales as $sale) {
+            self::assertSame(
+                [$first->getId(), $second->getId()],
+                $this->memberOrNull($payload, $sale->getId())['productIds'] ?? null,
+            );
+        }
+
+        self::assertSame(
+            1,
+            self::countSqlQueriesSelectingFrom($statements, 'sale_product'),
+            'The products of the whole page are read in one statement, not one per operation.',
+        );
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->createFixtureFactory()->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0],
+        );
+    }
+
+    private function runningSale(array $overrides): Sale
+    {
+        return $this->createFixtureFactory()->sale($overrides + [
+            'active' => true,
+            'title' => 'Winter operation',
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+    }
+
+    private function reservedSaleFor(Customer $customer): Sale
+    {
+        $sale = $this->runningSale([
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'title' => 'Reserved operation',
+        ]);
+        $this->createFixtureFactory()->saleCustomer($sale, $customer);
+
+        return $sale;
+    }
+
+    private function newCustomer(?string $password = null): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer(
+            $factory->customerTitle(),
+            null === $password ? [] : ['password' => $password],
+        );
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return list<string>
+     */
+    private function keysOf(array $payload): array
+    {
+        $keys = [];
+
+        foreach ($payload as $key => $value) {
+            if (\is_string($key)) {
+                $keys[] = $key;
+            }
+
+            if (\is_array($value)) {
+                $keys = [...$keys, ...$this->keysOf($value)];
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $uri, ?string $token = null): array
+    {
+        $response = $this->jsonRequest('GET', $uri, token: $token);
+        self::assertJsonResponseSuccessful($response);
+
+        return json_decode((string) $response->getContent(), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>|null
+     */
+    private function memberOrNull(array $payload, ?int $saleId): ?array
+    {
+        foreach ($payload['hydra:member'] ?? [] as $member) {
+            if (($member['id'] ?? null) === $saleId) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Http/BackOffice/AdminInterfaceLanguageTest.php
+++ b/tests/Http/BackOffice/AdminInterfaceLanguageTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\BackOffice;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\HttpFoundation\Session\Session;
+use Thelia\Model\Admin;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+use Thelia\Tests\Support\BackOffice\AdminSessionInjector;
+
+/**
+ * The interface language of the back-office: the one the language switcher of the
+ * top bar picks, carried by a "lang" query parameter, resolved by
+ * {@see \Thelia\Domain\Localization\Service\LangService::handleLang()} and stored
+ * in the session as the admin language.
+ *
+ * Most of what is asserted here is decided at kernel.request and written to the
+ * session and to the admin row, before any template is involved: it holds for
+ * every back-office template. The one test that reads a rendered page names the
+ * template it needs and skips otherwise.
+ *
+ * The edition language of the contents (the flag row of an edition screen, read
+ * from "edit_language_id") is a different thing and is left untouched.
+ */
+final class AdminInterfaceLanguageTest extends WebIntegrationTestCase
+{
+    private const PASSWORD = 'password';
+
+    private AdminSessionInjector $injector;
+
+    private ?Session $lastSession = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->injector = new AdminSessionInjector();
+
+        $dispatcher = $this->getService(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($this->injector);
+
+        // The KernelBrowser hands back a Request with no session attached, so the
+        // session of the request that was just handled is caught on its way out.
+        // kernel.response and not kernel.request: the login controller decides the
+        // language of a fresh session itself, long after kernel.request is over.
+        if ($dispatcher instanceof SymfonyEventDispatcherInterface) {
+            $dispatcher->addListener(
+                KernelEvents::RESPONSE,
+                function (ResponseEvent $event): void {
+                    $request = $event->getRequest();
+
+                    if ($request->hasSession()) {
+                        $session = $request->getSession();
+                        $this->lastSession = $session instanceof Session ? $session : null;
+                    }
+                },
+                -1024,
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // A test skipped before setUp() completed leaves no injector behind.
+        if (isset($this->injector)) {
+            $this->injector->clear();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testSwitchingTheInterfaceLanguageStoresItInTheSession(): void
+    {
+        $admin = $this->injectAdminSession('en_US');
+
+        $this->client->request('GET', '/admin/home?lang=fr');
+
+        self::assertSame('fr_FR', $this->sessionAdminLocale());
+
+        // The choice outlives the request that made it: the next page carries no
+        // parameter and must still be served in the chosen language.
+        $this->client->request('GET', '/admin/home');
+
+        self::assertSame('fr_FR', $this->sessionAdminLocale());
+        self::assertSame('fr_FR', $this->storedLocaleOf($admin->getId()));
+    }
+
+    public function testSwitchingTheInterfaceLanguagePersistsItOnTheAdmin(): void
+    {
+        $admin = $this->injectAdminSession('en_US');
+
+        $this->client->request('GET', '/admin/home?lang=fr');
+
+        self::assertSame(
+            'fr_FR',
+            $this->storedLocaleOf($admin->getId()),
+            'The interface language must be written to admin.locale so it survives a logout',
+        );
+    }
+
+    public function testAnInterfaceLanguageAskedForByLocaleIsAcceptedToo(): void
+    {
+        $admin = $this->injectAdminSession('en_US');
+
+        $this->client->request('GET', '/admin/home?lang=es_ES');
+
+        self::assertSame('es_ES', $this->sessionAdminLocale());
+        self::assertSame('es_ES', $this->storedLocaleOf($admin->getId()));
+    }
+
+    public function testAPlainPageViewLeavesTheStoredInterfaceLanguageAlone(): void
+    {
+        $admin = $this->injectAdminSession('it_IT');
+
+        $this->client->request('GET', '/admin/home');
+
+        self::assertSame('it_IT', $this->storedLocaleOf($admin->getId()));
+    }
+
+    public function testLoggingInAdoptsTheInterfaceLanguageStoredOnTheAdmin(): void
+    {
+        $this->logInAs($this->newAdmin('fr_FR'));
+
+        self::assertSame(
+            'fr_FR',
+            $this->sessionAdminLocale(),
+            'A fresh session must take its interface language from admin.locale',
+        );
+    }
+
+    /**
+     * The whole point, seen from the page: an administrator whose stored interface
+     * language is French signs in and is served a French back-office, with no
+     * language parameter anywhere in the url.
+     */
+    public function testAPageIsRenderedInTheStoredInterfaceLanguageAfterLoggingIn(): void
+    {
+        $this->skipUnlessTwigBackOffice();
+
+        $this->logInAs($this->newAdmin('fr_FR'));
+
+        $this->client->request('GET', '/admin/sales');
+
+        $body = (string) $this->client->getResponse()->getContent();
+
+        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertStringContainsString(
+            'Nouvelle promotion',
+            $body,
+            'The back-office chrome must be rendered in the interface language of the administrator',
+        );
+    }
+
+    private function newAdmin(string $locale): Admin
+    {
+        $factory = new FixtureFactory($this->getPropelConnection());
+
+        return $factory->admin(['locale' => $locale, 'password' => self::PASSWORD]);
+    }
+
+    /**
+     * Signs in through the real login form, so that the language of the session is
+     * decided by the login itself and not by an injected session.
+     */
+    private function logInAs(Admin $admin): void
+    {
+        $crawler = $this->client->request('GET', '/admin/login');
+        $token = $crawler->filter('input[name="thelia_admin_login[_token]"]');
+
+        self::assertGreaterThan(0, $token->count(), 'The login form must carry a CSRF token');
+
+        $this->client->request('POST', '/admin/checklogin', [
+            'thelia_admin_login' => [
+                'username' => $admin->getLogin(),
+                'password' => self::PASSWORD,
+                'success_url' => '/admin',
+                '_token' => (string) $token->attr('value'),
+            ],
+        ]);
+    }
+
+    /**
+     * The French strings asserted below belong to the catalogues of the default-twig
+     * back-office template. A project running another back-office template has no
+     * such catalogue, and nothing to assert.
+     */
+    private function skipUnlessTwigBackOffice(): void
+    {
+        $template = static::getContainer()->getParameter('thelia_admin_template');
+
+        if ('default-twig' !== $template) {
+            self::markTestSkipped(\sprintf(
+                'The installed back-office template is "%s", not "default-twig".',
+                \is_string($template) ? $template : 'unknown',
+            ));
+        }
+    }
+
+    private function injectAdminSession(string $locale): Admin
+    {
+        // Built without createFixtureFactory(): that helper pushes a synthetic
+        // request when the stack is empty, and it would then be the "main"
+        // request of the calls below — the one the session is read from.
+        $factory = new FixtureFactory($this->getPropelConnection());
+
+        $admin = $factory->admin(['locale' => $locale]);
+        $admin->eraseCredentials();
+        $this->injector->setAdmin($admin);
+
+        return $admin;
+    }
+
+    private function sessionAdminLocale(): string
+    {
+        self::assertInstanceOf(Session::class, $this->lastSession, 'No session was carried by the last request');
+
+        return $this->lastSession->getAdminLang()->getLocale();
+    }
+
+    /**
+     * Read straight from the connection: the Propel instance pool holds the very
+     * object the request wrote to, so asking it would prove nothing about what
+     * reached the database.
+     */
+    private function storedLocaleOf(int $adminId): string
+    {
+        $statement = $this->getPropelConnection()->prepare('SELECT locale FROM admin WHERE id = :id');
+        $statement->execute(['id' => $adminId]);
+
+        return (string) $statement->fetchColumn();
+    }
+}

--- a/tests/Http/Flexy/SaleShowcaseTest.php
+++ b/tests/Http/Flexy/SaleShowcaseTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Http\Flexy;
+
+use Thelia\Core\Template\TemplateHelperInterface;
+use Thelia\Model\Category;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\WebIntegrationTestCase;
+
+/**
+ * A reserved-sale operation carries a rewritten url naming the `sale` view, the way a brand
+ * or a category does. Serving its page — title, countdown, product grid — is the theme's
+ * part; the core resolves the url, publishes `sale_id` in the query, and decides who gets to
+ * see the operation at all through {@see \Thelia\Domain\Sale\ReservedSaleVisibility}.
+ *
+ * These tests pin what a shop gets out of that contract: a public operation's page lists its
+ * products and shows a countdown exactly when its settings ask for one, a reserved operation
+ * an anonymous visitor is not named on answers 404 rather than a page with nothing on it, and
+ * a hidden drop's products stay off a listing page the same way they stay off the API.
+ *
+ * The page belongs to the front-office theme, which ships as its own package on its own
+ * release cycle: a theme older than the sale showcase is reported as skipped rather than
+ * failed.
+ */
+final class SaleShowcaseTest extends WebIntegrationTestCase
+{
+    private const SALE_TEMPLATE = 'sale.html.twig';
+
+    /** Present in the template only once the showcase component is wired in. */
+    private const SHOWCASE_MARKER = 'Layouts:SaleShowcase';
+
+    /** Present in the rendered page only while the countdown component is on it. */
+    private const COUNTDOWN_MARKER = 'Molecules--Countdown--base';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $frontTemplate = $this->getService(TemplateHelperInterface::class)->getActiveFrontTemplate();
+        $salePage = $frontTemplate->getAbsolutePath().\DIRECTORY_SEPARATOR.self::SALE_TEMPLATE;
+
+        if (!file_exists($salePage) || !str_contains((string) file_get_contents($salePage), self::SHOWCASE_MARKER)) {
+            self::markTestSkipped('The installed front-office theme has no reserved-sale showcase page.');
+        }
+    }
+
+    public function testAPublicOperationPageCarriesItsTitleAndProducts(): void
+    {
+        $factory = $this->factory();
+        $product = $this->product($factory, $factory->category(), 'Sale showcase product');
+
+        $sale = $this->runningSale($factory, ['title' => 'Winter drop']);
+        $sale->setRewrittenUrl('en_US', 'flexy-sale-showcase-test.html');
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-showcase-test.html');
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        self::assertStringContainsString('Winter drop', $content, 'The page must carry the operation title.');
+        self::assertStringContainsString('Sale showcase product', $content, 'The page must list the products of the operation.');
+    }
+
+    public function testTheCountdownShowsWhenTheOperationAsksForIt(): void
+    {
+        $factory = $this->factory();
+        $product = $this->product($factory, $factory->category(), 'Countdown-on product');
+
+        $sale = $this->runningSale($factory, ['countdownMode' => Sale::COUNTDOWN_MODE_FROM_OPENING]);
+        $sale->setRewrittenUrl('en_US', 'flexy-sale-countdown-on-test.html');
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-countdown-on-test.html');
+
+        self::assertStringContainsString(
+            self::COUNTDOWN_MARKER,
+            (string) $this->client->getResponse()->getContent(),
+            'A running countdown must render the Countdown component.',
+        );
+    }
+
+    public function testTheCountdownIsAbsentWhenTheOperationDoesNotAskForIt(): void
+    {
+        $factory = $this->factory();
+        // countdownMode defaults to Sale::COUNTDOWN_MODE_NONE.
+        $product = $this->product($factory, $factory->category(), 'Countdown-off product');
+
+        $sale = $this->runningSale($factory);
+        $sale->setRewrittenUrl('en_US', 'flexy-sale-countdown-off-test.html');
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-countdown-off-test.html');
+
+        self::assertStringNotContainsString(
+            self::COUNTDOWN_MARKER,
+            (string) $this->client->getResponse()->getContent(),
+            'A mode-NONE operation must not show a countdown.',
+        );
+    }
+
+    public function testAProductInARunningSaleCarriesItsLabelOnItsListingCard(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $product = $this->product($factory, $category, 'Listing sale product');
+        $category->setRewrittenUrl('en_US', 'flexy-sale-listing-test.html');
+
+        $sale = $this->runningSale($factory, ['saleLabel' => 'LISTING-SALE-TAG']);
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-listing-test.html');
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        self::assertStringContainsString('Listing sale product', $content);
+        self::assertStringContainsString('LISTING-SALE-TAG', $content, 'The card must carry the operation label.');
+        self::assertStringContainsString('Tag--sale', $content, 'The label must render as the sale variant of Molecules:Tag.');
+    }
+
+    /**
+     * `Sale::active` is maintained by a scheduled command that can lag behind the clock: an
+     * operation left flagged active past its own end date must not keep advertising a label
+     * that no longer means anything.
+     */
+    public function testAProductInAnOperationPastItsEndDateCarriesNoLabelOnItsListingCard(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $product = $this->product($factory, $category, 'Stale sale product');
+        $category->setRewrittenUrl('en_US', 'flexy-sale-stale-listing-test.html');
+
+        $sale = $this->runningSale($factory, [
+            'saleLabel' => 'STALE-SALE-TAG',
+            'endDate' => new \DateTime('-1 hour'),
+        ]);
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-stale-listing-test.html');
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        self::assertStringContainsString('Stale sale product', $content);
+        self::assertStringNotContainsString(
+            'STALE-SALE-TAG',
+            $content,
+            'An operation whose end date has passed must not keep its label, even while still flagged active.',
+        );
+    }
+
+    /**
+     * A reserved operation not open to the visitor answers the same as a missing one: a 404,
+     * never a page rendered with nothing worth showing on it.
+     */
+    public function testAnAnonymousVisitorGetsA404OnAReservedOperation(): void
+    {
+        $factory = $this->factory();
+        $product = $this->product($factory, $factory->category(), 'Reserved product');
+
+        $sale = $this->runningSale($factory, ['audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS]);
+        $sale->setRewrittenUrl('en_US', 'flexy-sale-reserved-test.html');
+        $factory->saleProduct($sale, $product);
+
+        $this->client->request('GET', '/flexy-sale-reserved-test.html');
+
+        self::assertSame(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testProductsOfAHiddenReservedOperationAreAbsentFromAListingPage(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $hiddenProduct = $this->product($factory, $category, 'Hidden drop product');
+        $category->setRewrittenUrl('en_US', 'flexy-sale-hidden-listing-test.html');
+
+        $sale = $this->runningSale($factory, [
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+        ]);
+        $factory->saleProduct($sale, $hiddenProduct);
+        $factory->saleCustomer($sale, $factory->customer($factory->customerTitle()));
+
+        $this->assertPageRenders('/flexy-sale-hidden-listing-test.html');
+
+        self::assertStringNotContainsString(
+            'Hidden drop product',
+            (string) $this->client->getResponse()->getContent(),
+            'A hidden reserved operation must keep its products off an anonymous listing.',
+        );
+    }
+
+    private function runningSale(FixtureFactory $factory, array $overrides = []): Sale
+    {
+        return $factory->sale($overrides + [
+            'active' => true,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+            'saleLabel' => $overrides['saleLabel'] ?? 'SALE-LABEL',
+        ]);
+    }
+
+    /**
+     * Built without createFixtureFactory(): that helper pushes a synthetic request when the
+     * stack is empty, and it would then be the "main" request of the page render below — the
+     * one the session, and therefore the current language, is read from.
+     */
+    private function factory(): FixtureFactory
+    {
+        return new FixtureFactory($this->getPropelConnection());
+    }
+
+    private function product(FixtureFactory $factory, Category $category, string $title): Product
+    {
+        $product = $factory->product($category, $factory->taxRule(), $factory->currency());
+
+        $product->setLocale('en_US')->setTitle($title)->save($this->getPropelConnection());
+
+        return $product;
+    }
+
+    /**
+     * The listing page's Subheader requires a title: a bare factory->category() carries no
+     * i18n row at all, and the page would 500 rather than render.
+     */
+    private function category(FixtureFactory $factory): Category
+    {
+        $category = $factory->category();
+        $category->setLocale('en_US')->setTitle('Sale listing test category')->save($this->getPropelConnection());
+
+        return $category;
+    }
+}

--- a/tests/Http/Flexy/SaleShowcaseTest.php
+++ b/tests/Http/Flexy/SaleShowcaseTest.php
@@ -112,6 +112,41 @@ final class SaleShowcaseTest extends WebIntegrationTestCase
         );
     }
 
+    /**
+     * Naming the discount and asking for a countdown are two independent settings of an
+     * operation: a merchant who sets the second one without the first still gets the
+     * countdown where the shopper decides, on the card and on the product sheet.
+     */
+    public function testTheCountdownShowsOnAListingCardOfALabellessOperation(): void
+    {
+        $factory = $this->factory();
+        $category = $this->category($factory);
+        $product = $this->product($factory, $category, 'Labelless countdown product');
+        $category->setRewrittenUrl('en_US', 'flexy-sale-labelless-countdown-test.html');
+
+        $sale = $this->runningSale($factory, [
+            'saleLabel' => '',
+            'countdownMode' => Sale::COUNTDOWN_MODE_FROM_OPENING,
+        ]);
+        $factory->saleProduct($sale, $product);
+
+        $this->assertPageRenders('/flexy-sale-labelless-countdown-test.html');
+
+        $content = (string) $this->client->getResponse()->getContent();
+
+        self::assertStringContainsString('Labelless countdown product', $content);
+        self::assertStringContainsString(
+            self::COUNTDOWN_MARKER,
+            $content,
+            'A countdown asked for by the operation must show even when the discount has no label.',
+        );
+        self::assertStringNotContainsString(
+            'Tag--sale',
+            $content,
+            'An operation with no label must not print an empty label tag.',
+        );
+    }
+
     public function testAProductInARunningSaleCarriesItsLabelOnItsListingCard(): void
     {
         $factory = $this->factory();

--- a/tests/Integration/Action/ReservedProductViewCheckTest.php
+++ b/tests/Integration/Action/ReservedProductViewCheckTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Event\ViewCheckEvent;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * The product page is resolved from its rewritten URL through the VIEW_CHECK
+ * event. A product hidden by a reserved operation must answer the same 404 there
+ * as everywhere else: the query filter alone leaves the page to render a null
+ * product, which is a 500, not a 404.
+ */
+final class ReservedProductViewCheckTest extends ActionIntegrationTestCase
+{
+    public function testTheProductViewOfAHiddenProductIsNotFoundForAVisitor(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleHiding($product);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->dispatch(new ViewCheckEvent('product', $product->getId()), TheliaEvents::VIEW_CHECK);
+    }
+
+    public function testTheProductViewOfAPubliclySoldProductStillAnswers(): void
+    {
+        $product = $this->catalogProduct();
+
+        $this->dispatch(new ViewCheckEvent('product', $product->getId()), TheliaEvents::VIEW_CHECK);
+
+        // Reaching this line is the assertion: no NotFoundHttpException was thrown.
+        self::assertTrue(true);
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $this->factory->currency(),
+            ['baseQuantity' => 100, 'basePrice' => 100.0],
+        );
+    }
+
+    private function reservedSaleHiding(Product $product): Sale
+    {
+        $sale = $this->factory->sale([
+            'active' => true,
+            'startDate' => new \DateTime('-1 hour'),
+            'endDate' => new \DateTime('+1 day'),
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+        ]);
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $this->factory->customer($this->factory->customerTitle()));
+
+        return $sale;
+    }
+}

--- a/tests/Integration/Action/ReservedSaleActionTest.php
+++ b/tests/Integration/Action/ReservedSaleActionTest.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Thelia\Core\Event\Sale\SaleActiveStatusCheckEvent;
+use Thelia\Core\Event\Sale\SaleCreateEvent;
+use Thelia\Core\Event\Sale\SaleDeleteEvent;
+use Thelia\Core\Event\Sale\SaleToggleActivityEvent;
+use Thelia\Core\Event\Sale\SaleUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\Currency;
+use Thelia\Model\Product;
+use Thelia\Model\ProductPriceQuery;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleCustomerQuery;
+use Thelia\Model\SaleQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * A reserved operation is a promise made to named customers, not a catalog price.
+ * It must never write `product_sale_elements.promo` nor `product_price.promo_price`:
+ * those two are what every visitor sees, and a shared product would leak the
+ * reserved discount to the whole shop — or, worse, lose the public discount it
+ * already had.
+ */
+final class ReservedSaleActionTest extends ActionIntegrationTestCase
+{
+    public function testAnActiveReservedOperationWritesNoPublicPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->factory->customer($this->factory->customerTitle());
+
+        // Product::create() writes promo_price = price, so "untouched" is the base price.
+        $untouchedPromoPrice = $this->promoPriceOf($this->defaultPseFor($product), $currency);
+        self::assertSame(100.0, $untouchedPromoPrice);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$customer->getId()],
+        ]);
+
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(0, (int) $pse->getPromo(), 'a reserved operation leaves the public promo flag alone');
+        self::assertSame(
+            $untouchedPromoPrice,
+            $this->promoPriceOf($pse, $currency),
+            'a reserved operation writes no public promo price',
+        );
+    }
+
+    /**
+     * The reset of `promo` in updateProductsSaleStatus covers every sale element of
+     * every product of the operation, not just the ones it discounts. Running it for
+     * a reserved operation would wipe the public discount of a product both
+     * operations happen to include.
+     */
+    public function testAReservedOperationDoesNotWipeThePublicPromoOfASharedProduct(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $publicSale = $this->createSale();
+        $this->updateSale($publicSale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+        ]);
+
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(1, (int) $pse->getPromo(), 'the public operation is the one that flags the sale element');
+        $publicPromoPrice = $this->promoPriceOf($pse, $currency);
+        self::assertGreaterThan(0.0, $publicPromoPrice);
+
+        $reservedSale = $this->createSale();
+        $this->updateSale($reservedSale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '50'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(1, (int) $pse->getPromo(), 'the public promo flag survives the reserved operation');
+        self::assertSame(
+            $publicPromoPrice,
+            $this->promoPriceOf($pse, $currency),
+            'the public promo price survives the reserved operation',
+        );
+    }
+
+    /**
+     * An operation that was public wrote public flags. Making it reserved has to take
+     * them back, otherwise the discount stays visible to everyone for good.
+     */
+    public function testTurningAPublicOperationIntoAReservedOneClearsThePublicFlags(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+        ]);
+
+        self::assertSame(1, (int) $this->defaultPseFor($product)->getPromo());
+
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        self::assertSame(
+            0,
+            (int) $this->defaultPseFor($product)->getPromo(),
+            'the promo flag the operation wrote while it was public is taken back',
+        );
+    }
+
+    public function testUpdatePersistsTheAudienceAndCountdownFields(): void
+    {
+        $sale = $this->createSale();
+
+        $this->updateSale($sale, [
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+            'countdownMode' => Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdownLeadHours' => 48,
+        ]);
+
+        $reloaded = SaleQuery::create()->findPk($sale->getId());
+        self::assertSame(Sale::AUDIENCE_MODE_CUSTOMERS, $reloaded->getAudienceMode());
+        self::assertTrue($reloaded->getHideProducts());
+        self::assertSame(Sale::COUNTDOWN_MODE_LEAD_HOURS, $reloaded->getCountdownMode());
+        self::assertSame(48, $reloaded->getCountdownLeadHours());
+        self::assertTrue($reloaded->isReserved());
+    }
+
+    public function testUpdateResynchronisesTheTargetedCustomers(): void
+    {
+        $first = $this->factory->customer($this->factory->customerTitle());
+        $second = $this->factory->customer($this->factory->customerTitle());
+        $sale = $this->createSale();
+
+        $this->updateSale($sale, [
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$first->getId(), $second->getId()],
+        ]);
+
+        self::assertSame([$first->getId(), $second->getId()], $this->targetedCustomerIds($sale));
+
+        // Removing one from the selection removes the row, it does not just stop reading it.
+        $this->updateSale($sale, [
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$second->getId()],
+        ]);
+
+        self::assertSame([$second->getId()], $this->targetedCustomerIds($sale));
+    }
+
+    /**
+     * An operation open to everyone has no audience to keep: leaving the rows behind
+     * would make it reserved again the moment someone flips the mode back.
+     */
+    public function testGoingBackToAPublicAudienceEmptiesTheTargeting(): void
+    {
+        $customer = $this->factory->customer($this->factory->customerTitle());
+        $sale = $this->createSale();
+
+        $this->updateSale($sale, [
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$customer->getId()],
+        ]);
+        self::assertCount(1, $this->targetedCustomerIds($sale));
+
+        $this->updateSale($sale, [
+            'audienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+            'customerIds' => [$customer->getId()],
+        ]);
+
+        self::assertSame([], $this->targetedCustomerIds($sale));
+    }
+
+    /**
+     * The mirror of the switch above: an operation that opens up to everyone starts
+     * writing the public flags it never wrote while it was reserved.
+     */
+    public function testTurningAReservedOperationIntoAPublicOneWritesThePublicFlags(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        self::assertSame(0, (int) $this->defaultPseFor($product)->getPromo());
+
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+        ]);
+
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(1, (int) $pse->getPromo());
+        self::assertSame(90.0, $this->promoPriceOf($pse, $currency));
+    }
+
+    public function testDeletingAReservedOperationWritesNoPublicPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => true,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        $this->dispatch(new SaleDeleteEvent($sale->getId()), TheliaEvents::SALE_DELETE);
+
+        self::assertNull(SaleQuery::create()->findPk($sale->getId()));
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(0, (int) $pse->getPromo());
+        self::assertSame(100.0, $this->promoPriceOf($pse, $currency));
+    }
+
+    public function testTogglingAReservedOperationWritesNoPublicPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => false,
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        $this->dispatch(
+            new SaleToggleActivityEvent(SaleQuery::create()->findPk($sale->getId())),
+            TheliaEvents::SALE_TOGGLE_ACTIVITY,
+        );
+
+        self::assertSame(1, (int) SaleQuery::create()->findPk($sale->getId())->getActive());
+
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(0, (int) $pse->getPromo());
+        self::assertSame(100.0, $this->promoPriceOf($pse, $currency), 'the catalog promo price is left as it was');
+    }
+
+    /**
+     * The scheduled command opens and closes operations outside any HTTP request.
+     * A reserved one still changes its `active` flag — that is what makes its price
+     * resolvable — but writes no price of its own.
+     */
+    public function testCheckSaleActivationOpensAndClosesAReservedOperationWithoutWritingPrices(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->createSale();
+        $this->updateSale($sale, [
+            'active' => false,
+            'startDate' => new \DateTime('-2 days'),
+            'endDate' => new \DateTime('+2 days'),
+            'products' => [$product->getId()],
+            'priceOffsets' => [$currency->getId() => '10'],
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'customerIds' => [$this->factory->customer($this->factory->customerTitle())->getId()],
+        ]);
+
+        $this->dispatch(new SaleActiveStatusCheckEvent(), TheliaEvents::CHECK_SALE_ACTIVATION_EVENT);
+
+        self::assertSame(1, (int) SaleQuery::create()->findPk($sale->getId())->getActive(), 'the operation opens');
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(0, (int) $pse->getPromo());
+        self::assertSame(100.0, $this->promoPriceOf($pse, $currency));
+
+        // Its end date is now in the past: the next run closes it.
+        SaleQuery::create()->findPk($sale->getId())
+            ->setEndDate(new \DateTime('-1 hour'))
+            ->save();
+
+        $this->dispatch(new SaleActiveStatusCheckEvent(), TheliaEvents::CHECK_SALE_ACTIVATION_EVENT);
+
+        self::assertSame(0, (int) SaleQuery::create()->findPk($sale->getId())->getActive(), 'the operation closes');
+        $pse = $this->defaultPseFor($product);
+        self::assertSame(0, (int) $pse->getPromo());
+        self::assertSame(100.0, $this->promoPriceOf($pse, $currency));
+    }
+
+    private function createSale(): Sale
+    {
+        return $this->dispatch(
+            (new SaleCreateEvent())->setLocale('en_US')->setTitle('Operation')->setSaleLabel('OP'),
+            TheliaEvents::SALE_CREATE,
+        )->getSale();
+    }
+
+    private function updateSale(Sale $sale, array $overrides = []): SaleUpdateEvent
+    {
+        $event = new SaleUpdateEvent($sale->getId());
+        $event
+            ->setLocale('en_US')
+            ->setTitle($overrides['title'] ?? 'Operation')
+            ->setSaleLabel($overrides['saleLabel'] ?? 'OP')
+            ->setActive($overrides['active'] ?? true)
+            ->setStartDate($overrides['startDate'] ?? new \DateTime('-1 day'))
+            ->setEndDate($overrides['endDate'] ?? new \DateTime('+1 day'))
+            ->setPriceOffsetType($overrides['priceOffsetType'] ?? Sale::OFFSET_TYPE_PERCENTAGE)
+            ->setDisplayInitialPrice(true)
+            ->setChapo('')
+            ->setDescription('')
+            ->setPostscriptum('')
+            ->setPriceOffsets($overrides['priceOffsets'] ?? [])
+            ->setProducts($overrides['products'] ?? [])
+            ->setProductAttributes($overrides['productAttributes'] ?? [])
+            ->setAudienceMode($overrides['audienceMode'] ?? Sale::AUDIENCE_MODE_PUBLIC)
+            ->setHideProducts($overrides['hideProducts'] ?? false)
+            ->setCountdownMode($overrides['countdownMode'] ?? Sale::COUNTDOWN_MODE_NONE)
+            ->setCountdownLeadHours($overrides['countdownLeadHours'] ?? null)
+            ->setCustomerIds($overrides['customerIds'] ?? []);
+
+        return $this->dispatch($event, TheliaEvents::SALE_UPDATE);
+    }
+
+    private function catalogProduct(Currency $currency): Product
+    {
+        return $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0],
+        );
+    }
+
+    private function defaultPseFor(Product $product): ProductSaleElements
+    {
+        return ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+    }
+
+    private function promoPriceOf(ProductSaleElements $pse, Currency $currency): float
+    {
+        return (float) ProductPriceQuery::create()
+            ->filterByProductSaleElementsId($pse->getId())
+            ->filterByCurrencyId($currency->getId())
+            ->findOne()
+            ->getPromoPrice();
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function targetedCustomerIds(Sale $sale): array
+    {
+        return array_map(
+            static fn ($saleCustomer): int => $saleCustomer->getCustomerId(),
+            iterator_to_array(
+                SaleCustomerQuery::create()
+                    ->filterBySaleId($sale->getId())
+                    ->orderByCustomerId()
+                    ->find(),
+            ),
+        );
+    }
+}

--- a/tests/Integration/Action/ReservedSaleCartActionTest.php
+++ b/tests/Integration/Action/ReservedSaleCartActionTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Action;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Thelia\Core\Event\Cart\CartEvent;
+use Thelia\Core\Event\Cart\CartRestoreEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Core\Security\SecurityContext;
+use Thelia\Model\Cart;
+use Thelia\Model\ConfigQuery;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\SaleCustomerQuery;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * A reserved price is only a promise until the customer puts the product in
+ * their cart: the cart line is what the order is built from, so the line is
+ * where the price the shop agreed to has to be written down.
+ *
+ * The catalog price is 100 excluding tax, the shop's default tax rule adds 20%,
+ * and every reserved operation below takes 10% off the taxed price — which comes
+ * back to 90 excluding tax.
+ */
+final class ReservedSaleCartActionTest extends ActionIntegrationTestCase
+{
+    private const CATALOG_PRICE = 100.0;
+
+    private const RESERVED_PRICE = 90.0;
+
+    public function testAProductIsAddedToTheCartAtTheReservedPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $this->reservedOperationOn($product, $currency, $customer);
+
+        $cartItem = $this->addToCart($this->factory->cart($customer), $product);
+
+        self::assertSame(1, (int) $cartItem->getPromo(), 'the line is flagged as a special offer');
+        self::assertSame(self::RESERVED_PRICE, (float) $cartItem->getPromoPrice());
+        self::assertSame(self::RESERVED_PRICE, $cartItem->getRealPrice());
+    }
+
+    public function testACustomerTheOperationDoesNotNamePaysTheCatalogPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $this->reservedOperationOn($product, $currency, $this->newCustomer());
+
+        $cartItem = $this->addToCart($this->factory->cart($this->newCustomer()), $product);
+
+        self::assertSame(0, (int) $cartItem->getPromo());
+        self::assertSame(self::CATALOG_PRICE, $cartItem->getRealPrice());
+    }
+
+    public function testAVisitorPaysTheCatalogPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $this->reservedOperationOn($product, $currency, $this->newCustomer());
+
+        $cartItem = $this->addToCart($this->factory->cart(), $product);
+
+        self::assertSame(0, (int) $cartItem->getPromo());
+        self::assertSame(self::CATALOG_PRICE, $cartItem->getRealPrice());
+    }
+
+    /**
+     * A customer taken out of the selection loses the price on the next refresh:
+     * a line written weeks ago is not a price the shop still owes.
+     */
+    public function testACustomerRemovedFromTheSelectionFallsBackToTheCatalogPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $sale = $this->reservedOperationOn($product, $currency, $customer);
+
+        $cart = $this->factory->cart($customer);
+        self::assertSame(self::RESERVED_PRICE, $this->addToCart($cart, $product)->getRealPrice());
+
+        SaleCustomerQuery::create()->filterBySaleId($sale->getId())->delete();
+
+        $refreshed = $this->restoreCartAsCustomer($cart, $customer);
+
+        self::assertSame(0, (int) $refreshed->getPromo());
+        self::assertSame(self::CATALOG_PRICE, $refreshed->getRealPrice());
+    }
+
+    public function testAnOperationThatHasEndedFallsBackToTheCatalogPrice(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $sale = $this->reservedOperationOn($product, $currency, $customer);
+
+        $cart = $this->factory->cart($customer);
+        self::assertSame(self::RESERVED_PRICE, $this->addToCart($cart, $product)->getRealPrice());
+
+        $sale->setEndDate(new \DateTime('-1 minute'))->save();
+
+        $refreshed = $this->restoreCartAsCustomer($cart, $customer);
+
+        self::assertSame(0, (int) $refreshed->getPromo());
+        self::assertSame(self::CATALOG_PRICE, $refreshed->getRealPrice());
+    }
+
+    /**
+     * Everything in a cart filled before signing in has to be repriced at sign-in,
+     * not only when the customer carries a discount rate.
+     */
+    public function testSigningInAppliesTheReservedPriceToAnAnonymousCart(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $this->reservedOperationOn($product, $currency, $customer);
+
+        $anonymousCart = $this->factory->cart();
+        $item = $this->addToCart($anonymousCart, $product);
+        self::assertSame(self::CATALOG_PRICE, $item->getRealPrice(), 'nothing is reserved for nobody');
+
+        $signedIn = $this->restoreCartAsCustomer($anonymousCart, $customer);
+
+        self::assertSame(1, (int) $signedIn->getPromo());
+        self::assertSame(self::RESERVED_PRICE, $signedIn->getRealPrice());
+    }
+
+    private function reservedOperationOn(Product $product, Currency $currency, Customer $customer): Sale
+    {
+        $sale = $this->factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'priceOffsetType' => Sale::OFFSET_TYPE_PERCENTAGE,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+
+        $this->factory->saleOffsetCurrency($sale, $currency, 10.0);
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        return $sale;
+    }
+
+    private function addToCart(Cart $cart, Product $product): \Thelia\Model\CartItem
+    {
+        $event = new CartEvent($cart);
+        $event
+            ->setProductId($product->getId())
+            ->setProductSaleElementsId($this->defaultPseFor($product)->getId())
+            ->setQuantity(1)
+            ->setNewness(true)
+            ->setAppend(true);
+
+        $this->dispatch($event, TheliaEvents::CART_ADDITEM);
+
+        return $event->getCartItem();
+    }
+
+    /**
+     * Restores the cart the way a request does — through the cart cookie, with the
+     * customer in session — and hands back the single line of the restored cart.
+     */
+    private function restoreCartAsCustomer(Cart $cart, Customer $customer): \Thelia\Model\CartItem
+    {
+        $this->mainRequest()->cookies->set(
+            ConfigQuery::read('cart.cookie_name', 'thelia_cart'),
+            $cart->getToken(),
+        );
+        $this->getService(SecurityContext::class)->setCustomerUser($customer);
+
+        $event = new CartRestoreEvent();
+        $this->dispatch($event, TheliaEvents::CART_RESTORE_CURRENT);
+
+        $restored = $event->getCart();
+        $restored->clearCartItems();
+
+        return $restored->getCartItems()->getFirst()
+            ?? self::fail('The restored cart lost its only line.');
+    }
+
+    private function mainRequest(): Request
+    {
+        return $this->getService(RequestStack::class)->getMainRequest();
+    }
+
+    private function catalogProduct(Currency $currency): Product
+    {
+        return $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $currency,
+            ['baseQuantity' => 100, 'basePrice' => self::CATALOG_PRICE],
+        );
+    }
+
+    private function defaultPseFor(Product $product): ProductSaleElements
+    {
+        return ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+    }
+
+    private function newCustomer(): Customer
+    {
+        return $this->factory->customer($this->factory->customerTitle());
+    }
+}

--- a/tests/Integration/Action/ReservedSaleCartActionTest.php
+++ b/tests/Integration/Action/ReservedSaleCartActionTest.php
@@ -21,6 +21,7 @@ use Thelia\Core\Event\Cart\CartRestoreEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\SecurityContext;
 use Thelia\Model\Cart;
+use Thelia\Model\CartItemQuery;
 use Thelia\Model\ConfigQuery;
 use Thelia\Model\Currency;
 use Thelia\Model\Customer;
@@ -143,6 +144,69 @@ final class ReservedSaleCartActionTest extends ActionIntegrationTestCase
 
         self::assertSame(1, (int) $signedIn->getPromo());
         self::assertSame(self::RESERVED_PRICE, $signedIn->getRealPrice());
+    }
+
+    /**
+     * Entitlement can move while the cart sits open, and the visitor never signs in
+     * again: changing the quantity of a line is the moment to settle the price, not a
+     * moment to carry a price the shop no longer owes.
+     */
+    public function testChangingAQuantityDropsAReservedPriceTheCustomerHasLost(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $sale = $this->reservedOperationOn($product, $currency, $customer);
+
+        $cart = $this->factory->cart($customer);
+        $item = $this->addToCart($cart, $product);
+        self::assertSame(self::RESERVED_PRICE, $item->getRealPrice());
+
+        SaleCustomerQuery::create()->filterBySaleId($sale->getId())->delete();
+
+        $changed = $this->changeQuantity($cart, $item, 3);
+
+        self::assertSame(3, (int) $changed->getQuantity());
+        self::assertSame(0, (int) $changed->getPromo());
+        self::assertSame(self::CATALOG_PRICE, $changed->getRealPrice());
+    }
+
+    /**
+     * The other way round: a customer named on the operation after filling their cart
+     * gets the price on the next line they touch, without signing out and back in.
+     */
+    public function testChangingAQuantityAppliesAReservedPriceTheCustomerHasGained(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $sale = $this->reservedOperationOn($product, $currency, $this->newCustomer());
+
+        $cart = $this->factory->cart($customer);
+        $item = $this->addToCart($cart, $product);
+        self::assertSame(self::CATALOG_PRICE, $item->getRealPrice());
+
+        $this->factory->saleCustomer($sale, $customer);
+
+        $changed = $this->changeQuantity($cart, $item, 2);
+
+        self::assertSame(1, (int) $changed->getPromo());
+        self::assertSame(self::RESERVED_PRICE, $changed->getRealPrice());
+    }
+
+    private function changeQuantity(Cart $cart, \Thelia\Model\CartItem $cartItem, int $quantity): \Thelia\Model\CartItem
+    {
+        $event = new CartEvent($cart);
+        $event
+            ->setCartItemId($cartItem->getId())
+            ->setQuantity($quantity);
+
+        $this->dispatch($event, TheliaEvents::CART_UPDATEITEM);
+
+        $cartItem->clearAllReferences();
+
+        return CartItemQuery::create()->findPk($cartItem->getId())
+            ?? self::fail('The changed line is gone from the cart.');
     }
 
     private function reservedOperationOn(Product $product, Currency $currency, Customer $customer): Sale

--- a/tests/Integration/Api/Service/DataAccess/ProductSaleElementsAccessReservedPriceTest.php
+++ b/tests/Integration/Api/Service/DataAccess/ProductSaleElementsAccessReservedPriceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Api\Service\DataAccess;
+
+use Thelia\Api\Service\DataAccess\ProductSaleElementsAccessService;
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsCustomer;
+
+/**
+ * The combination picker of a product page reads its prices from this data
+ * access, not from the API resource: it needs every sale element of the product
+ * at once, keyed by the attribute values that select it.
+ *
+ * It is therefore a price path of its own, and the reserved price has to travel
+ * on it too — otherwise the page shows one price and the picker another.
+ */
+final class ProductSaleElementsAccessReservedPriceTest extends IntegrationTestCase
+{
+    use LogsInAsCustomer;
+
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+    private ProductSaleElementsAccessService $accessService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = $this->createFixtureFactory();
+        $this->currency = $factory->currency();
+        $this->category = $factory->category();
+        $this->taxRule = $factory->taxRule();
+        $this->accessService = $this->getService(ProductSaleElementsAccessService::class);
+    }
+
+    public function testTheNamedCustomerReadsTheReservedPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->reservedSaleOn($product, $customer);
+        $this->loginAsCustomerInSession($customer);
+
+        $saleElement = $this->firstSaleElementOf($product);
+
+        self::assertTrue($saleElement['isPromo']);
+        self::assertEqualsWithDelta(90.0, (float) $saleElement['promoUntaxedPrice'], 0.000001);
+        // The offset is taken off the taxed price: 100 HT / 120 TTC, minus 10%.
+        self::assertEqualsWithDelta(108.0, (float) $saleElement['promoPrice'], 0.000001);
+        self::assertEqualsWithDelta(100.0, (float) $saleElement['untaxedPrice'], 0.000001);
+    }
+
+    public function testAVisitorReadsTheCatalogPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer());
+
+        $saleElement = $this->firstSaleElementOf($product);
+
+        self::assertFalse($saleElement['isPromo']);
+        self::assertEqualsWithDelta(100.0, (float) $saleElement['promoUntaxedPrice'], 0.000001);
+    }
+
+    public function testACustomerTheOperationDoesNotNameReadsTheCatalogPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer());
+        $this->loginAsCustomerInSession($this->newCustomer());
+
+        self::assertFalse($this->firstSaleElementOf($product)['isPromo']);
+    }
+
+    /**
+     * The picker is reached by a product id, so it has to answer nothing at all for
+     * a product a private drop keeps out of the catalog: the page is 404 for this
+     * visitor, and its prices must not be readable behind it.
+     */
+    public function testAPrivateDropAnswersNoSaleElementAtAll(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer(), hideProducts: true);
+
+        self::assertSame([], $this->saleElementsOf($product));
+    }
+
+    public function testTheNamedCustomerStillReadsThePrivateDrop(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->reservedSaleOn($product, $customer, hideProducts: true);
+        $this->loginAsCustomerInSession($customer);
+
+        self::assertCount(1, $this->saleElementsOf($product));
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->createFixtureFactory()->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0, 'title' => 'Picker product'],
+        );
+    }
+
+    private function reservedSaleOn(Product $product, Customer $customer, bool $hideProducts = false): Sale
+    {
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => $hideProducts,
+            'priceOffsetType' => Sale::OFFSET_TYPE_PERCENTAGE,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $factory->saleProduct($sale, $product);
+        $factory->saleCustomer($sale, $customer);
+        $factory->saleOffsetCurrency($sale, $this->currency, 10.0);
+
+        return $sale;
+    }
+
+    private function newCustomer(): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer($factory->customerTitle());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function firstSaleElementOf(Product $product): array
+    {
+        $saleElements = $this->saleElementsOf($product);
+
+        self::assertNotSame([], $saleElements, 'The product under test has to be readable, otherwise nothing is measured.');
+
+        return $saleElements[0];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function saleElementsOf(Product $product): array
+    {
+        return json_decode(
+            (string) $this->accessService->psesByProduct($product->getId()),
+            true,
+            flags: \JSON_THROW_ON_ERROR,
+        );
+    }
+}

--- a/tests/Integration/Core/Template/ReservedSaleProductLoopTest.php
+++ b/tests/Integration/Core/Template/ReservedSaleProductLoopTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Template;
+
+use Thelia\Core\Template\Loop\LoopExecutor;
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsCustomer;
+
+/**
+ * What the legacy loops of a Smarty template make of a reserved operation.
+ *
+ * They are the other half of the front — the back office runs on them too — so
+ * the two rules the API enforces have to hold here as well: the products of a
+ * hidden operation are out of the catalog of whoever it is not open to, and the
+ * customer it is open to reads the price it gives them.
+ *
+ * The back office is deliberately exempt from both: an administrator setting an
+ * operation up has to see what is in it.
+ */
+final class ReservedSaleProductLoopTest extends IntegrationTestCase
+{
+    use LogsInAsCustomer;
+
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $factory = $this->createFixtureFactory();
+        $this->currency = $factory->currency();
+        $this->category = $factory->category();
+        $this->taxRule = $factory->taxRule();
+    }
+
+    public function testAVisitorDoesNotSeeTheProductsOfAHiddenReservedOperation(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        self::assertNull($this->productRow($product));
+    }
+
+    public function testACustomerTheOperationDoesNotNameDoesNotSeeThemEither(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $this->loginAsCustomerInSession($this->newCustomer());
+
+        self::assertNull($this->productRow($product));
+    }
+
+    public function testTheCustomerTheOperationNamesSeesThem(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->hiddenReservedSaleOn($product, $customer);
+        $this->loginAsCustomerInSession($customer);
+
+        self::assertNotNull($this->productRow($product));
+    }
+
+    public function testTheBackOfficeSeesEverything(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        self::assertNotNull($this->productRow($product, ['backend_context' => 1]));
+    }
+
+    public function testTheHiddenProductsAreOutOfTheComplexLoopToo(): void
+    {
+        $product = $this->catalogProduct();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        self::assertNull($this->productRow($product, ['complex' => 1]));
+    }
+
+    public function testAPublicOperationHidesNothing(): void
+    {
+        $product = $this->catalogProduct();
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+            'hideProducts' => true,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $factory->saleProduct($sale, $product);
+
+        self::assertNotNull($this->productRow($product));
+    }
+
+    public function testTheNamedCustomerReadsTheReservedPriceOnTheProductLoop(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->reservedSaleOn($product, $customer, offset: 10.0);
+        $this->loginAsCustomerInSession($customer);
+
+        $row = $this->productRow($product);
+
+        self::assertSame(1, (int) $row['IS_PROMO'], 'The reserved price is a promo for the customer it is resolved for.');
+        self::assertEqualsWithDelta(90.0, (float) $row['PROMO_PRICE'], 0.000001);
+        self::assertEqualsWithDelta(90.0, (float) $row['BEST_PRICE'], 0.000001);
+        // The offset is taken off the TAXED price and converted back, so a 10%
+        // operation on a 100 HT / 120 TTC product charges 108 TTC, that is 90 HT.
+        self::assertEqualsWithDelta(108.0, (float) $row['TAXED_PROMO_PRICE'], 0.000001);
+        self::assertEqualsWithDelta(108.0, (float) $row['BEST_TAXED_PRICE'], 0.000001);
+        self::assertEqualsWithDelta(100.0, (float) $row['PRICE'], 0.000001, 'The catalog price is untouched.');
+    }
+
+    public function testAVisitorReadsTheCatalogPriceOnTheProductLoop(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer(), offset: 10.0);
+
+        $row = $this->productRow($product);
+
+        self::assertSame(0, (int) $row['IS_PROMO']);
+        self::assertEqualsWithDelta(100.0, (float) $row['BEST_PRICE'], 0.000001);
+    }
+
+    public function testACustomerTheOperationDoesNotNameReadsTheCatalogPrice(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer(), offset: 10.0);
+        $this->loginAsCustomerInSession($this->newCustomer());
+
+        $row = $this->productRow($product);
+
+        self::assertSame(0, (int) $row['IS_PROMO']);
+        self::assertEqualsWithDelta(100.0, (float) $row['BEST_PRICE'], 0.000001);
+    }
+
+    public function testTheBackOfficeReadsTheCatalogPriceWhoeverIsSignedIn(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->reservedSaleOn($product, $customer, offset: 10.0);
+        $this->loginAsCustomerInSession($customer);
+
+        $row = $this->productRow($product, ['backend_context' => 1]);
+
+        self::assertSame(0, (int) $row['IS_PROMO'], 'The catalog is what the back office edits.');
+        self::assertEqualsWithDelta(100.0, (float) $row['BEST_PRICE'], 0.000001);
+    }
+
+    public function testTheNamedCustomerReadsTheReservedPriceOnTheSaleElementLoop(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+        $this->reservedSaleOn($product, $customer, offset: 10.0);
+        $this->loginAsCustomerInSession($customer);
+
+        $row = $this->saleElementRow($this->defaultPseFor($product));
+
+        self::assertSame(1, (int) $row['IS_PROMO']);
+        self::assertEqualsWithDelta(90.0, (float) $row['PROMO_PRICE'], 0.000001);
+        self::assertEqualsWithDelta(100.0, (float) $row['PRICE'], 0.000001);
+    }
+
+    public function testAVisitorReadsTheCatalogPriceOnTheSaleElementLoop(): void
+    {
+        $product = $this->catalogProduct();
+        $this->reservedSaleOn($product, $this->newCustomer(), offset: 10.0);
+
+        $row = $this->saleElementRow($this->defaultPseFor($product));
+
+        self::assertSame(0, (int) $row['IS_PROMO']);
+        self::assertEqualsWithDelta(100.0, (float) $row['PROMO_PRICE'], 0.000001);
+    }
+
+    /**
+     * DISPLAY_INITIAL_PRICE is read from whichever active operation covers the
+     * product. A reserved one the visitor is not part of must not be that one:
+     * it would decide how a price they are not getting is displayed.
+     */
+    public function testAReservedOperationDoesNotDecideHowAVisitorSeesThePrice(): void
+    {
+        $product = $this->catalogProduct();
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'displayInitialPrice' => false,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $factory->saleProduct($sale, $product);
+        $factory->saleCustomer($sale, $this->newCustomer());
+        $factory->saleOffsetCurrency($sale, $this->currency, 10.0);
+
+        $row = $this->productRow($product);
+
+        self::assertSame(
+            1,
+            (int) $row['SHOW_ORIGINAL_PRICE'],
+            'An operation the visitor is not part of has nothing to say about their price.',
+        );
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->createFixtureFactory()->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0, 'title' => 'Loop product'],
+        );
+    }
+
+    private function hiddenReservedSaleOn(Product $product, Customer $customer): Sale
+    {
+        return $this->reservedSaleOn($product, $customer, offset: 10.0, hideProducts: true);
+    }
+
+    private function reservedSaleOn(
+        Product $product,
+        Customer $customer,
+        float $offset,
+        bool $hideProducts = false,
+    ): Sale {
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => $hideProducts,
+            'priceOffsetType' => Sale::OFFSET_TYPE_PERCENTAGE,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $factory->saleProduct($sale, $product);
+        $factory->saleCustomer($sale, $customer);
+        $factory->saleOffsetCurrency($sale, $this->currency, $offset);
+
+        return $sale;
+    }
+
+    private function newCustomer(): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer($factory->customerTitle());
+    }
+
+    private function defaultPseFor(Product $product): ProductSaleElements
+    {
+        return ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function productRow(Product $product, array $arguments = []): ?array
+    {
+        return $this->firstRow('product', $arguments + ['id' => $product->getId()]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function saleElementRow(ProductSaleElements $saleElements, array $arguments = []): ?array
+    {
+        return $this->firstRow('product_sale_elements', $arguments + ['id' => $saleElements->getId()]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function firstRow(string $loop, array $arguments): ?array
+    {
+        $result = $this->getService(LoopExecutor::class)->execute($loop, $arguments);
+
+        foreach ($result as $row) {
+            return $row->getVarVal();
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Core/Template/SaleLoopTest.php
+++ b/tests/Integration/Core/Template/SaleLoopTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Core\Template;
+
+use Thelia\Core\Template\Loop\LoopExecutor;
+use Thelia\Model\Customer;
+use Thelia\Model\Sale;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsCustomer;
+
+/**
+ * The sale loop, as a Smarty template reads it: the address of the operation's
+ * page, who it is open to, and how long it still has to run.
+ *
+ * A reserved operation is only part of the front for the customers it names —
+ * the back office keeps listing every one of them, drafts included, because
+ * that is where they are set up.
+ */
+final class SaleLoopTest extends IntegrationTestCase
+{
+    use LogsInAsCustomer;
+
+    public function testTheOperationHandsOutTheAddressOfItsPage(): void
+    {
+        $sale = $this->createFixtureFactory()->sale([
+            'active' => true,
+            'title' => 'Winter drop',
+        ]);
+
+        $row = $this->saleRow($sale);
+
+        self::assertStringEndsWith('winter-drop.html', (string) $row['URL']);
+    }
+
+    public function testTheAudienceSettingsTravelWithTheOperation(): void
+    {
+        $factory = $this->createFixtureFactory();
+        $customer = $this->newCustomer();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+        ]);
+        $factory->saleCustomer($sale, $customer);
+        $this->loginAsCustomerInSession($customer);
+
+        $row = $this->saleRow($sale);
+
+        self::assertSame(Sale::AUDIENCE_MODE_CUSTOMERS, (int) $row['AUDIENCE_MODE']);
+        self::assertSame(1, (int) $row['HIDE_PRODUCTS']);
+    }
+
+    public function testTheCountdownIsAnsweredAsANumberOfSeconds(): void
+    {
+        $sale = $this->createFixtureFactory()->sale([
+            'active' => true,
+            'countdownMode' => Sale::COUNTDOWN_MODE_FROM_OPENING,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+2 hours'),
+        ]);
+
+        $row = $this->saleRow($sale);
+
+        self::assertSame(Sale::COUNTDOWN_MODE_FROM_OPENING, (int) $row['COUNTDOWN_MODE']);
+        self::assertSame(1, (int) $row['SHOULD_DISPLAY_COUNTDOWN']);
+        self::assertGreaterThan(7100, (int) $row['COUNTDOWN_REMAINING_SECONDS']);
+        self::assertLessThanOrEqual(7200, (int) $row['COUNTDOWN_REMAINING_SECONDS']);
+    }
+
+    public function testAnOperationWithNoCountdownAnswersNoRemainingSeconds(): void
+    {
+        $sale = $this->createFixtureFactory()->sale([
+            'active' => true,
+            'countdownMode' => Sale::COUNTDOWN_MODE_NONE,
+            'endDate' => new \DateTime('+2 hours'),
+        ]);
+
+        $row = $this->saleRow($sale);
+
+        self::assertSame(0, (int) $row['SHOULD_DISPLAY_COUNTDOWN']);
+        // LoopResultRow::set() turns a null into an empty string, the way every
+        // other optional output of every other loop is answered.
+        self::assertSame('', $row['COUNTDOWN_REMAINING_SECONDS']);
+    }
+
+    public function testTheLeadTimeTravelsWithTheOperation(): void
+    {
+        $sale = $this->createFixtureFactory()->sale([
+            'active' => true,
+            'countdownMode' => Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdownLeadHours' => 3,
+            'endDate' => new \DateTime('+10 hours'),
+        ]);
+
+        $row = $this->saleRow($sale);
+
+        self::assertSame(3, (int) $row['COUNTDOWN_LEAD_HOURS']);
+        self::assertSame(
+            0,
+            (int) $row['SHOULD_DISPLAY_COUNTDOWN'],
+            'Ten hours out, a countdown that starts three hours before the end is not due.',
+        );
+    }
+
+    public function testAVisitorDoesNotListAReservedOperation(): void
+    {
+        $sale = $this->reservedSaleFor($this->newCustomer());
+
+        self::assertNull($this->saleRow($sale));
+    }
+
+    public function testACustomerTheOperationDoesNotNameDoesNotListItEither(): void
+    {
+        $sale = $this->reservedSaleFor($this->newCustomer());
+        $this->loginAsCustomerInSession($this->newCustomer());
+
+        self::assertNull($this->saleRow($sale));
+    }
+
+    public function testTheCustomerTheOperationNamesListsIt(): void
+    {
+        $customer = $this->newCustomer();
+        $sale = $this->reservedSaleFor($customer);
+        $this->loginAsCustomerInSession($customer);
+
+        self::assertNotNull($this->saleRow($sale));
+    }
+
+    public function testTheBackOfficeListsEveryOperation(): void
+    {
+        $sale = $this->reservedSaleFor($this->newCustomer());
+
+        self::assertNotNull($this->saleRow($sale, ['backend_context' => 1]));
+    }
+
+    public function testAPublicOperationIsListedByEverybody(): void
+    {
+        $sale = $this->createFixtureFactory()->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_PUBLIC,
+        ]);
+
+        self::assertNotNull($this->saleRow($sale));
+    }
+
+    private function reservedSaleFor(Customer $customer): Sale
+    {
+        $factory = $this->createFixtureFactory();
+        $sale = $factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $factory->saleCustomer($sale, $customer);
+
+        return $sale;
+    }
+
+    private function newCustomer(): Customer
+    {
+        $factory = $this->createFixtureFactory();
+
+        return $factory->customer($factory->customerTitle());
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function saleRow(Sale $sale, array $arguments = []): ?array
+    {
+        $result = $this->getService(LoopExecutor::class)->execute('sale', $arguments + ['id' => $sale->getId()]);
+
+        foreach ($result as $row) {
+            return $row->getVarVal();
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
+++ b/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
@@ -1,0 +1,453 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Sale;
+
+use Thelia\Core\Event\Sale\SaleCreateEvent;
+use Thelia\Core\Event\Sale\SaleUpdateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Domain\Sale\ReservedPrice;
+use Thelia\Domain\Sale\ReservedSalePriceResolver;
+use Thelia\Model\AttributeCombination;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Product;
+use Thelia\Model\ProductPriceQuery;
+use Thelia\Model\ProductSaleElements;
+use Thelia\Model\ProductSaleElementsQuery;
+use Thelia\Model\Sale;
+use Thelia\Test\ActionIntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * The price a named customer gets from a reserved operation.
+ *
+ * Nothing about it is written to the catalog, so it has to be computed on the
+ * way out — for a whole batch of sale elements at once, and to the same cent
+ * the public path would have written.
+ */
+final class ReservedSalePriceResolverTest extends ActionIntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private ReservedSalePriceResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = $this->getService(ReservedSalePriceResolver::class);
+    }
+
+    /**
+     * The parity criterion: the same operation, run publicly, writes exactly the
+     * number the resolver hands to the customer it is reserved for.
+     */
+    public function testTheReservedPriceMatchesWhatThePublicPathWouldHaveWritten(): void
+    {
+        $currency = $this->factory->currency();
+        $publicProduct = $this->catalogProduct($currency);
+        $reservedProduct = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $publicPromoPrice = $this->publicPromoPriceWrittenFor($publicProduct, $currency, '10');
+
+        $sale = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($sale, $reservedProduct);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($reservedProduct);
+        $resolved = $this->resolver->resolve([$pse->getId()], $currency, $customer);
+
+        self::assertArrayHasKey($pse->getId(), $resolved);
+        self::assertSame($publicPromoPrice, $resolved[$pse->getId()]->untaxedPromoPrice);
+    }
+
+    public function testAnAmountOffsetIsResolvedToo(): void
+    {
+        $currency = $this->factory->currency();
+        $publicProduct = $this->catalogProduct($currency);
+        $reservedProduct = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $publicPromoPrice = $this->publicPromoPriceWrittenFor(
+            $publicProduct,
+            $currency,
+            '25',
+            Sale::OFFSET_TYPE_AMOUNT,
+        );
+
+        $sale = $this->runningReservedSale($currency, '25', Sale::OFFSET_TYPE_AMOUNT);
+        $this->factory->saleProduct($sale, $reservedProduct);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($reservedProduct);
+        $resolved = $this->resolver->resolve([$pse->getId()], $currency, $customer);
+
+        // `product_price.promo_price` is a DECIMAL(16,6), so the public reference is
+        // the resolved price rounded to the sixth decimal — parity to the cent.
+        self::assertEqualsWithDelta(
+            $publicPromoPrice,
+            $resolved[$pse->getId()]->untaxedPromoPrice,
+            0.000001,
+        );
+    }
+
+    public function testTheResolvedPriceCarriesTheOperationItComesFrom(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+        $endDate = new \DateTime('+3 days');
+
+        $sale = $this->runningReservedSale($currency, '10', Sale::OFFSET_TYPE_PERCENTAGE, ['endDate' => $endDate]);
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($product);
+        $reserved = $this->resolver->resolve([$pse->getId()], $currency, $customer)[$pse->getId()];
+
+        self::assertInstanceOf(ReservedPrice::class, $reserved);
+        self::assertSame($pse->getId(), $reserved->productSaleElementsId);
+        self::assertSame($sale->getId(), $reserved->saleId);
+        self::assertSame($endDate->format('Y-m-d H:i:s'), $reserved->saleEndDate->format('Y-m-d H:i:s'));
+        self::assertTrue($reserved->displayInitialPrice);
+    }
+
+    public function testAVisitorGetsNoReservedPrice(): void
+    {
+        [$currency, $pse] = $this->reservedOperationOnOneProduct($this->newCustomer());
+
+        self::assertSame([], $this->resolver->resolve([$pse->getId()], $currency, null));
+    }
+
+    public function testACustomerTheOperationDoesNotNameGetsNoReservedPrice(): void
+    {
+        [$currency, $pse] = $this->reservedOperationOnOneProduct($this->newCustomer());
+
+        self::assertSame([], $this->resolver->resolve([$pse->getId()], $currency, $this->newCustomer()));
+    }
+
+    /**
+     * The active flag is only as fresh as the last run of the scheduled command,
+     * so the dates are what decides — evaluated in SQL, at the instant asked.
+     */
+    public function testAnOperationWhoseEndDateHasPassedGivesNoPriceEvenWhileStillFlaggedActive(): void
+    {
+        $customer = $this->newCustomer();
+        [$currency, $pse, $sale] = $this->reservedOperationOnOneProduct($customer);
+
+        $sale->setEndDate(new \DateTime('-1 minute'))->save();
+
+        self::assertSame(1, (int) $sale->getActive(), 'the flag is deliberately left on');
+        self::assertSame([], $this->resolver->resolve([$pse->getId()], $currency, $customer));
+    }
+
+    public function testAnOperationThatHasNotStartedYetGivesNoPrice(): void
+    {
+        $customer = $this->newCustomer();
+        [$currency, $pse, $sale] = $this->reservedOperationOnOneProduct($customer);
+
+        $sale->setStartDate(new \DateTime('+1 hour'))->save();
+
+        self::assertSame([], $this->resolver->resolve([$pse->getId()], $currency, $customer));
+    }
+
+    /**
+     * Two reserved operations on the same sale element: the customer gets the
+     * better of the two, not the one that happens to be read last.
+     */
+    public function testTheLowestOfTwoReservedOperationsWins(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $mild = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($mild, $product);
+        $this->factory->saleCustomer($mild, $customer);
+
+        $generous = $this->runningReservedSale($currency, '40');
+        $this->factory->saleProduct($generous, $product);
+        $this->factory->saleCustomer($generous, $customer);
+
+        $pse = $this->defaultPseFor($product);
+        $reserved = $this->resolver->resolve([$pse->getId()], $currency, $customer)[$pse->getId()];
+
+        self::assertSame(60.0, $reserved->untaxedPromoPrice);
+        self::assertSame($generous->getId(), $reserved->saleId);
+    }
+
+    /**
+     * The customer always sees the best price available: a reserved operation that
+     * is dearer than the public special offer already running is not applied at all.
+     */
+    public function testAReservedPriceAboveTheCurrentEffectivePriceIsNotApplied(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        // The public operation takes 50% off, the reserved one only 10%.
+        $this->publicPromoPriceWrittenFor($product, $currency, '50');
+
+        $sale = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($product);
+
+        self::assertSame(1, (int) $pse->getPromo(), 'the public offer is running');
+        self::assertSame([], $this->resolver->resolve([$pse->getId()], $currency, $customer));
+    }
+
+    public function testAReservedPriceBelowTheCurrentPublicOfferIsApplied(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $this->publicPromoPriceWrittenFor($product, $currency, '10');
+
+        $sale = $this->runningReservedSale($currency, '60');
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($product);
+        $resolved = $this->resolver->resolve([$pse->getId()], $currency, $customer);
+
+        self::assertSame(40.0, $resolved[$pse->getId()]->untaxedPromoPrice);
+    }
+
+    /**
+     * An operation selecting one attribute value discounts only the sale elements
+     * carrying it — the same selection Action\Sale makes for a public operation.
+     */
+    public function testOnlyTheSaleElementsCarryingTheSelectedAttributeValueAreResolved(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $attribute = $this->factory->attribute();
+        $selected = $this->factory->attributeAv($attribute);
+        $notSelected = $this->factory->attributeAv($attribute);
+
+        $selectedPse = $this->extraPseWithPrice($product, $currency, $attribute->getId(), $selected->getId());
+        $otherPse = $this->extraPseWithPrice($product, $currency, $attribute->getId(), $notSelected->getId());
+
+        $sale = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($sale, $product, $selected);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $resolved = $this->resolver->resolve(
+            [$selectedPse->getId(), $otherPse->getId(), $this->defaultPseFor($product)->getId()],
+            $currency,
+            $customer,
+        );
+
+        self::assertSame([$selectedPse->getId()], array_keys($resolved));
+    }
+
+    /**
+     * A price the currency has no row of its own for is converted from the default
+     * currency, exactly as ProductSaleElements::getPricesByCurrency() does.
+     */
+    public function testAPriceIsConvertedFromTheDefaultCurrency(): void
+    {
+        $defaultCurrency = $this->factory->currency();
+        $otherCurrency = $this->factory->currency(['code' => 'XTS', 'rate' => 2.0, 'symbol' => 'X']);
+        $product = $this->catalogProduct($defaultCurrency);
+        $customer = $this->newCustomer();
+
+        $sale = $this->runningReservedSale($otherCurrency, '10');
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $pse = $this->defaultPseFor($product);
+        $resolved = $this->resolver->resolve([$pse->getId()], $otherCurrency, $customer);
+
+        // 100 in the default currency at a rate of 2 is 200, minus 10% is 180.
+        self::assertSame(180.0, $resolved[$pse->getId()]->untaxedPromoPrice);
+    }
+
+    /**
+     * The whole point of the batch entry point: a catalog page with fifty sale
+     * elements must not cost fifty queries.
+     */
+    public function testResolvingAWholeBatchCostsNoQueryPerSaleElement(): void
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+        $customer = $this->newCustomer();
+
+        $sale = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        $onePse = [$this->defaultPseFor($product)->getId()];
+        $manyPses = $onePse;
+        for ($i = 0; $i < 6; ++$i) {
+            $manyPses[] = $this->extraPseWithPrice($product, $currency)->getId();
+        }
+
+        $forOne = $this->recordSqlQueries(function () use ($onePse, $currency, $customer): void {
+            self::assertCount(1, $this->resolver->resolve($onePse, $currency, $customer));
+        });
+
+        $forMany = $this->recordSqlQueries(function () use ($manyPses, $currency, $customer): void {
+            self::assertCount(7, $this->resolver->resolve($manyPses, $currency, $customer));
+        });
+
+        self::assertSame(
+            \count($forOne),
+            \count($forMany),
+            \sprintf(
+                "resolving 7 sale elements ran %d statements against %d for a single one:\n%s",
+                \count($forMany),
+                \count($forOne),
+                implode("\n", $forMany),
+            ),
+        );
+    }
+
+    public function testAnEmptyBatchAsksTheDatabaseNothing(): void
+    {
+        $currency = $this->factory->currency();
+        $customer = $this->newCustomer();
+
+        $statements = $this->recordSqlQueries(function () use ($currency, $customer): void {
+            self::assertSame([], $this->resolver->resolve([], $currency, $customer));
+        });
+
+        self::assertSame([], $statements);
+    }
+
+    /**
+     * @return array{0: Currency, 1: ProductSaleElements, 2: Sale}
+     */
+    private function reservedOperationOnOneProduct(Customer $customer): array
+    {
+        $currency = $this->factory->currency();
+        $product = $this->catalogProduct($currency);
+
+        $sale = $this->runningReservedSale($currency, '10');
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+
+        return [$currency, $this->defaultPseFor($product), $sale];
+    }
+
+    private function runningReservedSale(
+        Currency $currency,
+        string $offset,
+        int $offsetType = Sale::OFFSET_TYPE_PERCENTAGE,
+        array $overrides = [],
+    ): Sale {
+        $sale = $this->factory->sale($overrides + [
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'priceOffsetType' => $offsetType,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+
+        $this->factory->saleOffsetCurrency($sale, $currency, (float) $offset);
+
+        return $sale;
+    }
+
+    /**
+     * Runs a public operation through Action\Sale and returns the promo price it
+     * wrote in the catalog — the reference the reserved path has to match.
+     */
+    private function publicPromoPriceWrittenFor(
+        Product $product,
+        Currency $currency,
+        string $offset,
+        int $offsetType = Sale::OFFSET_TYPE_PERCENTAGE,
+    ): float {
+        $sale = $this->dispatch(
+            (new SaleCreateEvent())->setLocale('en_US')->setTitle('Public')->setSaleLabel('PUB'),
+            TheliaEvents::SALE_CREATE,
+        )->getSale();
+
+        $event = new SaleUpdateEvent($sale->getId());
+        $event
+            ->setLocale('en_US')
+            ->setTitle('Public')
+            ->setSaleLabel('PUB')
+            ->setActive(true)
+            ->setStartDate(new \DateTime('-1 day'))
+            ->setEndDate(new \DateTime('+1 day'))
+            ->setPriceOffsetType($offsetType)
+            ->setDisplayInitialPrice(true)
+            ->setChapo('')
+            ->setDescription('')
+            ->setPostscriptum('')
+            ->setPriceOffsets([$currency->getId() => $offset])
+            ->setProducts([$product->getId()])
+            ->setProductAttributes([]);
+
+        $this->dispatch($event, TheliaEvents::SALE_UPDATE);
+
+        return (float) ProductPriceQuery::create()
+            ->filterByProductSaleElementsId($this->defaultPseFor($product)->getId())
+            ->filterByCurrencyId($currency->getId())
+            ->findOne()
+            ->getPromoPrice();
+    }
+
+    private function catalogProduct(Currency $currency): Product
+    {
+        return $this->factory->product(
+            $this->factory->category(),
+            $this->factory->taxRule(),
+            $currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0],
+        );
+    }
+
+    private function extraPseWithPrice(
+        Product $product,
+        Currency $currency,
+        ?int $attributeId = null,
+        ?int $attributeAvId = null,
+    ): ProductSaleElements {
+        $pse = $this->factory->productSaleElement($product);
+        $this->factory->productPrice($pse, $currency, ['price' => '100.000000', 'promoPrice' => '100.000000']);
+
+        if (null !== $attributeId && null !== $attributeAvId) {
+            (new AttributeCombination())
+                ->setProductSaleElementsId($pse->getId())
+                ->setAttributeId($attributeId)
+                ->setAttributeAvId($attributeAvId)
+                ->save();
+        }
+
+        return $pse;
+    }
+
+    private function defaultPseFor(Product $product): ProductSaleElements
+    {
+        return ProductSaleElementsQuery::create()
+            ->filterByProductId($product->getId())
+            ->filterByIsDefault(true)
+            ->findOne();
+    }
+
+    private function newCustomer(): Customer
+    {
+        return $this->factory->customer($this->factory->customerTitle());
+    }
+}

--- a/tests/Integration/Domain/Sale/ReservedSaleVisibilityTest.php
+++ b/tests/Integration/Domain/Sale/ReservedSaleVisibilityTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Sale;
+
+use Thelia\Domain\Sale\ReservedSaleVisibility;
+use Thelia\Domain\Sale\SaleAudienceChecker;
+use Thelia\Model\Category;
+use Thelia\Model\Currency;
+use Thelia\Model\Customer;
+use Thelia\Model\Map\ProductTableMap;
+use Thelia\Model\Product;
+use Thelia\Model\ProductQuery;
+use Thelia\Model\Sale;
+use Thelia\Model\TaxRule;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\LogsInAsCustomer;
+
+/**
+ * The rule the catalog is narrowed by, on the shared class every caller goes
+ * through — the API extensions, the legacy loops and the theme sitemap alike.
+ *
+ * A product covered by several hidden operations is the case worth spelling out:
+ * being left out of one of them is not what hides a product. Being left out of
+ * every one of them is.
+ */
+final class ReservedSaleVisibilityTest extends IntegrationTestCase
+{
+    use LogsInAsCustomer;
+
+    private ReservedSaleVisibility $visibility;
+    private FixtureFactory $factory;
+    private Currency $currency;
+    private Category $category;
+    private TaxRule $taxRule;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->visibility = $this->getService(ReservedSaleVisibility::class);
+        $this->factory = $this->createFixtureFactory();
+        $this->currency = $this->factory->currency();
+        $this->category = $this->factory->category();
+        $this->taxRule = $this->factory->taxRule();
+    }
+
+    /**
+     * Two hidden operations cover the same product and the customer is named on
+     * one of them. The operation they are part of is what decides: the product is
+     * theirs to see, and the one they are not part of does not take it back.
+     */
+    public function testAProductCoveredByTwoHiddenOperationsIsVisibleToACustomerNamedOnOneOfThem(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+
+        $this->hiddenReservedSaleOn($product, $customer);
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        $this->loginAsCustomerInSession($customer);
+        $this->forgetMemoisedAudience();
+
+        self::assertTrue(
+            $this->isVisible($product),
+            'An operation the customer is named on shows the product, whatever the other one says.',
+        );
+    }
+
+    public function testTheSameProductStaysHiddenFromAVisitorNamedOnNeitherOperation(): void
+    {
+        $product = $this->catalogProduct();
+
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        self::assertFalse($this->isVisible($product));
+    }
+
+    public function testTheSameProductStaysHiddenFromACustomerNamedOnNeitherOperation(): void
+    {
+        $product = $this->catalogProduct();
+
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        $this->loginAsCustomerInSession($this->newCustomer());
+        $this->forgetMemoisedAudience();
+
+        self::assertFalse($this->isVisible($product));
+    }
+
+    /**
+     * The entitlement only ever covers the product the operation holds: another
+     * product of an operation the customer is not named on stays out of reach.
+     */
+    public function testTheEntitlementDoesNotSpillOverToTheOtherProductsOfTheOtherOperation(): void
+    {
+        $shared = $this->catalogProduct();
+        $otherProduct = $this->catalogProduct();
+        $customer = $this->newCustomer();
+
+        $this->hiddenReservedSaleOn($shared, $customer);
+        $someoneElses = $this->hiddenReservedSaleOn($shared, $this->newCustomer());
+        $this->factory->saleProduct($someoneElses, $otherProduct);
+
+        $this->loginAsCustomerInSession($customer);
+        $this->forgetMemoisedAudience();
+
+        self::assertTrue($this->isVisible($shared));
+        self::assertFalse($this->isVisible($otherProduct));
+    }
+
+    /**
+     * An operation whose window has closed is no operation at all: it neither
+     * hides a product nor shows one.
+     */
+    public function testAClosedOperationNeitherHidesNorShows(): void
+    {
+        $product = $this->catalogProduct();
+        $customer = $this->newCustomer();
+
+        $entitledButOver = $this->hiddenReservedSaleOn($product, $customer);
+        $entitledButOver->setEndDate(new \DateTime('-1 minute'))->save();
+        $this->hiddenReservedSaleOn($product, $this->newCustomer());
+
+        $this->loginAsCustomerInSession($customer);
+        $this->forgetMemoisedAudience();
+
+        self::assertFalse(
+            $this->isVisible($product),
+            'The operation that would show the product is over, and the one hiding it is not.',
+        );
+    }
+
+    private function isVisible(Product $product): bool
+    {
+        $query = ProductQuery::create()->filterById($product->getId());
+        $this->visibility->applyTo($query, ProductTableMap::COL_ID);
+
+        return $query->count() > 0;
+    }
+
+    private function catalogProduct(): Product
+    {
+        return $this->factory->product(
+            $this->category,
+            $this->taxRule,
+            $this->currency,
+            ['baseQuantity' => 100, 'basePrice' => 100.0, 'title' => 'Reserved catalog product'],
+        );
+    }
+
+    private function hiddenReservedSaleOn(Product $product, Customer $customer): Sale
+    {
+        $sale = $this->factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hideProducts' => true,
+            'startDate' => new \DateTime('-1 day'),
+            'endDate' => new \DateTime('+1 day'),
+        ]);
+        $this->factory->saleProduct($sale, $product);
+        $this->factory->saleCustomer($sale, $customer);
+        $this->factory->saleOffsetCurrency($sale, $this->currency, 10.0);
+
+        return $sale;
+    }
+
+    private function newCustomer(): Customer
+    {
+        return $this->factory->customer($this->factory->customerTitle());
+    }
+
+    /**
+     * Both services answer from memory for the whole request, which a test signing
+     * somebody in halfway through has to undo by hand.
+     */
+    private function forgetMemoisedAudience(): void
+    {
+        $this->getService(SaleAudienceChecker::class)->reset();
+        $this->visibility->reset();
+    }
+}

--- a/tests/Integration/Domain/Sale/SaleAudienceCheckerTest.php
+++ b/tests/Integration/Domain/Sale/SaleAudienceCheckerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Domain\Sale;
+
+use Thelia\Domain\Sale\SaleAudienceChecker;
+use Thelia\Model\Customer;
+use Thelia\Model\Sale;
+use Thelia\Test\FixtureFactory;
+use Thelia\Test\IntegrationTestCase;
+use Thelia\Test\Trait\RecordsSqlQueries;
+
+/**
+ * Who a sale operation is open to, and whether the shop has any reserved
+ * operation running at all — the question the cache bypass of step C asks
+ * on every page.
+ */
+final class SaleAudienceCheckerTest extends IntegrationTestCase
+{
+    use RecordsSqlQueries;
+
+    private SaleAudienceChecker $checker;
+
+    private FixtureFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->checker = $this->getService(SaleAudienceChecker::class);
+        $this->factory = $this->createFixtureFactory();
+    }
+
+    public function testAnOperationOpenToEveryoneEntitlesEveryone(): void
+    {
+        $sale = $this->factory->sale(['active' => true]);
+
+        self::assertTrue($this->checker->isCustomerEntitled($sale, null), 'a visitor gets a public operation');
+        self::assertTrue($this->checker->isCustomerEntitled($sale, $this->newCustomer()));
+    }
+
+    public function testAReservedOperationEntitlesNoVisitor(): void
+    {
+        $sale = $this->reservedSale();
+
+        self::assertFalse($this->checker->isCustomerEntitled($sale, null));
+    }
+
+    public function testAReservedOperationEntitlesTheCustomersItNames(): void
+    {
+        $named = $this->newCustomer();
+        $other = $this->newCustomer();
+        $sale = $this->reservedSale();
+        $this->factory->saleCustomer($sale, $named);
+
+        self::assertTrue($this->checker->isCustomerEntitled($sale, $named));
+        self::assertFalse($this->checker->isCustomerEntitled($sale, $other));
+    }
+
+    /**
+     * Customer groups are US #122. Until the groups are read, an operation targeting
+     * them names nobody, and nobody is entitled — which is the safe way round.
+     */
+    public function testAnOperationTargetingCustomerGroupsEntitlesNobodyYet(): void
+    {
+        $sale = $this->factory->sale([
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMER_GROUPS,
+        ]);
+
+        self::assertFalse($this->checker->isCustomerEntitled($sale, $this->newCustomer()));
+    }
+
+    public function testAShopWithNoReservedOperationSaysSo(): void
+    {
+        $this->factory->sale(['active' => true]);
+
+        self::assertFalse($this->checker->hasActiveReservedSale());
+    }
+
+    public function testAnActiveReservedOperationIsReported(): void
+    {
+        $this->reservedSale();
+
+        self::assertTrue($this->checker->hasActiveReservedSale());
+    }
+
+    public function testAnInactiveReservedOperationIsNotReported(): void
+    {
+        $this->factory->sale([
+            'active' => false,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+        ]);
+
+        self::assertFalse($this->checker->hasActiveReservedSale());
+    }
+
+    /**
+     * The answer is asked for on every page, so it costs one query per request,
+     * not one per caller.
+     */
+    public function testTheAnswerIsMemoisedForTheRequest(): void
+    {
+        $this->reservedSale();
+
+        $statements = $this->recordSqlQueries(function (): void {
+            self::assertTrue($this->checker->hasActiveReservedSale());
+            self::assertTrue($this->checker->hasActiveReservedSale());
+            self::assertTrue($this->checker->hasActiveReservedSale());
+        });
+
+        self::assertSame(1, self::countSqlQueriesSelectingFrom($statements, 'sale'));
+    }
+
+    public function testTheEntitledOperationsOfAVisitorAreNone(): void
+    {
+        $this->reservedSale();
+
+        self::assertSame([], $this->checker->getEntitledReservedSaleIds(null));
+    }
+
+    public function testOnlyTheRunningReservedOperationsTheCustomerIsNamedOnAreEntitled(): void
+    {
+        $customer = $this->newCustomer();
+
+        $running = $this->reservedSale(['startDate' => new \DateTime('-1 day'), 'endDate' => new \DateTime('+1 day')]);
+        $this->factory->saleCustomer($running, $customer);
+
+        $overWithoutDates = $this->reservedSale(['endDate' => new \DateTime('-1 hour')]);
+        $this->factory->saleCustomer($overWithoutDates, $customer);
+
+        $notStartedYet = $this->reservedSale(['startDate' => new \DateTime('+1 hour')]);
+        $this->factory->saleCustomer($notStartedYet, $customer);
+
+        $inactive = $this->factory->sale(['active' => false, 'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS]);
+        $this->factory->saleCustomer($inactive, $customer);
+
+        // Running, but somebody else's.
+        $someoneElses = $this->reservedSale();
+        $this->factory->saleCustomer($someoneElses, $this->newCustomer());
+
+        // Running and open to everyone: not a reserved entitlement.
+        $this->factory->sale(['active' => true]);
+
+        self::assertSame([$running->getId()], $this->checker->getEntitledReservedSaleIds($customer));
+    }
+
+    /**
+     * An operation with neither a start nor an end date runs for as long as its
+     * active flag says so.
+     */
+    public function testAnOperationWithoutDatesIsEntitledWhileItIsActive(): void
+    {
+        $customer = $this->newCustomer();
+        $sale = $this->reservedSale();
+        $this->factory->saleCustomer($sale, $customer);
+
+        self::assertSame([$sale->getId()], $this->checker->getEntitledReservedSaleIds($customer));
+    }
+
+    public function testTheEntitledOperationsAreMemoisedPerCustomer(): void
+    {
+        $customer = $this->newCustomer();
+        $sale = $this->reservedSale();
+        $this->factory->saleCustomer($sale, $customer);
+
+        $statements = $this->recordSqlQueries(function () use ($customer, $sale): void {
+            self::assertSame([$sale->getId()], $this->checker->getEntitledReservedSaleIds($customer));
+            self::assertSame([$sale->getId()], $this->checker->getEntitledReservedSaleIds($customer));
+        });
+
+        self::assertSame(1, self::countSqlQueriesSelectingFrom($statements, 'sale'));
+    }
+
+    private function newCustomer(): Customer
+    {
+        return $this->factory->customer($this->factory->customerTitle());
+    }
+
+    private function reservedSale(array $overrides = []): Sale
+    {
+        return $this->factory->sale($overrides + [
+            'active' => true,
+            'audienceMode' => Sale::AUDIENCE_MODE_CUSTOMERS,
+        ]);
+    }
+}

--- a/tests/Integration/Model/SaleUrlRewritingTest.php
+++ b/tests/Integration/Model/SaleUrlRewritingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Integration\Model;
+
+use Thelia\Core\Event\Sale\SaleCreateEvent;
+use Thelia\Core\Event\TheliaEvents;
+use Thelia\Model\RewritingUrlQuery;
+use Thelia\Model\Sale;
+use Thelia\Test\ActionIntegrationTestCase;
+
+/**
+ * A sale operation is a page of the shop — the one a countdown and a private drop
+ * are shown on — so it needs an address of its own, generated from its title the
+ * way a product's is.
+ */
+final class SaleUrlRewritingTest extends ActionIntegrationTestCase
+{
+    public function testASaleOperationAnswersTheSaleView(): void
+    {
+        self::assertSame('sale', (new Sale())->getRewrittenUrlViewName());
+    }
+
+    public function testCreatingAnOperationGeneratesItsAddress(): void
+    {
+        $sale = $this->dispatch(
+            (new SaleCreateEvent())
+                ->setLocale('en_US')
+                ->setTitle('Private winter drop')
+                ->setSaleLabel('DROP'),
+            TheliaEvents::SALE_CREATE,
+        )->getSale();
+
+        $rewritingUrl = RewritingUrlQuery::create()
+            ->filterByView('sale')
+            ->filterByViewId((string) $sale->getId())
+            ->filterByViewLocale('en_US')
+            ->findOne();
+
+        self::assertNotNull($rewritingUrl, 'The operation has to be reachable at an address of its own.');
+        self::assertSame('private-winter-drop.html', $rewritingUrl->getUrl());
+    }
+
+    public function testTheOperationHandsOutThatAddress(): void
+    {
+        $sale = $this->dispatch(
+            (new SaleCreateEvent())
+                ->setLocale('en_US')
+                ->setTitle('Members only sale')
+                ->setSaleLabel('MEMBERS'),
+            TheliaEvents::SALE_CREATE,
+        )->getSale();
+
+        self::assertStringEndsWith('members-only-sale.html', $sale->getUrl('en_US'));
+    }
+
+    /**
+     * A second operation with the same title gets an address of its own rather than
+     * stealing the first one's.
+     */
+    public function testTwoOperationsWithTheSameTitleGetTwoAddresses(): void
+    {
+        $titles = ['Flash sale', 'Flash sale'];
+        $urls = [];
+
+        foreach ($titles as $title) {
+            $sale = $this->dispatch(
+                (new SaleCreateEvent())->setLocale('en_US')->setTitle($title)->setSaleLabel('FLASH'),
+                TheliaEvents::SALE_CREATE,
+            )->getSale();
+
+            $urls[] = $sale->getUrl('en_US');
+        }
+
+        self::assertNotSame($urls[0], $urls[1]);
+    }
+}

--- a/tests/Playwright/specs/backoffice/sale-edit-twig.spec.ts
+++ b/tests/Playwright/specs/backoffice/sale-edit-twig.spec.ts
@@ -1,0 +1,359 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { loginAdmin } from '../../helpers/admin';
+import { ddevMysql } from '../../helpers/db';
+
+/**
+ * Reserved sales and countdown (US #153) on the sale edit screen.
+ *
+ * The test works on a sale it creates itself and deletes at the end, so it never
+ * changes the audience of the demo sales the front-office specs rely on.
+ */
+test.describe('Back-office — reserved sale and countdown (BO Twig)', () => {
+  test.skip(
+    (process.env.BO_TEMPLATE ?? 'default') !== 'default-twig',
+    'BO Twig only.',
+  );
+
+  test.beforeEach(async ({ page }) => { await loginAdmin(page); });
+
+  test('a sale can be reserved for named customers and given a countdown', async ({ page }) => {
+    const title = `E2E reserved sale ${Date.now()}`;
+
+    await test.step('create a sale to work on', async () => {
+      await page.goto('/admin/sales');
+      await page.getByTestId('sale-create-btn').click();
+      await page.getByTestId('sale-create-form').locator('input[name="thelia_sale_creation[title]"]').fill(title);
+      await Promise.all([
+        page.waitForURL(/\/admin\/sale\/update\/\d+/),
+        page.getByTestId('sale-create-submit').click(),
+      ]);
+    });
+
+    const saleId = Number(/\/admin\/sale\/update\/(\d+)/.exec(page.url())?.[1]);
+    expect(saleId).toBeGreaterThan(0);
+
+    await expect(page.getByTestId('sale-edit-page')).toBeVisible();
+    await expect(page.getByTestId('sale-targeting-card')).toBeVisible();
+    await expect(page.getByTestId('sale-countdown-card')).toBeVisible();
+
+    await test.step('a public sale hides the settings that only apply to a reserved one', async () => {
+      await expect(page.getByTestId('sale-audience-0')).toBeChecked();
+      await expect(page.getByTestId('sale-customers-select')).toBeHidden();
+      await expect(page.getByTestId('sale-hide-products')).toBeHidden();
+      await expect(page.getByTestId('sale-countdown-lead-hours')).toBeHidden();
+    });
+
+    await test.step('an end date is needed before a countdown can be asked for', async () => {
+      await page.getByTestId('sale-start-date').fill('2026-01-01 00:00:00');
+      await page.getByTestId('sale-end-date').fill('2026-12-31 23:59:59');
+    });
+
+    const select = page.getByTestId('sale-customers-select');
+    let pickedCustomer = '';
+
+    await test.step('reserving the sale reveals the customer picker', async () => {
+      await page.getByTestId('sale-audience-1').check();
+      await expect(select).toBeVisible();
+      await expect(page.getByTestId('sale-hide-products')).toBeVisible();
+
+      const options = select.locator('option');
+      const total = await options.count();
+      expect(total).toBeGreaterThan(0);
+
+      const label = ((await options.first().textContent()) ?? '').trim();
+      pickedCustomer = (await options.first().getAttribute('value')) ?? '';
+      expect(pickedCustomer).not.toBe('');
+
+      // The filter hides the options that do not match, client-side.
+      await page.getByTestId('sale-customers-filter').fill(label.split(' ')[0]);
+      await expect(select.locator('option:not([hidden])')).not.toHaveCount(total);
+      await expect(select.locator(`option[value="${pickedCustomer}"]`)).not.toHaveAttribute('hidden', /.*/);
+
+      await select.selectOption([pickedCustomer]);
+      await page.getByTestId('sale-hide-products').check();
+    });
+
+    await test.step('the lead hours only show up for the mode that uses them', async () => {
+      await page.getByTestId('sale-countdown-mode').selectOption('1');
+      await expect(page.getByTestId('sale-countdown-lead-hours')).toBeVisible();
+      await page.getByTestId('sale-countdown-lead-hours').fill('48');
+    });
+
+    await test.step('saving keeps every setting', async () => {
+      await Promise.all([
+        page.waitForURL(new RegExp(`/admin/sale/update/${saleId}$`)),
+        page.getByTestId('sale-edit-submit').click(),
+      ]);
+
+      await expect(page.getByTestId('bo-flash-danger')).toHaveCount(0);
+      await expect(page.getByTestId('sale-audience-1')).toBeChecked();
+      await expect(page.getByTestId('sale-hide-products')).toBeChecked();
+      await expect(page.getByTestId('sale-countdown-mode')).toHaveValue('1');
+      await expect(page.getByTestId('sale-countdown-lead-hours')).toHaveValue('48');
+      await expect(page.getByTestId('sale-customers-select')).toHaveValues([pickedCustomer]);
+    });
+
+    await test.step('switching the countdown mode clears the number of hours', async () => {
+      await page.getByTestId('sale-countdown-mode').selectOption('2');
+      await expect(page.getByTestId('sale-countdown-lead-hours')).toBeHidden();
+      await Promise.all([
+        page.waitForURL(new RegExp(`/admin/sale/update/${saleId}$`)),
+        page.getByTestId('sale-edit-submit').click(),
+      ]);
+
+      await expect(page.getByTestId('bo-flash-danger')).toHaveCount(0);
+      await expect(page.getByTestId('sale-countdown-mode')).toHaveValue('2');
+      expect(await ddevMysql(`SELECT countdown_lead_hours FROM sale WHERE id = ${saleId}`)).toBe('NULL');
+
+      // Back to the hours mode for the refusal check below.
+      await page.getByTestId('sale-countdown-mode').selectOption('1');
+      await page.getByTestId('sale-countdown-lead-hours').fill('48');
+      await Promise.all([
+        page.waitForURL(new RegExp(`/admin/sale/update/${saleId}$`)),
+        page.getByTestId('sale-edit-submit').click(),
+      ]);
+      await expect(page.getByTestId('sale-countdown-lead-hours')).toHaveValue('48');
+    });
+
+    await test.step('the list flags the sale as reserved, and for how many customers', async () => {
+      await page.goto('/admin/sales');
+      const badge = page.getByTestId(`sale-reserved-badge-${saleId}`);
+      await expect(badge).toBeVisible();
+      await expect(badge).toHaveAttribute('data-reserved-count', '1');
+      await expect(badge).toContainText('1');
+      // The delete action must carry the row id the confirm dialog copies into its form.
+      await expect(page.locator(`tr[data-row-id="${saleId}"] [data-testid="datatable-action-delete"]`).first())
+        .toHaveAttribute('data-sale-id', String(saleId));
+    });
+
+    await test.step('a sale left reserved for nobody is flagged as an alert', async () => {
+      // sale_customer.customer_id cascades on delete, so purging a customer empties the
+      // audience of a reserved sale without touching the sale: the shop owner has no
+      // other way of noticing that the operation went invisible. Reproduce it at the
+      // source rather than through the back office, which refuses to save that state.
+      await ddevMysql(`DELETE FROM sale_customer WHERE sale_id = ${saleId}`);
+
+      await page.goto('/admin/sales');
+      const badge = page.getByTestId(`sale-reserved-badge-${saleId}`);
+      await expect(badge).toBeVisible();
+      await expect(badge).toHaveAttribute('data-reserved-count', '0');
+      await expect(badge).toHaveClass(/bg-danger/);
+      await expect(badge).toContainText(/no customer|aucun client/i);
+
+      await page.goto(`/admin/sale/update/${saleId}`);
+      await expect(page.getByTestId('sale-reserved-empty')).toBeVisible();
+      await expect(page.getByTestId('sale-customers-count')).toHaveCount(0);
+
+      // Give the sale its audience back: the steps below save it, which a sale reserved
+      // for nobody is not allowed to do.
+      await ddevMysql(
+        `INSERT INTO sale_customer (sale_id, customer_id) VALUES (${saleId}, ${pickedCustomer})`,
+      );
+      await page.goto(`/admin/sale/update/${saleId}`);
+      await expect(page.getByTestId('sale-customers-count')).toHaveAttribute('data-reserved-count', '1');
+    });
+
+    await test.step('a countdown without an end date is refused, and says why', async () => {
+      await page.goto(`/admin/sale/update/${saleId}`);
+      await page.getByTestId('sale-end-date').fill('');
+      await page.getByTestId('sale-countdown-mode').selectOption('2');
+      await Promise.all([
+        page.waitForURL(new RegExp(`/admin/sale/update/${saleId}$`)),
+        page.getByTestId('sale-edit-submit').click(),
+      ]);
+
+      const flash = page.getByTestId('bo-flash-danger');
+      await expect(flash).toBeVisible();
+      await expect(flash).toContainText(/countdown|compte à rebours/i);
+      await expect(page.getByTestId('sale-countdown-mode')).toHaveValue('1');
+    });
+
+    await test.step('delete the sale it created', async () => {
+      await page.goto('/admin/sales');
+      // The confirm dialog is always in the page: reuse its tokenized action instead of
+      // driving the modal, which the overflow menu may hold at narrower widths.
+      const action = await page.getByTestId('sale-delete-form').getAttribute('action');
+      await page.goto(`${action}&sale_id=${saleId}`);
+      await expect(page.locator(`tr[data-row-id="${saleId}"]`)).toHaveCount(0);
+    });
+  });
+});
+
+/**
+ * Product selection of the sale edit screen: client-side filter, live count,
+ * select / deselect over what the filter shows, and the guarantee that loading
+ * a category never overwrites a manual tick.
+ *
+ * Read-only by design: every behaviour under test happens in the browser, so the
+ * test never saves the sale it inspects and leaves the demo data untouched — it
+ * asserts that at the end.
+ */
+test.describe('Back-office — sale product selection (BO Twig)', () => {
+  test.skip(
+    (process.env.BO_TEMPLATE ?? 'default') !== 'default-twig',
+    'BO Twig only.',
+  );
+
+  test.use({ viewport: { width: 1440, height: 1000 } });
+
+  const shotsDir = process.env.SHOTS_DIR ?? '';
+  const shoot = async (page: Page, name: string): Promise<void> => {
+    if (shotsDir === '') {
+      return;
+    }
+    await page.getByTestId('sale-product-filter').scrollIntoViewIfNeeded();
+    await page.screenshot({ path: `${shotsDir}/${name}.png`, fullPage: false });
+  };
+
+  // The row marker, not the product id: the attributes button of a row carries that
+  // id too.
+  const rows = (page: Page): Locator => page.getByTestId('sale-product-zone').locator('[data-sale-product-row]');
+  const visibleRows = (page: Page): Locator =>
+    page.getByTestId('sale-product-zone').locator('[data-sale-product-row]:not(.d-none)');
+  const selectedCount = async (page: Page): Promise<string | null> =>
+    page.getByTestId('sale-product-count').getAttribute('data-selected-count');
+
+  test('the loaded products can be filtered, counted and ticked in bulk without losing a manual choice', async ({ page }) => {
+    // The sale that already covers the most products: the screen has to tell what
+    // it covers from what a load has just added.
+    const saleId = Number(
+      await ddevMysql('SELECT sale_id FROM sale_product GROUP BY sale_id ORDER BY COUNT(*) DESC, sale_id LIMIT 1'),
+    );
+    expect(saleId).toBeGreaterThan(0);
+
+    const covered = (await ddevMysql(`SELECT product_id FROM sale_product WHERE sale_id = ${saleId} ORDER BY product_id`))
+      .split('\n')
+      .map((id) => Number(id.trim()))
+      .filter((id) => id > 0);
+    expect(covered.length).toBeGreaterThan(1);
+
+    await loginAdmin(page);
+    await page.goto(`/admin/sale/update/${saleId}`);
+    await expect(page.getByTestId('sale-product-zone')).toBeVisible();
+
+    const firstCovered = covered[0];
+    const secondCovered = covered[1];
+    const firstCheck = page.getByTestId(`sale-product-check-${firstCovered}`);
+    const secondCheck = page.getByTestId(`sale-product-check-${secondCovered}`);
+
+    await test.step('the persisted products are flagged as already covered, and counted', async () => {
+      await expect(rows(page)).toHaveCount(covered.length);
+      await expect(page.getByTestId(`sale-product-covered-${firstCovered}`)).toBeVisible();
+      await expect(page.getByTestId('sale-product-covered-' + firstCovered)).toContainText(/already covered|déjà couvert/i);
+      expect(await selectedCount(page)).toBe(String(covered.length));
+      await expect(page.getByTestId('sale-product-count')).toContainText(String(covered.length));
+      await shoot(page, 'covered-badge');
+    });
+
+    const filter = page.getByTestId('sale-product-filter');
+    const firstRef = ((await rows(page).filter({ has: firstCheck }).locator('code').textContent()) ?? '').trim();
+    expect(firstRef).not.toBe('');
+
+    await test.step('the filter narrows the list without dropping anything from the form', async () => {
+      await filter.fill(firstRef);
+      await expect(visibleRows(page)).toHaveCount(1);
+      // Hidden rows keep their checkbox: the count stays the total, and says how
+      // many the filter shows.
+      expect(await selectedCount(page)).toBe(String(covered.length));
+      await expect(page.getByTestId('sale-product-count')).toHaveAttribute('data-shown-count', '1');
+      await expect(page.getByTestId('sale-product-no-match')).toBeHidden();
+      await shoot(page, 'filter-active');
+
+      // The box sits inside the sale form: Enter must narrow the list, not save.
+      const before = page.url();
+      await filter.press('Enter');
+      await expect(page.getByTestId('sale-product-count')).toHaveAttribute('data-shown-count', '1');
+      expect(page.url()).toBe(before);
+
+      await filter.fill('zzz-no-such-product');
+      await expect(visibleRows(page)).toHaveCount(0);
+      await expect(page.getByTestId('sale-product-no-match')).toBeVisible();
+
+      await filter.fill('');
+      await expect(visibleRows(page)).toHaveCount(covered.length);
+      await expect(page.getByTestId('sale-product-no-match')).toBeHidden();
+    });
+
+    await test.step('deselect and select all only touch the rows the filter shows', async () => {
+      await filter.fill(firstRef);
+      await page.getByTestId('sale-product-deselect-all').click();
+      await expect(firstCheck).not.toBeChecked();
+      await expect(secondCheck).toBeChecked();
+      expect(await selectedCount(page)).toBe(String(covered.length - 1));
+      await shoot(page, 'deselect-all-filtered');
+
+      await page.getByTestId('sale-product-select-all').click();
+      await expect(firstCheck).toBeChecked();
+      expect(await selectedCount(page)).toBe(String(covered.length));
+
+      // Everything visible: the actions then carry the whole list.
+      await filter.fill('');
+      await page.getByTestId('sale-product-deselect-all').click();
+      expect(await selectedCount(page)).toBe('0');
+      await expect(page.getByTestId('sale-product-count')).toContainText('0');
+      await shoot(page, 'all-deselected');
+
+      await page.getByTestId('sale-product-select-all').click();
+      expect(await selectedCount(page)).toBe(String(covered.length));
+    });
+
+    await test.step('loading a category merges: a manual untick survives it', async () => {
+      await firstCheck.uncheck();
+      expect(await selectedCount(page)).toBe(String(covered.length - 1));
+
+      await page.getByTestId('sale-load-products').click();
+      await expect(rows(page)).not.toHaveCount(covered.length);
+      const loaded = await rows(page).count();
+      expect(loaded).toBeGreaterThan(covered.length);
+
+      // The row was already there, so the load left it exactly as it was found.
+      await expect(firstCheck).not.toBeChecked();
+      expect(await selectedCount(page)).toBe(String(loaded - 1));
+      // The newly loaded products are not flagged as covered by the sale.
+      await expect(page.getByTestId('sale-product-zone').locator('[data-persisted="1"]')).toHaveCount(covered.length);
+      await expect(page.getByTestId('sale-product-zone').locator('.badge.text-bg-light')).toHaveCount(covered.length);
+
+      // Untick one of the freshly loaded rows, then load a further category: both
+      // manual choices have to come back untouched.
+      const freshCheck = page
+        .getByTestId('sale-product-zone')
+        .locator('[data-sale-product-row]:not([data-persisted])')
+        .first()
+        .locator('input[type="checkbox"]');
+      await freshCheck.uncheck();
+      expect(await selectedCount(page)).toBe(String(loaded - 2));
+
+      const categories = page.getByTestId('sale-categories');
+      const already = await categories.evaluate(
+        (select) => Array.from((select as HTMLSelectElement).selectedOptions).map((option) => option.value),
+      );
+      const extra = await categories.evaluate(
+        (select, picked) => Array.from((select as HTMLSelectElement).options)
+          .map((option) => option.value)
+          .filter((value) => !(picked as string[]).includes(value)),
+        already,
+      );
+      expect(extra.length).toBeGreaterThan(0);
+
+      await categories.selectOption([...already, ...extra]);
+      await page.getByTestId('sale-load-products').click();
+      await expect(rows(page)).not.toHaveCount(loaded);
+      const merged = await rows(page).count();
+      expect(merged).toBeGreaterThan(loaded);
+
+      await expect(firstCheck).not.toBeChecked();
+      await expect(freshCheck).not.toBeChecked();
+      expect(await selectedCount(page)).toBe(String(merged - 2));
+      // No row was rebuilt, so nothing is there twice either.
+      await expect(rows(page).filter({ has: firstCheck })).toHaveCount(1);
+      await shoot(page, 'merged-load');
+    });
+
+    await test.step('nothing was persisted: the sale still covers what it covered', async () => {
+      expect(await ddevMysql(`SELECT COUNT(*) FROM sale_product WHERE sale_id = ${saleId}`))
+        .toBe(String(covered.length));
+      await page.goto(`/admin/sale/update/${saleId}`);
+      await expect(rows(page)).toHaveCount(covered.length);
+    });
+  });
+});

--- a/tests/Unit/Api/Service/API/ResourceCacheTest.php
+++ b/tests/Unit/Api/Service/API/ResourceCacheTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Api\Service\API;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Thelia\Api\Service\API\ResourceCache;
+use Thelia\Domain\Sale\SaleAudienceChecker;
+
+/**
+ * The cross-request cache of the data access layer keys on the path, the format
+ * and the locale — never on who is asking. Only paths whose answer is the same
+ * for everybody are eligible.
+ *
+ * A running reserved operation breaks that promise for the catalog: two visitors
+ * asking for the same product are owed two different prices. The catalog paths
+ * are therefore bypassed for as long as such an operation runs, and cached again
+ * as soon as none does.
+ */
+final class ResourceCacheTest extends TestCase
+{
+    private const CATALOG_PATH = '/api/front/products/1';
+    private const NEUTRAL_PATH = '/api/front/countries';
+
+    public function testTheCatalogIsCachedWhenNoReservedOperationRuns(): void
+    {
+        $cache = $this->cache(hasActiveReservedSale: false);
+
+        self::assertSame(['first'], $cache->remember('key', self::CATALOG_PATH, static fn (): array => ['first']));
+        self::assertSame(
+            ['first'],
+            $cache->remember('key', self::CATALOG_PATH, static fn (): array => ['second']),
+            'The second read is answered from the cache, so the payload is the first one.',
+        );
+    }
+
+    public function testTheCatalogIsBypassedWhileAReservedOperationRuns(): void
+    {
+        $cache = $this->cache(hasActiveReservedSale: true);
+
+        self::assertSame(['first'], $cache->remember('key', self::CATALOG_PATH, static fn (): array => ['first']));
+        self::assertSame(
+            ['second'],
+            $cache->remember('key', self::CATALOG_PATH, static fn (): array => ['second']),
+            'A reserved price would be served to whoever asked next: the catalog is not cached at all.',
+        );
+    }
+
+    /**
+     * The bypass is aimed at the two paths a price travels on. Everything else the
+     * allow list holds answers the same thing to everybody, reserved operation or
+     * not, and keeps its cache.
+     */
+    public function testTheOtherCachedPathsAreUntouchedByAReservedOperation(): void
+    {
+        $cache = $this->cache(hasActiveReservedSale: true);
+
+        self::assertSame(['first'], $cache->remember('key', self::NEUTRAL_PATH, static fn (): array => ['first']));
+        self::assertSame(
+            ['first'],
+            $cache->remember('key', self::NEUTRAL_PATH, static fn (): array => ['second']),
+        );
+    }
+
+    public function testTheSaleOperationsAreNeverAskedAboutWhenTheCacheIsOff(): void
+    {
+        $saleAudienceChecker = $this->createMock(SaleAudienceChecker::class);
+        $saleAudienceChecker->expects(self::never())->method('hasActiveReservedSale');
+
+        $cache = new ResourceCache(
+            new ArrayAdapter(),
+            enabled: false,
+            ttl: 60,
+            allowedPrefixes: ['/api/front/products'],
+            reservedSaleSensitivePrefixes: ['/api/front/products'],
+            saleAudienceChecker: $saleAudienceChecker,
+        );
+
+        self::assertSame(['computed'], $cache->remember('key', self::CATALOG_PATH, static fn (): array => ['computed']));
+    }
+
+    private function cache(bool $hasActiveReservedSale): ResourceCache
+    {
+        $saleAudienceChecker = $this->createMock(SaleAudienceChecker::class);
+        $saleAudienceChecker->method('hasActiveReservedSale')->willReturn($hasActiveReservedSale);
+
+        return new ResourceCache(
+            new ArrayAdapter(),
+            enabled: true,
+            ttl: 60,
+            allowedPrefixes: ['/api/front/products', '/api/front/product_sale_elements', '/api/front/countries'],
+            reservedSaleSensitivePrefixes: ['/api/front/products', '/api/front/product_sale_elements'],
+            saleAudienceChecker: $saleAudienceChecker,
+        );
+    }
+}

--- a/tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest.php
+++ b/tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\BackOfficeDefaultTwig\Form;
+
+use BackOfficeDefaultTwigBundle\Form\Sale\SaleType;
+use BackOfficeDefaultTwigBundle\Service\Sale\SaleCustomerIdsReader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Validator\Validation;
+use Thelia\Model\Sale;
+
+final class SaleTypeTest extends TestCase
+{
+    /** A submission that saves a plain public sale with no countdown. */
+    private const VALID_SUBMISSION = [
+        'id' => '7',
+        'locale' => 'fr_FR',
+        'title' => 'Soldes de printemps',
+        'label' => '-20%',
+        'chapo' => '',
+        'description' => '',
+        'postscriptum' => '',
+        'active' => '1',
+        'display_initial_price' => '1',
+        'start_date' => '2026-09-01 00:00:00',
+        'end_date' => '2026-09-30 23:59:59',
+        'price_offset_type' => '10',
+        'audience_mode' => '0',
+        'countdown_mode' => '0',
+    ];
+
+    public function testTargetingAndCountdownFieldsArePresentByDefault(): void
+    {
+        $form = $this->createForm();
+
+        $this->assertTrue($form->has('audience_mode'));
+        $this->assertTrue($form->has('hide_products'));
+        $this->assertTrue($form->has('countdown_mode'));
+    }
+
+    public function testCustomerGroupsIsNotAnOfferedAudience(): void
+    {
+        $choices = $this->createForm()->get('audience_mode')->getConfig()->getOption('choices');
+
+        $this->assertNotContains(
+            Sale::AUDIENCE_MODE_CUSTOMER_GROUPS,
+            array_values((array) $choices),
+            'customer groups are US #122: the mode must not be offered in the back office yet',
+        );
+    }
+
+    public function testAnAudienceOutsideTheOfferedChoicesIsRefused(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'audience_mode' => (string) Sale::AUDIENCE_MODE_CUSTOMER_GROUPS,
+        ]));
+
+        $this->assertFalse($form->isValid(), 'posting the customer-groups mode must not go through');
+    }
+
+    public function testLeadHoursFieldIsOnlyBuiltForTheLeadHoursMode(): void
+    {
+        $this->assertFalse(
+            $this->createForm(['countdown_mode' => Sale::COUNTDOWN_MODE_NONE])->has('countdown_lead_hours'),
+            'a sale without countdown has no lead hours to fill in',
+        );
+        $this->assertFalse(
+            $this->createForm(['countdown_mode' => Sale::COUNTDOWN_MODE_FROM_OPENING])->has('countdown_lead_hours'),
+            'a countdown shown from the opening never reads the lead hours',
+        );
+        $this->assertTrue(
+            $this->createForm(['countdown_mode' => Sale::COUNTDOWN_MODE_LEAD_HOURS])->has('countdown_lead_hours'),
+        );
+    }
+
+    public function testTargetingFieldsAreDroppedWhenTheAdminCannotViewCustomers(): void
+    {
+        $form = $this->createForm(null, ['can_target_customers' => false]);
+
+        $this->assertFalse($form->has('audience_mode'), 'the audience cannot be edited without the customer list');
+        $this->assertFalse($form->has('hide_products'));
+        $this->assertTrue($form->has('countdown_mode'), 'the countdown holds no personal data and stays editable');
+    }
+
+    public function testACountdownWithoutAnEndDateIsRefused(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'countdown_mode' => (string) Sale::COUNTDOWN_MODE_FROM_OPENING,
+            'end_date' => '',
+        ]));
+
+        $this->assertFalse($form->isValid());
+        $this->assertStringContainsString('end date', (string) $form->getErrors(true, true)->current()->getMessage());
+    }
+
+    public function testLeadHoursBelowOneHourIsRefused(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'countdown_mode' => (string) Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdown_lead_hours' => '0',
+        ]));
+
+        $this->assertFalse($form->isValid());
+        $this->assertStringContainsString('hours', (string) $form->getErrors(true, true)->current()->getMessage());
+    }
+
+    public function testMissingLeadHoursIsRefusedWhenTheModeNeedsThem(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'countdown_mode' => (string) Sale::COUNTDOWN_MODE_LEAD_HOURS,
+        ]));
+
+        $this->assertTrue($form->has('countdown_lead_hours'), 'the field must be added back for the submitted mode');
+        $this->assertFalse($form->isValid());
+    }
+
+    public function testLeadHoursPostedForAnotherModeAreDroppedInsteadOfRefused(): void
+    {
+        // The input stays in the page when the shop owner switches the mode, so the
+        // browser keeps posting it. Dropping the value must not read as an extra field.
+        $form = $this->createForm(['countdown_mode' => Sale::COUNTDOWN_MODE_LEAD_HOURS, 'countdown_lead_hours' => 48]);
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'countdown_mode' => (string) Sale::COUNTDOWN_MODE_FROM_OPENING,
+            'countdown_lead_hours' => '48',
+        ]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+        $this->assertFalse($form->has('countdown_lead_hours'));
+        // The value that stays in the data array is cleared by SaleEventFactory, which
+        // sends a threshold only for the mode that compares it to the end date.
+        $this->assertSame(Sale::COUNTDOWN_MODE_FROM_OPENING, ((array) $form->getData())['countdown_mode']);
+    }
+
+    public function testAReservedSaleWithoutAnySelectedCustomerIsRefused(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'audience_mode' => (string) Sale::AUDIENCE_MODE_CUSTOMERS,
+        ]));
+
+        $this->assertFalse($form->isValid());
+        $this->assertStringContainsString('at least one customer', (string) $form->getErrors(true, true)->current()->getMessage());
+    }
+
+    public function testAReservedSaleWithSelectedCustomersIsAccepted(): void
+    {
+        $form = $this->createForm(null, [], ['sale_customers' => ['3', '3', '5']]);
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'audience_mode' => (string) Sale::AUDIENCE_MODE_CUSTOMERS,
+            'hide_products' => '1',
+        ]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+
+        $data = (array) $form->getData();
+        $this->assertSame(Sale::AUDIENCE_MODE_CUSTOMERS, $data['audience_mode']);
+        $this->assertTrue($data['hide_products']);
+    }
+
+    /**
+     * Hiding the discounted products only means something for a sale that is reserved
+     * for someone. The checkbox stays in the page when the shop owner switches back to
+     * public, so the browser keeps posting it: stored as is, a flag ticked once would
+     * come back on the day the sale is reserved again.
+     */
+    public function testAHiddenProductsFlagPostedForAPublicSaleIsDropped(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'audience_mode' => (string) Sale::AUDIENCE_MODE_PUBLIC,
+            'hide_products' => '1',
+        ]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+
+        $data = (array) $form->getData();
+        $this->assertSame(Sale::AUDIENCE_MODE_PUBLIC, $data['audience_mode']);
+        $this->assertFalse($data['hide_products'], 'a public sale hides nothing from nobody');
+    }
+
+    public function testTheStoredTargetingSurvivesASaveMadeWithoutTheCustomerRight(): void
+    {
+        $form = $this->createForm(null, ['can_target_customers' => false]);
+        // Nothing renders the radios, so the browser posts no audience at all.
+        $form->submit(array_diff_key(self::VALID_SUBMISSION, ['audience_mode' => null]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+        $this->assertArrayNotHasKey(
+            'audience_mode',
+            (array) $form->getData(),
+            'no audience in the payload is what tells the event factory to replay the stored one',
+        );
+    }
+
+    public function testAValidCountdownSubmissionNormalizesItsValues(): void
+    {
+        $form = $this->createForm();
+        $form->submit(array_merge(self::VALID_SUBMISSION, [
+            'countdown_mode' => (string) Sale::COUNTDOWN_MODE_LEAD_HOURS,
+            'countdown_lead_hours' => '12',
+        ]));
+
+        $this->assertTrue($form->isValid(), (string) $form->getErrors(true, false));
+
+        $data = (array) $form->getData();
+        $this->assertSame(Sale::COUNTDOWN_MODE_LEAD_HOURS, $data['countdown_mode']);
+        $this->assertSame(12, $data['countdown_lead_hours']);
+        $this->assertSame(Sale::AUDIENCE_MODE_PUBLIC, $data['audience_mode']);
+        $this->assertFalse($data['hide_products']);
+    }
+
+    /**
+     * @param array<string, mixed>|null $data
+     * @param array<string, mixed>      $options
+     * @param array<string, mixed>      $post    the request payload carrying the unmapped `sale_customers[]`
+     */
+    private function createForm(?array $data = null, array $options = [], array $post = []): FormInterface
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request([], $post));
+
+        $factory = Forms::createFormFactoryBuilder()
+            ->addExtension(new ValidatorExtension(Validation::createValidator()))
+            ->addType(new SaleType(new IdentityTranslator(), new SaleCustomerIdsReader($requestStack)))
+            ->getFormFactory();
+
+        return $factory->createNamed('thelia_sale', SaleType::class, $data, $options);
+    }
+}

--- a/tests/Unit/Domain/Sale/SaleDiscountCalculatorTest.php
+++ b/tests/Unit/Domain/Sale/SaleDiscountCalculatorTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Domain\Sale;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Domain\Sale\SaleDiscountCalculator;
+use Thelia\Domain\Taxation\TaxEngine\OrderProductTaxCollection;
+use Thelia\Domain\Taxation\TaxEngine\TaxCalculatorInterface;
+use Thelia\Model\Cart;
+use Thelia\Model\Country;
+use Thelia\Model\Order;
+use Thelia\Model\Product;
+use Thelia\Model\Sale;
+use Thelia\Model\State;
+use Thelia\Model\TaxRule;
+
+/**
+ * The discount of a sale operation is taken off the TAXED price, then converted
+ * back: a 10% operation has to take 10% off what the customer actually pays,
+ * not 10% off the untaxed price, which would not be the same number once the
+ * tax is added back on a rounded figure.
+ */
+final class SaleDiscountCalculatorTest extends TestCase
+{
+    public function testAnAmountOffsetIsTakenOffTheTaxedPrice(): void
+    {
+        // 100 HT -> 120 TTC, minus 12 -> 108 TTC -> 90 HT
+        self::assertSame(
+            90.0,
+            $this->calculator()->computeUntaxedPromoPrice(
+                100.0,
+                Sale::OFFSET_TYPE_AMOUNT,
+                12.0,
+                $this->taxCalculator(),
+            ),
+        );
+    }
+
+    public function testAPercentageOffsetIsTakenOffTheTaxedPrice(): void
+    {
+        // 100 HT -> 120 TTC, minus 10% -> 108 TTC -> 90 HT
+        self::assertSame(
+            90.0,
+            $this->calculator()->computeUntaxedPromoPrice(
+                100.0,
+                Sale::OFFSET_TYPE_PERCENTAGE,
+                10.0,
+                $this->taxCalculator(),
+            ),
+        );
+    }
+
+    /**
+     * An offset type the shop does not know about must leave the price alone
+     * rather than guess, so a bad row in `sale` never gives products away.
+     */
+    public function testAnUnknownOffsetTypeLeavesThePriceUntouched(): void
+    {
+        self::assertSame(
+            100.0,
+            $this->calculator()->computeUntaxedPromoPrice(
+                100.0,
+                999,
+                50.0,
+                $this->taxCalculator(),
+            ),
+        );
+    }
+
+    /**
+     * An amount larger than the price is floored at zero, never turned into a
+     * negative price the shop would owe the customer.
+     */
+    public function testAnAmountOffsetLargerThanThePriceIsFlooredAtZero(): void
+    {
+        self::assertSame(
+            0.0,
+            $this->calculator()->computeUntaxedPromoPrice(
+                100.0,
+                Sale::OFFSET_TYPE_AMOUNT,
+                500.0,
+                $this->taxCalculator(),
+            ),
+        );
+    }
+
+    public function testAFullPercentageOffsetGivesAZeroPrice(): void
+    {
+        self::assertSame(
+            0.0,
+            $this->calculator()->computeUntaxedPromoPrice(
+                100.0,
+                Sale::OFFSET_TYPE_PERCENTAGE,
+                100.0,
+                $this->taxCalculator(),
+            ),
+        );
+    }
+
+    private function calculator(): SaleDiscountCalculator
+    {
+        return new SaleDiscountCalculator();
+    }
+
+    /**
+     * A 20% VAT calculator, so that the taxed and the untaxed price are
+     * distinguishable and the round trip is verifiable.
+     */
+    private function taxCalculator(): TaxCalculatorInterface
+    {
+        return new class implements TaxCalculatorInterface {
+            public function load(Product $product, Country $country, ?State $state = null): static
+            {
+                return $this;
+            }
+
+            public function loadTaxRule(TaxRule $taxRule, Country $country, Product $product, ?State $state = null): static
+            {
+                return $this;
+            }
+
+            public function loadTaxRuleWithoutCountry(TaxRule $taxRule, Product $product): static
+            {
+                return $this;
+            }
+
+            public function loadTaxRuleWithoutProduct(TaxRule $taxRule, Country $country, ?State $state = null): static
+            {
+                return $this;
+            }
+
+            public function getTaxAmountFromUntaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null): int|float
+            {
+                return $untaxedPrice * 0.2;
+            }
+
+            public function getTaxAmountFromTaxedPrice($taxedPrice): int|float
+            {
+                return $taxedPrice - $taxedPrice / 1.2;
+            }
+
+            public function getTaxedPrice(float $untaxedPrice, ?OrderProductTaxCollection &$taxCollection = null, ?string $askedLocale = null): int|float
+            {
+                return $untaxedPrice * 1.2;
+            }
+
+            public function getUntaxedPrice($taxedPrice): int|float
+            {
+                return $taxedPrice / 1.2;
+            }
+
+            public function computeUntaxedCartDiscount(Cart $cart, Country $country, ?State $state = null): int|float
+            {
+                return 0;
+            }
+
+            public function computeUntaxedOrderDiscount(Order $order): int|float
+            {
+                return 0;
+            }
+
+            public function computeCartTaxFactor(Cart $cart, Country $country, ?State $state = null): float
+            {
+                return 1.0;
+            }
+
+            public function computeOrderTaxFactor(Order $order): float
+            {
+                return 1.0;
+            }
+        };
+    }
+}

--- a/tests/Unit/Model/SaleTest.php
+++ b/tests/Unit/Model/SaleTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Thelia package.
+ * http://www.thelia.net
+ *
+ * (c) OpenStudio <info@thelia.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Thelia\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Thelia\Model\Sale;
+
+/**
+ * The two questions the whole reserved-sales feature asks of a sale row:
+ * who is it open to, and does its countdown show right now.
+ */
+final class SaleTest extends TestCase
+{
+    public function testASaleOpenToEveryoneIsNotReserved(): void
+    {
+        $sale = new Sale();
+
+        // A row created before the column existed reads the default.
+        self::assertSame(Sale::AUDIENCE_MODE_PUBLIC, $sale->getAudienceMode());
+        self::assertFalse($sale->isReserved());
+    }
+
+    public function testASaleTargetingNamedCustomersIsReserved(): void
+    {
+        $sale = (new Sale())->setAudienceMode(Sale::AUDIENCE_MODE_CUSTOMERS);
+
+        self::assertTrue($sale->isReserved());
+    }
+
+    /**
+     * Customer groups are US #122; the mode is already reserved so that a group
+     * operation never writes a public price the day the groups land.
+     */
+    public function testASaleTargetingCustomerGroupsIsReserved(): void
+    {
+        $sale = (new Sale())->setAudienceMode(Sale::AUDIENCE_MODE_CUSTOMER_GROUPS);
+
+        self::assertTrue($sale->isReserved());
+    }
+
+    public function testNoCountdownIsDisplayedWhenTheModeIsNone(): void
+    {
+        $sale = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_NONE)
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+
+        self::assertFalse($sale->shouldDisplayCountdown(new \DateTime('2026-01-10 11:00:00')));
+    }
+
+    public function testTheCountdownFromTheOpeningIsDisplayedAtOnce(): void
+    {
+        $sale = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_FROM_OPENING)
+            ->setStartDate(new \DateTime('2026-01-01 00:00:00'))
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+
+        self::assertTrue($sale->shouldDisplayCountdown(new \DateTime('2026-01-01 00:00:01')));
+    }
+
+    /**
+     * The lead-hours mode has a threshold: nothing before it, the countdown from it on.
+     */
+    public function testTheLeadHoursCountdownStaysHiddenBeforeItsThreshold(): void
+    {
+        $sale = $this->saleEndingWithLeadHours(48);
+
+        self::assertFalse($sale->shouldDisplayCountdown(new \DateTime('2026-01-08 11:59:59')));
+    }
+
+    public function testTheLeadHoursCountdownAppearsOnItsThreshold(): void
+    {
+        $sale = $this->saleEndingWithLeadHours(48);
+
+        self::assertTrue($sale->shouldDisplayCountdown(new \DateTime('2026-01-08 12:00:00')));
+        self::assertTrue($sale->shouldDisplayCountdown(new \DateTime('2026-01-10 11:00:00')));
+    }
+
+    /**
+     * A countdown counts down to something. Without an end date there is nothing
+     * to count to, whatever the mode says.
+     */
+    public function testNoCountdownIsDisplayedWithoutAnEndDate(): void
+    {
+        $now = new \DateTime('2026-01-08 12:00:00');
+
+        $fromOpening = (new Sale())->setCountdownMode(Sale::COUNTDOWN_MODE_FROM_OPENING);
+        self::assertFalse($fromOpening->shouldDisplayCountdown($now));
+
+        $leadHours = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_LEAD_HOURS)
+            ->setCountdownLeadHours(48);
+        self::assertFalse($leadHours->shouldDisplayCountdown($now));
+    }
+
+    /**
+     * The lead-hours mode without a number of hours has no threshold to compare
+     * against; that is a misconfigured row, not a countdown that starts now.
+     */
+    public function testTheLeadHoursCountdownStaysHiddenWithoutANumberOfHours(): void
+    {
+        $sale = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_LEAD_HOURS)
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+
+        self::assertFalse($sale->shouldDisplayCountdown(new \DateTime('2026-01-10 11:00:00')));
+    }
+
+    /**
+     * An operation that has not opened yet counts down to nothing a visitor can
+     * act on: the products are not on offer, so neither mode shows a countdown
+     * before the start date.
+     */
+    public function testNoCountdownIsDisplayedBeforeTheOperationOpens(): void
+    {
+        $fromOpening = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_FROM_OPENING)
+            ->setStartDate(new \DateTime('2026-01-05 00:00:00'))
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+
+        self::assertFalse($fromOpening->shouldDisplayCountdown(new \DateTime('2026-01-04 23:59:59')));
+        self::assertTrue($fromOpening->shouldDisplayCountdown(new \DateTime('2026-01-05 00:00:00')));
+    }
+
+    /**
+     * The lead-hours threshold can fall before the operation opens — a window
+     * shorter than the lead time does exactly that. The start date wins.
+     */
+    public function testTheLeadHoursCountdownStaysHiddenBeforeTheOperationOpens(): void
+    {
+        $sale = $this->saleEndingWithLeadHours(48)
+            ->setStartDate(new \DateTime('2026-01-09 00:00:00'));
+
+        // Inside the 48-hour window of the end date, but the operation is not open yet.
+        self::assertFalse($sale->shouldDisplayCountdown(new \DateTime('2026-01-08 13:00:00')));
+        self::assertTrue($sale->shouldDisplayCountdown(new \DateTime('2026-01-09 00:00:00')));
+    }
+
+    /**
+     * An operation with no start date has always been open, so nothing about the
+     * countdown changes for it.
+     */
+    public function testAnOperationWithoutAStartDateCountsDownAsBefore(): void
+    {
+        $sale = (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_FROM_OPENING)
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+
+        self::assertTrue($sale->shouldDisplayCountdown(new \DateTime('2026-01-01 00:00:00')));
+    }
+
+    private function saleEndingWithLeadHours(int $leadHours): Sale
+    {
+        return (new Sale())
+            ->setCountdownMode(Sale::COUNTDOWN_MODE_LEAD_HOURS)
+            ->setCountdownLeadHours($leadHours)
+            ->setEndDate(new \DateTime('2026-01-10 12:00:00'));
+    }
+}


### PR DESCRIPTION
A sale can now be public or reserved for named customers, optionally hiding its products from everyone else, and carries a countdown display setting (never / from N hours before the end / from the opening).

A reserved sale never writes `promo` or `promo_price` to the catalog. Its price is resolved at read time for entitled customers only, batched, with the same taxed-offset formula as the public path (now shared in `SaleDiscountCalculator`). Visibility is enforced at query level — front API, loops, product view (404) and the theme sitemap through `ReservedSaleVisibility` — the customer list never leaves the back office, and the shared data-access cache is bypassed only while a reserved sale runs. New read-only `/front/sales` and `/admin/sales` resources expose the settings, the remaining seconds and the rewritten URL (new `sale` view). Cart prices are re-evaluated on login, on change and on restore; an order keeps the price it was placed at.

Also fixes two bugs found on the way: a session cache serving a deleted cart, and the back-office interface language, which was written to the storefront session key at login — an admin's choice now sticks, persists on `admin.locale`, and no longer flips the shop language.

`docs/reserved-sales.md` maps the feature. The schema restore step in CI stays until the config release is tagged. Groups targeting is modeled (`audience_mode = 2`) but ships with the customer groups story.

Companion PRs:
- config: https://github.com/thelia/config/pull/11
- back-office: https://github.com/thelia-templates/default-twig/pull/73
- theme: https://github.com/thelia-templates/flexy/pull/200
