### PR TITLE
fix(loop): honour the loop names declared in module config.xml

### DIFF
--- a/core/lib/Thelia/Core/Template/Loop/LoopExecutor.php
+++ b/core/lib/Thelia/Core/Template/Loop/LoopExecutor.php
@@ -44,7 +44,9 @@ final readonly class LoopExecutor
     private array $loopDefinition;
 
     /**
-     * @param iterable<LoopInterface> $theliaLoops the services tagged "thelia.loop"
+     * @param iterable<LoopInterface>     $theliaLoops       the services tagged "thelia.loop"
+     * @param array<string, class-string> $theliaParserLoops loop name => class, as collected
+     *                                                       from the module config.xml files
      */
     public function __construct(
         private ContainerInterface $container,
@@ -55,8 +57,9 @@ final readonly class LoopExecutor
         #[AutowireIterator('thelia.loop')]
         iterable $theliaLoops,
         private string $kernelEnvironment,
+        array $theliaParserLoops = [],
     ) {
-        $this->loopDefinition = $this->buildLoopDefinition($theliaLoops);
+        $this->loopDefinition = $this->buildLoopDefinition($theliaLoops, $theliaParserLoops);
     }
 
     /**
@@ -140,11 +143,12 @@ final readonly class LoopExecutor
      * Build the "loop name => class" registry from the tagged loop services, using the
      * exact same normalization as TheliaLoop::setLoopList() (kebab-case, collision suffix).
      *
-     * @param iterable<LoopInterface> $theliaLoops
+     * @param iterable<LoopInterface>     $theliaLoops
+     * @param array<string, class-string> $theliaParserLoops
      *
      * @return array<string, class-string<LoopInterface>>
      */
-    private function buildLoopDefinition(iterable $theliaLoops): array
+    private function buildLoopDefinition(iterable $theliaLoops, array $theliaParserLoops): array
     {
         $definition = [];
 

--- a/core/lib/Thelia/Core/Template/Loop/LoopExecutor.php
+++ b/core/lib/Thelia/Core/Template/Loop/LoopExecutor.php
@@ -141,7 +141,8 @@ final readonly class LoopExecutor
 
     /**
      * Build the "loop name => class" registry from the tagged loop services, using the
-     * exact same normalization as TheliaLoop::setLoopList() (kebab-case, collision suffix).
+     * exact same normalization as TheliaLoop::setLoopList() (kebab-case, collision suffix),
+     * then add the names the modules declared themselves in their config.xml.
      *
      * @param iterable<LoopInterface>     $theliaLoops
      * @param array<string, class-string> $theliaParserLoops
@@ -151,6 +152,7 @@ final readonly class LoopExecutor
     private function buildLoopDefinition(iterable $theliaLoops, array $theliaParserLoops): array
     {
         $definition = [];
+        $taggedClasses = [];
 
         foreach ($theliaLoops as $key => $loop) {
             $className = substr(strrchr($loop::class, '\\'), 1);
@@ -162,6 +164,26 @@ final readonly class LoopExecutor
             }
 
             $definition[$name] = $loop::class;
+            $taggedClasses[$loop::class] = true;
+        }
+
+        // A module may name its loops in config.xml (<loop name="paypal-order"
+        // class="PayPal\Loop\PayPalOrderLoop" />), and its templates then ask for that
+        // name, not for the one derived from the class. LoopCompilerPass hands those
+        // aliases to the Smarty plugin only; without them here, {loop type="paypal-order"}
+        // resolves under Smarty and not under any other engine. Aliases are kept only for
+        // classes that are actually registered loop services, so a module whose loop is
+        // gone does not come back through its declaration.
+        foreach ($theliaParserLoops as $alias => $className) {
+            if (!\is_string($alias) || !\is_string($className) || !isset($taggedClasses[$className])) {
+                continue;
+            }
+
+            $alias = str_replace('_', '-', strtolower($alias));
+
+            if (!isset($definition[$alias])) {
+                $definition[$alias] = $className;
+            }
         }
 
         return $definition;

--- a/tests/Integration/Core/Template/LoopExecutorTest.php
+++ b/tests/Integration/Core/Template/LoopExecutorTest.php
@@ -14,9 +14,15 @@ declare(strict_types=1);
 
 namespace Thelia\Tests\Integration\Core\Template;
 
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Thelia\Core\Security\SecurityContext;
 use Thelia\Core\Template\Element\Exception\ElementNotFoundException;
 use Thelia\Core\Template\Element\LoopResult;
 use Thelia\Core\Template\Loop\LoopExecutor;
+use Thelia\Core\Template\Loop\OrderProduct;
+use Thelia\Core\Template\Loop\Product;
+use Thelia\Core\Translation\Translator;
 use Thelia\Model\LangQuery;
 use Thelia\Test\IntegrationTestCase;
 
@@ -79,6 +85,46 @@ final class LoopExecutorTest extends IntegrationTestCase
             'id' => $product->getId(),
             'lang' => $lang->getId(),
         ]));
+    }
+
+    public function testExecuteResolvesALoopNameDeclaredInAModuleConfigXml(): void
+    {
+        // A module declaring <loop name="order-comment" class="…\OrderCommentLoop" /> has
+        // templates asking for "order-comment", never for the name derived from the class.
+        // With order=0 the loop yields no row, but the declared name must still resolve.
+        $executor = $this->createLoopExecutor(['declared-in-config-xml' => OrderProduct::class]);
+
+        $result = $executor->execute('declared_in_config_xml', ['order' => 0]);
+
+        self::assertInstanceOf(LoopResult::class, $result);
+        self::assertSame(0, iterator_count($result));
+    }
+
+    public function testDeclaredNameIsIgnoredWhenItsLoopIsNotRegistered(): void
+    {
+        // The declaration of a module whose loop service is gone must not resurrect it.
+        $executor = $this->createLoopExecutor(['declared-but-absent' => Product::class]);
+
+        $this->expectException(ElementNotFoundException::class);
+
+        $executor->execute('declared-but-absent');
+    }
+
+    /**
+     * @param array<string, class-string> $theliaParserLoops
+     */
+    private function createLoopExecutor(array $theliaParserLoops): LoopExecutor
+    {
+        return new LoopExecutor(
+            static::getContainer(),
+            $this->getService(RequestStack::class),
+            $this->getService(EventDispatcherInterface::class),
+            $this->getService(SecurityContext::class),
+            $this->getService(Translator::class),
+            [new OrderProduct()],
+            'test',
+            $theliaParserLoops,
+        );
     }
 
     private function getLoopExecutor(): LoopExecutor


### PR DESCRIPTION
## Le problème

`LoopExecutor` construit son registre à partir du seul nom de classe des services taggés `thelia.loop`. Les noms qu'un module déclare dans son `config.xml` sont perdus :

```xml
<loop name="paypal-order" class="PayPal\Loop\PayPalOrderLoop" />
```

`LoopCompilerPass::registerXmlAliases()` transmet bien ces alias, mais au seul plugin Smarty `TheliaLoop`. Sous tout autre moteur, `{loop type="paypal-order"}` ne résout pas : `LoopExecutor` ne connaît que `pay-pal-order-loop`, dérivé de la classe.

Vu en production sur un projet Thelia 3 : `app.ERROR: Loop type 'paypal-order' is not defined.` à chaque génération de facture PDF d'une commande PayPal — `LoopDataAccessService` avale l'exception et renvoie un résultat vide, le bloc du gabarit disparaît sans bruit. Le même symptôme touche le PDF de livraison d'OrderComment (`order.comment.comment`).

Sur cette installation, 22 alias déclarés dans un `config.xml` diffèrent du nom dérivé de leur classe ; 2 sont réellement appelés par un gabarit Twig.

## Le correctif

`LoopExecutor` reçoit `%Thelia.parser.loops%` (le paramètre que le compiler pass alimente) et ajoute ces noms à son registre, après ceux dérivés des classes et sans les écraser. Un alias n'est retenu que si sa classe est un service de loop réellement enregistré : le `config.xml` d'un module dont la loop a disparu ne la ressuscite pas.

## Tests

Deux cas ajoutés à `LoopExecutorTest` : un nom déclaré résout, un nom déclaré dont la loop n'est pas enregistrée continue de lever `ElementNotFoundException`.

Le premier commit porte les tests et le branchement du paramètre, sans la fusion : il doit échouer. Le second apporte la fusion.