### PR TITLE
fix(test): skip the sale form tests when the published theme lacks the service

### DIFF
--- a/tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest.php
+++ b/tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest.php
@@ -46,6 +46,18 @@ final class SaleTypeTest extends TestCase
         'countdown_mode' => '0',
     ];
 
+    protected function setUp(): void
+    {
+        // The bundle under test ships in its own package (thelia-templates/default-twig),
+        // and the core CI installs the published version, not its main branch. A screen
+        // this suite already covers can therefore be absent from the release the runner
+        // resolves: skip, the way assertPageRenders() does for the back-office HTTP
+        // tests, instead of turning the core red over a dependency it does not control.
+        if (!class_exists(SaleCustomerIdsReader::class)) {
+            self::markTestSkipped('SaleCustomerIdsReader is not in the published default-twig version yet.');
+        }
+    }
+
     public function testTargetingAndCountdownFieldsArePresentByDefault(): void
     {
         $form = $this->createForm();


### PR DESCRIPTION
## Le symptôme

`main` est rouge depuis le merge de #3921 : 14 erreurs, toutes dans `SaleTypeTest`, sur les trois versions de PHP.

```
Error: Class "BackOfficeDefaultTwigBundle\Service\Sale\SaleCustomerIdsReader" not found
tests/Unit/BackOfficeDefaultTwig/Form/SaleTypeTest.php:245
```

## La cause

`SaleCustomerIdsReader` existe sur `main` de `thelia-templates/default-twig` (`src/Service/Sale/SaleCustomerIdsReader.php`) mais dans **aucun tag** : le dernier est `1.0.3`. Le cœur requiert `thelia/backoffice-default-twig-template: ^1.0` et n'a pas de `composer.lock`, donc le runner installe `1.0.3`, qui ne connaît pas ce service.

C'est le piège déjà constaté le 08/09 sur les tests HTTP du back-office : la CI du cœur teste le thème **publié**, pas sa branche. `WebIntegrationTestCase::assertPageRenders()` transforme ce cas en test ignoré ; les tests unitaires du bundle n'avaient pas d'équivalent.

## Le correctif

`setUp()` ignore la classe de tests quand le service n'existe pas dans la version installée. Les 14 erreurs deviennent 14 tests ignorés, et ils se remettent à tourner d'eux-mêmes dès que la release de `default-twig` embarque le service.

Cela ne remplace pas cette release : tant qu'elle n'est pas publiée, le comportement ajouté par #3921 n'est couvert par aucun test exécuté.