### PR TITLE
ci: prove the core against the theme branch tips

### DIFF
--- a/.github/workflows/phpstan-botwig.yml
+++ b/.github/workflows/phpstan-botwig.yml
@@ -12,14 +12,18 @@ name: phpstan-botwig
 # were found"). A .env.test.local points it at the runner's MySQL.
 on:
   push:
-    branches: [ twig, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ twig, main ]
+    branches: [ main ]
 
 jobs:
   phpstan-botwig:
     name: PHPStan level 5 (BO Twig bundle)
     runs-on: ubuntu-latest
+    env:
+      # Without a token, Flex silently skips the thelia/thelia-recipes endpoint
+      # and the GitHub archive the theme branch is downloaded from is rate limited.
+      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,38 +40,28 @@ jobs:
           ini-values: post_max_size=20M
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, gd, zip
 
-      - name: Install Composer dependencies
+      - name: Resolve the back-office theme from its development branch
+        # The analysed code has to be the branch phpstan-baseline-botwig.neon was
+        # written against. This used to be a `git clone` over the installed package,
+        # which kept the released tag's dependencies while analysing the branch's
+        # code; resolving the branch through Composer keeps the two in step.
         run: |
-          composer install --no-progress --prefer-dist --optimize-autoloader
-          composer update --no-interaction --prefer-dist
+          composer require --no-update --no-scripts --no-audit \
+            "thelia/backoffice-default-twig-template:dev-main as 1.99.0"
 
-      - name: Restore the project schema the config package overwrote
-        # Same step, and same reason, as the CI workflow: the thelia/config package
-        # installs into local/ and replaces the version-controlled
-        # local/config/schema.xml with its own copy. Without the restore, the models
-        # this job builds have no guest checkout columns and PHPStan reports their
-        # accessors as undefined methods, on every pull request at once.
-        #
-        # The grep is the point of the step: a restore that silently did nothing would
-        # bring those errors straight back.
+      - name: Install Composer dependencies
+        run: composer update --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Check that the analysed theme is the branch tip
         run: |
-          git checkout -- local/config/schema.xml
-          grep -q is_guest local/config/schema.xml \
-            || { echo "::error::local/config/schema.xml has no is_guest column after the restore"; exit 1; }
-          grep -q audience_mode local/config/schema.xml \
-            || { echo "::error::local/config/schema.xml has no audience_mode column after the restore"; exit 1; }
+          version=$(composer show thelia/backoffice-default-twig-template --format=json | php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];')
+          echo "thelia/backoffice-default-twig-template -> $version"
+          case "$version" in dev-main*) ;; *) echo "::error::the theme resolved to $version, expected dev-main"; exit 1 ;; esac
 
       - name: Prepare test env (builds the Propel models via App\Kernel)
         run: |
           printf 'DATABASE_HOST=127.0.0.1\nDATABASE_PORT=3306\nDATABASE_USER=root\nDATABASE_PASSWORD=root\nDATABASE_NAME=test\n' > .env.test.local
           php bin/test-prepare
-
-      - name: Sync the bundle to its working branch
-        # composer installs the published tag; replace the source with the live
-        # branch so the analysed code matches phpstan-baseline-botwig.neon.
-        run: |
-          rm -rf templates/backOffice/default-twig
-          git clone --depth 1 --branch main https://github.com/thelia-templates/default-twig.git templates/backOffice/default-twig
 
       - name: PHPStan (level and paths come from phpstan-botwig.neon)
         run: ./vendor/bin/phpstan analyse -c phpstan-botwig.neon --no-progress --error-format=github

--- a/.github/workflows/phpstan-botwig.yml
+++ b/.github/workflows/phpstan-botwig.yml
@@ -53,10 +53,14 @@ jobs:
         run: composer update --no-progress --prefer-dist --optimize-autoloader
 
       - name: Check that the analysed theme is the branch tip
+        # A development version, not `dev-main`: a package that declares a
+        # branch-alias reports its alias instead.
         run: |
-          version=$(composer show thelia/backoffice-default-twig-template --format=json | php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];')
-          echo "thelia/backoffice-default-twig-template -> $version"
-          case "$version" in dev-main*) ;; *) echo "::error::the theme resolved to $version, expected dev-main"; exit 1 ;; esac
+          info=$(composer show thelia/backoffice-default-twig-template --format=json)
+          version=$(php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];' <<< "$info")
+          reference=$(php -r '$p = json_decode(stream_get_contents(STDIN), true); echo $p["source"]["reference"] ?? $p["dist"]["reference"] ?? "unknown";' <<< "$info")
+          echo "thelia/backoffice-default-twig-template -> $version ($reference)"
+          case "$version" in dev-*|*-dev) ;; *) echo "::error::the theme resolved to $version, expected a development version"; exit 1 ;; esac
 
       - name: Prepare test env (builds the Propel models via App\Kernel)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ twig, main ]
+    branches: [ main ]
   pull_request:
-    branches: [ twig, main ]
+    branches: [ main ]
 
 jobs:
   ci:
@@ -20,6 +20,10 @@ jobs:
     timeout-minutes: 30
     env:
       PHP_CS_FIXER_IGNORE_ENV: 1
+      # Without a token, Flex silently skips the thelia/thelia-recipes endpoint
+      # and the GitHub archives the theme branches are downloaded from are rate
+      # limited per runner IP.
+      COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,53 +40,64 @@ jobs:
           ini-values: post_max_size=20M
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, gd, zip
 
-      - name: Install Composer dependencies
-        run: |
-          composer install --no-progress --prefer-dist --optimize-autoloader
-          composer update --no-interaction --prefer-dist
-
-      - name: Restore the project schema the config package overwrote
-        # The thelia/config package installs into local/ and replaces the
-        # version-controlled local/config/schema.xml with its own copy. Until the
-        # package ships the guest checkout columns (release follow-up), the file
-        # committed in this repository is the source of truth for the CI build.
-        #
-        # The grep is the point of the step: a restore that silently did nothing would
-        # build models without the guest columns, and every guest test would fail far
-        # from here with an unrelated message.
-        run: |
-          git checkout -- local/config/schema.xml
-          grep -q is_guest local/config/schema.xml \
-            || { echo "::error::local/config/schema.xml has no is_guest column after the restore"; exit 1; }
-          grep -q audience_mode local/config/schema.xml \
-            || { echo "::error::local/config/schema.xml has no audience_mode column after the restore"; exit 1; }
-
       - name: Prepare the test database credentials
-        # bin/test-prepare (run by `composer test`) reads these to create the test
-        # database, build the Propel models and generate the JWT keys.
+        # bin/test-prepare (run below and by `composer test`) reads these to create
+        # the test database, build the Propel models and generate the JWT keys.
         run: printf 'DATABASE_HOST=127.0.0.1\nDATABASE_PORT=3306\nDATABASE_USER=root\nDATABASE_PASSWORD=root\nDATABASE_NAME=test\n' > .env.test.local
 
-      - name: Install the front theme importmap vendors
-        # The Flexy theme renders its JavaScript through AssetMapper and its Composer
-        # package ships no assets/vendor/: without them the front pages cannot render
-        # and their smoke tests skip instead of asserting a 200. The vendor directory
-        # follows the active front template, which the kernel reads from the database,
-        # so the test database has to exist first — `composer ci` builds it again,
-        # idempotently. A failed download only brings the skips back, never a red job.
-        continue-on-error: true
+      - name: Resolve the themes from their development branch
+        # This repository is the development monorepo, not what a shop installs
+        # (that is thelia/thelia-project). It has one contract to prove: the tip of
+        # the core works with the tip of the themes. Resolving the *released* themes
+        # instead proved a combination nobody ever runs — a core ahead of its release
+        # against themes behind theirs — and every feature that spans both had to be
+        # switched off with a skip guard to keep the suite green.
+        #
+        # phpstan-botwig.yml already analyses the back-office theme from its branch
+        # for the same reason; this aligns the test job with it.
+        #
+        # The `as` alias keeps the released constraint satisfiable for any package
+        # that requires a theme by version.
+        run: |
+          composer require --no-update --no-scripts --no-audit \
+            "thelia/flexy:dev-main as 1.99.0" \
+            "thelia/backoffice-default-twig-template:dev-main as 1.99.0" \
+            "thelia/email-default-template:dev-main as 1.99.0" \
+            "thelia/pdf-default-template:dev-main as 1.99.0"
+
+      - name: Install Composer dependencies
+        # No composer.lock is committed, so `install` resolves exactly like `update`;
+        # running both did the resolution twice.
+        run: composer update --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Check that the themes under test are the branch tips
+        # A theme silently resolved to its released tag would bring the skip guards
+        # back and the job would stay green while proving nothing.
+        run: |
+          for package in flexy backoffice-default-twig-template email-default-template pdf-default-template; do
+            version=$(composer show "thelia/$package" --format=json | php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];')
+            echo "thelia/$package -> $version"
+            case "$version" in dev-main*) ;; *) echo "::error::thelia/$package resolved to $version, expected dev-main"; exit 1 ;; esac
+          done
+
+      - name: Build the test database and the theme assets
+        # Every HTTP test renders a page, and a page whose theme assets are missing
+        # raises an exception that WebIntegrationTestCase::assertPageRenders() turns
+        # into a *skipped* test. Without this step the two HTTP suites reported 116
+        # skips out of 147: the suites that prove pages render were switched off.
+        # The asset commands read the active templates from the database, so
+        # bin/test-prepare comes first.
         run: |
           php bin/test-prepare
           php bin/console importmap:install --env=test
+          php bin/console tailwind:build --env=test
+          php bin/console sass:build --env=test
 
       - name: Lint the YAML config and the Twig themes
-        # Runs in the test environment: booting the kernel needs the generated Propel
-        # model classes, which bin/test-prepare builds (rerun here, it is idempotent,
-        # in case the best-effort step above did not reach it). The back-office
-        # default-twig theme is left out on purpose: its `safe_hook` Twig function is
-        # unknown to the bare console environment, so a plain lint reports false errors
-        # on it; that theme is covered by the phpstan-botwig job instead.
+        # The back-office default-twig theme is left out on purpose: its `safe_hook`
+        # Twig function is unknown to the bare console environment, so a plain lint
+        # reports false errors on it; that theme is covered by the phpstan-botwig job.
         run: |
-          php bin/test-prepare
           php bin/console lint:yaml config/ --env=test
           php bin/console lint:twig templates/frontOffice templates/email templates/pdf core/lib/Thelia/Resources/views --env=test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,12 +72,16 @@ jobs:
 
       - name: Check that the themes under test are the branch tips
         # A theme silently resolved to its released tag would bring the skip guards
-        # back and the job would stay green while proving nothing.
+        # back and the job would stay green while proving nothing. The expected
+        # string is a development version, not `dev-main`: a package that declares
+        # a branch-alias reports its alias instead (thelia/flexy shows 1.0.x-dev).
         run: |
           for package in flexy backoffice-default-twig-template email-default-template pdf-default-template; do
-            version=$(composer show "thelia/$package" --format=json | php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];')
-            echo "thelia/$package -> $version"
-            case "$version" in dev-main*) ;; *) echo "::error::thelia/$package resolved to $version, expected dev-main"; exit 1 ;; esac
+            info=$(composer show "thelia/$package" --format=json)
+            version=$(php -r 'echo json_decode(stream_get_contents(STDIN), true)["versions"][0];' <<< "$info")
+            reference=$(php -r '$p = json_decode(stream_get_contents(STDIN), true); echo $p["source"]["reference"] ?? $p["dist"]["reference"] ?? "unknown";' <<< "$info")
+            echo "thelia/$package -> $version ($reference)"
+            case "$version" in dev-*|*-dev) ;; *) echo "::error::thelia/$package resolved to $version, expected a development version"; exit 1 ;; esac
           done
 
       - name: Build the test database and the theme assets

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "ext-simplexml": "*",
         "ext-dom": "*"
     },
+    "replace": {
+        "thelia/config": "*"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.*",
         "phpstan/phpstan": "2.*",

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -712,13 +712,15 @@ final class FixtureFactory
      * asserting on it fails on whichever engine it was not written against. Cut
      * every date this factory stores to the second.
      */
-    private static function wholeSeconds(?\DateTimeInterface $date): ?\DateTimeInterface
+    private static function wholeSeconds(?\DateTimeInterface $date): ?\DateTime
     {
         if (null === $date) {
             return null;
         }
 
-        return \DateTimeImmutable::createFromInterface($date)->setTime(
+        // A copy, and a mutable one: the API resources type their date setters
+        // ?DateTime, and the caller's own object must not be touched.
+        return \DateTime::createFromInterface($date)->setTime(
             (int) $date->format('H'),
             (int) $date->format('i'),
             (int) $date->format('s'),

--- a/core/lib/Thelia/Test/FixtureFactory.php
+++ b/core/lib/Thelia/Test/FixtureFactory.php
@@ -215,7 +215,7 @@ final class FixtureFactory
         // Timestampable only fills created_at when it is untouched, so setting it
         // here survives the insert.
         if (isset($overrides['createdAt'])) {
-            $product->setCreatedAt($overrides['createdAt']);
+            $product->setCreatedAt(self::wholeSeconds($overrides['createdAt']));
         }
 
         // A product has no product_i18n row unless a title is asked for, which is
@@ -240,7 +240,7 @@ final class FixtureFactory
         // Product::create() saves the product several times, so updated_at can only
         // be forced once the creation is over.
         if (isset($overrides['updatedAt'])) {
-            $product->setUpdatedAt($overrides['updatedAt'])->save($this->connection);
+            $product->setUpdatedAt(self::wholeSeconds($overrides['updatedAt']))->save($this->connection);
         }
 
         return $product;
@@ -579,7 +579,7 @@ final class FixtureFactory
         $coupon->setType($overrides['type'] ?? 'thelia.coupon.type.remove_x_amount');
         $coupon->setSerializedEffects(json_encode($overrides['effects'] ?? ['amount' => 5.0], \JSON_THROW_ON_ERROR));
         $coupon->setIsEnabled($overrides['isEnabled'] ?? true);
-        $coupon->setExpirationDate($overrides['expirationDate'] ?? new \DateTime('+1 month'));
+        $coupon->setExpirationDate(self::wholeSeconds($overrides['expirationDate'] ?? new \DateTime('+1 month')));
         $coupon->setMaxUsage($overrides['maxUsage'] ?? Coupon::UNLIMITED_COUPON_USE);
         $coupon->setIsCumulative($overrides['isCumulative'] ?? false);
         $coupon->setIsRemovingPostage($overrides['isRemovingPostage'] ?? false);
@@ -704,14 +704,35 @@ final class FixtureFactory
      * The operation discounts nothing on its own — link the products with
      * saleProduct() and give it an offset per currency with saleOffsetCurrency().
      */
+    /**
+     * A DATETIME column holds whole seconds, and the engines disagree on how a
+     * fractional one gets there: MySQL rounds it up, MariaDB truncates it. A date
+     * built from `new \DateTime('+2 hours')` carries microseconds, so it reads back
+     * one second later on one engine and unchanged on the other, and a test
+     * asserting on it fails on whichever engine it was not written against. Cut
+     * every date this factory stores to the second.
+     */
+    private static function wholeSeconds(?\DateTimeInterface $date): ?\DateTimeInterface
+    {
+        if (null === $date) {
+            return null;
+        }
+
+        return \DateTimeImmutable::createFromInterface($date)->setTime(
+            (int) $date->format('H'),
+            (int) $date->format('i'),
+            (int) $date->format('s'),
+        );
+    }
+
     public function sale(array $overrides = []): Sale
     {
         $n = $this->next();
 
         $sale = new Sale();
         $sale->setActive($overrides['active'] ?? false);
-        $sale->setStartDate($overrides['startDate'] ?? null);
-        $sale->setEndDate($overrides['endDate'] ?? null);
+        $sale->setStartDate(self::wholeSeconds($overrides['startDate'] ?? null));
+        $sale->setEndDate(self::wholeSeconds($overrides['endDate'] ?? null));
         $sale->setPriceOffsetType($overrides['priceOffsetType'] ?? Sale::OFFSET_TYPE_PERCENTAGE);
         $sale->setDisplayInitialPrice($overrides['displayInitialPrice'] ?? true);
         $sale->setAudienceMode($overrides['audienceMode'] ?? Sale::AUDIENCE_MODE_PUBLIC);

--- a/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
+++ b/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
@@ -108,7 +108,10 @@ final class ReservedSalePriceResolverTest extends ActionIntegrationTestCase
         $currency = $this->factory->currency();
         $product = $this->catalogProduct($currency);
         $customer = $this->newCustomer();
-        $endDate = new \DateTime('+3 days');
+        // Seconds only: MySQL rounds a fractional second up when it writes a
+        // DATETIME column and MariaDB truncates it, so a date carrying microseconds
+        // reads back one second later on one engine and unchanged on the other.
+        $endDate = new \DateTime((new \DateTime('+3 days'))->format('Y-m-d H:i:s'));
 
         $sale = $this->runningReservedSale($currency, '10', Sale::OFFSET_TYPE_PERCENTAGE, ['endDate' => $endDate]);
         $this->factory->saleProduct($sale, $product);

--- a/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
+++ b/tests/Integration/Domain/Sale/ReservedSalePriceResolverTest.php
@@ -108,10 +108,7 @@ final class ReservedSalePriceResolverTest extends ActionIntegrationTestCase
         $currency = $this->factory->currency();
         $product = $this->catalogProduct($currency);
         $customer = $this->newCustomer();
-        // Seconds only: MySQL rounds a fractional second up when it writes a
-        // DATETIME column and MariaDB truncates it, so a date carrying microseconds
-        // reads back one second later on one engine and unchanged on the other.
-        $endDate = new \DateTime((new \DateTime('+3 days'))->format('Y-m-d H:i:s'));
+        $endDate = new \DateTime('+3 days');
 
         $sale = $this->runningReservedSale($currency, '10', Sale::OFFSET_TYPE_PERCENTAGE, ['endDate' => $endDate]);
         $this->factory->saleProduct($sale, $product);


### PR DESCRIPTION
The test job resolves the released themes while `core/` is the tip of `main`. No shop installs that combination — a shop installs `thelia/thelia-project`, whose skeleton pins released packages — and no contributor works on it either. The result is that every feature spanning the core and a theme has to be switched off with a skip guard to keep the suite green: 18 of them across 14 test files today, one more proposed in #3924.

On the last green run of `main` (40790bcf, PHP 8.3), 123 tests were skipped. The two suites that prove a page renders ran 31 tests out of 147:

| suite | tests | skipped |
|---|---|---|
| unit | 478 | 0 |
| integration | 959 | 6 |
| api | 350 | 1 |
| http-flexy | 122 | 95 |
| http-backoffice | 25 | 21 |

This repository is the development monorepo. It has one contract to prove: the tip of the core works with the tip of the themes. What a user receives is a different contract, and it belongs to the skeleton, not to every pull request.

## What changes

- **Themes resolved from `dev-main`**, aliased so any `^1.0` constraint stays satisfiable, plus a canary step that fails the job if one falls back to its tag — a silent fallback would bring the guards back and the green would prove nothing again.
- **`phpstan-botwig` resolves the theme the same way.** It already analysed the branch, by cloning it over the installed package; going through Composer keeps the dependencies in step with the code being analysed.
- **Theme assets are built before the suites run.** A page whose assets are missing raises an exception that `WebIntegrationTestCase::assertPageRenders()` turns into a *skipped* test. Measured by removing `var/sass` and the theme's `assets/vendor` from a working install: `http-backoffice` goes from 5 to 13 skips out of 17 — 8 tests switched off by the missing build alone.
- **`replace: thelia/config`.** The repository owns `local/config/`; reinstalling the released package over it is what the schema restore step worked around, and what forces a config release before a pull request that adds a column can go green.
- Accessories: a GitHub token so Flex stops silently skipping the `thelia-recipes` endpoint, one `composer update` instead of `install` then `update`, and the deleted `twig` branch dropped from the triggers.

## What it does not do yet

The 18 skip guards are left in place. With the themes at their tip they no longer fire, so this run measures how many of the 123 skipped tests come back **and pass**. Removing them is a follow-up, as is giving `thelia-templates/default-twig` the CI that `flexy` already has and adding a nightly job on the published stack — the one that would have caught the 1.0.4 incident.
