### PR TITLE
fix(boot): survive a cache clear instead of requiring files that are gone

### DIFF
--- a/core/lib/Thelia/Core/Propel/PropelInitService.php
+++ b/core/lib/Thelia/Core/Propel/PropelInitService.php
@@ -243,11 +243,14 @@ class PropelInitService
             // installed, so the question is put to the connection the request
             // works on anyway. The other way round it cost a second
             // connection, its handshake and a query, on every single request.
-            if (!$this->loadPropelRuntime()) {
-                return false;
-            }
+            $loaded = $this->loadPropelRuntime();
 
-            return TheliaKernel::isInstalled();
+            // null means the init file went away between the check above and the
+            // load - a cache clear running on another worker - so the build path
+            // below takes over rather than the request dying on a fatal.
+            if (null !== $loaded) {
+                return $loaded && TheliaKernel::isInstalled();
+            }
         }
 
         if (!$force && !TheliaKernel::isInstalled()) {
@@ -268,8 +271,8 @@ class PropelInitService
                 return false;
             }
 
-            if (!$force && $this->isCacheComplete()) {
-                return $this->loadPropelRuntime() && TheliaKernel::isInstalled();
+            if (!$force && $this->isCacheComplete() && ($loaded = $this->loadPropelRuntime()) !== null) {
+                return $loaded && TheliaKernel::isInstalled();
             }
 
             (new Filesystem())->mkdir(\dirname($buildingFlag));
@@ -334,6 +337,13 @@ class PropelInitService
         $hashFile = $this->getPropelCacheDir().'hash';
         $modelHashFile = $this->getPropelModelDir().'hash';
 
+        // A worker that answered a request before the cache was emptied still
+        // holds those paths in its stat cache, and would call a wiped cache
+        // complete - then die on the require that follows.
+        foreach ([$this->getPropelInitFile(), $hashFile, $modelHashFile] as $file) {
+            clearstatcache(true, $file);
+        }
+
         return file_exists($this->getPropelInitFile())
             && is_dir($this->getPropelSchemaDir())
             && file_exists($hashFile)
@@ -345,9 +355,28 @@ class PropelInitService
      * @return bool false when no database answers behind the configured
      *              credentials, which is the shop the installer is there for
      */
-    private function loadPropelRuntime(): bool
+    /**
+     * @return bool|null true once the runtime is up, false when the database
+     *                   refuses the connection, null when the init file is not
+     *                   there any more and the cache has to be rebuilt
+     */
+    private function loadPropelRuntime(): ?bool
     {
-        require_once $this->getPropelInitFile();
+        $initFile = $this->getPropelInitFile();
+
+        clearstatcache(true, $initFile);
+
+        if (!is_file($initFile)) {
+            return null;
+        }
+
+        try {
+            require_once $initFile;
+        } catch (\Throwable) {
+            // The file can still go away between the check and the read, and a
+            // half-written one is no better: either way the cache is rebuilt.
+            return null;
+        }
 
         try {
             $theliaDatabaseConnection = Propel::getConnection('TheliaMain');

--- a/core/lib/Thelia/Core/TheliaKernel.php
+++ b/core/lib/Thelia/Core/TheliaKernel.php
@@ -273,79 +273,123 @@ class TheliaKernel extends Kernel
 
     protected function checkMySQLConfigurations(ConnectionInterface $con): void
     {
-        if (!file_exists($this->getCacheDir().DS.'check_mysql_configurations.php')) {
-            $serverSqlMode = [];
-            $canUpdate = false;
-            $logs = [];
-            // The verdict is cached across requests, so it must describe the
-            // server-configured sql_mode (@@GLOBAL, what every fresh connection
-            // inherits), never the current session: bin/install boots several
-            // kernels over one shared connection, and a session corrected by a
-            // previous kernel would cache a "nothing to do" verdict that every
-            // later web request would then run with.
-            /** @var PDODataFetcher $result */
-            $result = $con->query('SELECT VERSION() as version, @@GLOBAL.sql_mode as global_sql_mode');
+        $verdict = $this->readMySQLConfigurationsVerdict();
 
-            if ($result && $data = $result->fetch(\PDO::FETCH_ASSOC)) {
-                $serverSqlMode = explode(',', (string) $data['global_sql_mode']);
+        if (null === $verdict) {
+            $verdict = $this->probeMySQLConfigurations($con);
 
-                if (empty($serverSqlMode[0])) {
-                    unset($serverSqlMode[0]);
-                }
-
-                // MariaDB is not impacted by this problem
-                if (!str_contains((string) $data['version'], 'MariaDB')) {
-                    // MySQL 5.6+ compatibility
-                    if (version_compare($data['version'], '5.6.0', '>=')) {
-                        // add NO_ENGINE_SUBSTITUTION
-                        if (!\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
-                            $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
-                            $canUpdate = true;
-                            $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
-                        }
-
-                        // remove ONLY_FULL_GROUP_BY
-                        if (($key = array_search('ONLY_FULL_GROUP_BY', $serverSqlMode, true)) !== false) {
-                            unset($serverSqlMode[$key]);
-                            $canUpdate = true;
-                            $logs[] = 'Remove sql_mode ONLY_FULL_GROUP_BY. Please configure your MySQL server.';
-                        }
-                    }
-                } else {
-                    // MariaDB 10.1.7+ compatibility
-                    if (version_compare($data['version'], '10.1.7', '>=') && !\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
-                        $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
-                        $canUpdate = true;
-                        $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
-                    }
-                }
-            } else {
-                $logs[] = 'Failed to get MySQL version and sql_mode';
-            }
-
-            foreach ($logs as $log) {
+            foreach ($verdict['logs'] as $log) {
                 Tlog::getInstance()->addWarning($log);
             }
 
             (new Filesystem())->dumpFile(
-                $this->getCacheDir().DS.'check_mysql_configurations.php',
-                '<?php return '.VarExporter::export([
-                    'modes' => array_values($serverSqlMode),
-                    'canUpdate' => $canUpdate,
-                    'logs' => $logs,
-                ]).';',
+                $this->getMySQLConfigurationsVerdictFile(),
+                '<?php return '.VarExporter::export($verdict).';',
             );
         }
 
-        $cache = require $this->getCacheDir().DS.'check_mysql_configurations.php';
-
-        if (empty($cache['canUpdate'])) {
+        if (empty($verdict['canUpdate'])) {
             return;
         }
 
-        if (null === $con->query("SET SESSION sql_mode='".implode(',', $cache['modes'])."';")) {
+        if (null === $con->query("SET SESSION sql_mode='".implode(',', $verdict['modes'])."';")) {
             throw new \RuntimeException('Failed to set MySQL global and session sql_mode');
         }
+    }
+
+    private function getMySQLConfigurationsVerdictFile(): string
+    {
+        return $this->getCacheDir().DS.'check_mysql_configurations.php';
+    }
+
+    /**
+     * Reading and writing are kept apart, and the file is never read back right
+     * after being written: emptying the cache directory leaves workers whose
+     * realpath cache still answers that the file is there, and reading it then
+     * raised a warning the error handler turned into a fatal - every back-office
+     * action that clears the cache (the button, activating a module) answered 500
+     * on the requests that followed until a worker recycled.
+     *
+     * @return array{modes: list<string>, canUpdate: bool, logs: list<string>}|null
+     */
+    private function readMySQLConfigurationsVerdict(): ?array
+    {
+        $file = $this->getMySQLConfigurationsVerdictFile();
+
+        clearstatcache(true, $file);
+
+        if (!is_file($file)) {
+            return null;
+        }
+
+        $verdict = @include $file;
+
+        if (!\is_array($verdict) || !isset($verdict['modes'], $verdict['canUpdate'], $verdict['logs'])) {
+            return null;
+        }
+
+        return $verdict;
+    }
+
+    /**
+     * @return array{modes: list<string>, canUpdate: bool, logs: list<string>}
+     */
+    private function probeMySQLConfigurations(ConnectionInterface $con): array
+    {
+        $serverSqlMode = [];
+        $canUpdate = false;
+        $logs = [];
+        // The verdict is cached across requests, so it must describe the
+        // server-configured sql_mode (@@GLOBAL, what every fresh connection
+        // inherits), never the current session: bin/install boots several
+        // kernels over one shared connection, and a session corrected by a
+        // previous kernel would cache a "nothing to do" verdict that every
+        // later web request would then run with.
+        /** @var PDODataFetcher $result */
+        $result = $con->query('SELECT VERSION() as version, @@GLOBAL.sql_mode as global_sql_mode');
+
+        if ($result && $data = $result->fetch(\PDO::FETCH_ASSOC)) {
+            $serverSqlMode = explode(',', (string) $data['global_sql_mode']);
+
+            if (empty($serverSqlMode[0])) {
+                unset($serverSqlMode[0]);
+            }
+
+            // MariaDB is not impacted by this problem
+            if (!str_contains((string) $data['version'], 'MariaDB')) {
+                // MySQL 5.6+ compatibility
+                if (version_compare($data['version'], '5.6.0', '>=')) {
+                    // add NO_ENGINE_SUBSTITUTION
+                    if (!\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
+                        $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
+                        $canUpdate = true;
+                        $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
+                    }
+
+                    // remove ONLY_FULL_GROUP_BY
+                    if (($key = array_search('ONLY_FULL_GROUP_BY', $serverSqlMode, true)) !== false) {
+                        unset($serverSqlMode[$key]);
+                        $canUpdate = true;
+                        $logs[] = 'Remove sql_mode ONLY_FULL_GROUP_BY. Please configure your MySQL server.';
+                    }
+                }
+            } else {
+                // MariaDB 10.1.7+ compatibility
+                if (version_compare($data['version'], '10.1.7', '>=') && !\in_array('NO_ENGINE_SUBSTITUTION', $serverSqlMode, true)) {
+                    $serverSqlMode[] = 'NO_ENGINE_SUBSTITUTION';
+                    $canUpdate = true;
+                    $logs[] = 'Add sql_mode NO_ENGINE_SUBSTITUTION. Please configure your MySQL server.';
+                }
+            }
+        } else {
+            $logs[] = 'Failed to get MySQL version and sql_mode';
+        }
+
+        return [
+            'modes' => array_values($serverSqlMode),
+            'canUpdate' => $canUpdate,
+            'logs' => $logs,
+        ];
     }
 
     protected function getContainerBaseClass(): string

--- a/tests/Integration/Core/Propel/PropelInitServiceTest.php
+++ b/tests/Integration/Core/Propel/PropelInitServiceTest.php
@@ -77,6 +77,20 @@ final class PropelInitServiceTest extends IntegrationTestCase
         self::assertSame(['ActiveModule'], $this->getActiveModuleCodes());
     }
 
+    /**
+     * A cache clear running on one worker takes the init file away while others
+     * are booting on a stat cache that still lists it: loading the runtime then
+     * killed the request. Answering "rebuild me" keeps the boot alive.
+     */
+    public function testLoadingTheRuntimeWithoutItsInitFileAsksForARebuild(): void
+    {
+        self::assertFileDoesNotExist($this->service->getPropelInitFile());
+
+        $method = new \ReflectionMethod($this->service, 'loadPropelRuntime');
+
+        self::assertNull($method->invoke($this->service));
+    }
+
     private function getActiveModuleCodes(): ?array
     {
         $method = new \ReflectionMethod($this->service, 'getActiveModuleCodes');

--- a/tests/Unit/Core/TheliaKernelSqlModeTest.php
+++ b/tests/Unit/Core/TheliaKernelSqlModeTest.php
@@ -67,6 +67,28 @@ final class TheliaKernelSqlModeTest extends TestCase
     }
 
     /**
+     * Emptying the cache directory leaves workers that still believe the verdict
+     * file is there, and reading it then killed the boot: every back-office action
+     * clearing the cache answered 500 until the worker recycled. An unreadable file
+     * puts the kernel in that same position, without a worker to recycle.
+     */
+    public function testAnUnreadableVerdictIsRebuiltInsteadOfBreakingTheBoot(): void
+    {
+        $verdictFile = $this->cacheDir.'/check_mysql_configurations.php';
+        file_put_contents($verdictFile, '<?php return '.var_export(['modes' => [], 'canUpdate' => false, 'logs' => []], true).';');
+        chmod($verdictFile, 0o000);
+
+        if (is_readable($verdictFile)) {
+            self::markTestSkipped('The test user reads the file whatever its mode.');
+        }
+
+        $modes = $this->resolveSessionSqlMode('8.0.40', ['ONLY_FULL_GROUP_BY', 'STRICT_TRANS_TABLES']);
+
+        self::assertNotContains('ONLY_FULL_GROUP_BY', $modes);
+        self::assertContains('STRICT_TRANS_TABLES', $modes);
+    }
+
+    /**
      * @param string[] $serverModes
      *
      * @return string[] the sql_mode the kernel settles on for the session


### PR DESCRIPTION
Clearing the application cache from the back-office — the button on the advanced configuration screen, or activating/deactivating a module — answered 500 on the requests that followed, with nothing in the application log.

Two places on the boot path wrote a file to the cache, then read it back with `require`. Emptying the cache directory leaves PHP-FPM workers whose stat cache still reports those files as present: they skip the rebuild, and the `require` raises a warning the error handler turns into a fatal.

Both were reproduced on a Clever Cloud instance (10 FPM workers, PHP 8.4), firing 15 concurrent requests right after a cache clear:

- `TheliaKernel::checkMySQLConfigurations()` — 7 of 15 answered 500 in ~0.2 s, `AH01071: Got error 'PHP message: Uncaught Warning: require(.../var/cache/prod/check_mysql_configurations.php): Failed to open stream: No such file or directory'`.
- `PropelInitService::loadPropelRuntime()` — same shape on `var/propel/prod/config/propel.init.php`, caught live while an administrator was re-enabling a module.

What changes:

- The sql_mode verdict is probed into memory, used from there, and only written for the next boot. Reading is defensive: `clearstatcache()`, `is_file()`, and a verdict that does not come back as the expected array triggers a rebuild — one query on the connection already open.
- `isCacheComplete()` drops the stat cache entries of the files it checks, and `loadPropelRuntime()` returns null when the init file is not there any more (or fails to load) so `init()` rebuilds under its lock rather than dying.

Both tests fail on the previous code and pass on this one.