### PR TITLE
feat(promotion): whole-cart lot for buy X get Y, and the offered line kept on the order

### DIFF
--- a/core/lib/Thelia/Api/Resource/OrderProduct.php
+++ b/core/lib/Thelia/Api/Resource/OrderProduct.php
@@ -292,6 +292,13 @@ class OrderProduct implements PropelResourceInterface
     ])]
     public ?string $virtualDocument = null;
 
+    /**
+     * Whether a promotion offered this line. Read only: the order says what the cart
+     * said when it was placed, and no caller gets to turn a paid line into a gift.
+     */
+    #[Groups([self::GROUP_ADMIN_READ, Order::GROUP_FRONT_READ_SINGLE, self::GROUP_FRONT_READ_SINGLE])]
+    public bool $isOffered = false;
+
     #[Groups([self::GROUP_ADMIN_READ, self::GROUP_FRONT_READ_SINGLE])]
     public ?\DateTime $createdAt = null;
 
@@ -609,6 +616,18 @@ class OrderProduct implements PropelResourceInterface
     public function getVirtualDocument(): ?string
     {
         return $this->virtualDocument;
+    }
+
+    public function isOffered(): bool
+    {
+        return $this->isOffered;
+    }
+
+    public function setIsOffered(bool $isOffered): self
+    {
+        $this->isOffered = $isOffered;
+
+        return $this;
     }
 
     public function setVirtualDocument(?string $virtualDocument): self

--- a/core/lib/Thelia/Domain/Order/Service/OrderProductFactory.php
+++ b/core/lib/Thelia/Domain/Order/Service/OrderProductFactory.php
@@ -61,6 +61,11 @@ readonly class OrderProductFactory
             ->setTaxRuleTitle($taxRuleI18n->getTitle())
             ->setTaxRuleDescription($taxRuleI18n->getDescription())
             ->setEanCode($productSaleElements->getEanCode())
+            // A line a promotion offered is priced at zero by the cart discount, not by
+            // its own price: without this marker the order cannot tell the gift from a
+            // purchase once the cart is gone. The generated getter is ?int, so a strict
+            // comparison against a boolean would never be true.
+            ->setIsOffered((int) ($cartItem->getIsOffered() ?? 0))
             ->setCartItemId($cartItem->getId());
 
         $orderProduct->save($connection);

--- a/core/lib/Thelia/Domain/Promotion/Coupon/Type/BuyXGetY.php
+++ b/core/lib/Thelia/Domain/Promotion/Coupon/Type/BuyXGetY.php
@@ -49,6 +49,14 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
     public const TRIGGER_SCOPE_CATEGORY = 'category';
     public const TRIGGER_SCOPE_SELECTION = 'selection';
 
+    /**
+     * The whole cart is the lot. It forms at most one, whatever the cart holds, which
+     * is what « one gift from eighty euros » needs: paired with a cart-total condition,
+     * the merchant offers one thing per cart instead of one per article. The triggering
+     * quantity then reads as a minimum number of articles, not as a divisor.
+     */
+    public const TRIGGER_SCOPE_CART = 'cart';
+
     public const TARGET_MODE_SAME = 'same';
     public const TARGET_MODE_PRODUCT = 'product';
     public const TARGET_MODE_CHEAPEST = 'cheapest';
@@ -163,12 +171,12 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
     {
         $cart = $this->facade->getCart();
 
-        if (null === $cart || [] === $this->triggerIds) {
+        if (null === $cart || !$this->hasTriggerSelection()) {
             return 0.0;
         }
 
         $unitPrices = $this->eligibleUnitPrices($cart);
-        $lots = intdiv(\count($unitPrices), $this->triggerQuantity);
+        $lots = $this->lotsFor($unitPrices);
 
         if (0 === $lots) {
             return 0.0;
@@ -192,7 +200,7 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
         if (self::TARGET_MODE_PRODUCT !== $this->targetMode
             || null === $this->targetProductId
             || null === $this->getCouponModelId()
-            || [] === $this->triggerIds) {
+            || !$this->hasTriggerSelection()) {
             return [];
         }
 
@@ -202,7 +210,7 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
             return [];
         }
 
-        $lots = intdiv(\count($this->eligibleUnitPrices($cart)), $this->triggerQuantity);
+        $lots = $this->lotsFor($this->eligibleUnitPrices($cart));
 
         if (0 === $lots) {
             return [];
@@ -226,6 +234,7 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
     private function eligibleUnitPrices(Cart $cart): array
     {
         $country = $this->facade->getDeliveryCountry();
+        $wholeCartIsTheLot = self::TRIGGER_SCOPE_CART === $this->triggerScope;
         $categoryProductIds = self::TRIGGER_SCOPE_CATEGORY === $this->triggerScope
             ? $this->triggerProductIdsInCart($cart)
             : null;
@@ -244,9 +253,13 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
 
             $productId = (int) $cartItem->getProductId();
 
-            $isTrigger = null !== $categoryProductIds
-                ? \in_array($productId, $categoryProductIds, true)
-                : \in_array($productId, $this->triggerIds, true);
+            $isTrigger = match (true) {
+                // Every paid line of the cart forms the lot: nothing is named, so
+                // nothing has to match.
+                $wholeCartIsTheLot => true,
+                null !== $categoryProductIds => \in_array($productId, $categoryProductIds, true),
+                default => \in_array($productId, $this->triggerIds, true),
+            };
 
             if (!$isTrigger) {
                 continue;
@@ -333,11 +346,11 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
 
         $cart = $this->facade->getCart();
 
-        if (null === $cart || [] === $this->triggerIds) {
+        if (null === $cart || !$this->hasTriggerSelection()) {
             return 0.0;
         }
 
-        $lots = intdiv(\count($this->eligibleUnitPrices($cart)), $this->triggerQuantity);
+        $lots = $this->lotsFor($this->eligibleUnitPrices($cart));
 
         if (0 === $lots) {
             return 0.0;
@@ -390,9 +403,13 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
             throw new \InvalidArgumentException($this->translator->trans('Please select what triggers the offer: a product, a category or a selection'));
         }
 
-        $triggerIds = $this->normalizeIdList($raw[self::TRIGGER_IDS_FIELD] ?? []);
+        // The whole cart names nothing, so a stored selection would only mislead the
+        // next reader of these effects.
+        $triggerIds = self::TRIGGER_SCOPE_CART === $scope
+            ? []
+            : $this->normalizeIdList($raw[self::TRIGGER_IDS_FIELD] ?? []);
 
-        if ([] === $triggerIds) {
+        if (self::TRIGGER_SCOPE_CART !== $scope && [] === $triggerIds) {
             throw new \InvalidArgumentException($this->translator->trans('Please select at least one triggering product or category'));
         }
 
@@ -535,7 +552,41 @@ class BuyXGetY extends CouponAbstract implements OfferedLineProviderInterface
      */
     private function triggerScopes(): array
     {
-        return [self::TRIGGER_SCOPE_PRODUCT, self::TRIGGER_SCOPE_CATEGORY, self::TRIGGER_SCOPE_SELECTION];
+        return [
+            self::TRIGGER_SCOPE_PRODUCT,
+            self::TRIGGER_SCOPE_CATEGORY,
+            self::TRIGGER_SCOPE_SELECTION,
+            self::TRIGGER_SCOPE_CART,
+        ];
+    }
+
+    /**
+     * Whether the rule knows what triggers it. Every scope but the cart one names
+     * products or categories; the cart scope needs nothing named.
+     */
+    private function hasTriggerSelection(): bool
+    {
+        return self::TRIGGER_SCOPE_CART === $this->triggerScope || [] !== $this->triggerIds;
+    }
+
+    /**
+     * How many complete lots the cart forms.
+     *
+     * Every scope but the cart one divides: six articles of a three-for-two rule are
+     * two lots, hence two offers. The cart itself is a single lot, so the offer lands
+     * once and the triggering quantity is read as a floor.
+     *
+     * @param float[] $unitPrices
+     */
+    private function lotsFor(array $unitPrices): int
+    {
+        $units = \count($unitPrices);
+
+        if (self::TRIGGER_SCOPE_CART === $this->triggerScope) {
+            return $units >= $this->triggerQuantity ? 1 : 0;
+        }
+
+        return intdiv($units, $this->triggerQuantity);
     }
 
     /**

--- a/local/config/schema.xml
+++ b/local/config/schema.xml
@@ -781,6 +781,7 @@
     <column description="not managed yet" name="parent" type="INTEGER" />
     <column defaultValue="0" name="virtual" required="true" type="TINYINT" />
     <column name="virtual_document" size="255" type="VARCHAR" />
+    <column defaultValue="0" description="the line was offered by a promotion, copied from the cart so the order and its documents still say so once the cart is gone" name="is_offered" required="true" type="TINYINT" />
     <foreign-key foreignTable="order" name="fk_order_product_order_id" onDelete="CASCADE" onUpdate="RESTRICT">
       <reference foreign="id" local="order_id" />
     </foreign-key>

--- a/setup/thelia.sql
+++ b/setup/thelia.sql
@@ -896,6 +896,7 @@ CREATE TABLE `order_product`
     `parent` INTEGER COMMENT 'not managed yet',
     `virtual` TINYINT DEFAULT 0 NOT NULL,
     `virtual_document` VARCHAR(255),
+    `is_offered` TINYINT DEFAULT 0 NOT NULL COMMENT 'the line was offered by a promotion, copied from the cart so the order and its documents still say so once the cart is gone',
     `created_at` DATETIME,
     `updated_at` DATETIME,
     PRIMARY KEY (`id`),

--- a/setup/update/sql/3.1.0.sql
+++ b/setup/update/sql/3.1.0.sql
@@ -350,6 +350,23 @@ PREPARE add_column_statement FROM @statement;
 EXECUTE add_column_statement;
 DEALLOCATE PREPARE add_column_statement;
 
+-- ---------------------------------------------------------------------
+-- The offered line, once the cart is gone
+--
+-- A line a promotion offered is priced at zero by the cart discount, not by its
+-- own price: on the order it therefore reads exactly like a line the customer
+-- paid for. `order_product.is_offered` copies the cart marker at the moment the
+-- order is written, the way the title, the price and the tax rule are already
+-- copied, so the back office, the invoice and a later return can still tell the
+-- gift from a purchase long after the cart it came from has been purged.
+-- ---------------------------------------------------------------------
+
+SET @add_column := (SELECT COUNT(*) = 0 FROM `information_schema`.`COLUMNS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'order_product' AND `COLUMN_NAME` = 'is_offered');
+SET @statement := IF(@add_column, 'ALTER TABLE `order_product` ADD `is_offered` TINYINT DEFAULT 0 NOT NULL COMMENT \'the line was offered by a promotion, copied from the cart so the order and its documents still say so once the cart is gone\' AFTER `virtual_document`', 'DO 0');
+PREPARE add_column_statement FROM @statement;
+EXECUTE add_column_statement;
+DEALLOCATE PREPARE add_column_statement;
+
 SET @add_index := (SELECT COUNT(*) = 0 FROM `information_schema`.`STATISTICS` WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'cart_item' AND `INDEX_NAME` = 'idx_cart_item_offered_by_coupon_id');
 SET @statement := IF(@add_index, 'ALTER TABLE `cart_item` ADD INDEX `idx_cart_item_offered_by_coupon_id` (`offered_by_coupon_id`)', 'DO 0');
 PREPARE add_index_statement FROM @statement;

--- a/tests/Integration/Domain/Promotion/AutomaticPromotionCartTest.php
+++ b/tests/Integration/Domain/Promotion/AutomaticPromotionCartTest.php
@@ -716,8 +716,53 @@ final class AutomaticPromotionCartTest extends ActionIntegrationPromotionTestCas
     }
 
     /**
-     * @param list<int> $triggerIds
+     * « One gift from eighty euros » — the scenario the category and product scopes
+     * cannot express, because they hand out one gift per complete lot found in the
+     * cart. The cart scope forms a single lot, so a seven-article cart gets one gift.
      */
+    public function testTheWholeCartScopeOffersOneGiftWhateverTheNumberOfArticles(): void
+    {
+        $gift = $this->product();
+        $this->offerPromotion(
+            BuyXGetY::TRIGGER_SCOPE_CART,
+            [],
+            $gift,
+            triggerQuantity: 1,
+            title: 'One gift for the whole cart',
+        );
+
+        $cart = $this->newEmptyCart();
+        $this->addItem($cart, $this->product(), quantity: 4);
+        $this->addItem($cart, $this->product(), quantity: 3);
+
+        $offered = $this->offeredLines($cart);
+
+        self::assertCount(1, $offered, 'The whole cart is one lot, so one line is offered.');
+        self::assertSame($gift->getId(), $offered[0]->getProductId());
+        self::assertSame(1.0, (float) $offered[0]->getQuantity(), 'One gift, not one per article.');
+    }
+
+    public function testTheWholeCartScopeTakesTheGiftBackWhenTheCartEmpties(): void
+    {
+        $gift = $this->product();
+        $this->offerPromotion(
+            BuyXGetY::TRIGGER_SCOPE_CART,
+            [],
+            $gift,
+            triggerQuantity: 2,
+            title: 'One gift from two articles',
+        );
+
+        $cart = $this->newEmptyCart();
+        $line = $this->addItem($cart, $this->product(), quantity: 2);
+
+        self::assertCount(1, $this->offeredLines($cart));
+
+        $this->changeItemQuantity($cart, $line, 1.0);
+
+        self::assertCount(0, $this->offeredLines($cart), 'Below the floor, the gift goes away.');
+    }
+
     private function offerPromotion(
         string $scope,
         array $triggerIds,

--- a/tests/Integration/Domain/Promotion/AutomaticPromotionOrderTest.php
+++ b/tests/Integration/Domain/Promotion/AutomaticPromotionOrderTest.php
@@ -81,6 +81,32 @@ final class AutomaticPromotionOrderTest extends ActionIntegrationPromotionTestCa
         self::assertSame(99.0, $this->stockOf($gift), 'The offered unit must leave the stock too.');
     }
 
+    /**
+     * The cart prices the gift at zero through the discount, not through the line
+     * itself: without a marker copied onto the order, the back office, the invoice
+     * and a later return read the gift as a line the customer paid for.
+     */
+    public function testTheOrderSaysWhichLineWasOffered(): void
+    {
+        [, $trigger, $gift, $order] = $this->placeOrderWithAnOfferedGift();
+
+        $offered = [];
+        $paid = [];
+
+        foreach ($order->getOrderProducts() as $orderProduct) {
+            if (1 === $orderProduct->getIsOffered()) {
+                $offered[] = $orderProduct->getProductRef();
+
+                continue;
+            }
+
+            $paid[] = $orderProduct->getProductRef();
+        }
+
+        self::assertSame([$gift->getRef()], $offered, 'The gift is the only line the order calls offered.');
+        self::assertSame([$trigger->getRef()], $paid, 'The triggering line stays a paid line.');
+    }
+
     public function testTheUsageOfAnAutomaticPromotionIsCountedWhenTheOrderIsPaidAndGivenBackOnCancellation(): void
     {
         [$coupon, , , $order] = $this->placeOrderWithAnOfferedGift(maxUsage: 1);

--- a/tests/Unit/Domain/Promotion/BuyXGetYTest.php
+++ b/tests/Unit/Domain/Promotion/BuyXGetYTest.php
@@ -45,6 +45,69 @@ final class BuyXGetYTest extends TestCase
         self::assertSame(10.0, $coupon->exec());
     }
 
+    /**
+     * The whole cart as the lot: it forms one, never several. Paired with a cart-total
+     * condition this is what « one gift from eighty euros » needs — the scope that
+     * divides would hand out one gift per article.
+     */
+    public function testTheWholeCartFormsASingleLotWhateverItHolds(): void
+    {
+        $cart = $this->cartWith([
+            ['productId' => 7, 'quantity' => 4, 'price' => 10.0],
+            ['productId' => 9, 'quantity' => 3, 'price' => 20.0],
+        ]);
+
+        $coupon = $this->coupon($cart, [
+            BuyXGetY::TRIGGER_SCOPE_FIELD => BuyXGetY::TRIGGER_SCOPE_CART,
+            BuyXGetY::TRIGGER_QUANTITY_FIELD => 2,
+            BuyXGetY::TARGET_MODE_FIELD => BuyXGetY::TARGET_MODE_CHEAPEST,
+            BuyXGetY::OFFERED_QUANTITY_FIELD => 1,
+        ]);
+
+        self::assertSame(
+            10.0,
+            $coupon->exec(),
+            'Seven articles form one lot, so exactly one unit is offered, the cheapest.',
+        );
+    }
+
+    public function testTheWholeCartOffersNothingBelowTheMinimumNumberOfArticles(): void
+    {
+        $cart = $this->cartWith([
+            ['productId' => 7, 'quantity' => 1, 'price' => 10.0],
+        ]);
+
+        $coupon = $this->coupon($cart, [
+            BuyXGetY::TRIGGER_SCOPE_FIELD => BuyXGetY::TRIGGER_SCOPE_CART,
+            BuyXGetY::TRIGGER_QUANTITY_FIELD => 2,
+            BuyXGetY::TARGET_MODE_FIELD => BuyXGetY::TARGET_MODE_CHEAPEST,
+            BuyXGetY::OFFERED_QUANTITY_FIELD => 1,
+        ]);
+
+        self::assertSame(0.0, $coupon->exec(), 'The triggering quantity is a floor, not a divisor.');
+    }
+
+    /**
+     * The cart scope names nothing, so the guard that refuses a rule without a
+     * selection must not refuse it.
+     */
+    public function testTheWholeCartNeedsNoProductOrCategoryNamed(): void
+    {
+        $cart = $this->cartWith([
+            ['productId' => 7, 'quantity' => 2, 'price' => 15.0],
+        ]);
+
+        $coupon = $this->coupon($cart, [
+            BuyXGetY::TRIGGER_SCOPE_FIELD => BuyXGetY::TRIGGER_SCOPE_CART,
+            BuyXGetY::TRIGGER_IDS_FIELD => [],
+            BuyXGetY::TRIGGER_QUANTITY_FIELD => 2,
+            BuyXGetY::TARGET_MODE_FIELD => BuyXGetY::TARGET_MODE_CHEAPEST,
+            BuyXGetY::OFFERED_QUANTITY_FIELD => 1,
+        ]);
+
+        self::assertSame(15.0, $coupon->exec());
+    }
+
     public function testACartShortOfAFullLotOffersNothing(): void
     {
         $cart = $this->cartWith([


### PR DESCRIPTION
Two follow-ups to the automatic cart promotions of #3928, both raised by its recette.

### The whole cart as the triggering lot

The three existing scopes divide the cart: six articles of a three-for-two rule form two
lots, hence two offers. A merchant who wanted *one* gift from a spending threshold had no
way to say it. Modelled the only way that was available, a one-article lot over the
categories plus a cart-total condition, a seven-article cart produced **seven** gifts.

`trigger_scope = cart` forms a single lot whatever the cart holds, names no product or
category, and reads the triggering quantity as a floor instead of a divisor. Paired with a
cart-total condition it says « one gift from eighty euros », which is scenario 3 of the
ticket this feature answers.

### The offered line, recognisable on the order

A line a promotion offered is priced at zero by the cart discount, not by its own price:
once the order is written it reads exactly like a line the customer paid for. The back
office showed the gift as a purchase, the invoice could not name it, and a partial refund
would have started from the wrong price.

`order_product.is_offered` copies the cart marker when the order is written, the way the
title, the price and the tax rule already are, so an order placed years ago still tells
the gift from a purchase long after the cart it came from has been purged. The front API
exposes it read only.

### Tests

Five added, each seen failing first:

- the whole cart forms a single lot whatever it holds, and offers nothing below the floor;
- the cart scope needs no product or category named;
- one gift for a seven-article cart, taken back when the cart drops below the floor;
- the order names the offered line and leaves the triggering one a paid line.

Five suites green (2 223 tests), `cs-diff` and `phpstan` at zero. Walked in the browser on
a fresh install with demo data: the back office offers the fourth scope with its plain
language preview, a five-article cart gets one gift, and the placed order carries the
marker on that line only.

### Schema

`order_product.is_offered` lands in `local/config/schema.xml`, in the fresh install SQL and
in the pending update script, guarded by `information_schema` like its neighbours.
