### PR TITLE
Fix attributes and path commerce guys address (#3226)

### DIFF
--- a/local/modules/TheliaSmarty/Template/Plugins/Format.php
+++ b/local/modules/TheliaSmarty/Template/Plugins/Format.php
@@ -12,7 +12,7 @@
 
 namespace TheliaSmarty\Template\Plugins;
 
-use CommerceGuys\Addressing\Model\Address;
+use CommerceGuys\Addressing\Address;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Thelia\Core\HttpFoundation\Session\Session;
@@ -452,7 +452,9 @@ class Format extends AbstractSmartyPlugin
             'address_line1',
             'address_line2',
             'organization',
-            'recipient',
+            'given_name',
+            'additional_name',
+            'family_name',
             'locale',
         ];
         $valid = false;


### PR DESCRIPTION
* Update SchemaLocator.php

Replaces the use of a relative path with an absolute path. For example, when the generation of models in the cache is called from the Thelia php console, it uses the path local/config/shema.xml. Whereas if the generation of models in the cache is called from an http request, it uses the path web/local/config/shema.xml.

* Update SchemaLocator.php

fix code style

* fix the path of commerceguys address and its attributes

---------